### PR TITLE
Fix couple of syntax errors

### DIFF
--- a/prowler
+++ b/prowler
@@ -284,14 +284,14 @@ check13(){
   TITLE13="$BLUE 1.3$NORMAL Ensure credentials unused for 90 days or greater are disabled (Scored)"
   echo -e "\n$TITLE13 "
   COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED=$(cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$4 }' |grep true | awk '{ print $1 }')
-  if [ $COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED ]; then
+  if [[ $COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED ]]; then
     COMMAND13=$(
     for i in $COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED; do
       cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$5 }' |grep $i| awk '{ print $1 }'|tr '\n' ' ';
     done)
     # list of users that have used password
     USERS_PASSWORD_USED=$($AWSCLI iam list-users --query "Users[?PasswordLastUsed].UserName" --output text --profile $PROFILE --region $REGION)
-    if [ $USERS_PASSWORD_USED ]; then
+    if [[ $USERS_PASSWORD_USED ]]; then
       # look for users with a password last used more or equal to 90 days
       for i in $USERS_PASSWORD_USED; do
         DATEUSED=$($AWSCLI iam list-users --query "Users[?UserName=='$i'].PasswordLastUsed" --output text --profile $PROFILE --region $REGION | cut -d'T' -f1)


### PR DESCRIPTION
In two places, the COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED variable was being treated as a string, not a list which causes errors when running the script if multiple users exist in the account.