### PR TITLE
Use common code for CloudWatch metric checks

### DIFF
--- a/checks/check31
+++ b/checks/check31
@@ -16,48 +16,6 @@ CHECK_ALTERNATE_check301="check31"
 
 check31(){
   # "Ensure a log metric filter and alarm exist for unauthorized API calls (Scored)"
-  CLOUDWATCH_GROUP=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text| tr '	' '
-' | awk -F: '{ print $7 }')
-  if [[ $CLOUDWATCH_GROUP ]];then
-    for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | tr '	' '
-' | grep $group | awk -F: '{ print $4 }'  | head -n 1)
-      #METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' | awk '/UnauthorizedOperation/ || /AccessDenied/ {print $3}')
-      METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --output text | grep METRICFILTERS | awk 'BEGIN {IGNORECASE=1}; /UnauthorizedOperation/ || /AccessDenied/ {print $3};')
-      if [[ $METRICFILTER_SET ]];then
-        for metric in $METRICFILTER_SET; do
-          metric_name=$($AWSCLI logs describe-metric-filters $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --log-group-name $group --filter-name-prefix $metric --output text --query 'metricFilters[0].metricTransformations[0].metricName')
-          HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[?MetricName==`'$metric_name'`]' --output text)
-          if [[ $HAS_ALARM_ASSOCIATED ]];then
-            CHECK31OK="$CHECK31OK $group:$metric"
-          else
-            CHECK31WARN="$CHECK31WARN $group:$metric"
-          fi
-        done
-      else
-        CHECK31WARN="$CHECK31WARN $group"
-      fi
-    done
-
-    if [[ $CHECK31OK ]]; then
-      for group in $CHECK31OK; do
-        metric=${group#*:}
-        group=${group%:*}
-        textPass "CloudWatch group $group found with metric filter $metric and alarms set for Unauthorized Operation and Access Denied"
-      done
-    fi
-    if [[ $CHECK31WARN ]]; then
-      for group in $CHECK31WARN; do
-        case $group in
-           *:*) metric=${group#*:}
-                group=${group%:*}
-                textFail "CloudWatch group $group found with metric filter $metric but no alarms associated"
-                ;;
-             *) textFail "CloudWatch group $group found but no metric filters or alarms associated"
-        esac
-      done
-    fi
-  else
-    textFail "No CloudWatch group found for CloudTrail events"
-  fi
+  METRIC_GREP="UnauthorizedOperation.*AccessDenied"
+  cw_metric_check $METRIC_GREP "Unauthorized Operation and Access Denied"
 }

--- a/checks/check32
+++ b/checks/check32
@@ -16,24 +16,6 @@ CHECK_ALTERNATE_check302="check32"
 
 check32(){
   # "Ensure a log metric filter and alarm exist for Management Console sign-in without MFA (Scored)"
-  CLOUDWATCH_GROUP=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | tr '	' '
-' | awk -F: '{ print $7 }')
-  if [[ $CLOUDWATCH_GROUP ]];then
-    for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }' | head -n 1)
-      METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' |grep filterPattern|grep MFAUsed| awk '/ConsoleLogin/ && (/additionalEventData.MFAUsed.*\!=.*\"Yes/) {print $1}')
-      if [[ $METRICFILTER_SET ]];then
-        HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | awk 'BEGIN {IGNORECASE=1}; /ConsoleLogin/ || /MFAUsed/;')
-        if [[ $HAS_ALARM_ASSOCIATED ]];then
-          textPass "CloudWatch group $group found with metric filters and alarms set for sign-in Console without MFA enabled"
-        else
-          textFail "CloudWatch group $group found with metric filters but no alarms associated"
-        fi
-      else
-        textFail "CloudWatch group $group found but no metric filters or alarms associated"
-      fi
-    done
-  else
-    textFail "No CloudWatch group found for CloudTrail events"
-  fi
+  METRIC_GREP="ConsoleLogin.*additionalEventData.MFAUsed.*!=.*\"Yes"
+  cw_metric_check $METRIC_GREP "sign-in Console without MFA enabled"
 }

--- a/checks/check33
+++ b/checks/check33
@@ -16,24 +16,6 @@ CHECK_ALTERNATE_check303="check33"
 
 check33(){
   # "Ensure a log metric filter and alarm exist for usage of root account (Scored)"
-  CLOUDWATCH_GROUP=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | tr '	' '
-' | awk -F: '{ print $7 }')
-  if [[ $CLOUDWATCH_GROUP ]];then
-    for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }' | head -n 1)
-      METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION |grep -E 'userIdentity.*Root.*AwsServiceEvent')
-      if [[ $METRICFILTER_SET ]];then
-        HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | tr '[:upper:]' '[:lower:]'| grep -Ei 'userIdentity|Root|AwsServiceEvent')
-        if [[ $HAS_ALARM_ASSOCIATED ]];then
-          textPass "CloudWatch group $group found with metric filters and alarms set for usage of root account"
-        else
-          textFail "CloudWatch group $group found with metric filters but no alarms associated"
-        fi
-      else
-        textFail "CloudWatch group $group found but no metric filters or alarms associated"
-      fi
-    done
-  else
-    textFail "No CloudWatch group found for CloudTrail events"
-  fi
+  METRIC_GREP="userIdentity.*Root.*AwsServiceEvent"
+  cw_metric_check $METRIC_GREP "usage of root account"
 }

--- a/checks/check34
+++ b/checks/check34
@@ -16,24 +16,6 @@ CHECK_ALTERNATE_check304="check34"
 
 check34(){
   # "Ensure a log metric filter and alarm exist for IAM policy changes (Scored)"
-  CLOUDWATCH_GROUP=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | tr '	' '
-' | awk -F: '{ print $7 }')
-  if [[ $CLOUDWATCH_GROUP ]];then
-    for group in $CLOUDWATCH_GROUP; do
-      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }' | head -n 1)
-      METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters' | grep -E 'DeleteGroupPolicy.*DeleteRolePolicy.*DeleteUserPolicy.*PutGroupPolicy.*PutRolePolicy.*PutUserPolicy.*CreatePolicy.*DeletePolicy.*CreatePolicyVersion.*DeletePolicyVersion.*AttachRolePolicy.*DetachRolePolicy.*AttachUserPolicy.*DetachUserPolicy.*AttachGroupPolicy.*DetachGroupPolicy')
-      if [[ $METRICFILTER_SET ]];then
-        HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | awk 'BEGIN {IGNORECASE=1}; /DeletePolicy/ || /DeletePolicies/ || /Policies/ || /Policy/;')
-        if [[ $HAS_ALARM_ASSOCIATED ]];then
-          textPass "CloudWatch group $group found with metric filters and alarms for IAM policy changes"
-        else
-          textFail "CloudWatch group $group found with metric filters but no alarms associated"
-        fi
-      else
-        textFail "CloudWatch group $group found but no metric filters or alarms associated"
-      fi
-    done
-  else
-    textFail "No CloudWatch group found for CloudTrail events"
-  fi
+  METRIC_GREP="DeleteGroupPolicy.*DeleteRolePolicy.*DeleteUserPolicy.*PutGroupPolicy.*PutRolePolicy.*PutUserPolicy.*CreatePolicy.*DeletePolicy.*CreatePolicyVersion.*DeletePolicyVersion.*AttachRolePolicy.*DetachRolePolicy.*AttachUserPolicy.*DetachUserPolicy.*AttachGroupPolicy.*DetachGroupPolicy"
+  cw_metric_check $METRIC_GREP "IAM policy changes"
 }

--- a/include/check_helper
+++ b/include/check_helper
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Prowler - the handy cloud security tool (copyright 2018) by Toni de la Fuente
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# Helper for running CloudWatch Metric & Alarm checks
+# param: METRIC_GREP
+# param: SUCESS_MSG
+
+cw_metric_check(){
+  METRIC_GREP=$1
+  SUCCESS_MSG=$2
+
+  CLOUDWATCH_GROUP=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | tr '	' '
+' | awk -F: '{ print $7 }')
+  if [[ $CLOUDWATCH_GROUP ]];then
+    for group in $CLOUDWATCH_GROUP; do
+      CLOUDWATCH_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text | awk -F: '{ print $4 }' | head -n 1)
+      METRICFILTER_SET=$($AWSCLI logs describe-metric-filters --log-group-name $group $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'metricFilters[*].[filterName, metricTransformations[0].metricName, filterPattern]' --output text | grep -i -E $METRIC_GREP)
+      METRICS_NAME=$(echo $METRICFILTER_SET | awk '{print $2}')
+      if [[ $METRICFILTER_SET && $METRICS_NAME ]];then
+        HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region $CLOUDWATCH_LOGGROUP_REGION --query 'MetricAlarms[].MetricName' --output text | grep $METRICS_NAME)
+        if [[ $HAS_ALARM_ASSOCIATED ]];then
+          textPass "CloudWatch group $group found with metric filters and alarms for $SUCCESS_MSG"
+        else
+          textFail "CloudWatch group $group found with metric filters $METRIC_NAME but no alarms associated"
+        fi
+      else
+        textFail "CloudWatch group $group found but no metric filters or alarms associated"
+      fi
+    done
+  else
+    textFail "No CloudWatch group found for CloudTrail events"
+  fi
+}

--- a/prowler
+++ b/prowler
@@ -158,6 +158,7 @@ done
 . $PROWLER_DIR/include/banner
 . $PROWLER_DIR/include/whoami
 . $PROWLER_DIR/include/credentials_report
+. $PROWLER_DIR/include/check_helper
 
 # Get a list of all available AWS Regions
 REGIONS=$($AWSCLI ec2 describe-regions --query 'Regions[].RegionName' \


### PR DESCRIPTION
Common code for CloudWatch Metrics checks. This ought to be less arbitrary when looking to connect Metrics to Alarms.  Rewrote checks 31-34 as quick proofs.

Related to: https://github.com/toniblyx/prowler/issues/289
