### PR TITLE
Fixed check122 to match CIS 1.22 checks requirements, instead of '=~ …

### DIFF
--- a/checks/check122
+++ b/checks/check122
@@ -22,7 +22,7 @@ check122(){
     for policy in $LIST_CUSTOM_POLICIES; do
       POLICY_ARN=$(echo $policy | awk -F ',' '{print $1}')
       POLICY_VERSION=$(echo $policy | awk -F ',' '{print $2}')
-      POLICY_WITH_FULL=$($AWSCLI iam get-policy-version --output text --policy-arn $POLICY_ARN --version-id $POLICY_VERSION --query "PolicyVersion.Document.Statement[?Action!=null]|[?Effect == 'Allow' && contains(Resource, '*') && contains (Action, '*')]" $PROFILE_OPT --region $REGION)
+      POLICY_WITH_FULL=$($AWSCLI iam get-policy-version --output text --policy-arn $POLICY_ARN --version-id $POLICY_VERSION --query "PolicyVersion.Document.Statement[?Action!=null]|[?Effect == 'Allow' && Resource == '*' && Action == '*']" $PROFILE_OPT --region $REGION)
       if [[ $POLICY_WITH_FULL ]]; then
         POLICIES_ALLOW_LIST="$POLICIES_ALLOW_LIST $POLICY_ARN"
       fi
@@ -30,7 +30,7 @@ check122(){
     if [[ $POLICIES_ALLOW_LIST ]]; then
       textInfo "List of custom policies: "
       for policy in $POLICIES_ALLOW_LIST; do
-        textInfo "Policy $policy allows \"*:*\""
+        textFail "Policy $policy allows \"*:*\""
       done
     else
         textPass "No custom policy found that allow full \"*:*\" administrative privileges"


### PR DESCRIPTION
The CIS benchmark document states: IAM policies that have a statement with "Effect": "Allow" with "Action": "\*" over "Resource": "\*" should be removed.

In the code we have `contains(Resource, '*')` and `contains (Action, '*')`. This covers cases like `s3:Get*`, `arn:aws:s3:::my-bucket/*`, etc. and might generate false alarms. 

Also the the result has been updated from **INFO** to **FAIL**.