### PR TITLE
Fix issue with CLOUDWATCH_LOGGROUP_REGION possibly returning multiple duplicate regions

### DIFF
--- a/checks/check31
+++ b/checks/check31
@@ -21,7 +21,7 @@ check31(){
   if [[ $CLOUDWATCH_GROUP ]];then
     for group in $CLOUDWATCH_GROUP; do
       CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | tr '	' '
-' | grep $group | awk -F: '{ print $4 }')
+' | grep $group | awk -F: '{ print $4 }'  | head -n 1)
       #METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' | awk '/UnauthorizedOperation/ || /AccessDenied/ {print $3}')
       METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --output text | grep METRICFILTERS | awk 'BEGIN {IGNORECASE=1}; /UnauthorizedOperation/ || /AccessDenied/ {print $3};')
       if [[ $METRICFILTER_SET ]];then

--- a/checks/check310
+++ b/checks/check310
@@ -20,7 +20,8 @@ check310(){
 ' | awk -F: '{ print $7 }')
   if [[ $CLOUDWATCH_GROUP ]];then
     for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }')
+      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | tr '	' '
+' | grep $group | awk -F: '{ print $4 }'  | head -n 1)
       METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' | grep -E 'AuthorizeSecurityGroupIngress.*AuthorizeSecurityGroupEgress.*RevokeSecurityGroupIngress.*RevokeSecurityGroupEgress.*CreateSecurityGroup.*DeleteSecurityGroup')
       if [[ $METRICFILTER_SET ]];then
         HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | awk 'BEGIN {IGNORECASE=1}; /SecurityGroup/;')

--- a/checks/check311
+++ b/checks/check311
@@ -20,7 +20,8 @@ check311(){
 ' | awk -F: '{ print $7 }')
   if [[ $CLOUDWATCH_GROUP ]];then
     for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }')
+      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | tr '	' '
+' | grep $group | awk -F: '{ print $4 }'  | head -n 1)
       METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' | grep -E 'CreateNetworkAcl.*CreateNetworkAclEntry.*DeleteNetworkAcl.*DeleteNetworkAclEntry.*ReplaceNetworkAclEntry.*ReplaceNetworkAclAssociation')
       if [[ $METRICFILTER_SET ]];then
         HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | awk 'BEGIN {IGNORECASE=1}; /NetworkAcl/;')

--- a/checks/check312
+++ b/checks/check312
@@ -20,7 +20,8 @@ check312(){
 ' | awk -F: '{ print $7 }')
   if [[ $CLOUDWATCH_GROUP ]];then
     for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }')
+      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | tr '	' '
+' | grep $group | awk -F: '{ print $4 }'  | head -n 1)
       METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' | grep -E 'CreateCustomerGateway.*DeleteCustomerGateway.*AttachInternetGateway.*CreateInternetGateway.*DeleteInternetGateway.*DetachInternetGateway')
       if [[ $METRICFILTER_SET ]];then
         HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | awk 'BEGIN {IGNORECASE=1}; /InternetGateway/ || /CustomerGateway/;')

--- a/checks/check313
+++ b/checks/check313
@@ -20,7 +20,8 @@ check313(){
 ' | awk -F: '{ print $7 }')
   if [[ $CLOUDWATCH_GROUP ]];then
     for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }')
+      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | tr '	' '
+' | grep $group | awk -F: '{ print $4 }'  | head -n 1)
       METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' | grep -E 'CreateRoute.*CreateRouteTable.*ReplaceRoute.*ReplaceRouteTableAssociation.*DeleteRouteTable.*DeleteRoute.*DisassociateRouteTable')
       if [[ $METRICFILTER_SET ]];then
         HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | awk 'BEGIN {IGNORECASE=1}; /Route/;')

--- a/checks/check314
+++ b/checks/check314
@@ -20,7 +20,8 @@ check314(){
 ' | awk -F: '{ print $7 }')
   if [[ $CLOUDWATCH_GROUP ]];then
     for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }')
+      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | tr '	' '
+' | grep $group | awk -F: '{ print $4 }'  | head -n 1)
       METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' | grep -E 'CreateVpc.*DeleteVpc.*ModifyVpcAttribute.*AcceptVpcPeeringConnection.*CreateVpcPeeringConnection.*DeleteVpcPeeringConnection.*RejectVpcPeeringConnection.*AttachClassicLinkVpc.*DetachClassicLinkVpc.*DisableVpcClassicLink.*EnableVpcClassicLink')
       if [[ $METRICFILTER_SET ]];then
         HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | awk 'BEGIN {IGNORECASE=1}; /VPC/;')

--- a/checks/check32
+++ b/checks/check32
@@ -20,7 +20,7 @@ check32(){
 ' | awk -F: '{ print $7 }')
   if [[ $CLOUDWATCH_GROUP ]];then
     for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }')
+      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }' | head -n 1)
       METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' |grep filterPattern|grep MFAUsed| awk '/ConsoleLogin/ && (/additionalEventData.MFAUsed.*\!=.*\"Yes/) {print $1}')
       if [[ $METRICFILTER_SET ]];then
         HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | awk 'BEGIN {IGNORECASE=1}; /ConsoleLogin/ || /MFAUsed/;')

--- a/checks/check33
+++ b/checks/check33
@@ -20,7 +20,7 @@ check33(){
 ' | awk -F: '{ print $7 }')
   if [[ $CLOUDWATCH_GROUP ]];then
     for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }')
+      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }' | head -n 1)
       METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION |grep -E 'userIdentity.*Root.*AwsServiceEvent')
       if [[ $METRICFILTER_SET ]];then
         HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | tr '[:upper:]' '[:lower:]'| grep -Ei 'userIdentity|Root|AwsServiceEvent')

--- a/checks/check34
+++ b/checks/check34
@@ -20,7 +20,7 @@ check34(){
 ' | awk -F: '{ print $7 }')
   if [[ $CLOUDWATCH_GROUP ]];then
     for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }')
+      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }' | head -n 1)
       METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' | grep -E 'DeleteGroupPolicy.*DeleteRolePolicy.*DeleteUserPolicy.*PutGroupPolicy.*PutRolePolicy.*PutUserPolicy.*CreatePolicy.*DeletePolicy.*CreatePolicyVersion.*DeletePolicyVersion.*AttachRolePolicy.*DetachRolePolicy.*AttachUserPolicy.*DetachUserPolicy.*AttachGroupPolicy.*DetachGroupPolicy')
       if [[ $METRICFILTER_SET ]];then
         HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | awk 'BEGIN {IGNORECASE=1}; /DeletePolicy/ || /DeletePolicies/ || /Policies/ || /Policy/;')

--- a/checks/check35
+++ b/checks/check35
@@ -20,7 +20,7 @@ check35(){
 ' | awk -F: '{ print $7 }')
   if [[ $CLOUDWATCH_GROUP ]];then
     for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }')
+      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }' | head -n 1)
       METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' | grep -E 'CreateTrail.*UpdateTrail.*DeleteTrail.*StartLogging.*StopLogging')
       if [[ $METRICFILTER_SET ]];then
         HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | awk 'BEGIN {IGNORECASE=1}; /TrailChange/ || /Trails/ || /CreateTrail/ || /UpdateTrail/ || /DeleteTrail/ || /StartLogging/ || /StopLogging/;')

--- a/checks/check36
+++ b/checks/check36
@@ -20,7 +20,7 @@ check36(){
 ' | awk -F: '{ print $7 }')
   if [[ $CLOUDWATCH_GROUP ]];then
     for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }')
+      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }' | head -n 1)
       METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' | grep -E 'ConsoleLogin.*Failed')
       if [[ $METRICFILTER_SET ]];then
         HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | awk 'BEGIN {IGNORECASE=1}; /FailedLogin/ || /ConsoleLogin/ || /Failed/;')

--- a/checks/check37
+++ b/checks/check37
@@ -20,7 +20,7 @@ check37(){
 ' | awk -F: '{ print $7 }')
   if [[ $CLOUDWATCH_GROUP ]];then
     for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }')
+      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }' | head -n 1)
       METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' | grep -E 'kms.amazonaws.com.*DisableKey.*ScheduleKeyDeletion')
       if [[ $METRICFILTER_SET ]];then
         HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | awk 'BEGIN {IGNORECASE=1}; /DisableKey/ || /ScheduleKeyDeletion/ || /kms/;')

--- a/checks/check38
+++ b/checks/check38
@@ -20,7 +20,7 @@ check38(){
 ' | awk -F: '{ print $7 }')
   if [[ $CLOUDWATCH_GROUP ]];then
     for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }')
+      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }' | head -n 1)
       METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' | grep -E 's3.amazonaws.com.*PutBucketAcl.*PutBucketPolicy.*PutBucketCors.*PutBucketLifecycle.*PutBucketReplication.*DeleteBucketPolicy.*DeleteBucketCors.*DeleteBucketLifecycle.*DeleteBucketReplication')
       if [[ $METRICFILTER_SET ]];then
         HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | awk 'BEGIN {IGNORECASE=1}; /S3/ || /BucketPolicy/ || /BucketPolicies/;')

--- a/checks/check39
+++ b/checks/check39
@@ -20,7 +20,7 @@ check39(){
 ' | awk -F: '{ print $7 }')
   if [[ $CLOUDWATCH_GROUP ]];then
     for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }')
+      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }' | head -n 1)
       METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' | grep -E 'config.amazonaws.com.*StopConfigurationRecorder.*DeleteDeliveryChannel.*PutDeliveryChannel.*PutConfigurationRecorder')
       if [[ $METRICFILTER_SET ]];then
         HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | awk 'BEGIN {IGNORECASE=1}; /config/ || /ConfigurationRecorder/ || /DeliveryChannel/;')


### PR DESCRIPTION
2 of my CT configs point to the same group (dont ask)

This leads to: 

```
$ /home/marc/.pyenv/shims/aws cloudtrail describe-trails --region us-east-1 --query trailList[*]                                 
[                                                                                                                                
    {                                              
        "Name": "one",
        "S3BucketName": "com-redact:one",             
        "SnsTopicName": "arn:aws:sns:us-east-1:...",           
        "SnsTopicARN": "arn:aws:sns:us-east-1:...",    
        "IncludeGlobalServiceEvents": true,                                                                                                                                        
        "IsMultiRegionTrail": true,                                                                                              
        "HomeRegion": "us-east-1",                                                                                               
        "TrailARN": "arn:aws:cloudtrail:us-east-1:redact:role:trail/one",                                                                                                   
        "LogFileValidationEnabled": true,                                                                                                                                                                                                             "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1::log-group:CloudTrail/DefaultLogGroup:*",               
        "CloudWatchLogsRoleArn": "arn:aws:iam::redact:role/cloudtrail_cloudwatchlogs",                                     
        "KmsKeyId": "arn:aws:kms:us-east-1:redact:role:key/56a945de-dad5-4720-a081-067e2acb8cfd",                                                                                                                             
        "HasCustomEventSelectors": false                                                                                                                                                                                                          
    },                                                                           
    {                                              
        "Name": "two",
        "S3BucketName": "com-redact:two",             
        "SnsTopicName": "arn:aws:sns:us-east-1:...",           
        "SnsTopicARN": "arn:aws:sns:us-east-1:...",    
        "IncludeGlobalServiceEvents": true,                                                                                                                                        
        "IsMultiRegionTrail": true,                                                                                              
        "HomeRegion": "us-east-1",                                                                                               
        "TrailARN": "arn:aws:cloudtrail:us-east-1:redact:role:trail/redact:one",                                                                                                   
        "LogFileValidationEnabled": true,                                                                                                                                                                                                             "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:.:log-group:CloudTrail/DefaultLogGroup:*",               
        "CloudWatchLogsRoleArn": "arn:aws:iam::redact:role/cloudtrail_cloudwatchlogs",                                     
        "KmsKeyId": "arn:aws:kms:us-east-1:redact:role:key/56a945de-dad5-4720-a081-067e2acb8cfd",                                                                                                                             
        "HasCustomEventSelectors": false                                                                                                                                                                                                          }                                                                                                                            
]   
```

which ends up with:
`CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | tr '      ' | grep $group | awk -F: '{ print $4 }') ` being `us-east-1 us-east-1` and causes `check31` to be weird with:

```
 3.0 Monitoring - [group3] ******************************************                                                                   
                                                                                                                                                          
 3.1  [check31] Ensure a log metric filter and alarm exist for unauthorized API calls (Scored)                                                                                                                                                usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]                                                                                                                                                
To see help text, you can run:                                                                                                   
                                                                                                                                                                                                                               
  aws help                                                                                                                                                                                                                                      aws <command> help                                                                                                             
  aws <command> <subcommand> help                                                                                                       
                                                                                                                                                                                                                                              Unknown options: us-east-1                                                                                                                                                                                                                    usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]                                                      
To see help text, you can run:                                                                                                   
                                                                                                                                      
  aws help                                                                                                                       
  aws <command> help                                                                                                                                      
  aws <command> <subcommand> help                                                                                                                         
                                                                                                                                 
Unknown options: us-east-1                                                                                                       
       FAIL! CloudWatch group CloudTrail/DefaultLogGroup found but no metric filters or alarms associated                        
       FAIL! CloudWatch group CloudTrail/DefaultLogGroup found but no metric filters or alarms associated                                                 
                                                                                                                                                          
 3.2  [check32] Ensure a log metric filter and alarm exist for Management Console sign-in without MFA (Scored)                          
       FAIL! CloudWatch group CloudTrail/DefaultLogGroup found but no metric filters or alarms associated                                                 
       FAIL! CloudWatch group CloudTrail/DefaultLogGroup found but no metric filters or alarms associated                        
                                                                                                                                                         
 3.3  [check33] Ensure a log metric filter and alarm exist for usage of root account (Scored)                                                          
       PASS! CloudWatch group CloudTrail/DefaultLogGroup found with metric filters and alarms set for usage of root account      
       PASS! CloudWatch group CloudTrail/DefaultLogGroup found with metric filters and alarms set for usage of root account      
                                                                                                                                        
 3.4  [check34] Ensure a log metric filter and alarm exist for IAM policy changes (Scored)                                                                
       FAIL! CloudWatch group CloudTrail/DefaultLogGroup found but no metric filters or alarms associated                                                                                                                                            FAIL! CloudWatch group CloudTrail/DefaultLogGroup found but no metric filters or alarms associated                                                                                                                  
                                                                                                                                 
 3.5  [check35] Ensure a log metric filter and alarm exist for CloudTrail configuration changes (Scored)                                                                                                                       
       FAIL! CloudWatch group CloudTrail/DefaultLogGroup found but no metric filters or alarms associated                                                                                                                                            FAIL! CloudWatch group CloudTrail/DefaultLogGroup found but no metric filters or alarms associated                        
                                                                                                                                        
 3.6  [check36] Ensure a log metric filter and alarm exist for AWS Management Console authentication failures (Scored)                                                                                                                               FAIL! CloudWatch group CloudTrail/DefaultLogGroup found but no metric filters or alarms associated  
```