### PR TITLE
Use awscli query instead of cut for Extra 7.13

### DIFF
--- a/checks/check_extra713
+++ b/checks/check_extra713
@@ -22,7 +22,7 @@ extra713(){
     LIST_OF_GUARDDUTY_DETECTORS=$($AWSCLI guardduty list-detectors $PROFILE_OPT --region $regx --output text |cut -f2)
     if [[ $LIST_OF_GUARDDUTY_DETECTORS ]];then
       while read -r detector;do
-        DETECTOR_ENABLED=$($AWSCLI guardduty get-detector --detector-id $detector $PROFILE_OPT --region $regx --output text| cut -f3|grep ENABLED)
+        DETECTOR_ENABLED=$($AWSCLI guardduty get-detector --detector-id $detector $PROFILE_OPT --region $regx --query "Status" --output text|grep ENABLED)
         if [[ $DETECTOR_ENABLED ]]; then
           textPass "$regx: GuardDuty detector $detector enabled" "$regx"
         else


### PR DESCRIPTION
Fixes #249.
The text output of `aws guardduty get-detector` has changed with awscli release 1.16.25, leading to GuardDuty detectors misreported as suspended.