### PR TITLE
Clarify warning message

### DIFF
--- a/prowler
+++ b/prowler
@@ -978,7 +978,7 @@ check27(){
         if [[ $CLOUDTRAILENC_ENABLED ]];then
           textOK "KMS key found for $trail"
         else
-          textWarn "encryption is not enabled in your CloudTrail trail $trail but KMS key not found!"
+          textWarn "encryption is not enabled in your CloudTrail trail $trail (KMS key not found)!"
         fi
       done
     else


### PR DESCRIPTION
A previous change replaced a comma in the message with the word "but" which is incorrect - the missing KMS key was the indicator that the trail was not encrypted.