### PR TITLE
Updated infoReferenceLong() text and moved the function call

### DIFF
--- a/prowler
+++ b/prowler
@@ -428,10 +428,13 @@ REGIONS=$($AWSCLI ec2 describe-regions --query 'Regions[].RegionName' \
 
 infoReferenceLong(){
   # Report review note:
-  textNotice "For more information:"
-  textNotice "https://benchmarks.cisecurity.org/tools2/amazon/CIS_Amazon_Web_Services_Foundations_Benchmark_v1.1.0.pdf"
-  textNotice "For bugs or feedback:"
-  textNotice "https://github.com/Alfresco/aws-cis-security-benchmark/issues"
+  echo -e ""
+  echo -e "For more information on the Prowler, feedback and issue reporting:"
+  echo -e "https://github.com/Alfresco/prowler"
+  echo -e ""
+  echo -e "For more information on the CIS benchmark:"
+  echo -e "https://benchmarks.cisecurity.org/tools2/amazon/CIS_Amazon_Web_Services_Foundations_Benchmark_v1.1.0.pdf"
+
 }
 
 
@@ -1582,6 +1585,7 @@ callCheck(){
 if [[ $MODE != "csv" ]]; then
   prowlerBanner
   printCurrentDate
+  infoReferenceLong
   printColorsCode
 fi
 getWhoami
@@ -1662,7 +1666,4 @@ extra71
 extra72
 extra73
 
-if [[ $MODE != "csv" ]]; then
-  infoReferenceLong
-fi
 cleanTemp


### PR DESCRIPTION
I guess the information about prowler and about the CIS benchmark should be at the top of the report.
Also made tweaks to the text.