### PR TITLE
ensure credential report is available before running any checks

### DIFF
--- a/prowler
+++ b/prowler
@@ -263,6 +263,11 @@ fi
 # Gather account data / test aws cli connectivity
 getWhoami
 
+# Generate the credential report, regardless of which checks we run
+# so that the checks can safely assume it's available
+genCredReport
+saveReport
+
 # Execute single check if called with -c
 if [[ $CHECK_ID ]];then
   execute_check $CHECK_ID
@@ -287,8 +292,6 @@ if [[ $PRINTCHECKSONLY == "1" ]]; then
   exit $EXITCODE
 fi
 
-genCredReport
-saveReport
 execute_all
 
 cleanTemp


### PR DESCRIPTION
rather than leaving check/group authors to determine if each check requires the credential report, just create the report before running checks.

running `prowler -p test_profile -c check112 -k`  returned a FAIL result, and did NOT generate the credential report.