### PR TITLE
missing aim roles

### DIFF
--- a/iam/prowler-policy-additions.json
+++ b/iam/prowler-policy-additions.json
@@ -12,6 +12,8 @@
         "sns:listsubscriptionsbytopic",
         "guardduty:ListDetectors",
         "trustedadvisor:Describe*",
+        "cloudtrail:GetEventSelectors",
+        "apigateway:GET",
         "support:*"
       ],
       "Effect": "Allow",


### PR DESCRIPTION
adding missing IAM roles
"cloudtrail:GetEventSelectors", "apigateway:GET",