### PR TITLE
Use a query to get AccountMFAEnabled rather than awk/sed

### DIFF
--- a/prowler
+++ b/prowler
@@ -696,7 +696,7 @@ check113(){
 check114(){
   ID114="1.14"
   TITLE114="Ensure hardware MFA is enabled for the root account (Scored)"
-  COMMAND113=$($AWSCLI iam get-account-summary $PROFILE_OPT --region $REGION --output json|grep AccountMFAEnabled | awk -F': ' '{ print $2 }'|sed 's/,//')
+  COMMAND113=$($AWSCLI iam get-account-summary $PROFILE_OPT --region $REGION --output json --query 'SummaryMap.AccountMFAEnabled')
   textTitle "$ID114" "$TITLE114" "SCORED" "LEVEL1"
   if [ "$COMMAND113" == "1" ]; then
     COMMAND114=$($AWSCLI iam list-virtual-mfa-devices $PROFILE_OPT --region $REGION --query 'VirtualMFADevices' --output text|grep :root |wc -l)


### PR DESCRIPTION
This fixes the same problem as https://github.com/Alfresco/prowler/pull/136. (Sorry I didn't notice this in the previous PR).

Parsing with awk/sed relies on the json being pretty printed (no other values on the same line), which is not always true, causing false-positive warings sometimes. Querying for SummaryMap.AccountMFAEnabled directly should be more robust.