### PR TITLE
Fix typo:  `INSTANCE-PROFILE` -> `$INSTANCE_PROFILE`"

### DIFF
--- a/include/aws_profile_loader
+++ b/include/aws_profile_loader
@@ -27,7 +27,7 @@ elif [[ $AWS_ACCESS_KEY_ID && $AWS_SECRET_ACCESS_KEY || $AWS_SESSION_TOKEN ]];th
     PROFILE="ENV"
     PROFILE_OPT=""
 elif [[ $INSTANCE_PROFILE ]];then
-    PROFILE="INSTANCE-PROFILE"
+    PROFILE="$INSTANCE_PROFILE"
     AWS_ACCESS_KEY_ID=$(curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/${INSTANCE_PROFILE} | grep AccessKeyId | cut -d':' -f2 | sed 's/[^0-9A-Z]*//g')
     AWS_SECRET_ACCESS_KEY_ID=$(curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/${INSTANCE_PROFILE} | grep SecretAccessKey | cut -d':' -f2 | sed 's/[^0-9A-Za-z/+=]*//g')
     AWS_SESSION_TOKEN=$(curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/${INSTANCE_PROFILE}  grep Token| cut -d':' -f2 | sed 's/[^0-9A-Za-z/+=]*//g')


### PR DESCRIPTION
Fixes:

```
 AWS-CLI Profile: [INSTANCE-PROFILE] AWS API Region: [us-east-1] AWS Filter Region: [all]
```

and 

```
 7.3 [extra73] Ensure there are no S3 buckets open to the Everyone or Any AWS user (Not Scored) (Not part of CIS benchmark)                                                                       
       INFO! Looking for open S3 Buckets (ACLs and Policies) in all regions...                                                                                                 
                                                                     
The config profile (INSTANCE-PROFILE) could not be found                                 
                                                                                      
 7.4 [extra74] Ensure there are no Security Groups without ingress filtering being used (Not Scored) (Not part of CIS benchmark) 
```


Becomes correct:

```
 AWS-CLI Profile: [local-credentials] AWS API Region: [us-east-1] AWS Filter Region: [all]
```