### PR TITLE
Added check for integer in response from AWS

### DIFF
--- a/checks/check111
+++ b/checks/check111
@@ -17,7 +17,7 @@ CHECK_ALTERNATE_check111="check111"
 check111(){
   # "Ensure IAM password policy expires passwords within 90 days or less (Scored)"
   COMMAND111=$($AWSCLI iam get-account-password-policy $PROFILE_OPT --region $REGION --query PasswordPolicy.MaxPasswordAge --output text 2> /dev/null)
-  if [[ $COMMAND111 ]];then
+  if [[ $COMMAND111 == [0-9]* ]];then
     if [[ "$COMMAND111" -le "90" ]];then
       textPass "Password Policy includes expiration (Value: $COMMAND111)"
     else


### PR DESCRIPTION
If no password policy is set, AWS CLI returns the value "None"

This current results in the following:
```
 1.11  [check111] Ensure IAM password policy expires passwords within 90 days or less (Scored)
       PASS! Password Policy includes expiration (Value: None)
```
Added a basic check to ensure the response returned is a integer.


Post change we are now returned:
```
1.11  [check111] Ensure IAM password policy expires passwords within 90 days or less (Scored)
       FAIL! Password expiration is not set
```