### PR TITLE
Updated check29 to validate against FlowLogId which is valid for both…

### DIFF
--- a/checks/check29
+++ b/checks/check29
@@ -17,7 +17,7 @@ CHECK_ALTERNATE_check209="check29"
 check29(){
   # "Ensure VPC Flow Logging is Enabled in all VPCs (Scored)"
   for regx in $REGIONS; do
-    CHECK_FL=$($AWSCLI ec2 describe-flow-logs $PROFILE_OPT --region $regx --query 'FlowLogs[?FlowLogStatus==`ACTIVE`].LogGroupName' --output text)
+    CHECK_FL=$($AWSCLI ec2 describe-flow-logs $PROFILE_OPT --region $regx --query 'FlowLogs[?FlowLogStatus==`ACTIVE`].FlowLogId' --output text)
     if [[ $CHECK_FL ]];then
       for FL in $CHECK_FL;do
         textPass "VPCFlowLog is enabled for LogGroupName: $FL in Region $regx" "$regx"


### PR DESCRIPTION
… CloudWatch and s3 destinations

The existing check fails if VPC FlowLogs are enabled and set to deliver to an s3 bucket.  The LogGroupName metadata is only populated when the destination is set to go to Cloudwatch.

All VPC Flow logs will have a valid FlowLogId so changing the filter will validate the check appropriately.