### PR TITLE
Fix check extra73

### DIFF
--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -44,9 +44,9 @@ CHECK_ALTERNATE_check703="extra73"
 
 extra73(){
   textInfo "Looking for open S3 Buckets (ACLs and Policies) in all regions...  "
-  ALL_BUCKETS_LIST=$($AWSCLI s3api list-buckets --query 'Buckets[*].{Name:Name}' $PROFILE_OPT --region $REGION --output text)
+  ALL_BUCKETS_LIST=$($AWSCLI s3api list-buckets --query 'Buckets[*].{Name:Name}' $PROFILE_OPT --output text)
   for bucket in $ALL_BUCKETS_LIST; do
-    BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location --bucket $bucket $PROFILE_OPT --region $REGION --output text)
+    BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location --bucket $bucket $PROFILE_OPT --output text)
     if [[ "None" == $BUCKET_LOCATION ]]; then
       BUCKET_LOCATION="us-east-1"
     fi

--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -53,31 +53,38 @@ extra73(){
     if [[ "EU" == $BUCKET_LOCATION ]]; then
       BUCKET_LOCATION="eu-west-1"
     fi
-    # check if AllUsers is in the ACL as Grantee
-    CHECK_BUCKET_ALLUSERS_ACL=$($AWSCLI s3api get-bucket-acl $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --query "Grants[?Grantee.URI == 'http://acs.amazonaws.com/groups/global/AllUsers']" --output text |grep -v GRANTEE)
-    CHECK_BUCKET_ALLUSERS_ACL_SINGLE_LINE=$(echo -ne $CHECK_BUCKET_ALLUSERS_ACL)
-    # check if AuthenticatedUsers is in the ACL as Grantee, they will have access with sigened URL only
-    CHECK_BUCKET_AUTHUSERS_ACL=$($AWSCLI s3api get-bucket-acl $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --query "Grants[?Grantee.URI == 'http://acs.amazonaws.com/groups/global/AuthenticatedUsers']" --output text |grep -v GRANTEE)
-    CHECK_BUCKET_AUTHUSERS_ACL_SINGLE_LINE=$(echo -ne $CHECK_BUCKET_AUTHUSERS_ACL)
-    # to prevent error NoSuchBucketPolicy first clean the output controlling stderr
-    TEMP_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-${bucket}.policy.XXXXXXXXXX)
-    $AWSCLI s3api get-bucket-policy $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --output text --query Policy > $TEMP_POLICY_FILE 2> /dev/null
-    # check if the S3 policy has Principal as *
-    CHECK_BUCKET_ALLUSERS_POLICY=$(cat $TEMP_POLICY_FILE | sed -e 's/[{}]/''/g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}'|awk '/Principal/ && !skip { print } { skip = /Deny/} '|grep ^\"Principal|grep \*)
-    if [[ $CHECK_BUCKET_ALLUSERS_ACL || $CHECK_BUCKET_AUTHUSERS_ACL || $CHECK_BUCKET_ALLUSERS_POLICY ]];then
-      if [[ $CHECK_BUCKET_ALLUSERS_ACL ]];then
-        textFail "$BUCKET_LOCATION: $bucket bucket is open to the Internet (Everyone) with permissions: $CHECK_BUCKET_ALLUSERS_ACL_SINGLE_LINE" "$regx"
-      fi
-      if [[ $CHECK_BUCKET_AUTHUSERS_ACL ]];then
-        textFail "$BUCKET_LOCATION: $bucket bucket is open to Authenticated users (Any AWS user) with permissions: $CHECK_BUCKET_AUTHUSERS_ACL_SINGLE_LINE" "$regx"
-      fi
-      if [[ $CHECK_BUCKET_ALLUSERS_POLICY ]];then
-        textFail "$BUCKET_LOCATION: $bucket bucket policy \"may\" allow Anonymous users to perform actions (Principal: \"*\")" "$regx"
-      fi
+    # Check Explicit Deny and Avoid Error
+    CHEK_FOR_EXPLICIT_DENY=$($AWSCLI s3api get-bucket-acl $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket 2> /dev/null)
+    CHEK_FOR_EXPLICIT_DENY="$?"
+    if [[ $CHEK_FOR_EXPLICIT_DENY -eq 255 ]]; then
+      textPass "$BUCKET_LOCATION: bucket have an explicit Deny. Not possible to get ACL." "$regx"
     else
-      textPass "$BUCKET_LOCATION: $bucket bucket is not open" "$regx"
+      # check if AllUsers is in the ACL as Grantee
+      CHECK_BUCKET_ALLUSERS_ACL=$($AWSCLI s3api get-bucket-acl $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --query "Grants[?Grantee.URI == 'http://acs.amazonaws.com/groups/global/AllUsers']" --output text |grep -v GRANTEE)
+      CHECK_BUCKET_ALLUSERS_ACL_SINGLE_LINE=$(echo -ne $CHECK_BUCKET_ALLUSERS_ACL)
+      # check if AuthenticatedUsers is in the ACL as Grantee, they will have access with sigened URL only
+      CHECK_BUCKET_AUTHUSERS_ACL=$($AWSCLI s3api get-bucket-acl $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --query "Grants[?Grantee.URI == 'http://acs.amazonaws.com/groups/global/AuthenticatedUsers']" --output text |grep -v GRANTEE)
+      CHECK_BUCKET_AUTHUSERS_ACL_SINGLE_LINE=$(echo -ne $CHECK_BUCKET_AUTHUSERS_ACL)
+      # to prevent error NoSuchBucketPolicy first clean the output controlling stderr
+      TEMP_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-${bucket}.policy.XXXXXXXXXX)
+      $AWSCLI s3api get-bucket-policy $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --output text --query Policy > $TEMP_POLICY_FILE 2> /dev/null
+      # check if the S3 policy has Principal as *
+      CHECK_BUCKET_ALLUSERS_POLICY=$(cat $TEMP_POLICY_FILE | sed -e 's/[{}]/''/g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}'|awk '/Principal/ && !skip { print } { skip = /Deny/} '|grep ^\"Principal|grep \*)
+      if [[ $CHECK_BUCKET_ALLUSERS_ACL || $CHECK_BUCKET_AUTHUSERS_ACL || $CHECK_BUCKET_ALLUSERS_POLICY ]];then
+        if [[ $CHECK_BUCKET_ALLUSERS_ACL ]];then
+          textFail "$BUCKET_LOCATION: $bucket bucket is open to the Internet (Everyone) with permissions: $CHECK_BUCKET_ALLUSERS_ACL_SINGLE_LINE" "$regx"
+        fi
+        if [[ $CHECK_BUCKET_AUTHUSERS_ACL ]];then
+          textFail "$BUCKET_LOCATION: $bucket bucket is open to Authenticated users (Any AWS user) with permissions: $CHECK_BUCKET_AUTHUSERS_ACL_SINGLE_LINE" "$regx"
+        fi
+        if [[ $CHECK_BUCKET_ALLUSERS_POLICY ]];then
+          textFail "$BUCKET_LOCATION: $bucket bucket policy \"may\" allow Anonymous users to perform actions (Principal: \"*\")" "$regx"
+        fi
+      else
+        textPass "$BUCKET_LOCATION: $bucket bucket is not open" "$regx"
+      fi
+      rm -fr $TEMP_POLICY_FILE
     fi
-    rm -fr $TEMP_POLICY_FILE
   done
 }
 

--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -34,9 +34,9 @@ CHECK_ALTERNATE_check703="extra73"
 #
 #     BUCKET_POLICY_STATUS=$($AWSCLI s3api get-bucket-policy-status --bucket $bucket --query PolicyStatus.IsPublic --output text | grep False)
 #     if [[ $BUCKET_POLICY_STATUS ]];then
-#       textFail "$BUCKET_LOCATION: $bucket bucket is Public!" "$regx"
+#       textFail "$BUCKET_LOCATION: $bucket bucket is Public!" "$BUCKET_LOCATION"
 #     else
-#       textPass "$BUCKET_LOCATION: $bucket bucket is not Public" "$regx"
+#       textPass "$BUCKET_LOCATION: $bucket bucket is not Public" "$BUCKET_LOCATION"
 #     fi
 #   done
 # }
@@ -57,7 +57,7 @@ extra73(){
     CHEK_FOR_EXPLICIT_DENY=$($AWSCLI s3api get-bucket-acl $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket 2> /dev/null)
     CHEK_FOR_EXPLICIT_DENY="$?"
     if [[ $CHEK_FOR_EXPLICIT_DENY -eq 255 ]]; then
-      textPass "$BUCKET_LOCATION: bucket have an explicit Deny. Not possible to get ACL." "$regx"
+      textPass "$BUCKET_LOCATION: bucket have an explicit Deny. Not possible to get ACL." "$BUCKET_LOCATION"
     else
       # check if AllUsers is in the ACL as Grantee
       CHECK_BUCKET_ALLUSERS_ACL=$($AWSCLI s3api get-bucket-acl $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --query "Grants[?Grantee.URI == 'http://acs.amazonaws.com/groups/global/AllUsers']" --output text |grep -v GRANTEE)
@@ -72,16 +72,16 @@ extra73(){
       CHECK_BUCKET_ALLUSERS_POLICY=$(cat $TEMP_POLICY_FILE | sed -e 's/[{}]/''/g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}'|awk '/Principal/ && !skip { print } { skip = /Deny/} '|grep ^\"Principal|grep \*)
       if [[ $CHECK_BUCKET_ALLUSERS_ACL || $CHECK_BUCKET_AUTHUSERS_ACL || $CHECK_BUCKET_ALLUSERS_POLICY ]];then
         if [[ $CHECK_BUCKET_ALLUSERS_ACL ]];then
-          textFail "$BUCKET_LOCATION: $bucket bucket is open to the Internet (Everyone) with permissions: $CHECK_BUCKET_ALLUSERS_ACL_SINGLE_LINE" "$regx"
+          textFail "$BUCKET_LOCATION: $bucket bucket is open to the Internet (Everyone) with permissions: $CHECK_BUCKET_ALLUSERS_ACL_SINGLE_LINE" "$BUCKET_LOCATION"
         fi
         if [[ $CHECK_BUCKET_AUTHUSERS_ACL ]];then
-          textFail "$BUCKET_LOCATION: $bucket bucket is open to Authenticated users (Any AWS user) with permissions: $CHECK_BUCKET_AUTHUSERS_ACL_SINGLE_LINE" "$regx"
+          textFail "$BUCKET_LOCATION: $bucket bucket is open to Authenticated users (Any AWS user) with permissions: $CHECK_BUCKET_AUTHUSERS_ACL_SINGLE_LINE" "$BUCKET_LOCATION"
         fi
         if [[ $CHECK_BUCKET_ALLUSERS_POLICY ]];then
-          textFail "$BUCKET_LOCATION: $bucket bucket policy \"may\" allow Anonymous users to perform actions (Principal: \"*\")" "$regx"
+          textFail "$BUCKET_LOCATION: $bucket bucket policy \"may\" allow Anonymous users to perform actions (Principal: \"*\")" "$BUCKET_LOCATION"
         fi
       else
-        textPass "$BUCKET_LOCATION: $bucket bucket is not open" "$regx"
+        textPass "$BUCKET_LOCATION: $bucket bucket is not open" "$BUCKET_LOCATION"
       fi
       rm -fr $TEMP_POLICY_FILE
     fi
@@ -122,16 +122,16 @@ extra73(){
 #   CHECK_BUCKET_ALLUSERS_POLICY=$(cat $TEMP_POLICY_FILE | sed -e 's/[{}]/''/g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}'|awk '/Principal/ && !skip { print } { skip = /Deny/} '|grep ^\"Principal|grep \*)
 #   if [[ $CHECK_BUCKET_ALLUSERS_ACL || $CHECK_BUCKET_AUTHUSERS_ACL || $CHECK_BUCKET_ALLUSERS_POLICY ]];then
 #     if [[ $CHECK_BUCKET_ALLUSERS_ACL ]];then
-#       textWarn "$BUCKET_LOCATION: $bucket bucket is open to the Internet (Everyone) with permissions: $CHECK_BUCKET_ALLUSERS_ACL_SINGLE_LINE" "$regx"
+#       textWarn "$BUCKET_LOCATION: $bucket bucket is open to the Internet (Everyone) with permissions: $CHECK_BUCKET_ALLUSERS_ACL_SINGLE_LINE" "$BUCKET_LOCATION"
 #     fi
 #     if [[ $CHECK_BUCKET_AUTHUSERS_ACL ]];then
-#       textWarn "$BUCKET_LOCATION: $bucket bucket is open to Authenticated users (Any AWS user) with permissions: $CHECK_BUCKET_AUTHUSERS_ACL_SINGLE_LINE" "$regx"
+#       textWarn "$BUCKET_LOCATION: $bucket bucket is open to Authenticated users (Any AWS user) with permissions: $CHECK_BUCKET_AUTHUSERS_ACL_SINGLE_LINE" "$BUCKET_LOCATION"
 #     fi
 #     if [[ $CHECK_BUCKET_ALLUSERS_POLICY ]];then
-#       textWarn "$BUCKET_LOCATION: $bucket bucket policy \"may\" allow Anonymous users to perform actions (Principal: \"*\")" "$regx"
+#       textWarn "$BUCKET_LOCATION: $bucket bucket policy \"may\" allow Anonymous users to perform actions (Principal: \"*\")" "$BUCKET_LOCATION"
 #     fi
 #   else
-#     textOK "$BUCKET_LOCATION: $bucket bucket is not open" "$regx"
+#     textOK "$BUCKET_LOCATION: $bucket bucket is not open" "$BUCKET_LOCATION"
 #   fi
 #   rm -fr $TEMP_POLICY_FILE
 # }

--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -54,9 +54,8 @@ extra73(){
       BUCKET_LOCATION="eu-west-1"
     fi
     # Check Explicit Deny and Avoid Error
-    CHEK_FOR_EXPLICIT_DENY=$($AWSCLI s3api get-bucket-acl $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket 2> /dev/null)
-    CHEK_FOR_EXPLICIT_DENY="$?"
-    if [[ $CHEK_FOR_EXPLICIT_DENY -eq 255 ]]; then
+    CHEK_FOR_EXPLICIT_DENY=$($AWSCLI s3api get-bucket-acl $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --output text 2>&1)
+    if [[ $(echo "$CHEK_FOR_EXPLICIT_DENY" | grep AccessDenied) ]] ; then
       textPass "$BUCKET_LOCATION: bucket have an explicit Deny. Not possible to get ACL." "$BUCKET_LOCATION"
     else
       # check if AllUsers is in the ACL as Grantee


### PR DESCRIPTION
HI @toniblyx, for this check, i found some problems:

1. There are some cases where S3 buckets have explicit deny on it (so if not possible even to get bucket acl being Admin, the only way is being root). 
You can try this behaviour by adding to a bucket something like:

```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Deny",
      "Principal": "*",
      "Action": "s3:*",
      "Resource": [
        "arn:aws:s3:::buckettest",
        "arn:aws:s3:::buckettest/*"
      ],
      "Condition": {
        "ArnNotLike": {
          "aws:SourceArn": [
            "arn:aws:iam::ACCOUNTNUMBER:user/USERNAME",
            "arn:aws:sts::ACCOUNTNUMNER:assumed-role/ROLEASSUMED/*"
          ]
        }
      }
    }
  ]
}
```

In those cases checks will show:

`An error occurred (AccessDenied) when calling the GetBucketAcl operation: Access Denied`

So, i added a way to get that condition by catching status error code for get bucket acl command before executing the following checks and show a new message. For me this condition is Pass.

2. Second, I found you were using "$regx", when you should be using $BUCKET_LOCATION for location output. 