### PR TITLE
Match the entire username when running check12

### DIFF
--- a/prowler
+++ b/prowler
@@ -269,7 +269,7 @@ check12(){
   COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED=$(cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$4 }' |grep true | awk '{ print $1 }')
   COMMAND12=$(
     for i in $COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED; do
-      cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$8 }' |grep $i| grep false | awk '{ print $1 }'|tr '\n' ' ';
+      cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$8 }' |grep -w $i| grep false | awk '{ print $1 }'|tr '\n' ' ';
     done)
   echo -e "\n$TITLE12"
     if [[ $COMMAND12 ]]; then


### PR DESCRIPTION
When a password-enabled user with a short name (e.g. "bc") is matched against another user whose username contains the first (e.g. "abcd"), check12 would erroneously display the second user "abcd" as having a password and no MFA even if the second user was not password-enabled.

This change ensures that grep matches the whole word.