### PR TITLE
Check 1.24: fix error getting policy version when multiple policies share the same words

### DIFF
--- a/prowler
+++ b/prowler
@@ -856,7 +856,7 @@ check124(){
   if [[ $LIST_CUSTOM_POLICIES ]]; then
     textNotice "Looking for custom policies: (skipping default policies - it may take few seconds...)"
     for policy in $LIST_CUSTOM_POLICIES; do
-      POLICY_VERSION=$($AWSCLI iam list-policies $PROFILE_OPT --region $REGION --query 'Policies[*].[Arn,DefaultVersionId]' --output text|grep -w $policy |awk '{ print $2}')
+      POLICY_VERSION=$($AWSCLI iam list-policies $PROFILE_OPT --region $REGION --query 'Policies[*].[Arn,DefaultVersionId]' --output text |awk "\$1 == \"$policy\" { print \$2 }")
       POLICY_WITH_FULL=$($AWSCLI iam get-policy-version --output text --policy-arn $policy --version-id $POLICY_VERSION --query "PolicyVersion.Document.Statement[?Effect == 'Allow' && contains(Resource, '*') && contains (Action, '*')]" $PROFILE_OPT --region $REGION)
       if [[ $POLICY_WITH_FULL ]]; then
         POLICIES_ALLOW_LIST="$POLICIES_ALLOW_LIST $policy"


### PR DESCRIPTION
If I have two policies called `policy` and `policy-staging`, prowler fails to get the right policy version -- the `POLICY_VERSION` string will look like `v3\nv2`, which breaks the next command.

In this PR, I fix it by replacing `grep -w $policy` with a slightly more complex awk script. An alternative (which I'm happy to implement if you think it's preferable) would to use `grep "$policy\t | awk '{ print $2 }'`.