### PR TITLE
Improvements and additions to option configurations

### DIFF
--- a/prowler
+++ b/prowler
@@ -45,8 +45,9 @@ RED="[1;31m"
 YELLOW="[1;33m"
 WHITE="[1;37m"
 
-DEFULT_AWS_PROFILE="default"
-DEFAULT_AWS_REGION="us-east-1"
+# Set the defaults for these getopts variables
+PROFILE="default"
+REGION="us-east-1"
 
 # Command usage menu
 usage(){
@@ -158,11 +159,6 @@ elif [[ "$OSTYPE" == "cygwin" ]]; then
 else
       echo "Unknown Operating System"
       exit
-fi
-
-if [[ "$#" -le 2 ]]; then
-  PROFILE=$DEFULT_AWS_PROFILE
-  REGION=$DEFAULT_AWS_REGION
 fi
 
 if [[ ! -f ~/.aws/credentials ]]; then

--- a/prowler
+++ b/prowler
@@ -49,6 +49,7 @@ WHITE="[1;37m"
 PROFILE="default"
 REGION="us-east-1"
 FILTERREGION=""
+MAXITEMS=100
 
 # Command usage menu
 usage(){
@@ -59,12 +60,13 @@ usage(){
       -r <region>         specify an AWS region to direct API requests to (i.e.: us-east-1)
       -c <checknum>       specify a check number or group from the AWS CIS benchmark (i.e.: check11 for check 1.1 or check3 for entire section 3)
       -f <filterregion>   specify an AWS region to run checks against (i.e.: us-west-1)
+      -m <maxitems>       specify the maximum number of items to return for long-running requests (default: 100)
       -h                  this help
   "
   exit
 }
 
-while getopts "hp:r:c:f:" OPTION; do
+while getopts "hp:r:c:f:m:" OPTION; do
    case $OPTION in
      h )
         usage
@@ -81,6 +83,9 @@ while getopts "hp:r:c:f:" OPTION; do
         ;;
      f )
         FILTERREGION=$OPTARG
+        ;;
+     m )
+        MAXITEMS=$OPTARG
         ;;
      : )
         echo -e "\n$RED ERROR!$NORMAL  -$OPTARG requires an argument\n"
@@ -1004,7 +1009,7 @@ check315(){
     TOPICS_LIST=$($AWSCLI sns list-topics --profile $PROFILE --region $regx --output text --query 'Topics[*].TopicArn')
     if [[ $TOPICS_LIST ]];then
         for topic in $TOPICS_LIST; do
-          CHECK_TOPIC_LIST=$($AWSCLI sns list-subscriptions-by-topic --topic-arn $topic --profile $PROFILE --region $regx --query 'Subscriptions[*].{Endpoint:Endpoint,Protocol:Protocol}' --output text)
+          CHECK_TOPIC_LIST=$($AWSCLI sns list-subscriptions-by-topic --topic-arn $topic --profile $PROFILE --region $regx --query 'Subscriptions[*].{Endpoint:Endpoint,Protocol:Protocol}' --output text --max-items $MAXITEMS | grep -v "None")
           if [[ $CHECK_TOPIC_LIST ]]; then
             TOPIC_SHORT=$(echo $topic | awk -F: '{ print $7 }')
             echo -e "     $NOTICE Region $regx with Topic $TOPIC_SHORT: $NORMAL "

--- a/prowler
+++ b/prowler
@@ -48,21 +48,23 @@ WHITE="[1;37m"
 # Set the defaults for these getopts variables
 PROFILE="default"
 REGION="us-east-1"
+FILTERREGION=""
 
 # Command usage menu
 usage(){
   echo -e "\nUSAGE:
       `basename $0` -p <profile> -r <region> [ -h ]
   Options:
-      -p <profile>  specify your AWS profile to use (i.e.: default)
-      -r <region>   specify a desired AWS region to use (i.e.: us-east-1)
-      -c <checknum> specify a check number or group from the AWS CIS benchmark (i.e.: check11 for check 1.1 or check3 for entire section 3)
-      -h            this help
+      -p <profile>        specify your AWS profile to use (i.e.: default)
+      -r <region>         specify an AWS region to direct API requests to (i.e.: us-east-1)
+      -c <checknum>       specify a check number or group from the AWS CIS benchmark (i.e.: check11 for check 1.1 or check3 for entire section 3)
+      -f <filterregion>   specify an AWS region to run checks against (i.e.: us-west-1)
+      -h                  this help
   "
   exit
 }
 
-while getopts "hp:r:c:" OPTION; do
+while getopts "hp:r:c:f:" OPTION; do
    case $OPTION in
      h )
         usage
@@ -76,6 +78,9 @@ while getopts "hp:r:c:" OPTION; do
         ;;
      c )
         CHECKNUMBER=$OPTARG
+        ;;
+     f )
+        FILTERREGION=$OPTARG
         ;;
      : )
         echo -e "\n$RED ERROR!$NORMAL  -$OPTARG requires an argument\n"
@@ -192,7 +197,7 @@ echo -e " |_|$NORMAL$BLUE CIS based AWS Account Hardening Tool$NORMAL\n"
 # Get whoami in AWS, who is the user running this shell script
 getWhoami() {
   echo -e "\nThis report is being generated using credentials below:\n"
-  echo -e "AWS-CLI Profile: $NOTICE[$PROFILE]$NORMAL AWS Region: $NOTICE[$REGION]$NORMAL\n"
+  echo -e "AWS-CLI Profile: $NOTICE[$PROFILE]$NORMAL AWS API Region: $NOTICE[$REGION]$NORMAL AWS Filter Region: $NOTICE[${FILTERREGION:-all}]\n"
   $AWSCLI sts get-caller-identity --output table --profile $PROFILE --region $REGION
 }
 
@@ -228,7 +233,8 @@ cleanTemp(){
 REGIONS=$($AWSCLI ec2 describe-regions --query 'Regions[].RegionName' \
   --output text \
   --profile $PROFILE \
-  --region $REGION)
+  --region $REGION \
+  --region-names $FILTERREGION)
 
 infoReferenceLong(){
   # Report review note:


### PR DESCRIPTION
Three changes in this PR broken into individual commits if you'd prefer to cherry-pick them.

1. Set defaults for environment variables. This is preparation for the next two changes.
2. Add the option to filter API requests by region. The default behavior of the `-r` option didn't do what I was expecting -- filter which regions checks ran against. This change adds another option `-f`, which lets the user filter which regions to run a check against when $REGIONS is used as an iterator.
3. Add the option to configure max-items for large AWS resources. SNS topics can have 100,000+ subscribers, so limiting the number of results returned keeps the check output sane.

Feedback welcome!
