### PR TITLE
Restore check levels

### DIFF
--- a/checks/check11
+++ b/checks/check11
@@ -11,6 +11,7 @@
 CHECK_ID_check11="1.1,1.01"
 CHECK_TITLE_check11="[check11] Avoid the use of the root account (Scored)"
 CHECK_SCORED_check11="SCORED"
+CHECK_TYPE_check11="LEVEL1"
 CHECK_ALTERNATE_check101="check11"
 
 check11(){

--- a/checks/check110
+++ b/checks/check110
@@ -11,7 +11,8 @@
 CHECK_ID_check110="1.10"
 CHECK_TITLE_check110="[check110] Ensure IAM password policy prevents password reuse: 24 or greater (Scored)"
 CHECK_SCORED_check110="SCORED"
-CHECK_ALTERNATE_check110="check110" 
+CHECK_TYPE_check110="LEVEL1"
+CHECK_ALTERNATE_check110="check110"
 
 check110(){
   # "Ensure IAM password policy prevents password reuse: 24 or greater (Scored)"

--- a/checks/check111
+++ b/checks/check111
@@ -11,6 +11,7 @@
 CHECK_ID_check111="1.11"
 CHECK_TITLE_check111="[check111] Ensure IAM password policy expires passwords within 90 days or less (Scored)"
 CHECK_SCORED_check111="SCORED"
+CHECK_TYPE_check111="LEVEL1"
 CHECK_ALTERNATE_check111="check111"
 
 check111(){

--- a/checks/check112
+++ b/checks/check112
@@ -10,7 +10,8 @@
 
 CHECK_ID_check112="1.12"
 CHECK_TITLE_check112="[check112] Ensure no root account access key exists (Scored)"
-CHECK_SCORED_check112="SCORED" 
+CHECK_SCORED_check112="SCORED"
+CHECK_TYPE_check112="LEVEL1"
 CHECK_ALTERNATE_check112="check112"
 
 check112(){

--- a/checks/check113
+++ b/checks/check113
@@ -11,7 +11,8 @@
 CHECK_ID_check113="1.13"
 CHECK_TITLE_check113="[check113] Ensure MFA is enabled for the root account (Scored)"
 CHECK_SCORED_check113="SCORED"
-CHECK_ALTERNATE_check113="check113" 
+CHECK_TYPE_check113="LEVEL1"
+CHECK_ALTERNATE_check113="check113"
 
 check113(){
   # "Ensure MFA is enabled for the root account (Scored)"

--- a/checks/check114
+++ b/checks/check114
@@ -11,7 +11,8 @@
 CHECK_ID_check114="1.14"
 CHECK_TITLE_check114="[check114] Ensure hardware MFA is enabled for the root account (Scored)"
 CHECK_SCORED_check114="SCORED"
-CHECK_ALTERNATE_check114="check114" 
+CHECK_TYPE_check114="LEVEL2"
+CHECK_ALTERNATE_check114="check114"
 
 check114(){
   # "Ensure hardware MFA is enabled for the root account (Scored)"

--- a/checks/check115
+++ b/checks/check115
@@ -11,7 +11,8 @@
 CHECK_ID_check115="1.15"
 CHECK_TITLE_check115="[check115] Ensure security questions are registered in the AWS account (Not Scored)"
 CHECK_SCORED_check115="SCORED"
-CHECK_ALTERNATE_check115="check115" 
+CHECK_TYPE_check115="LEVEL1"
+CHECK_ALTERNATE_check115="check115"
 
 check115(){
   # "Ensure security questions are registered in the AWS account (Not Scored)"

--- a/checks/check116
+++ b/checks/check116
@@ -11,7 +11,8 @@
 CHECK_ID_check116="1.16"
 CHECK_TITLE_check116="[check116] Ensure IAM policies are attached only to groups or roles (Scored)"
 CHECK_SCORED_check116="SCORED"
-CHECK_ALTERNATE_check116="check116" 
+CHECK_TYPE_check116="LEVEL1"
+CHECK_ALTERNATE_check116="check116"
 
 check116(){
   # "Ensure IAM policies are attached only to groups or roles (Scored)"

--- a/checks/check117
+++ b/checks/check117
@@ -11,7 +11,8 @@
 CHECK_ID_check117="1.17"
 CHECK_TITLE_check117="[check117] Enable detailed billing (Scored)"
 CHECK_SCORED_check117="SCORED"
-CHECK_ALTERNATE_check117="check117" 
+CHECK_TYPE_check117="LEVEL1"
+CHECK_ALTERNATE_check117="check117"
 
 check117(){
   # "Enable detailed billing (Scored)"

--- a/checks/check118
+++ b/checks/check118
@@ -11,7 +11,8 @@
 CHECK_ID_check118="1.18"
 CHECK_TITLE_check118="[check118] Ensure IAM Master and IAM Manager roles are active (Scored)"
 CHECK_SCORED_check118="SCORED"
-CHECK_ALTERNATE_check118="check118" 
+CHECK_TYPE_check118="LEVEL1"
+CHECK_ALTERNATE_check118="check118"
 
 check118(){
   # "Ensure IAM Master and IAM Manager roles are active (Scored)"

--- a/checks/check119
+++ b/checks/check119
@@ -11,6 +11,7 @@
 CHECK_ID_check119="1.19"
 CHECK_TITLE_check119="[check119] Maintain current contact details (Scored)"
 CHECK_SCORED_check119="SCORED"
+CHECK_TYPE_check119="LEVEL1"
 CHECK_ALTERNATE_check119="check119"
 
 check119(){

--- a/checks/check12
+++ b/checks/check12
@@ -11,6 +11,7 @@
 CHECK_ID_check12="1.2,1.02"
 CHECK_TITLE_check12="[check12] Ensure multi-factor authentication (MFA) is enabled for all IAM users that have a console password (Scored)"
 CHECK_SCORED_check12="SCORED"
+CHECK_TYPE_check12="LEVEL1"
 CHECK_ALTERNATE_check102="check12"
 
 check12(){

--- a/checks/check120
+++ b/checks/check120
@@ -11,7 +11,8 @@
 CHECK_ID_check120="1.20"
 CHECK_TITLE_check120="[check120] Ensure security contact information is registered (Scored)"
 CHECK_SCORED_check120="SCORED"
-CHECK_ALTERNATE_check120="check120" 
+CHECK_TYPE_check120="LEVEL1"
+CHECK_ALTERNATE_check120="check120"
 
 check120(){
   # "Ensure security contact information is registered (Scored)"

--- a/checks/check121
+++ b/checks/check121
@@ -11,7 +11,8 @@
 CHECK_ID_check121="1.21"
 CHECK_TITLE_check121="[check121] Ensure IAM instance roles are used for AWS resource access from instances (Not Scored)"
 CHECK_SCORED_check121="NOT_SCORED"
-CHECK_ALTERNATE_check121="check121" 
+CHECK_TYPE_check121="LEVEL2"
+CHECK_ALTERNATE_check121="check121"
 
 check121(){
   # "Ensure IAM instance roles are used for AWS resource access from instances (Not Scored)"

--- a/checks/check122
+++ b/checks/check122
@@ -11,7 +11,8 @@
 CHECK_ID_check122="1.22"
 CHECK_TITLE_check122="[check122] Ensure a support role has been created to manage incidents with AWS Support (Scored)"
 CHECK_SCORED_check122="SCORED"
-CHECK_ALTERNATE_check122="check122" 
+CHECK_TYPE_check122="LEVEL1"
+CHECK_ALTERNATE_check122="check122"
 
 check122(){
   # "Ensure a support role has been created to manage incidents with AWS Support (Scored)"

--- a/checks/check123
+++ b/checks/check123
@@ -10,7 +10,8 @@
 
 CHECK_ID_check123="1.23"
 CHECK_TITLE_check123="[check123] Do not setup access keys during initial user setup for all IAM users that have a console password (Not Scored)"
-CHECK_SCORED_check123="NOT_SCORED" 
+CHECK_SCORED_check123="NOT_SCORED"
+CHECK_TYPE_check123="LEVEL1"
 CHECK_ALTERNATE_check123="check123"
 
 check123(){

--- a/checks/check124
+++ b/checks/check124
@@ -11,7 +11,8 @@
 CHECK_ID_check124="1.24"
 CHECK_TITLE_check124="[check124] Ensure IAM policies that allow full \"*:*\" administrative privileges are not created (Scored)"
 CHECK_SCORED_check124="SCORED"
-CHECK_ALTERNATE_check124="check124" 
+CHECK_TYPE_check124="LEVEL1"
+CHECK_ALTERNATE_check124="check124"
 
 check124(){
   # "Ensure IAM policies that allow full \"*:*\" administrative privileges are not created (Scored)"

--- a/checks/check13
+++ b/checks/check13
@@ -11,6 +11,7 @@
 CHECK_ID_check13="1.3,1.03"
 CHECK_TITLE_check13="[check13] Ensure credentials unused for 90 days or greater are disabled (Scored)"
 CHECK_SCORED_check13="SCORED"
+CHECK_TYPE_check13="LEVEL1"
 CHECK_ALTERNATE_check103="check13"
 
 check13(){

--- a/checks/check14
+++ b/checks/check14
@@ -11,6 +11,7 @@
 CHECK_ID_check14="1.4,1.04"
 CHECK_TITLE_check14="[check14] Ensure access keys are rotated every 90 days or less (Scored)"
 CHECK_SCORED_check14="SCORED"
+CHECK_TYPE_check14="LEVEL1"
 CHECK_ALTERNATE_check104="check14"
 
 check14(){

--- a/checks/check15
+++ b/checks/check15
@@ -11,7 +11,8 @@
 CHECK_ID_check15="1.5,1.05"
 CHECK_TITLE_check15="[check15] Ensure IAM password policy requires at least one uppercase letter (Scored)"
 CHECK_SCORED_check15="SCORED"
-CHECK_ALTERNATE_check105="check15" 
+CHECK_TYPE_check15="LEVEL1"
+CHECK_ALTERNATE_check105="check15"
 
 check15(){
   # "Ensure IAM password policy requires at least one uppercase letter (Scored)"

--- a/checks/check16
+++ b/checks/check16
@@ -11,6 +11,7 @@
 CHECK_ID_check16="1.6,1.06"
 CHECK_TITLE_check16="[check16] Ensure IAM password policy require at least one lowercase letter (Scored)"
 CHECK_SCORED_check16="SCORED"
+CHECK_TYPE_check16="LEVEL1"
 CHECK_ALTERNATE_check106="check16"
 
 check16(){

--- a/checks/check17
+++ b/checks/check17
@@ -11,6 +11,7 @@
 CHECK_ID_check17="1.7,1.07"
 CHECK_TITLE_check17="[check17] Ensure IAM password policy require at least one symbol (Scored)"
 CHECK_SCORED_check17="SCORED"
+CHECK_TYPE_check17="LEVEL1"
 CHECK_ALTERNATE_check107="check17"
 
 check17(){

--- a/checks/check18
+++ b/checks/check18
@@ -11,6 +11,7 @@
 CHECK_ID_check18="1.8,1.08"
 CHECK_TITLE_check18="[check18] Ensure IAM password policy require at least one number (Scored)"
 CHECK_SCORED_check18="SCORED"
+CHECK_TYPE_check19="LEVEL1"
 CHECK_ALTERNATE_check18="check18"
 
 check18(){

--- a/checks/check18
+++ b/checks/check18
@@ -11,8 +11,8 @@
 CHECK_ID_check18="1.8,1.08"
 CHECK_TITLE_check18="[check18] Ensure IAM password policy require at least one number (Scored)"
 CHECK_SCORED_check18="SCORED"
-CHECK_TYPE_check19="LEVEL1"
-CHECK_ALTERNATE_check18="check18"
+CHECK_TYPE_check18="LEVEL1"
+CHECK_ALTERNATE_check108="check18"
 
 check18(){
   # "Ensure IAM password policy require at least one number (Scored)"

--- a/checks/check19
+++ b/checks/check19
@@ -11,7 +11,8 @@
 CHECK_ID_check19="1.9,1.09"
 CHECK_TITLE_check19="[check19] Ensure IAM password policy requires minimum length of 14 or greater (Scored)"
 CHECK_SCORED_check19="SCORED"
-CHECK_ALTERNATE_check109="check19" 
+CHECK_TYPE_check19="LEVEL1"
+CHECK_ALTERNATE_check109="check19"
 
 check19(){
   # "Ensure IAM password policy requires minimum length of 14 or greater (Scored)"

--- a/checks/check21
+++ b/checks/check21
@@ -11,7 +11,8 @@
 CHECK_ID_check21="2.1,2.01"
 CHECK_TITLE_check21="[check21] Ensure CloudTrail is enabled in all regions (Scored)"
 CHECK_SCORED_check21="SCORED"
-CHECK_ALTERNATE_check201="check21" 
+CHECK_TYPE_check21="LEVEL1"
+CHECK_ALTERNATE_check201="check21"
 
 check21(){
   # "Ensure CloudTrail is enabled in all regions (Scored)"

--- a/checks/check22
+++ b/checks/check22
@@ -11,7 +11,8 @@
 CHECK_ID_check22="2.2,2.02"
 CHECK_TITLE_check22="[check22] Ensure CloudTrail log file validation is enabled (Scored)"
 CHECK_SCORED_check22="SCORED"
-CHECK_ALTERNATE_check202="check22" 
+CHECK_TYPE_check22="LEVEL2"
+CHECK_ALTERNATE_check202="check22"
 
 check22(){
   # "Ensure CloudTrail log file validation is enabled (Scored)"

--- a/checks/check23
+++ b/checks/check23
@@ -11,7 +11,8 @@
 CHECK_ID_check23="2.3,2.03"
 CHECK_TITLE_check23="[check23] Ensure the S3 bucket CloudTrail logs to is not publicly accessible (Scored)"
 CHECK_SCORED_check23="SCORED"
-CHECK_ALTERNATE_check203="check23" 
+CHECK_TYPE_check23="LEVEL1"
+CHECK_ALTERNATE_check203="check23"
 
 check23(){
   # "Ensure the S3 bucket CloudTrail logs to is not publicly accessible (Scored)"

--- a/checks/check24
+++ b/checks/check24
@@ -11,7 +11,8 @@
 CHECK_ID_check24="2.4,2.04"
 CHECK_TITLE_check24="[check24] Ensure CloudTrail trails are integrated with CloudWatch Logs (Scored)"
 CHECK_SCORED_check24="SCORED"
-CHECK_ALTERNATE_check204="check24" 
+CHECK_TYPE_check24="LEVEL1"
+CHECK_ALTERNATE_check204="check24"
 
 check24(){
   # "Ensure CloudTrail trails are integrated with CloudWatch Logs (Scored)"

--- a/checks/check25
+++ b/checks/check25
@@ -11,7 +11,8 @@
 CHECK_ID_check25="2.5,2.05"
 CHECK_TITLE_check25="[check25] Ensure AWS Config is enabled in all regions (Scored)"
 CHECK_SCORED_check25="SCORED"
-CHECK_ALTERNATE_check205="check25" 
+CHECK_TYPE_check25="LEVEL1"
+CHECK_ALTERNATE_check205="check25"
 
 check25(){
   # "Ensure AWS Config is enabled in all regions (Scored)"

--- a/checks/check26
+++ b/checks/check26
@@ -11,7 +11,8 @@
 CHECK_ID_check26="2.6,2.06"
 CHECK_TITLE_check26="[check26] Ensure S3 bucket access logging is enabled on the CloudTrail S3 bucket (Scored)"
 CHECK_SCORED_check26="SCORED"
-CHECK_ALTERNATE_check206="check26" 
+CHECK_TYPE_check26="LEVEL1"
+CHECK_ALTERNATE_check206="check26"
 
 check26(){
   # "Ensure S3 bucket access logging is enabled on the CloudTrail S3 bucket (Scored)"

--- a/checks/check27
+++ b/checks/check27
@@ -11,7 +11,8 @@
 CHECK_ID_check27="2.7,2.07"
 CHECK_TITLE_check27="[check27] Ensure CloudTrail logs are encrypted at rest using KMS CMKs (Scored)"
 CHECK_SCORED_check27="SCORED"
-CHECK_ALTERNATE_check207="check27" 
+CHECK_TYPE_check27="LEVEL2"
+CHECK_ALTERNATE_check207="check27"
 
 check27(){
   # "Ensure CloudTrail logs are encrypted at rest using KMS CMKs (Scored)"

--- a/checks/check28
+++ b/checks/check28
@@ -11,7 +11,8 @@
 CHECK_ID_check28="2.8,2.08"
 CHECK_TITLE_check28="[check28] Ensure rotation for customer created CMKs is enabled (Scored)"
 CHECK_SCORED_check28="SCORED"
-CHECK_ALTERNATE_check208="check28" 
+CHECK_TYPE_check28="LEVEL2"
+CHECK_ALTERNATE_check208="check28"
 
 check28(){
   # "Ensure rotation for customer created CMKs is enabled (Scored)"

--- a/checks/check31
+++ b/checks/check31
@@ -11,7 +11,8 @@
 CHECK_ID_check31="3.1,3.01"
 CHECK_TITLE_check31="[check31] Ensure a log metric filter and alarm exist for unauthorized API calls (Scored)"
 CHECK_SCORED_check31="SCORED"
-CHECK_ALTERNATE_check301="check31" 
+CHECK_TYPE_check31="LEVEL1"
+CHECK_ALTERNATE_check301="check31"
 
 check31(){
   # "Ensure a log metric filter and alarm exist for unauthorized API calls (Scored)"

--- a/checks/check310
+++ b/checks/check310
@@ -11,6 +11,7 @@
 CHECK_ID_check310="3.10"
 CHECK_TITLE_check310="[check310] Ensure a log metric filter and alarm exist for security group changes (Scored)"
 CHECK_SCORED_check310="SCORED"
+CHECK_TYPE_check310="LEVEL2"
 CHECK_ALTERNATE_check310="check310"
 
 check310(){

--- a/checks/check311
+++ b/checks/check311
@@ -10,7 +10,8 @@
 
 CHECK_ID_check311="3.11"
 CHECK_TITLE_check311="[check311] Ensure a log metric filter and alarm exist for changes to Network Access Control Lists (NACL) (Scored)"
-CHECK_SCORED_check311="SCORED" 
+CHECK_SCORED_check311="SCORED"
+CHECK_TYPE_check=311"LEVEL2"
 CHECK_ALTERNATE_check311="check311"
 
 check311(){

--- a/checks/check311
+++ b/checks/check311
@@ -11,7 +11,7 @@
 CHECK_ID_check311="3.11"
 CHECK_TITLE_check311="[check311] Ensure a log metric filter and alarm exist for changes to Network Access Control Lists (NACL) (Scored)"
 CHECK_SCORED_check311="SCORED"
-CHECK_TYPE_check=311"LEVEL2"
+CHECK_TYPE_check311="LEVEL2"
 CHECK_ALTERNATE_check311="check311"
 
 check311(){

--- a/checks/check312
+++ b/checks/check312
@@ -10,7 +10,8 @@
 
 CHECK_ID_check312="3.12"
 CHECK_TITLE_check312="[check312] Ensure a log metric filter and alarm exist for changes to network gateways (Scored)"
-CHECK_SCORED_check312="SCORED" 
+CHECK_SCORED_check312="SCORED"
+CHECK_TYPE_check312="LEVEL1"
 CHECK_ALTERNATE_check312="check312"
 
 check312(){

--- a/checks/check313
+++ b/checks/check313
@@ -10,7 +10,8 @@
 
 CHECK_ID_check313="3.13"
 CHECK_TITLE_check313="[check313] Ensure a log metric filter and alarm exist for route table changes (Scored)"
-CHECK_SCORED_check313="SCORED" 
+CHECK_SCORED_check313="SCORED"
+CHECK_TYPE_check313="LEVEL1"
 CHECK_ALTERNATE_check313="check313"
 
 check313(){

--- a/checks/check314
+++ b/checks/check314
@@ -10,7 +10,8 @@
 
 CHECK_ID_check314="3.14"
 CHECK_TITLE_check314="[check314] Ensure a log metric filter and alarm exist for VPC changes (Scored)"
-CHECK_SCORED_check314="SCORED" 
+CHECK_SCORED_check314="SCORED"
+CHECK_TYPE_check314="LEVEL1"
 CHECK_ALTERNATE_check314="check314"
 
 check314(){

--- a/checks/check315
+++ b/checks/check315
@@ -11,6 +11,7 @@
 CHECK_ID_check315="3.15"
 CHECK_TITLE_check315="[check315] Ensure appropriate subscribers to each SNS topic (Not Scored)"
 CHECK_SCORED_check315="SCORED"
+CHECK_TYPE_check315="LEVEL1"
 CHECK_ALTERNATE_check315="check315"
 
 check315(){

--- a/checks/check32
+++ b/checks/check32
@@ -11,6 +11,7 @@
 CHECK_ID_check32="3.2,3.02"
 CHECK_TITLE_check32="[check32] Ensure a log metric filter and alarm exist for Management Console sign-in without MFA (Scored)"
 CHECK_SCORED_check32="SCORED"
+CHECK_TYPE_check32="LEVEL1"
 CHECK_ALTERNATE_check302="check32"
 
 check32(){

--- a/checks/check33
+++ b/checks/check33
@@ -11,7 +11,8 @@
 CHECK_ID_check33="3.3,3.03"
 CHECK_TITLE_check33="[check33] Ensure a log metric filter and alarm exist for usage of root account (Scored)"
 CHECK_SCORED_check33="SCORED"
-CHECK_ALTERNATE_check303="check33" 
+CHECK_TYPE_check33="LEVEL1"
+CHECK_ALTERNATE_check303="check33"
 
 check33(){
   # "Ensure a log metric filter and alarm exist for usage of root account (Scored)"

--- a/checks/check34
+++ b/checks/check34
@@ -11,7 +11,8 @@
 CHECK_ID_check34="3.4,3.04"
 CHECK_TITLE_check34="[check34] Ensure a log metric filter and alarm exist for IAM policy changes (Scored)"
 CHECK_SCORED_check34="SCORED"
-CHECK_ALTERNATE_check304="check34" 
+CHECK_TYPE_check34="LEVEL1"
+CHECK_ALTERNATE_check304="check34"
 
 check34(){
   # "Ensure a log metric filter and alarm exist for IAM policy changes (Scored)"

--- a/checks/check35
+++ b/checks/check35
@@ -11,7 +11,8 @@
 CHECK_ID_check35="3.5,3.05"
 CHECK_TITLE_check35="[check35] Ensure a log metric filter and alarm exist for CloudTrail configuration changes (Scored)"
 CHECK_SCORED_check35="SCORED"
-CHECK_ALTERNATE_check305="check35" 
+CHECK_TYPE_check35="LEVEL1"
+CHECK_ALTERNATE_check305="check35"
 
 check35(){
   # "Ensure a log metric filter and alarm exist for CloudTrail configuration changes (Scored)"

--- a/checks/check36
+++ b/checks/check36
@@ -11,7 +11,8 @@
 CHECK_ID_check36="3.6,3.06"
 CHECK_TITLE_check36="[check36] Ensure a log metric filter and alarm exist for AWS Management Console authentication failures (Scored)"
 CHECK_SCORED_check36="SCORED"
-CHECK_ALTERNATE_check306="check36" 
+CHECK_TYPE_check36="LEVEL2"
+CHECK_ALTERNATE_check306="check36"
 
 check36(){
   # "Ensure a log metric filter and alarm exist for AWS Management Console authentication failures (Scored)"

--- a/checks/check37
+++ b/checks/check37
@@ -11,7 +11,8 @@
 CHECK_ID_check37="3.7,3.07"
 CHECK_TITLE_check37="[check37] Ensure a log metric filter and alarm exist for disabling or scheduled deletion of customer created CMKs (Scored)"
 CHECK_SCORED_check37="SCORED"
-CHECK_ALTERNATE_check307="check37" 
+CHECK_TYPE_check37="LEVEL2"
+CHECK_ALTERNATE_check307="check37"
 
 check37(){
   # "Ensure a log metric filter and alarm exist for disabling or scheduled deletion of customer created CMKs (Scored)"

--- a/checks/check38
+++ b/checks/check38
@@ -11,7 +11,8 @@
 CHECK_ID_check38="3.8,3.08"
 CHECK_TITLE_check38="[check38] Ensure a log metric filter and alarm exist for S3 bucket policy changes (Scored)"
 CHECK_SCORED_check38="SCORED"
-CHECK_ALTERNATE_check308="check38" 
+CHECK_TYPE_check38="LEVEL1"
+CHECK_ALTERNATE_check308="check38"
 
 check38(){
   # "Ensure a log metric filter and alarm exist for S3 bucket policy changes (Scored)"

--- a/checks/check39
+++ b/checks/check39
@@ -11,7 +11,8 @@
 CHECK_ID_check39="3.9,3.09"
 CHECK_TITLE_check39="[check39] Ensure a log metric filter and alarm exist for AWS Config configuration changes (Scored)"
 CHECK_SCORED_check39="SCORED"
-CHECK_ALTERNATE_check309="check39" 
+CHECK_TYPE_check39="LEVEL2"
+CHECK_ALTERNATE_check309="check39"
 
 check39(){
   # "Ensure a log metric filter and alarm exist for AWS Config configuration changes (Scored)"

--- a/checks/check41
+++ b/checks/check41
@@ -11,7 +11,8 @@
 CHECK_ID_check41="4.1,4.01"
 CHECK_TITLE_check41="[check41] Ensure no security groups allow ingress from 0.0.0.0/0 to port 22 (Scored)"
 CHECK_SCORED_check41="SCORED"
-CHECK_ALTERNATE_check401="check41" 
+CHECK_TYPE_check41="LEVEL2"
+CHECK_ALTERNATE_check401="check41"
 
 check41(){
   # "Ensure no security groups allow ingress from 0.0.0.0/0 to port 22 (Scored)"

--- a/checks/check42
+++ b/checks/check42
@@ -11,7 +11,8 @@
 CHECK_ID_check42="4.2,4.02"
 CHECK_TITLE_check42="[check42] Ensure no security groups allow ingress from 0.0.0.0/0 to port 3389 (Scored)"
 CHECK_SCORED_check42="SCORED"
-CHECK_ALTERNATE_check402="check42" 
+CHECK_TYPE_check42="LEVEL2"
+CHECK_ALTERNATE_check402="check42"
 
 check42(){
   # "Ensure no security groups allow ingress from 0.0.0.0/0 to port 3389 (Scored)"

--- a/checks/check43
+++ b/checks/check43
@@ -11,7 +11,8 @@
 CHECK_ID_check43="4.3,4.03"
 CHECK_TITLE_check43="[check43] Ensure VPC Flow Logging is Enabled in all VPCs (Scored)"
 CHECK_SCORED_check43="SCORED"
-CHECK_ALTERNATE_check403="check43" 
+CHECK_TYPE_check43="LEVEL2"
+CHECK_ALTERNATE_check403="check43"
 
 check43(){
   # "Ensure VPC Flow Logging is Enabled in all VPCs (Scored)"

--- a/checks/check44
+++ b/checks/check44
@@ -11,7 +11,8 @@
 CHECK_ID_check44="4.4,4.04"
 CHECK_TITLE_check44="[check44] Ensure the default security group of every VPC restricts all traffic (Scored)"
 CHECK_SCORED_check44="SCORED"
-CHECK_ALTERNATE_check404="check44" 
+CHECK_TYPE_check44="LEVEL2"
+CHECK_ALTERNATE_check404="check44"
 
 check44(){
   # "Ensure the default security group of every VPC restricts all traffic (Scored)"

--- a/checks/check45
+++ b/checks/check45
@@ -11,7 +11,8 @@
 CHECK_ID_check45="4.5,4.05"
 CHECK_TITLE_check45="[check45] Ensure routing tables for VPC peering are \"least access\" (Not Scored)"
 CHECK_SCORED_check45="NOT_SCORED"
-CHECK_ALTERNATE_check405="check45" 
+CHECK_TYPE_check45="LEVEL2"
+CHECK_ALTERNATE_check405="check45"
 
 check45(){
   # "Ensure routing tables for VPC peering are \"least access\" (Not Scored)"

--- a/checks/check_extra71
+++ b/checks/check_extra71
@@ -13,6 +13,7 @@
 CHECK_ID_extra71="7.1,7.01"
 CHECK_TITLE_extra71="[extra71] Ensure users with AdministratorAccess policy have MFA tokens enabled (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra71="NOT_SCORED"
+CHECK_TYPE_extra71="EXTRA"
 CHECK_ALTERNATE_extra701="extra71"
 CHECK_ALTERNATE_check71="extra71"
 CHECK_ALTERNATE_check701="extra71"

--- a/checks/check_extra710
+++ b/checks/check_extra710
@@ -13,6 +13,7 @@
 CHECK_ID_extra710="7.10"
 CHECK_TITLE_extra710="[extra710] Check for internet facing EC2 Instances (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra710="NOT_SCORED"
+CHECK_TYPE_extra710="EXTRA"
 CHECK_ALTERNATE_check710="extra710"
 
 extra710(){

--- a/checks/check_extra711
+++ b/checks/check_extra711
@@ -13,6 +13,7 @@
 CHECK_ID_extra711="7.11"
 CHECK_TITLE_extra711="[extra711] Check for Publicly Accessible Redshift Clusters (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra711="NOT_SCORED"
+CHECK_TYPE_extra711="EXTRA"
 CHECK_ALTERNATE_check711="extra711"
 
 extra711(){

--- a/checks/check_extra712
+++ b/checks/check_extra712
@@ -13,6 +13,7 @@
 CHECK_ID_extra712="7.12"
 CHECK_TITLE_extra712="[extra712] Check if Amazon Macie is enabled (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra712="NOT_SCORED"
+CHECK_TYPE_extra712="EXTRA"
 CHECK_ALTERNATE_check712="extra712"
 
 extra712(){

--- a/checks/check_extra713
+++ b/checks/check_extra713
@@ -13,6 +13,7 @@
 CHECK_ID_extra713="7.13"
 CHECK_TITLE_extra713="[extra713] Check if GuardDuty is enabled (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra713="NOT_SCORED"
+CHECK_TYPE_extra713="EXTRA"
 CHECK_ALTERNATE_check713="extra713"
 
 extra713(){

--- a/checks/check_extra714
+++ b/checks/check_extra714
@@ -13,6 +13,7 @@
 CHECK_ID_extra714="7.14"
 CHECK_TITLE_extra714="[extra714] Check if CloudFront distributions have logging enabled (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra714="NOT_SCORED"
+CHECK_TYPE_extra714="EXTRA"
 CHECK_ALTERNATE_check714="extra714"
 
 extra714(){

--- a/checks/check_extra715
+++ b/checks/check_extra715
@@ -13,6 +13,7 @@
 CHECK_ID_extra715="7.15"
 CHECK_TITLE_extra715="[extra715] Check if Elasticsearch Service domains have logging enabled (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra715="NOT_SCORED"
+CHECK_TYPE_extra715="EXTRA"
 CHECK_ALTERNATE_check715="extra715"
 
 extra715(){

--- a/checks/check_extra716
+++ b/checks/check_extra716
@@ -13,6 +13,7 @@
 CHECK_ID_extra716="7.16"
 CHECK_TITLE_extra716="[extra716] Check if Elasticsearch Service domains allow open access (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra716="NOT_SCORED"
+CHECK_TYPE_extra716="EXTRA"
 CHECK_ALTERNATE_check716="extra716"
 
 extra716(){

--- a/checks/check_extra717
+++ b/checks/check_extra717
@@ -13,6 +13,7 @@
 CHECK_ID_extra717="7.17"
 CHECK_TITLE_extra717="[extra717] Check if Elastic Load Balancers have logging enabled (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra717="NOT_SCORED"
+CHECK_TYPE_extra717="EXTRA"
 CHECK_ALTERNATE_check717="extra717"
 
 extra717(){

--- a/checks/check_extra718
+++ b/checks/check_extra718
@@ -13,6 +13,7 @@
 CHECK_ID_extra718="7.18"
 CHECK_TITLE_extra718="[extra718] Check if S3 buckets have server access logging enabled (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra718="NOT_SCORED"
+CHECK_TYPE_extra718="EXTRA"
 CHECK_ALTERNATE_check718="extra718"
 
 extra718(){

--- a/checks/check_extra719
+++ b/checks/check_extra719
@@ -13,6 +13,7 @@
 CHECK_ID_extra719="7.19"
 CHECK_TITLE_extra719="[extra719] Check if Route53 hosted zones are logging queries to CloudWatch Logs (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra719="NOT_SCORED"
+CHECK_TYPE_extra719="EXTRA"
 CHECK_ALTERNATE_check719="extra719"
 
 extra719(){

--- a/checks/check_extra72
+++ b/checks/check_extra72
@@ -13,6 +13,7 @@
 CHECK_ID_extra72="7.2,7.02"
 CHECK_TITLE_extra72="[extra72] Ensure there are no EBS Snapshots set as Public (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra72="NOT_SCORED"
+CHECK_TYPE_extra72="EXTRA"
 CHECK_ALTERNATE_extra702="extra72"
 CHECK_ALTERNATE_check72="extra72"
 CHECK_ALTERNATE_check702="extra72"

--- a/checks/check_extra720
+++ b/checks/check_extra720
@@ -13,6 +13,7 @@
 CHECK_ID_extra720="7.20"
 CHECK_TITLE_extra720="[extra720] Check if Lambda functions invoke API operations are being recorded by CloudTrail (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra720="NOT_SCORED"
+CHECK_TYPE_extra720="EXTRA"
 CHECK_ALTERNATE_check720="extra720"
 
 extra720(){

--- a/checks/check_extra721
+++ b/checks/check_extra721
@@ -13,6 +13,7 @@
 CHECK_ID_extra721="7.21"
 CHECK_TITLE_extra721="[extra721] Check if Redshift cluster has audit logging enabled (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra721="NOT_SCORED"
+CHECK_TYPE_extra721="EXTRA"
 CHECK_ALTERNATE_check721="extra721"
 
 extra721(){

--- a/checks/check_extra722
+++ b/checks/check_extra722
@@ -13,6 +13,7 @@
 CHECK_ID_extra722="7.22"
 CHECK_TITLE_extra722="[extra722] Check if API Gateway has logging enabled (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra722="NOT_SCORED"
+CHECK_TYPE_extra722="EXTRA"
 CHECK_ALTERNATE_check722="extra722"
 
 extra722(){

--- a/checks/check_extra723
+++ b/checks/check_extra723
@@ -13,6 +13,7 @@
 CHECK_ID_extra723="7.23"
 CHECK_TITLE_extra723="[extra723] Check if RDS Snapshots are public (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra723="NOT_SCORED"
+CHECK_TYPE_extra723="EXTRA"
 CHECK_ALTERNATE_check723="extra723"
 
 extra723(){

--- a/checks/check_extra724
+++ b/checks/check_extra724
@@ -13,6 +13,7 @@
 CHECK_ID_extra724="7.24"
 CHECK_TITLE_extra724="[extra724] Check if ACM certificates have Certificate Transparency logging enabled (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra724="NOT_SCORED"
+CHECK_TYPE_extra724="EXTRA"
 CHECK_ALTERNATE_check724="extra724"
 
 extra724(){

--- a/checks/check_extra725
+++ b/checks/check_extra725
@@ -14,6 +14,7 @@
 CHECK_ID_extra725="7.25"
 CHECK_TITLE_extra725="[extra725] Check if S3 buckets have Object-level logging enabled in CloudTrail (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra725="NOT_SCORED"
+CHECK_TYPE_extra725="EXTRA"
 CHECK_ALTERNATE_check725="extra725"
 
 # per Object-level logging is not configured at Bucket level but at CloudTrail trail level
@@ -54,7 +55,7 @@ extra725(){
       textFail "$regx: S3 bucket $bucket has Object-level logging disabled" "$regx"
    done
   fi
-  # delete all temp files 
+  # delete all temp files
   rm -fr $TEMP_BUCKET_LIST_FILE $TEMP_TRAILS_LIST_FILE $TEMP_BUCKETS_LOGGING_LIST_FILE
 
 }

--- a/checks/check_extra726
+++ b/checks/check_extra726
@@ -14,6 +14,7 @@
 CHECK_ID_extra726="7.26"
 CHECK_TITLE_extra726="[extra726] Check Trusted Advisor for errors and warnings (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra726="NOT_SCORED"
+CHECK_TYPE_extra726="EXTRA"
 CHECK_ALTERNATE_check726="extra726"
 
 extra726(){

--- a/checks/check_extra727
+++ b/checks/check_extra727
@@ -14,6 +14,7 @@
 CHECK_ID_extra727="7.27"
 CHECK_TITLE_extra727="[extra727] Check if SQS queues have policy set as Public (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra727="NOT_SCORED"
+CHECK_TYPE_extra727="EXTRA"
 CHECK_ALTERNATE_check727="extra727"
 
 extra727(){

--- a/checks/check_extra728
+++ b/checks/check_extra728
@@ -14,6 +14,7 @@
 CHECK_ID_extra728="7.28"
 CHECK_TITLE_extra728="[extra728] Check if SQS queues have Server Side Encryption enabled (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra728="NOT_SCORED"
+CHECK_TYPE_extra728="EXTRA"
 CHECK_ALTERNATE_check728="extra728"
 
 extra728(){

--- a/checks/check_extra729
+++ b/checks/check_extra729
@@ -14,6 +14,7 @@
 CHECK_ID_extra729="7.29"
 CHECK_TITLE_extra729="[extra729] Ensure there are no EBS Volumes unencrypted (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra729="NOT_SCORED"
+CHECK_TYPE_extra729="EXTRA"
 CHECK_ALTERNATE_check729="extra729"
 
 extra729(){

--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -13,6 +13,7 @@
 CHECK_ID_extra73="7.3,7.03"
 CHECK_TITLE_extra73="[extra73] Ensure there are no S3 buckets open to the Everyone or Any AWS user (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra73="NOT_SCORED"
+CHECK_TYPE_extra73="EXTRA"
 CHECK_ALTERNATE_extra703="extra73"
 CHECK_ALTERNATE_check73="extra73"
 CHECK_ALTERNATE_check703="extra73"

--- a/checks/check_extra74
+++ b/checks/check_extra74
@@ -13,6 +13,7 @@
 CHECK_ID_extra74="7.4,7.04"
 CHECK_TITLE_extra74="[extra74] Ensure there are no Security Groups without ingress filtering being used (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra74="NOT_SCORED"
+CHECK_TYPE_extra74="EXTRA"
 CHECK_ALTERNATE_extra704="extra74"
 CHECK_ALTERNATE_check74="extra74"
 CHECK_ALTERNATE_check704="extra74"

--- a/checks/check_extra75
+++ b/checks/check_extra75
@@ -13,6 +13,7 @@
 CHECK_ID_extra75="7.5,7.05"
 CHECK_TITLE_extra75="[extra75] Ensure there are no Security Groups not being used (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra75="NOT_SCORED"
+CHECK_TYPE_extra75="EXTRA"
 CHECK_ALTERNATE_extra705="extra75"
 CHECK_ALTERNATE_check75="extra75"
 CHECK_ALTERNATE_check705="extra75"

--- a/checks/check_extra76
+++ b/checks/check_extra76
@@ -13,6 +13,7 @@
 CHECK_ID_extra76="7.6,7.06"
 CHECK_TITLE_extra76="[extra75] Ensure there are no EC2 AMIs set as Public (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra76="NOT_SCORED"
+CHECK_TYPE_extra76="EXTRA"
 CHECK_ALTERNATE_extra706="extra76"
 CHECK_ALTERNATE_check76="extra76"
 CHECK_ALTERNATE_check706="extra76"

--- a/checks/check_extra77
+++ b/checks/check_extra77
@@ -10,10 +10,10 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
-
 CHECK_ID_extra77="7.7,7.07"
 CHECK_TITLE_extra77="[extra77] Ensure there are no ECR repositories set as Public (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra77="NOT_SCORED"
+CHECK_TYPE_extra77="EXTRA"
 CHECK_ALTERNATE_extra707="extra77"
 CHECK_ALTERNATE_check77="extra77"
 CHECK_ALTERNATE_check707="extra77"

--- a/checks/check_extra78
+++ b/checks/check_extra78
@@ -13,6 +13,7 @@
 CHECK_ID_extra78="7.8,7.08"
 CHECK_TITLE_extra78="[extra78] Ensure there are no Public Accessible RDS instances (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra78="NOT_SCORED"
+CHECK_TYPE_extra78="EXTRA"
 CHECK_ALTERNATE_extra708="extra78"
 CHECK_ALTERNATE_check78="extra78"
 CHECK_ALTERNATE_check708="extra78"

--- a/checks/check_extra79
+++ b/checks/check_extra79
@@ -13,6 +13,7 @@
 CHECK_ID_extra79="7.9,7.09"
 CHECK_TITLE_extra79="[extra79] Check for internet facing Elastic Load Balancers (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra79="NOT_SCORED"
+CHECK_TYPE_extra79="EXTRA"
 CHECK_ALTERNATE_extra709="extra79"
 CHECK_ALTERNATE_check79="extra79"
 CHECK_ALTERNATE_check709="extra79"

--- a/checks/check_sample
+++ b/checks/check_sample
@@ -14,6 +14,7 @@
 # CHECK_ID_checkN="N.N"
 # CHECK_TITLE_checkN="[checkN] Description (Not Scored) (Not part of CIS benchmark)"
 # CHECK_SCORED_checkN="NOT_SCORED"
+# CHECK_TYPE_checkN="EXTRA"
 # CHECK_ALTERNATE_checkN="extraN"
 #
 # extraN(){


### PR DESCRIPTION
the "CHECK_TYPE_checkN" variables were missing from all checks, resulting in a CSV output with "Unspecified or Invalid" as the level.

This restores the check levels of "Level 1", "Level 2", or "Extra" to existing checks.