### PR TITLE
fix(check13): should not pass if user never logged in

### DIFF
--- a/checks/check13
+++ b/checks/check13
@@ -21,11 +21,16 @@ check13(){
   if [[ $COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED ]]; then
     for i in $COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED; do
       DATEUSED=$($AWSCLI iam list-users --query "Users[?UserName=='$i'].PasswordLastUsed" --output text $PROFILE_OPT --region $REGION | cut -d'T' -f1)
-      HOWOLDER=$(how_older_from_today $DATEUSED)
-      if [ $HOWOLDER -gt "90" ];then
+      if [ "$DATEUSED" == "" ]
+      then
         textFail "User \"$i\" has not logged in during the last 90 days "
       else
-        textPass "User \"$i\" found with credentials used in the last 90 days"
+        HOWOLDER=$(how_older_from_today $DATEUSED)
+        if [ $HOWOLDER -gt "90" ];then
+          textFail "User \"$i\" has not logged in during the last 90 days "
+        else
+          textPass "User \"$i\" found with credentials used in the last 90 days"
+        fi
       fi
     done
   else


### PR DESCRIPTION
When a user never logged in but have password enabled (done when creating the account with a temporary password), an error in the script (date of empty string) make the check pass :

```
./include/os_detector: line 49: (1539759446 -  )/60/60/24: syntax error: operand expected (error token is ")/60/60/24")
./checks/check13: line 25: [: -gt: unary operator expected
usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ...
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
```
