### PR TITLE
Avoid name clashes on word boundaries

### DIFF
--- a/prowler
+++ b/prowler
@@ -484,7 +484,7 @@ check12(){
   COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED=$(cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$4 }' |grep true | awk '{ print $1 }')
   COMMAND12=$(
     for i in $COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED; do
-      cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$8 }' |grep -w $i| grep false | awk '{ print $1 }'
+      cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$8 }' |grep "$i " |grep false | awk '{ print $1 }'
     done)
   textTitle "$ID12" "$TITLE12" "SCORED" "LEVEL1"
     if [[ $COMMAND12 ]]; then


### PR DESCRIPTION
Firstly, thanks for making prowler available. It's proving very useful for us.

I think we've found an infidelity in check12 (users should only have passwort with MFA).

Let's say I have a user called `pascal` with password and MFA enabled. I also have a user called `pascal-dev` with neither password nor MFA enabled. In principle, this is a valid setup.

Unfortunately, `echo "pascal-dev" | grep -w "pascal"` matches, so it thinks that `pascal-dev` has password enabled, but no MFA. 

In this fix, we grep for `'pascal '`, including the space, to guarantee an exact match. Since IAM usernames can't include spaces, there is no room for a spurious match. 