### PR TITLE
Spelling fix "reshift" means "redshift"

### DIFF
--- a/checks/check_extra711
+++ b/checks/check_extra711
@@ -18,7 +18,7 @@ CHECK_ALTERNATE_check711="extra711"
 
 extra711(){
   # "Check for Publicly Accessible Redshift Clusters (Not Scored) (Not part of CIS benchmark)"
-  textInfo "Looking for Reshift clusters in all regions...  "
+  textInfo "Looking for Redshift clusters in all regions...  "
   for regx in $REGIONS; do
     LIST_OF_PUBLIC_REDSHIFT_CLUSTERS=$($AWSCLI redshift describe-clusters $PROFILE_OPT --region $regx --query 'Clusters[?PubliclyAccessible == `true`].[ClusterIdentifier,Endpoint.Address]' --output text)
     if [[ $LIST_OF_PUBLIC_REDSHIFT_CLUSTERS ]];then


### PR DESCRIPTION
Fixes a small spelling mistake in the Redshift check.