### PR TITLE
Policy requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,8 @@ Instead of using default policy SecurityAudit for the account you use for checks
 }
 ```
 
+### Incremental IAM Policy
+
 Alternatively, here is a policy which defines the permissions which are NOT present in the AWS Managed SecurityAudit policy. Attach both this policy and the AWS Managed SecurityAudit policy to the group and you're good to go.  
 
 ```
@@ -533,6 +535,8 @@ Alternatively, here is a policy which defines the permissions which are NOT pres
   ]
 }
 ```
+
+### Bootstrap Script
 
 Quick bash script to set up a "prowler" IAM user and "SecurityAudit" group with the required permissions. To run the script below, you need user with administrative permissions; set the AWS_DEFAULT_PROFILE to use that account.
 

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ Instead of using default policy SecurityAudit for the account you use for checks
             "redshift:describe*",
             "route53:getchange",
             "route53:getcheckeripranges",
-            "route53:getgeolocations",
+            "route53:getgeolocation",
             "route53:gethealthcheck",
             "route53:gethealthcheckcount",
             "route53:gethealthchecklastfailurereason",

--- a/README.md
+++ b/README.md
@@ -548,3 +548,5 @@ aws iam add-user-to-group --user-name prowler --group-name SecurityAudit
 aws iam create-access-key --user-name prowler
 unset ACCOUNT_ID AWS_DEFAULT_PROFILE
 ```
+
+The `aws iam create-access-key` command will output the secret access key and the key id; keep these somewhere safe, and add them to ~/.aws/credentials with an appropriate profile name to use them with prowler. This is the only time they secret key will be shown.  If you loose it, you will need to generate a replacement.

--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ Alternatively, here is a policy which defines the permissions which are NOT pres
         "cloudwatchlogs:DescribeMetricFilters",
         "es:DescribeElasticsearchDomainConfig",
         "ses:GetIdentityVerificationAttributes",
-        "sns:ListSubscriptionsByTopic",
+        "sns:ListSubscriptionsByTopic"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/prowler-policy-additions.json
+++ b/prowler-policy-additions.json
@@ -9,7 +9,7 @@
         "cloudwatchlogs:describemetricfilters",
         "es:describeelasticsearchdomainconfig",
         "ses:getidentityverificationattributes",
-        "sns:listsubscriptionsbytopic",
+        "sns:listsubscriptionsbytopic"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/prowler-policy-additions.json
+++ b/prowler-policy-additions.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "acm:describecertificate",
+        "acm:listcertificates",
+        "cloudwatchlogs:describeloggroups",
+        "cloudwatchlogs:describemetricfilters",
+        "es:describeelasticsearchdomainconfig",
+        "ses:getidentityverificationattributes",
+        "sns:listsubscriptionsbytopic",
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
Add a policy document with just the added permissions compared to the current SecurityAudit policy, along with an example of how to create a group and user with both policies applied.
