### PR TITLE
Update to 'check114'

### DIFF
--- a/prowler
+++ b/prowler
@@ -819,9 +819,9 @@ check114(){
   COMMAND113=$($AWSCLI iam get-account-summary $PROFILE_OPT --region $REGION --output json --query 'SummaryMap.AccountMFAEnabled')
   textTitle "$ID114" "$TITLE114" "SCORED" "LEVEL1"
   if [ "$COMMAND113" == "1" ]; then
-    COMMAND114=$($AWSCLI iam list-virtual-mfa-devices $PROFILE_OPT --region $REGION --query 'VirtualMFADevices' --output text|grep :root |wc -l)
-    if [ "$COMMAND114" == "1" ]; then
-      textOK "Virtual MFA is enabled for root"
+    COMMAND114=$($AWSCLI iam list-virtual-mfa-devices $PROFILE_OPT --region $REGION --output text --assignment-status Assigned --query 'VirtualMFADevices[*].[SerialNumber]' | grep '^arn:aws:iam::[0-9]\{12\}:mfa/root-account-mfa-device$')
+    if [[ "$COMMAND114" ]]; then
+      textWarn "Only Virtual MFA is enabled for root"
     else
       textOK "Hardware MFA is enabled for root "
     fi


### PR DESCRIPTION
Updated 'check114' to ensure hardware MFA is enabled for root account by:-
1) Querying for 'SerialNumber' of the Virtual MFA Devices list
2) 'SerialNumber' is ARN for Virtual MFA Device and Device Number for Hardware MFA Device; so did grep for ARN with 'root-account-mfa-device' in the expression