### PR TITLE
Fixed Bash test.

### DIFF
--- a/checks/check111
+++ b/checks/check111
@@ -18,7 +18,7 @@ check111(){
   # "Ensure IAM password policy expires passwords within 90 days or less (Scored)"
   COMMAND111=$($AWSCLI iam get-account-password-policy $PROFILE_OPT --region $REGION --query PasswordPolicy.MaxPasswordAge --output text 2> /dev/null)
   if [[ $COMMAND111 ]];then
-    if [ "$COMMAND111" -le "90" ];then
+    if [[ "$COMMAND111" -le "90" ]];then
       textPass "Password Policy includes expiration (Value: $COMMAND111)"
     else
       textFail "Password expiration is set greater than 90 days"


### PR DESCRIPTION
Before:
```
$ ./prowler -p dev -M csv -c check111

Generating "," delimited report on stdout for profile dev, account XXX
PROFILE,ACCOUNT_NUM,REGION,TITLE_ID,RESULT,SCORED,LEVEL,TITLE_TEXT,NOTES
0.0 Show report generation info
dev,XXX,XXX,0.0,INFO,Not Scored,Support,Show report generation info,ARN: arn:aws:iam::XXX:user/XXX  TIMESTAMP: 2018-08-10T10:22:44+0000
0.1 Generating AWS IAM Credential Report...
1.11 [check111] Ensure IAM password policy expires passwords within 90 days or less (Scored)
./checks/check111: line 21: [: None: integer expression expected
dev,XXX,XXX,1.11,FAIL,Scored,Level 1,[check111] Ensure IAM password policy expires passwords within 90 days or less (Scored),Password expiration is set greater than 90 days
```

After:
```
$ ./prowler -p dev -M csv -c check111

Generating "," delimited report on stdout for profile dev, account XXX
PROFILE,ACCOUNT_NUM,REGION,TITLE_ID,RESULT,SCORED,LEVEL,TITLE_TEXT,NOTES
0.0 Show report generation info
dev,XXX,XXX,0.0,INFO,Not Scored,Support,Show report generation info,ARN: arn:aws:iam::XXX:user/XXX  TIMESTAMP: 2018-08-10T10:23:46+0000
0.1 Generating AWS IAM Credential Report...
1.11 [check111] Ensure IAM password policy expires passwords within 90 days or less (Scored)
dev,XXX,XXX,1.11,PASS,Scored,Level 1,[check111] Ensure IAM password policy expires passwords within 90 days or less (Scored),Password Policy includes expiration (Value: None)
```