### PR TITLE
Update Scored Value for 115 and 315. Update 13 to only check users with enabled console password.

### DIFF
--- a/checks/check115
+++ b/checks/check115
@@ -10,7 +10,7 @@
 
 CHECK_ID_check115="1.15"
 CHECK_TITLE_check115="[check115] Ensure security questions are registered in the AWS account (Not Scored)"
-CHECK_SCORED_check115="SCORED"
+CHECK_SCORED_check115="NOT_SCORED"
 CHECK_TYPE_check115="LEVEL1"
 CHECK_ALTERNATE_check115="check115"
 

--- a/checks/check13
+++ b/checks/check13
@@ -17,25 +17,17 @@ CHECK_ALTERNATE_check103="check13"
 check13(){
   # "Ensure credentials unused for 90 days or greater are disabled (Scored)"
   COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED=$(cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$4 }' |grep true | awk '{ print $1 }')
+  # Only check Password last used for users with password enabled 
   if [[ $COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED ]]; then
-    COMMAND13=$(
     for i in $COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED; do
-      cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$5 }' |grep $i| awk '{ print $1 }'|tr '\n' ' ';
-    done)
-    # list of users that have used password
-    USERS_PASSWORD_USED=$($AWSCLI iam list-users --query "Users[?PasswordLastUsed].UserName" --output text $PROFILE_OPT --region $REGION)
-    if [[ $USERS_PASSWORD_USED ]]; then
-      # look for users with a password last used more or equal to 90 days
-      for i in $USERS_PASSWORD_USED; do
-        DATEUSED=$($AWSCLI iam list-users --query "Users[?UserName=='$i'].PasswordLastUsed" --output text $PROFILE_OPT --region $REGION | cut -d'T' -f1)
-        HOWOLDER=$(how_older_from_today $DATEUSED)
-        if [ $HOWOLDER -gt "90" ];then
-          textFail "User \"$i\" has not logged in during the last 90 days "
-        else
-          textPass "User \"$i\" found with credentials used in the last 90 days"
-        fi
-      done
-    fi
+      DATEUSED=$($AWSCLI iam list-users --query "Users[?UserName=='$i'].PasswordLastUsed" --output text $PROFILE_OPT --region $REGION | cut -d'T' -f1)
+      HOWOLDER=$(how_older_from_today $DATEUSED)
+      if [ $HOWOLDER -gt "90" ];then
+        textFail "User \"$i\" has not logged in during the last 90 days "
+      else
+        textPass "User \"$i\" found with credentials used in the last 90 days"
+      fi
+    done
   else
       textPass "No users found with password enabled"
   fi

--- a/checks/check315
+++ b/checks/check315
@@ -10,7 +10,7 @@
 
 CHECK_ID_check315="3.15"
 CHECK_TITLE_check315="[check315] Ensure appropriate subscribers to each SNS topic (Not Scored)"
-CHECK_SCORED_check315="SCORED"
+CHECK_SCORED_check315="NOT_SCORED"
 CHECK_TYPE_check315="LEVEL1"
 CHECK_ALTERNATE_check315="check315"
 


### PR DESCRIPTION
When I run prowler and export to json, I get a Scored value of 'Scored' instead of 'Not Scored' for 1.15 and 3.15. In their Title/Description it correctly says (Not Scored), but the outputted value needs to be updated.

Would it make sense to update check 1.3 to only check IAM users that have their password enabled? There are use cases where accounts previously used IAM account for console acess and now only use IAM accounts for Access keys. This use case still lists a last login value even though the user's console password has been disabled which results in a failed finding in the report that cannot be remediated.