### PR TITLE
Added check extra78

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It covers hardening and security best practices for all AWS regions related to:
 - Logging (8 checks)
 - Monitoring (15 checks)
 - Networking (5 checks)
-- Extra checks (5 checks) *see Extras section
+- Extras (8 checks) *see Extras section
 
 For a comprehesive list and resolution look at the guide on the link above.
 
@@ -587,6 +587,7 @@ At this momment we have 5 extra checks:
 - 7.5 (`extra75`) Ensure there are no Security Groups not being used (Not Scored) (Not part of CIS benchmark)
 - 7.6 (`extra76`) Ensure there are no EC2 AMIs set as Public (Not Scored) (Not part of CIS benchmark)
 - 7.7 (`extra77`) Ensure there are no ECR repositories set as Public (Not Scored) (Not part of CIS benchmark)
+- 7.8 (`extra78`) Ensure there are no Public Accessible RDS instances (Not Scored) (Not part of CIS benchmark)
 
 ```
 ./prowler -c extras
@@ -612,4 +613,4 @@ In order to add any new check feel free to create a new extra check in the extra
 ### Telegram
 Javier Pecete has done an awesome job integrating Prowler with Telegram, you have more details here https://github.com/i4specete/ServerTelegramBot
 ### Cloud Security Suite
-The guys of SecurityFTW have added Prowler in their Cloud Security Suite along with other cool security tools https://github.com/SecurityFTW/cs-suite 
+The guys of SecurityFTW have added Prowler in their Cloud Security Suite along with other cool security tools https://github.com/SecurityFTW/cs-suite

--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ The `aws iam create-access-key` command will output the secret access key and th
 
 ## Extras
 We are adding additional checks to improve the information gather from each account, these checks are out of the scope of the CIS benchmark for AWS but we consider them very helpful to get to know each AWS account set up and find issues on it.
-At this momment we have 5 extra checks:
+At this moment we have 8 extra checks:
 
 - 7.1 (`extra71`) Ensure users with AdministratorAccess policy have MFA tokens enabled (Not Scored) (Not part of CIS benchmark)
 - 7.2 (`extra72`) Ensure there are no EBS Snapshots set as Public (Not Scored) (Not part of CIS benchmark)
@@ -589,10 +589,11 @@ At this momment we have 5 extra checks:
 - 7.7 (`extra77`) Ensure there are no ECR repositories set as Public (Not Scored) (Not part of CIS benchmark)
 - 7.8 (`extra78`) Ensure there are no Public Accessible RDS instances (Not Scored) (Not part of CIS benchmark)
 
+To check all extras in one command:
 ```
 ./prowler -c extras
 ```
-or to run just one of the checks, to see if you have S3 buckets open:
+or to run just one of the checks:
 ```
 ./prowler -c extraNUMBER
 ```

--- a/prowler
+++ b/prowler
@@ -482,6 +482,9 @@ ID76="7.6,7.06"
 TITLE76="Ensure there are no EC2 AMIs set as Public (Not Scored) (Not part of CIS benchmark)"
 ID77="7.7,7.07"
 TITLE77="Ensure there are no ECR repositories set as Public (Not Scored) (Not part of CIS benchmark)"
+ID78="7.8,7.08"
+TITLE78="Ensure there are no Public Accessible RDS instances (Not Scored) (Not part of CIS benchmark)"
+
 
 printCsvHeader() {
   >&2 echo ""
@@ -1750,7 +1753,22 @@ extra77(){
     done
     rm -fr $TEMP_POLICY_FILE
   done
+}
 
+extra78(){
+  # "Ensure there are no Public Accessible RDS instances (Not Scored) (Not part of CIS benchmark)"
+  textTitle "$ID78" "$TITLE78" "NOT_SCORED" "EXTRA"
+  textNotice "Looking for RDS instances in all regions...  "
+  for regx in $REGIONS; do
+    LIST_OF_RDS_PUBLIC_INSTANCES=$($AWSCLI rds describe-db-instances $PROFILE_OPT --region $regx --query 'DBInstances[?PubliclyAccessible==`true`].{id:DBInstanceIdentifier}' --output text)
+    if [[ $LIST_OF_RDS_PUBLIC_INSTANCES ]];then
+      for rds_instance in $(echo $LIST_OF_RDS_PUBLIC_INSTANCES);do
+        textWarn "$regx: RDS instance $rds_instance is set as Publicly Accessible!" "$regx"
+      done
+      else
+        textOK "$regx: no Publicly Accessible RDS instances found" "$regx"
+    fi
+  done
 }
 
 callCheck(){
@@ -1815,6 +1833,7 @@ callCheck(){
       extra75|extra705 ) extra75;;
       extra76|extra706 ) extra76;;
       extra77|extra707 ) extra77;;
+      extra78|extra708 ) extra78;;
 
       ## Groups of Checks
       check1 )
@@ -1850,7 +1869,7 @@ callCheck(){
         check43;check44;check45
         ;;
       extras )
-        extra71;extra72;extra73;extra74;extra75;extra76;extra77
+        extra71;extra72;extra73;extra74;extra75;extra76;extra77;extra78
         ;;
       * )
         textWarn "ERROR! Use a valid check name (i.e. check41 or extra71)\n";
@@ -1928,6 +1947,7 @@ if [[ $PRINTCHECKSONLY == "1" ]]; then
   textTitle "$ID75" "$TITLE75" "NOT_SCORED" "EXTRA"
   textTitle "$ID76" "$TITLE76" "NOT_SCORED" "EXTRA"
   textTitle "$ID77" "$TITLE77" "NOT_SCORED" "EXTRA"
+  textTitle "$ID78" "$TITLE78" "NOT_SCORED" "EXTRA"
   exit $EXITCODE
 fi
 
@@ -2011,6 +2031,7 @@ extra74
 extra75
 extra76
 extra77
+extra78
 
 cleanTemp
 exit $EXITCODE


### PR DESCRIPTION
Ensure there are no Public Accessible RDS instances (Not Scored) (Not part of CIS benchmark)
NOTE: it doesn't check security groups, just check if PubliclyAccessible value of each RDS instance is set to true.