### PR TITLE
Use a query to get AccountMFAEnabled on a root account rather than awk/sed

### DIFF
--- a/prowler
+++ b/prowler
@@ -684,7 +684,7 @@ check112(){
 check113(){
   ID113="1.13"
   TITLE113="Ensure MFA is enabled for the root account (Scored)"
-  COMMAND113=$($AWSCLI iam get-account-summary $PROFILE_OPT --region $REGION --output json|grep AccountMFAEnabled | awk -F': ' '{ print $2 }'|sed 's/,//')
+  COMMAND113=$($AWSCLI iam get-account-summary $PROFILE_OPT --region $REGION --output json --query 'SummaryMap.AccountMFAEnabled')
   textTitle "$ID113" "$TITLE113" "SCORED" "LEVEL1"
   if [ "$COMMAND113" == "1" ]; then
     textOK "Virtual MFA is enabled for root"


### PR DESCRIPTION
Parsing with awk/sed relies on the json being pretty printed (no other values on the same line), which is not always true, causing false-positive warings sometimes. Querying for SummaryMap.AccountMFAEnabled directly should be more robust.