### PR TITLE
add guardduty regions

### DIFF
--- a/checks/check_extra713
+++ b/checks/check_extra713
@@ -21,14 +21,15 @@ extra713(){
   # Guardduty Regions are not the same as REGIONS
   PYTHON=$(which python)
   if [ ! -z "${PYTHON}" ]; then
+    #textInfo "Using python and boto3 for getting Guardduty Available Regions"
     GD_REGIONS=($($PYTHON -c "import boto3 ; session = boto3.session.Session() ; print (session.get_available_regions('guardduty'))"))
+    for GD_REGION in "${GD_REGIONS[@]}"; do GD_REGIONS_PARSED+="$(echo "$GD_REGION" | cut -d \' -f 2 | cut -d \' -f 1 && echo " ")"; done
   else
-    GD_REGIONS=$REGIONS
+    GD_REGIONS_PARSED=$REGIONS
   fi
 
   # "Check if GuardDuty is enabled (Not Scored) (Not part of CIS benchmark)"
-  for GD_REGION in "${GD_REGIONS[@]}"; do
-    regx="$(echo "$GD_REGION" | cut -d \' -f 2 | cut -d \' -f 1)"
+  for regx in $GD_REGIONS_PARSED; do
     LIST_OF_GUARDDUTY_DETECTORS=$($AWSCLI guardduty list-detectors $PROFILE_OPT --region $regx --output text 2> /dev/null | cut -f2)
     if [[ $LIST_OF_GUARDDUTY_DETECTORS ]];then
       while read -r detector;do

--- a/checks/check_extra713
+++ b/checks/check_extra713
@@ -17,8 +17,17 @@ CHECK_TYPE_extra713="EXTRA"
 CHECK_ALTERNATE_check713="extra713"
 
 extra713(){
+
+  # Guardduty Regions are not the same as REGIONS
+  PYTHON=$(which python)
+  if [ ! -z "${PYTHON}" ]; then
+    GD_REGIONS=$($PYTHON -c "import boto3 ; session = boto3.session.Session() ; print (session.get_available_regions('guardduty'))")
+  else
+    GD_REGIONS=$REGIONS
+  fi
+
   # "Check if GuardDuty is enabled (Not Scored) (Not part of CIS benchmark)"
-  for regx in $REGIONS; do
+  for regx in $GD_REGIONS; do
     LIST_OF_GUARDDUTY_DETECTORS=$($AWSCLI guardduty list-detectors $PROFILE_OPT --region $regx --output text 2> /dev/null | cut -f2)
     if [[ $LIST_OF_GUARDDUTY_DETECTORS ]];then
       while read -r detector;do

--- a/checks/check_extra713
+++ b/checks/check_extra713
@@ -21,13 +21,14 @@ extra713(){
   # Guardduty Regions are not the same as REGIONS
   PYTHON=$(which python)
   if [ ! -z "${PYTHON}" ]; then
-    GD_REGIONS=$($PYTHON -c "import boto3 ; session = boto3.session.Session() ; print (session.get_available_regions('guardduty'))")
+    GD_REGIONS=($($PYTHON -c "import boto3 ; session = boto3.session.Session() ; print (session.get_available_regions('guardduty'))"))
   else
     GD_REGIONS=$REGIONS
   fi
 
   # "Check if GuardDuty is enabled (Not Scored) (Not part of CIS benchmark)"
-  for regx in $GD_REGIONS; do
+  for GD_REGION in "${GD_REGIONS[@]}"; do
+    regx="$(echo "$GD_REGION" | cut -d \' -f 2 | cut -d \' -f 1)"
     LIST_OF_GUARDDUTY_DETECTORS=$($AWSCLI guardduty list-detectors $PROFILE_OPT --region $regx --output text 2> /dev/null | cut -f2)
     if [[ $LIST_OF_GUARDDUTY_DETECTORS ]];then
       while read -r detector;do

--- a/checks/check_extra713
+++ b/checks/check_extra713
@@ -21,7 +21,7 @@ extra713(){
   # Guardduty Regions are not the same as REGIONS
   PYTHON=$(which python)
   if [ ! -z "${PYTHON}" ]; then
-    #textInfo "Using python and boto3 for getting Guardduty Available Regions"
+    textInfo "Using python and boto3 for getting Guardduty Available Regions"
     GD_REGIONS=($($PYTHON -c "import boto3 ; session = boto3.session.Session() ; print (session.get_available_regions('guardduty'))"))
     for GD_REGION in "${GD_REGIONS[@]}"; do GD_REGIONS_PARSED+="$(echo "$GD_REGION" | cut -d \' -f 2 | cut -d \' -f 1 && echo " ")"; done
   else


### PR DESCRIPTION
Guardduty Regions are not the same as Regions. 

The thing is that is not possible to get Guardduty Regions using CLI, so i raised an issue here: https://github.com/aws/aws-cli/issues/4219

Meanwhile, we can use boto3, so i created a simple function to use boto3 if python is present. 

What do u think ? 