### PR TITLE
ignore None when user data is empty (gunzip: invalid magic)

### DIFF
--- a/checks/check_extra741
+++ b/checks/check_extra741
@@ -23,8 +23,9 @@ extra741(){
     if [[ $LIST_OF_EC2_INSTANCES ]];then
       for instance in $LIST_OF_EC2_INSTANCES; do
         USERDATA_FILE=$instance-userdata.decoded
-        USERDATA=$($AWSCLI ec2 describe-instance-attribute --attribute userData --query UserData.Value $PROFILE_OPT --region $regx --instance-id $instance --output text | decode_report > $USERDATA_FILE)
-        if [ -s $USERDATA_FILE ];then
+        USERDATA=$($AWSCLI ec2 describe-instance-attribute --attribute userData --query UserData.Value $PROFILE_OPT --region $regx --instance-id $instance --output text | grep -v None)
+        if [[ $USERDATA ]];then
+          echo "$USERDATA" | decode_report > $USERDATA_FILE
           FILE_FORMAT_ASCII=$(file -b $USERDATA_FILE|grep ASCII)
           #FINDINGS=$(grep '[A-Za-z0-9]\{20,40\}' $USERDATA_FILE | grep -i -e key -e secret -e token -e pass - |wc -l|tr -d '\ ')
           #FINDINGS=$(grep -i -e key -e secret -e token -e pass $USERDATA_FILE |wc -l|tr -d '\ ')

--- a/checks/check_extra741
+++ b/checks/check_extra741
@@ -22,34 +22,38 @@ extra741(){
     LIST_OF_EC2_INSTANCES=$($AWSCLI ec2 describe-instances $PROFILE_OPT --region $regx --query Reservations[*].Instances[*].InstanceId --output text --max-items $MAXITEMS | grep -v None)
     if [[ $LIST_OF_EC2_INSTANCES ]];then
       for instance in $LIST_OF_EC2_INSTANCES; do
-        USERDATA_FILE=$instance-userdata.decoded
-        USERDATA=$($AWSCLI ec2 describe-instance-attribute --attribute userData --query UserData.Value $PROFILE_OPT --region $regx --instance-id $instance --output text | grep -v None)
-        if [[ $USERDATA ]];then
+        USERDATA=$($AWSCLI ec2 describe-instance-attribute --attribute userData --query UserData.Value $PROFILE_OPT --region $regx --instance-id $instance --output text)
+        if [[ "$USERDATA" != "None" ]]; then
+          USERDATA_FILE=$instance-userdata.decoded
           echo "$USERDATA" | decode_report > $USERDATA_FILE
-          FILE_FORMAT_ASCII=$(file -b $USERDATA_FILE|grep ASCII)
-          #FINDINGS=$(grep '[A-Za-z0-9]\{20,40\}' $USERDATA_FILE | grep -i -e key -e secret -e token -e pass - |wc -l|tr -d '\ ')
-          #FINDINGS=$(grep -i -e key -e secret -e token -e pass $USERDATA_FILE |wc -l|tr -d '\ ')
-          # This finds ftp or http URLs with credentials and common keywords
-          FINDINGS=$(egrep -i '[[:alpha:]]*://[[:alnum:]]*:[[:alnum:]]*@.*/|key|secret|token|pass' $USERDATA_FILE |wc -l|tr -d '\ ')
-          if [[ $FILE_FORMAT_ASCII ]]; then
+          FILE_FORMAT=$(file -b $USERDATA_FILE)
+          if [[ $(echo "$FILE_FORMAT" | grep -i gzip) ]]; then
+            mv $USERDATA_FILE $USERDATA_FILE.gz ; gunzip $USERDATA_FILE.gz
+            #FINDINGS=$(grep '[A-Za-z0-9]\{20,40\}' $USERDATA_FILE | grep -i -e key -e secret -e token -e pass - |wc -l|tr -d '\ ')
+            #FINDINGS=$(grep -i -e key -e secret -e token -e pass $USERDATA_FILE |wc -l|tr -d '\ ')
+            # This finds ftp or http URLs with credentials and common keywords
+            FINDINGS=$(egrep -i '[[:alpha:]]*://[[:alnum:]]*:[[:alnum:]]*@.*/|secret|token|pass' $USERDATA_FILE |wc -l|tr -d '\ ')
+            if [[ $FINDINGS -eq 0 ]]; then
+              textPass "$regx: No keys found" "$instance" "$regx"
+              rm -f $USERDATA_FILE.gz
+            else
+                textFail "$regx: Found $FINDINGS keys! Check file $USERDATA_FILE" "$instance" "$regx"
+            fi
+          else
+            #FINDINGS=$(grep '[A-Za-z0-9]\{20,40\}' $USERDATA_FILE | grep -i -e key -e secret -e token -e pass - |wc -l|tr -d '\ ')
+            #FINDINGS=$(grep -i -e key -e secret -e token -e pass $USERDATA_FILE |wc -l|tr -d '\ ')
+            # This finds ftp or http URLs with credentials and common keywords
+            FINDINGS=$(egrep -i '[[:alpha:]]*://[[:alnum:]]*:[[:alnum:]]*@.*/|secret|token|pass' $USERDATA_FILE |wc -l|tr -d '\ ')
             if [[ $FINDINGS -eq "0" ]]; then
-              textPass "$regx: No keys found in $instance" "$regx"
+              textPass "$regx: No keys found" "$instance" "$regx"
               # delete file if nothing interesting is there
               rm -f $USERDATA_FILE
             else
-              textFail "$regx: Found $FINDINGS keys in $instance! Check file $USERDATA_FILE" "$regx"
-            fi
-          else
-            mv $USERDATA_FILE $USERDATA_FILE.gz ; gunzip $USERDATA_FILE.gz
-            if [[ $FINDINGS -eq 0 ]]; then
-              textPass "$regx: No keys found in $instance" "$regx"
-              rm -f $USERDATA_FILE.gz
-            else
-              textFail "$regx: Found $FINDINGS keys in $instance! Check file $USERDATA_FILE" "$regx"
+              textFail "$regx: Found $FINDINGS keys! Check file $USERDATA_FILE" "$instance" "$regx"
             fi
           fi
         else
-          textPass "$regx: $instance nothing found" "$regx"
+          textPass "$regx: Instance nothing found" "$instance" "$regx"
         fi
       done
     else


### PR DESCRIPTION
When user data is empty, output for `describe-instance-attribute --attribute userData --query UserData.Value` is "None".

If not excluding None from output, you get inconsistent data, ending in code trying to gunzip something because is not base64 encoded as ASCII:

`gunzip: invalid magic`



