### PR TITLE
fixed check122 to check result for the value None

### DIFF
--- a/checks/check122
+++ b/checks/check122
@@ -23,7 +23,7 @@ check122(){
       POLICY_ARN=$(echo $policy | awk -F ',' '{print $1}')
       POLICY_VERSION=$(echo $policy | awk -F ',' '{print $2}')
       POLICY_WITH_FULL=$($AWSCLI iam get-policy-version --output text --policy-arn $POLICY_ARN --version-id $POLICY_VERSION --query "PolicyVersion.Document.Statement[?Action!=null]|[?Effect == 'Allow' && Resource == '*' && Action == '*']" $PROFILE_OPT --region $REGION)
-      if [[ $POLICY_WITH_FULL ]]; then
+      if [[ "$POLICY_WITH_FULL" != "None" ]]; then
         POLICIES_ALLOW_LIST="$POLICIES_ALLOW_LIST $POLICY_ARN"
       fi
     done


### PR DESCRIPTION
The results of a search where the policy does not match returns "None".  As a result, "if [[ $POLICY_WITH_FULL ]]" is true and the policy is listed as having *:* privileges, even though it does not.