### PR TITLE
adding regex for wildcard option in cloudtrail extra 720

### DIFF
--- a/checks/check_extra720
+++ b/checks/check_extra720
@@ -25,7 +25,7 @@ extra720(){
         LIST_OF_TRAILS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query trailList[?HomeRegion==\`$regx\`].Name --output text)
         if [[ $LIST_OF_TRAILS ]]; then
           for trail in $LIST_OF_TRAILS; do
-            FUNCTION_ENABLED_IN_TRAIL=$($AWSCLI cloudtrail get-event-selectors $PROFILE_OPT --trail-name $trail --region $regx --query "EventSelectors[*].DataResources[?Type == \`AWS::Lambda::Function\`].Values" --output text |xargs -n1| grep -E "^arn:aws:lambda.*function:$lambdafunction$")
+            FUNCTION_ENABLED_IN_TRAIL=$($AWSCLI cloudtrail get-event-selectors $PROFILE_OPT --trail-name $trail --region $regx --query "EventSelectors[*].DataResources[?Type == \`AWS::Lambda::Function\`].Values" --output text |xargs -n1| grep -E "^arn:aws:lambda.*function:$lambdafunction$|^arn:aws:lambda$")
             if [[ $FUNCTION_ENABLED_IN_TRAIL ]]; then
               textPass "$regx: Lambda function $lambdafunction enabled in trail $trail" "$regx"
             else


### PR DESCRIPTION
Cloudtrail supports an option to select all current and future lambdas. This is failing with the current test. Added an or on the regex to detect this case 