### PR TITLE
Improve check28

### DIFF
--- a/prowler
+++ b/prowler
@@ -1153,26 +1153,23 @@ check28(){
   for regx in $REGIONS; do
   CHECK_KMS_KEYLIST=$($AWSCLI kms list-keys $PROFILE_OPT --region $regx --output text --query 'Keys[*].KeyId')
     if [[ $CHECK_KMS_KEYLIST ]];then
-      CHECK_KMS_KEYLIST_NO_DEFAULT=$(for key in $CHECK_KMS_KEYLIST ; do $AWSCLI kms describe-key --key-id $key $PROFILE_OPT --region $regx --output text|grep -v 'Default master key that protects my ACM private keys when no other key is defined'|awk '{ print $3 }'|awk -F'/' '{ print $2 }'; done)
+      CHECK_KMS_KEYLIST_NO_DEFAULT=$(for key in $CHECK_KMS_KEYLIST ; do $AWSCLI kms describe-key --key-id $key $PROFILE_OPT --region $regx --output text --query 'KeyMetadata.[KeyId, KeyManager]'|grep -v 'AWS'|awk '{ print $1 }'; done)
       for key in $CHECK_KMS_KEYLIST_NO_DEFAULT; do
         CHECK_KMS_KEY_TYPE=$($AWSCLI kms describe-key --key-id $key $PROFILE_OPT --region $regx --query 'KeyMetadata.Origin' | sed 's/["]//g')
           if [[ "$CHECK_KMS_KEY_TYPE" == "EXTERNAL" ]];then
             textOK "Key $key in Region $regx Customer Uploaded Key Material." "$regx"
           else
             CHECK_KMS_KEY_ROTATION=$($AWSCLI kms get-key-rotation-status --key-id $key $PROFILE_OPT --region $regx --output text)
-            #CHECK_KMS_DEFAULT_KEY=$($AWSCLI kms describe-key --key-id $key $PROFILE_OPT --region $regx --query 'KeyMetadata.Description' | sed -n '/Default master key that protects my ACM private keys when no other key is defined /p'|| echo "False")
-              if [[ "$CHECK_KMS_KEY_ROTATION" == "True" ]];then
-                    textOK "Key $key in Region $regx is set correctly"
-                  elif [[ "$CHECK_KMS_KEY_ROTATION" == "False" && $CHECK_KMS_DEFAULT_KEY ]];then
-                textNotice "Region $regx key $key is an AWS default master key and cannot be deleted nor modified." "$regx"
-              else
-                textWarn "Key $key in Region $regx is not set to rotate!!!" "$regx"
-              fi
+            if [[ "$CHECK_KMS_KEY_ROTATION" == "True" ]];then
+              textOK "Key $key in Region $regx is set correctly"
+            else
+              textWarn "Key $key in Region $regx is not set to rotate!!!" "$regx"
+            fi
           fi
       done
 
   else
-      textNotice "Region $regx doesn't have encryption keys" "$regx"
+    textNotice "Region $regx doesn't have encryption keys" "$regx"
   fi
   done
 }


### PR DESCRIPTION
The CIS benchmarks state that only customer managed CMKs should be checked, so
exclude all AWS managed CMKs, not just the one for ACM.

Also fix up some formatting and dead code.