### PR TITLE
Add logs:DescribeMetricFilters to Custom IAM Policy section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ Instead of using default policy SecurityAudit for the account you use for checks
             "kms:list*",
             "lambda:getpolicy",
             "lambda:listfunctions",
+            "logs:DescribeMetricFilters",
             "rds:describe*",
             "rds:downloaddblogfileportion",
             "rds:listtagsforresource",


### PR DESCRIPTION
The _logs:DescribeMetricFilters_ action is required for the Log Metric Filter checks. Without it, you get the following error:

**An error occurred (AccessDeniedException) when calling the DescribeMetricFilters operation: User: arn:aws:iam::XXXXXXXXXXXX:user/UAT-AWS-CIS-BENCHMARK-SCANNER is not authorized to perform: logs:DescribeMetricFilters on resource: arn:aws:logs:eu-west-1:XXXXXXXXXXXX:log-group:CloudTrail/DefaultLogGroup:log-stream:**

![image](https://cloud.githubusercontent.com/assets/10323889/21765188/9b464e20-d6aa-11e6-8328-2a94354960a9.png)
