### PR TITLE
Allow Prowler to run on Win10 in Git Bash

### DIFF
--- a/prowler
+++ b/prowler
@@ -221,8 +221,29 @@ elif [[ "$OSTYPE" == "cygwin" ]]; then
     {
       base64 -d
     }
+elif [[ "$OSTYPE" == "msys" ]]; then
+  # POSIX compatibility layer and Linux environment emulation for Windows
+  how_older_from_today()
+      {
+        DATE_TO_COMPARE=$1
+        TODAY_IN_DAYS=$(date -d "$(date +%Y-%m-%d)" +%s)
+        DATE_FROM_IN_DAYS=$(date -d $DATE_TO_COMPARE +%s)
+        DAYS_SINCE=$((($TODAY_IN_DAYS - $DATE_FROM_IN_DAYS )/60/60/24))
+        echo $DAYS_SINCE
+      }
+  timestamp_to_date()
+    {
+      # remove fractions of a second
+      TIMESTAMP_TO_CONVERT=$(echo $1 | cut -f1 -d".")
+      OUTPUT_DATE=$(date -d @$TIMESTAMP_TO_CONVERT +'%Y-%m-%d')
+      echo $OUTPUT_DATE
+    }
+  decode_report()
+    {
+      base64 -d
+    }
 else
-      echo "Unknown Operating System"
+      echo "Unknown Operating System" $OSTYPE
       exit
 fi
 
@@ -789,7 +810,7 @@ check123(){
   LIST_USERS=$($AWSCLI iam list-users --query 'Users[*].UserName' --output text --profile $PROFILE --region $REGION)
   # List of USERS with KEY1 last_used_date as N/A
   LIST_USERS_KEY1_NA=$(for user in $LIST_USERS; do grep $user $TEMP_REPORT_FILE|awk -F, '{ print $1,$11 }'|grep N/A |awk '{ print $1 }'; done)
-  LIST_USERS_KEY1_ACTIVE=$(for user in $LIST_USERS_KEY1_NA; do grep $user $TEMP_REPORT_FILE|awk -F, '{ print $1,$9 }'|grep "true$"|awk '{ print $1 }'|sed 's/[:blank:]+/,/g' ; done)
+  LIST_USERS_KEY1_ACTIVE=$(for user in $LIST_USERS_KEY1_NA; do grep $user $TEMP_REPORT_FILE|awk -F, '{ print $1,$9 }'|grep "true$"|awk '{ print $1 }'|sed 's/[[:blank:]]+/,/g' ; done)
   if [[ $LIST_USERS_KEY1_ACTIVE ]]; then
     for user in $LIST_USERS_KEY1_ACTIVE; do
       textNotice "$user has never used Access Key 1"
@@ -1405,11 +1426,13 @@ extra72(){
   for regx in $REGIONS; do
     LIST_OF_EBS_SNAPSHOTS=$($AWSCLI ec2 describe-snapshots --profile $PROFILE --region $regx --owner-ids $ACCOUNT_NUM --output text --query 'Snapshots[*].{ID:SnapshotId}')
     for snapshot in $LIST_OF_EBS_SNAPSHOTS; do
-      SNAPSHOT_IS_PUBLIC=$($AWSCLI ec2 describe-snapshot-attribute --profile $PROFILE --region $regx --output text --snapshot-id $snapshot --attribute createVolumePermission --query "CreateVolumePermissions[?Group=='all']")
+      SNAP=$(echo $snapshot | sed 's/\r$//')
+      textNotice "Looking for EBS Snapshot details for $SNAP"
+      SNAPSHOT_IS_PUBLIC=$($AWSCLI ec2 describe-snapshot-attribute --profile $PROFILE --region $regx --output text --snapshot-id $SNAP --attribute createVolumePermission --query "CreateVolumePermissions[?Group=='all']")
       if [[ $SNAPSHOT_IS_PUBLIC ]];then
-        textWarn "$regx: $snapshot is currently Public!" "$regx"
+        textWarn "$regx: $SNAP is currently Public in region $regx!"
       else
-        textOK "$regx: $snapshot is not Public" "$regx"
+        textOK "$SNAP is not Public, in region $regx"
       fi
     done
   done
@@ -1424,7 +1447,10 @@ extra73(){
   textNotice "Looking for open S3 Buckets (ACLs and Policies) in all regions...  "
   ALL_BUCKETS_LIST=$($AWSCLI s3api list-buckets --query 'Buckets[*].{Name:Name}' --profile $PROFILE --region $REGION --output text)
   for bucket in $ALL_BUCKETS_LIST; do
+    bucket=$(echo $bucket | sed 's/\r$//')
+    #textNotice "Checking bucket $bucket"
     BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location --bucket $bucket --profile $PROFILE --region $REGION --output text)
+    #textNotice "Initial bucket location determined to be $BUCKET_LOCATION"
     if [[ "None" == $BUCKET_LOCATION ]]; then
       BUCKET_LOCATION="us-east-1"
     fi


### PR DESCRIPTION
Enabled OS detection of "mysis" for Git Bash in Win10.
Fixed check 1.23:
sed: character class syntax is [[:space:]], not [:space:]
Fixed check 7.2:
) for parameter snapshotId is invalid. Expected: 'snap-...'.escribeSnapshotAttribute operation: Value (snap-fcc6a8dd
Fixed check for 7.3:
": Bucket name must match the regex "^[a-zA-Z0-9.\-_]{1,255}$"