### PR TITLE
Fix printing texts when both Ok and Warn are present in 'check31'

### DIFF
--- a/prowler
+++ b/prowler
@@ -1192,7 +1192,8 @@ check31(){
         group=${group%:*}
         textOK "CloudWatch group $group found with metric filter $metric and alarms set for Unauthorized Operation and Access Denied"
       done
-    else
+    fi
+    if [[ $CHECK31WARN ]]; then
       for group in $CHECK31WARN; do
         case $group in
            *:*) metric=${group#*:}


### PR DESCRIPTION
We may have groups in both Ok and Warn; so we have to go through both CHECK31OK and CHECK31WARN one by one.