### PR TITLE
Update check22

### DIFF
--- a/checks/check22
+++ b/checks/check22
@@ -20,7 +20,7 @@ check22(){
   if [[ $LIST_OF_TRAILS ]];then
     for trail in $LIST_OF_TRAILS;do
       LOGFILEVALIDATION_TRAIL_STATUS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].LogFileValidationEnabled' --output text --trail-name-list $trail)
-      if [[ "$LOGFILEVALIDATION_TRAIL_STATUS" == 'False' ]];then
+      if [[ "$LOGFILEVALIDATION_TRAIL_STATUS" == 'false' ]];then
         textFail "$trail trail in $REGION has not log file validation enabled"
       else
         textPass "$trail trail in $REGION has log file validation enabled"


### PR DESCRIPTION
Returned value is lower case "false". Thus, prowler will not detect a missing log file validation (false negative)

Probably, this behaviour should also be taken into account for other checks.
A quick grep for "False" indicated:

- check_21
- check_extra739
- check_extra737
- check_extra715
- check_extra740
- check_extra73