### PR TITLE
Parallelism Tweaks

### DIFF
--- a/prowler
+++ b/prowler
@@ -362,7 +362,7 @@ genCredReport() {
 
 # Save report to a file, decode it, deletion at finish and after every single check, acb stands for AWS CIS Benchmark
 saveReport(){
-  TEMP_REPORT_FILE=/tmp/.acb
+  TEMP_REPORT_FILE=$(mktemp -t prowler-XXXXX.cred_report )
   $AWSCLI iam get-credential-report --query 'Content' --output text --profile $PROFILE --region $REGION | decode_report > $TEMP_REPORT_FILE
 }
 
@@ -370,6 +370,9 @@ saveReport(){
 cleanTemp(){
   rm -fr $TEMP_REPORT_FILE
 }
+
+# Delete the temporary report file if we get interrupted/terminated
+trap cleanTemp SIGHUP SIGINT SIGTERM
 
 # Get a list of all available AWS Regions
 REGIONS=$($AWSCLI ec2 describe-regions --query 'Regions[].RegionName' \

--- a/prowler
+++ b/prowler
@@ -250,7 +250,7 @@ textOK(){
     else
       REPREGION=$REGION
     fi
-    echo "$PROFILE${SEP}$REPREGION${SEP}$TITLE_ID${SEP}PASS${SEP}$ITEM_SCORED${SEP}$TITLE_TEXT${SEP}$1"
+    echo "$PROFILE${SEP}$ACCOUNT_NUM${SEP}$REPREGION${SEP}$TITLE_ID${SEP}PASS${SEP}$ITEM_SCORED${SEP}$TITLE_TEXT${SEP}$1"
   else
     echo "      $OK OK! $NORMAL $1"
   fi
@@ -263,7 +263,7 @@ textNotice(){
     else
       REPREGION=$REGION
     fi
-    echo "$PROFILE${SEP}$REPREGION${SEP}$TITLE_ID${SEP}INFO${SEP}$ITEM_SCORED${SEP}$TITLE_TEXT${SEP}$1"
+    echo "$PROFILE${SEP}$ACCOUNT_NUM${SEP}$REPREGION${SEP}$TITLE_ID${SEP}INFO${SEP}$ITEM_SCORED${SEP}$TITLE_TEXT${SEP}$1"
   else
     echo "      $NOTICE INFO! $1 $NORMAL"
   fi
@@ -276,7 +276,7 @@ textWarn(){
     else
       REPREGION=$REGION
     fi
-    echo "$PROFILE${SEP}$REPREGION${SEP}$TITLE_ID${SEP}WARNING${SEP}$ITEM_SCORED${SEP}$TITLE_TEXT${SEP}$1"
+    echo "$PROFILE${SEP}$ACCOUNT_NUM${SEP}$REPREGION${SEP}$TITLE_ID${SEP}WARNING${SEP}$ITEM_SCORED${SEP}$TITLE_TEXT${SEP}$1"
   else
     echo "      $BAD WARNING! $1 $NORMAL"
   fi
@@ -307,9 +307,9 @@ printCsvHeader() {
   >&2 echo ""
   >&2 echo ""
   >&2 echo "Generating \"${SEP}\" delimited report on stdout;  Diagnostics on stderr."
-  >&2 echo "  Using Profile $PROFILE"
+  >&2 echo "  Using Profile $PROFILE,  Account $ACCOUNT_NUM"
   >&2 echo ""
-      echo "PROFILE${SEP}REGION${SEP}TITLE_ID${SEP}RESULT${SEP}SCORED${SEP}TITLE_TEXT${SEP}NOTES"
+      echo "PROFILE${SEP}ACCOUNT_NUM${SEP}REGION${SEP}TITLE_ID${SEP}RESULT${SEP}SCORED${SEP}TITLE_TEXT${SEP}NOTES"
 }
 
 prowlerBanner() {
@@ -323,6 +323,7 @@ prowlerBanner() {
 
 # Get whoami in AWS, who is the user running this shell script
 getWhoami(){
+  ACCOUNT_NUM=$($AWSCLI sts get-caller-identity --output json --profile $PROFILE --region $REGION --query "Account" | tr -d '"')
   if [[ $MODE == "csv" ]]; then
     CALLER_ARN=$($AWSCLI sts get-caller-identity --output json --profile $PROFILE --region $REGION --query "Arn" | tr -d '"')
     textTitle "0.0" "Show report generation info"


### PR DESCRIPTION
* Make the temporary file name random to allow multiple instances to run in parallel
* Add a trap handler to clean up the temporary file when interrupted/killed
* Add the account id to the CSV output, in addition to the profile.

Example parallel execution - runs up to 4 simultaneously `-P 4`
```
grep -E '^\[([0-9A-Aa-z_-]+)\]'  ~/.aws/credentials | tr -d '][' | shuf |  \
xargs -n 1 -L 1 -I @ -r -P 4 ./prowler -p @ -M csv  2> /dev/null  >> all-accounts.csv
```