### PR TITLE
Fail early

### DIFF
--- a/prowler
+++ b/prowler
@@ -324,7 +324,14 @@ prowlerBanner() {
 # Get whoami in AWS, who is the user running this shell script
 getWhoami(){
   if [[ $MODE == "csv" ]]; then
-    CALLER_ARN=$($AWSCLI sts get-caller-identity --output json --profile $PROFILE --region $REGION --query "Arn" | tr -d '"')
+    CALLER_ARN_RAW=$($AWSCLI sts get-caller-identity --output json --profile $PROFILE --region $REGION --query "Arn")
+    if [[ 255 -eq $? ]]; then
+      # Failed to get own identity ... exit
+      echo "ERROR WITH $PROFILE CREDENTIALS - EXITING!"
+      >&2 echo "ERROR WITH $PROFILE CREDENTIALS - EXITING!"
+      exit 2
+    fi
+    CALLER_ARN=$(echo $CALLER_ARN_RAW | tr -d '"')
     textTitle "0.0" "Show report generation info"
     textNotice "ARN: $CALLER_ARN  TIMESTAMP: $SCRIPT_START_TIME"
   else
@@ -333,10 +340,24 @@ getWhoami(){
     echo ""
     echo -e "AWS-CLI Profile: $NOTICE[$PROFILE]$NORMAL AWS API Region: $NOTICE[$REGION]$NORMAL AWS Filter Region: $NOTICE[${FILTERREGION:-all}]$NORMAL\n"
     if [[ $MONOCHROME -eq 1 ]]; then
-      $AWSCLI sts get-caller-identity --output json --profile $PROFILE --region $REGION | grep ':'
+      echo "Caller Identity:"
+      $AWSCLI sts get-caller-identity --output text --profile $PROFILE --region $REGION --query "Arn"
+      if [[ 255 -eq $? ]]; then
+        # Failed to get own identity ... exit
+        echo "ERROR WITH $PROFILE CREDENTIALS - EXITING!"
+        >&2 echo "ERROR WITH $PROFILE CREDENTIALS - EXITING!"
+        exit 2
+      fi
+      echo ""
     else
       echo "Caller Identity:"
       $AWSCLI sts get-caller-identity --output table --profile $PROFILE --region $REGION
+      if [[ 255 -eq $? ]]; then
+        # Failed to get own identity ... exit
+        echo "ERROR WITH $PROFILE CREDENTIALS - EXITING!"
+        >&2 echo "ERROR WITH $PROFILE CREDENTIALS - EXITING!"
+        exit 2
+      fi
       echo ""
     fi
   fi

--- a/prowler
+++ b/prowler
@@ -1230,12 +1230,19 @@ check315(){
   ID315="3.15"
   TITLE315="Ensure appropriate subscribers to each SNS topic (Not Scored)"
   textTitle "$ID315" "$TITLE315" "0"
+  CAN_SNS_LIST_SUBS=1
   for regx in $REGIONS; do
     TOPICS_LIST=$($AWSCLI sns list-topics --profile $PROFILE --region $regx --output text --query 'Topics[*].TopicArn')
-    if [[ $TOPICS_LIST ]];then
+    if [[ $TOPICS_LIST && $CAN_SNS_LIST_SUBS -eq 1 ]];then
         for topic in $TOPICS_LIST; do
-          CHECK_TOPIC_LIST=$($AWSCLI sns list-subscriptions-by-topic --topic-arn $topic --profile $PROFILE --region $regx --query 'Subscriptions[*].{Endpoint:Endpoint,Protocol:Protocol}' --output text --max-items $MAXITEMS | grep -v "None")
-          if [[ $CHECK_TOPIC_LIST ]]; then
+          CHECK_TOPIC_LIST=$($AWSCLI sns list-subscriptions-by-topic --topic-arn $topic --profile $PROFILE --region $regx --query 'Subscriptions[*].{Endpoint:Endpoint,Protocol:Protocol}' --output text --max-items $MAXITEMS)
+          if [[ $? -eq 255 ]]; then
+            # Permission error
+            export CAN_SNS_LIST_SUBS=0
+            textNotice "No permission to list topics"
+            break;
+          fi
+          if [[ $(grep -v 'None' $CHECK_TOPIC_LIST) ]]; then
             TOPIC_SHORT=$(echo $topic | awk -F: '{ print $7 }')
             textNotice "Region $regx with Topic $TOPIC_SHORT:" "$regx"
             textNotice "- Suscription: $CHECK_TOPIC_LIST" "$regx"
@@ -1244,6 +1251,8 @@ check315(){
             textWarn " - Region $regx and Topic $topic" "$regx"
           fi
         done
+    elif [[ $CAN_SNS_LIST_SUBS -eq 0 ]]; then
+      break
     else
       textNotice "Region $regx doesn't have topics" "$regx"
     fi

--- a/prowler
+++ b/prowler
@@ -1239,7 +1239,9 @@ check315(){
           if [[ $? -eq 255 ]]; then
             # Permission error
             export CAN_SNS_LIST_SUBS=0
-            textNotice "No permission to list topics"
+            textNotice "No permission to list subscribers in topics"
+            ntopics=$(echo $TOPICS_LIST | wc -w )
+            textNotice "Region $regx has $ntopics topics" "$regx"
             break;
           fi
           if [[ $(grep -v 'None' $CHECK_TOPIC_LIST) ]]; then
@@ -1252,7 +1254,9 @@ check315(){
           fi
         done
     elif [[ $CAN_SNS_LIST_SUBS -eq 0 ]]; then
-      break
+      ntopics=$(echo $TOPICS_LIST | wc -w )
+      textNotice "Region $regx has $ntopics topics" "$regx"
+      # break
     else
       textNotice "Region $regx doesn't have topics" "$regx"
     fi

--- a/prowler
+++ b/prowler
@@ -1235,7 +1235,7 @@ check315(){
     TOPICS_LIST=$($AWSCLI sns list-topics --profile $PROFILE --region $regx --output text --query 'Topics[*].TopicArn')
     if [[ $TOPICS_LIST && $CAN_SNS_LIST_SUBS -eq 1 ]];then
         for topic in $TOPICS_LIST; do
-          CHECK_TOPIC_LIST=$($AWSCLI sns list-subscriptions-by-topic --topic-arn $topic --profile $PROFILE --region $regx --query 'Subscriptions[*].{Endpoint:Endpoint,Protocol:Protocol}' --output text --max-items $MAXITEMS)
+          CHECK_TOPIC_LIST=$($AWSCLI sns list-subscriptions-by-topic --topic-arn $topic --profile $PROFILE --region $regx --query 'Subscriptions[*].{Endpoint:Endpoint,Protocol:Protocol}' --output text --max-items $MAXITEMS 2> /dev/null)
           if [[ $? -eq 255 ]]; then
             # Permission error
             export CAN_SNS_LIST_SUBS=0


### PR DESCRIPTION
Exit the script immediately if unable to get-caller-identity - this indicates an issue with the credentials (invalid key, typo in ~/.aws/credentials, etc).

For listing topic subscribers, detect a permission failure, and fall back to showing counts of SNS topics by region, rather than subscriber details.  This works around the missing permission in the AWS Managed "SecurityAudit" policy.