### PR TITLE
Separate handling of S3 default encryption and bucket policy encryption

### DIFF
--- a/checks/check_extra712
+++ b/checks/check_extra712
@@ -22,7 +22,7 @@ extra712(){
   textInfo "just looking if IAM Macie related permissions exist.  "
   MACIE_IAM_ROLES_CREATED=$($AWSCLI iam list-roles $PROFILE_OPT --query 'Roles[*].Arn'|grep AWSMacieServiceCustomer|wc -l)
   if [[ $MACIE_IAM_ROLES_CREATED -eq 2 ]];then
-    textPass "Macie related IAM roles exist, so it might be enabled. Check it out manually."
+    textPass "Macie related IAM roles exist so it might be enabled. Check it out manually."
   else
     textFail "No Macie related IAM roles found. It is most likely not to be enabled"
   fi

--- a/checks/check_extra734
+++ b/checks/check_extra734
@@ -11,7 +11,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 CHECK_ID_extra734="7.34"
-CHECK_TITLE_extra734="[extra734] Check if S3 buckets have default encryption (SSE) enabled and policy to enforce it (Not Scored) (Not part of CIS benchmark)"
+CHECK_TITLE_extra734="[extra734] Check if S3 buckets have default encryption (SSE) enabled or use a bucket policy to enforce it (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra734="NOT_SCORED"
 CHECK_TYPE_extra734="EXTRA"
 CHECK_ALTERNATE_check734="extra734"
@@ -20,29 +20,35 @@ extra734(){
   LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets $PROFILE_OPT --query Buckets[*].Name --output text|xargs -n1)
   if [[ $LIST_OF_BUCKETS ]]; then
     for bucket in $LIST_OF_BUCKETS;do
-     # query to get if has encryption enabled or not
-     RESULT=$(echo $bucket $($AWSCLI s3api get-bucket-encryption $PROFILE_OPT --bucket $bucket --query ServerSideEncryptionConfiguration.Rules[].ApplyServerSideEncryptionByDefault[].SSEAlgorithm --output text 2>&1 | grep -v ServerSideEncryptionConfigurationNotFoundError))
-     TEMP_SSE_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-${bucket}.policy.XXXXXXXXXX)
-     # get bucket policy
-     $AWSCLI s3api get-bucket-policy $PROFILE_OPT --bucket $bucket --output text --query Policy > $TEMP_SSE_POLICY_FILE 2> /dev/null
-     # check if the S3 policy forces SSE s3:x-amz-server-side-encryption:true
-     CHECK_BUCKET_SSE_POLICY=$(cat $TEMP_SSE_POLICY_FILE | sed -e 's/[{}]/''/g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}'| awk '/Condition/ && !skip { print } { skip = /x-amz-server-side-encryption/} '|grep \"true\")
-     echo "$RESULT" | while read RBUCKET SSEALG; do
+      # query to get if has encryption enabled or not
+      RESULT=$(echo $bucket $($AWSCLI s3api get-bucket-encryption $PROFILE_OPT --bucket $bucket --query ServerSideEncryptionConfiguration.Rules[].ApplyServerSideEncryptionByDefault[].SSEAlgorithm --output text 2>&1 | grep -v ServerSideEncryptionConfigurationNotFoundError))
+      TEMP_SSE_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-${bucket}.policy.XXXXXXXXXX)
+      # get bucket policy
+      $AWSCLI s3api get-bucket-policy $PROFILE_OPT --bucket $bucket --output text --query Policy > $TEMP_SSE_POLICY_FILE 2> /dev/null
+      # check if the S3 policy forces SSE s3:x-amz-server-side-encryption:true
+      CHECK_BUCKET_SSE_POLICY_PRESENT=$(cat $TEMP_SSE_POLICY_FILE | sed -e 's/[{}]/''/g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}'| awk '/Condition/ && !skip { print } { skip = /x-amz-server-side-encryption/} '|grep \"true\")
+      CHECK_BUCKET_SSE_POLICY_VALUE=$(cat $TEMP_SSE_POLICY_FILE | sed -e 's/[{}]/''/g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}'| awk '/Condition/ && !skip { print } { skip = /x-amz-server-side-encryption/} '|grep -Eo "AES256|aws:kms")
+      ENCRYPTION=false
+
+      echo "$RESULT" | while read RBUCKET SSEALG; do
         if [[ $SSEALG ]]; then
-          if [[ $CHECK_BUCKET_SSE_POLICY ]]; then
-            textPass "Bucket $RBUCKET has SSE enabled with algorithm $SSEALG and S3 policy to enforce it"
-          else
-            # I'll leave it as Pass but to prevent uploads of unencrypted
-            # objects to Amazon S3 a policy to enforce it is required
-            textPass "Bucket $RBUCKET has SSE enabled with algorithm $SSEALG but no S3 enforcing policy found!"
-          fi
-        else
-          textFail "Bucket $RBUCKET has Server Side Encryption disabled!"
+          textPass "Bucket $RBUCKET has default encryption enabled with algorithm $SSEALG"
+          ENCRYPTION=true
         fi
-     done
-     rm -fr $TEMP_SSE_POLICY_FILE
-   done
+      done
+      if [[ $CHECK_BUCKET_SSE_POLICY_PRESENT && $CHECK_BUCKET_SSE_POLICY_VALUE ]]; then
+        textPass "Bucket $bucket has S3 bucket policy to enforce encryption with $CHECK_BUCKET_SSE_POLICY_VALUE"
+        ENCRYPTION=true
+      fi
+      
+      if [ "$ENCRYPTION" == false ]; then
+        textFail "Bucket $bucket does not enforce encryption!"
+      fi
+
+    done
+    rm -fr $TEMP_SSE_POLICY_FILE
   else
     textInfo "No S3 Buckets found"
   fi
 }
+

--- a/checks/check_extra741
+++ b/checks/check_extra741
@@ -17,7 +17,7 @@ CHECK_TYPE_extra741="EXTRA"
 CHECK_ALTERNATE_check741="extra741"
 
 extra741(){
-  textInfo "Looking for keys in EC2 User Data in instances across all regions... (max 100 instances per region, use -m to increase it)  "
+  textInfo "Looking for keys in EC2 User Data in instances across all regions... (max 100 instances per region use -m to increase it)  "
   for regx in $REGIONS; do
     LIST_OF_EC2_INSTANCES=$($AWSCLI ec2 describe-instances $PROFILE_OPT --region $regx --query Reservations[*].Instances[*].InstanceId --output text --max-items $MAXITEMS | grep -v None)
     if [[ $LIST_OF_EC2_INSTANCES ]];then


### PR DESCRIPTION
Separate default encryption and bucket policy encryption

Default encryption (2017): https://aws.amazon.com/blogs/aws/new-amazon-s3-encryption-security-features/
Bucket policy (2016): https://aws.amazon.com/blogs/security/how-to-prevent-uploads-of-unencrypted-objects-to-amazon-s3/

