### PR TITLE
Fixed AccessDeniedException on extra730

### DIFF
--- a/checks/check_extra730
+++ b/checks/check_extra730
@@ -25,7 +25,7 @@ extra730(){
     LIST_OF_ACM_CERTS=$($AWSCLI acm list-certificates $PROFILE_OPT --region $regx --query 'CertificateSummaryList[].CertificateArn' --output text)
     if [[ $LIST_OF_ACM_CERTS ]];then
       for cert in $LIST_OF_ACM_CERTS; do
-        CERT_DATA=$($AWSCLI acm describe-certificate --certificate-arn $cert --query 'Certificate.[DomainName,NotAfter]' --output text)
+        CERT_DATA=$($AWSCLI acm describe-certificate $PROFILE_OPT --region $regx --certificate-arn $cert --query 'Certificate.[DomainName,NotAfter]' --output text)
         echo "$CERT_DATA" | while read FQDN NOTAFTER; do
           EXPIRES_DATE=$(timestamp_to_date $NOTAFTER)
           COUNTER_DAYS=$(how_many_days_from_today $EXPIRES_DATE)


### PR DESCRIPTION
When executing Prowler using a specific profile (in my case to assume a role) , check_extra730 returns:

"An error occurred (AccessDeniedException) when calling the DescribeCertificate operation: User: [ASSUMED_ROLE_ARN] is not authorized to perform: acm:DescribeCertificate on resource: [RESOURCE_ARN]"

This is because line 28 did not contain the following parameters: "$PROFILE_OPT --region $regx" .