### PR TITLE
Fixed test for no S3 buckets and moved code.

### DIFF
--- a/checks/check_extra725
+++ b/checks/check_extra725
@@ -25,29 +25,31 @@ extra725(){
   # create a file with a list of all buckets
   TEMP_BUCKET_LIST_FILE=$(mktemp -t prowler.bucket-list-XXXXXX)
   $AWSCLI s3api list-buckets --query 'Buckets[*].{Name:Name}' $PROFILE_OPT --region $REGION --output text > $TEMP_BUCKET_LIST_FILE
+  if [ ! -s $TEMP_BUCKET_LIST_FILE ]; then
+    textInfo "$regx: No S3 buckets found" "$regx"
+    exit
+  fi
 
   # now create a list with all trails available and their region
   TEMP_TRAILS_LIST_FILE=$(mktemp -t prowler.trails-list-XXXXXX)
   for regx in $REGIONS; do
     $AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query trailList[?HomeRegion==\`$regx\`].[Name,HomeRegion] --output text >> $TEMP_TRAILS_LIST_FILE
   done
-  if [ ! -s $TEMP_TRAILS_LIST_FILE ]; then
-    textInfo "$regx: No S3 buckets found" "$regx"
-    exit
-  fi
 
   # look for buckets being logged per trail and create a list with them
   TEMP_BUCKETS_LOGGING_LIST_FILE=$(mktemp -t prowler.buckets-logging-list-XXXXXX)
-  for trail in $(cat $TEMP_TRAILS_LIST_FILE | awk '{ print $1 }'); do
-    TRAIL_REGION=$(grep ^$trail $TEMP_TRAILS_LIST_FILE | awk '{ print $2 }')
-    BUCKETS_OBJECT_LOGGING_ENABLED=$($AWSCLI cloudtrail get-event-selectors --trail-name $trail $PROFILE_OPT --region $TRAIL_REGION --query "EventSelectors[*].DataResources[?Type == \`AWS::S3::Object\`].Values" --output text |xargs -n1 |cut -d: -f 6|sed 's/\///g')
+  while IFS='' read -r LINE || [[ -n "${LINE}" ]]; do
+    TRAIL_REGION=$(echo "${LINE}" | awk '{ print $2 }')
+    TRAIL_NAME=$(echo "${LINE}" | awk '{ print $1 }')
+    BUCKETS_OBJECT_LOGGING_ENABLED=$($AWSCLI cloudtrail get-event-selectors --trail-name "${TRAIL_NAME}" $PROFILE_OPT --region $TRAIL_REGION --query "EventSelectors[*].DataResources[?Type == \`AWS::S3::Object\`].Values" --output text |xargs -n1 |cut -d: -f 6|sed 's/\///g')
     echo $BUCKETS_OBJECT_LOGGING_ENABLED |tr " " "\n"|sort >> $TEMP_BUCKETS_LOGGING_LIST_FILE
     if [[ $BUCKETS_OBJECT_LOGGING_ENABLED ]]; then
       for bucket in $BUCKETS_OBJECT_LOGGING_ENABLED; do
         textPass "$regx: S3 bucket $bucket has Object-level logging enabled in trail $trail" "$regx"
-     done
+      done
     fi
-  done
+  done < $TEMP_TRAILS_LIST_FILE
+
   # diff to get the ones that are not in any trail then they are not logging
   BUCKETS_NOT_LOGGING=$(diff $TEMP_BUCKETS_LOGGING_LIST_FILE $TEMP_BUCKET_LIST_FILE | sed -n 's/^> //p')
   if [[ $BUCKETS_NOT_LOGGING ]]; then


### PR DESCRIPTION
Also change the method to run through the trails list file.  Reason for the change is that the old method would fail if all your trails are called "Default".  For example:

```
$ for regx in ap-south-1 eu-west-3 eu-west-2 eu-west-1 ap-northeast-2 ap-northeast-1 sa-east-1 ca-central-1 ap-southeast-1 ap-southeast-2 eu-central-1 us-east-1 us-east-2 us-west-1 us-west-2; do aws cloudtrail describe-trails --profile dev --region $regx --query trailList[?HomeRegion==\`$regx\`].[Name,HomeRegion] --output text; done
Default eu-west-1
Default ap-northeast-1
Default sa-east-1
Default ap-southeast-1
Default ap-southeast-2
Default eu-central-1
Default us-east-1
Default us-west-1
Default us-west-2
```
This would produce a lot of:
```
Unknown options: sa-east-1, ap-southeast-1, ap-southeast-2, eu-central-1, us-east-1, us-west-1, us-west-2, ap-northeast-1
usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
```