### PR TITLE
Ability to exclude check(s) from group run

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ This script has been written in bash using AWS-CLI and it works in Linux and OSX
     ```sh
     ./prowler -g group1 # for iam related checks
     ```
+    or exclude some checks in the group:
+    ```sh
+    ./prowler -g group4 -E check42,check43
+    ```
 
     Valid check numbers are based on the AWS CIS Benchmark guide, so 1.1 is check11 and 3.10 is check310
 

--- a/prowler
+++ b/prowler
@@ -243,13 +243,13 @@ execute_check() {
 execute_group() {
     show_group_title $1
     # run the checks in the group
-	IFS=',' read -ra CHECKS <<< ${GROUP_CHECKS[$1]}
+    IFS=',' read -ra CHECKS <<< ${GROUP_CHECKS[$1]}
 
-	# Exclude any checks specified
-	if [[ -n ${2} ]]; then
+    # Exclude any checks specified
+    if [[ -n ${2} ]]; then
         EXCLUDED_CHECKS=()
         NEW_CHECKS=()
-	    IFS=',' read -ra EXCLUDED_CHECKS <<< "${2},"
+        IFS=',' read -ra EXCLUDED_CHECKS <<< "${2},"
         for exc in ${EXCLUDED_CHECKS[@]} ; do
             for i in ${CHECKS[@]} ; do
                 [[ ${i} != ${exc} ]] && NEW_CHECKS+=(${i})
@@ -258,10 +258,10 @@ execute_group() {
         CHECKS=("${NEW_CHECKS[@]}")
         unset NEW_CHECKS
         unset EXCLUDED_CHECKS
-	fi
-	for i in ${CHECKS[@]}; do
+    fi
+    for i in ${CHECKS[@]}; do
         execute_check ${i}
-	done
+    done
 }
 
 # Function to execute group by name

--- a/prowler
+++ b/prowler
@@ -241,11 +241,26 @@ execute_check() {
 
 # Function to execute all checks in a group
 execute_group() {
-	show_group_title $1
-  # run the checks in the group
+    show_group_title $1
+    # run the checks in the group
 	IFS=',' read -ra CHECKS <<< ${GROUP_CHECKS[$1]}
+
+	# Exclude any checks specified
+	if [[ -n ${2} ]]; then
+        EXCLUDED_CHECKS=()
+        NEW_CHECKS=()
+	    IFS=',' read -ra EXCLUDED_CHECKS <<< "${2},"
+        for exc in ${EXCLUDED_CHECKS[@]} ; do
+            for i in ${CHECKS[@]} ; do
+                [[ ${i} != ${exc} ]] && NEW_CHECKS+=(${i})
+            done
+        done
+        CHECKS=("${NEW_CHECKS[@]}")
+        unset NEW_CHECKS
+        unset EXCLUDED_CHECKS
+	fi
 	for i in ${CHECKS[@]}; do
-    execute_check $i
+        execute_check ${i}
 	done
 }
 
@@ -257,7 +272,7 @@ execute_group_by_id() {
   fi
 	for i in "${!GROUP_ID[@]}"; do
 		if [ "${GROUP_ID[$i]}" == "$1" ]; then
-			execute_group $i
+			execute_group ${i} $2
 		fi
 	done
 }
@@ -350,14 +365,31 @@ fi
 # Gather account data / test aws cli connectivity
 getWhoami
 
+# Execute group of checks if called with -g
+if [[ $GROUP_ID_READ ]];then
+  if [[ " ${GROUP_ID[@]} " =~ " ${GROUP_ID_READ} " ]]; then
+    if [[ $MODE == "csv" ]]; then
+      BANNER=0
+    fi
+    execute_group_by_id ${GROUP_ID_READ} ${EXCLUDE_CHECK_ID}
+    cleanTemp
+    scoring
+    exit $EXITCODE
+  else
+    textFail "Use a valid check group ID i.e.: group1, extras, forensics-ready, etc."
+    show_all_group_titles
+    exit $EXITCODE
+  fi
+fi
+
 # Get a list of total checks excluding a list provided by the user and overwrite CHECK_ID with the result
 # if the list provided by the user contains an invalid check, this will be discarded.
 # if the list provided by the user contains  just one argument and is invalid, then it will be discarded and all tests will be executed
-if [[ $EXCLUDE_CHECK_ID ]];then
-  get_all_checks_without_exclusion $EXCLUDE_CHECK_ID
+if [[ ${EXCLUDE_CHECK_ID} ]];then
+  get_all_checks_without_exclusion ${EXCLUDE_CHECK_ID}
   function join { local IFS="$1"; shift; echo "$*"; }
   CHECKS_EXCLUDED=$(join , "${CHECKS_EXCLUDED[@]}")
-  CHECK_ID=$CHECKS_EXCLUDED
+  CHECK_ID=${CHECKS_EXCLUDED}
 fi
 
 # Execute single check if called with -c
@@ -370,22 +402,6 @@ if [[ $CHECK_ID ]];then
   exit $EXITCODE
 fi
 
-# Execute group of checks if called with -g
-if [[ $GROUP_ID_READ ]];then
-  if [[ " ${GROUP_ID[@]} " =~ " ${GROUP_ID_READ} " ]]; then
-    if [[ $MODE == "csv" ]]; then
-      BANNER=0
-    fi
-    execute_group_by_id $GROUP_ID_READ
-    cleanTemp
-    scoring
-    exit $EXITCODE
-  else
-    textFail "Use a valid check group ID i.e.: group1, extras, forensics-ready, etc."
-    show_all_group_titles
-    exit $EXITCODE
-  fi
-fi
 
 execute_all
 scoring


### PR DESCRIPTION
Fixes #351 whilst retaining the original functionality.

Tested with and without `-g`, with and without `-E`.