### PR TITLE
fixes #46 - checks 1.16, 1.17, 1.18 were missing from the default lis…

### DIFF
--- a/prowler
+++ b/prowler
@@ -763,7 +763,7 @@ check28(){
             CHECK_KMS_KEY_ROTATION=$($AWSCLI kms get-key-rotation-status --key-id $key --profile $PROFILE --region $regx --output text)
             CHECK_KMS_DEFAULT_KEY=$($AWSCLI kms describe-key --key-id $key --profile $PROFILE --region $regx --query 'KeyMetadata.Description' | sed -n '/Default master key that protects my /p')
               if [[ $CHECK_KMS_KEY_ROTATION == "True" ]];then
-                    echo -e "     $OK OK! Key $key in Region $regx is set correctly$NORMAL"                     
+                    echo -e "     $OK OK! Key $key in Region $regx is set correctly$NORMAL"
                   elif [[ $CHECK_KMS_KEY_ROTATION == "False" && $CHECK_KMS_DEFAULT_KEY ]];then
                 echo -e "     $NOTICE Region $regx key $key is an AWS default master key and cannot be deleted nor modified.$NORMAL"
               else
@@ -775,7 +775,7 @@ check28(){
   else
       echo -e "     $NOTICE Region $regx doesn't have encryption keys $NORMAL"
   fi
-  done 
+  done
 }
 
 check31(){
@@ -1187,6 +1187,9 @@ check112
 check113
 check114
 check115
+check116
+check117
+check118
 check119
 check120
 check121


### PR DESCRIPTION
fixes #46 - checks 1.16, 1.17, 1.18 were missing from the default list of checks

remove some trailing whitespace.