### PR TITLE
Allow check 1.20 to evaluate users, groups or roles

### DIFF
--- a/checks/check120
+++ b/checks/check120
@@ -19,10 +19,10 @@ check120(){
   SUPPORTPOLICYARN=$($AWSCLI iam list-policies --query "Policies[?PolicyName == 'AWSSupportAccess'].Arn" $PROFILE_OPT --region $REGION --output text)
   if [[ $SUPPORTPOLICYARN ]];then
     for policyarn in $SUPPORTPOLICYARN;do
-      POLICYROLES=$($AWSCLI iam list-entities-for-policy --policy-arn $SUPPORTPOLICYARN $PROFILE_OPT --region $REGION --query PolicyRoles[*] --output text)
+      POLICYROLES=$($AWSCLI iam list-entities-for-policy --policy-arn $SUPPORTPOLICYARN $PROFILE_OPT --region $REGION --output text | awk -F$'\t' '{ print $3 }')
       if [[ $POLICYROLES ]];then
-        for role in $POLICYROLES; do
-          textPass "Support Policy attached to $role role"
+        for name in $POLICYROLES; do
+          textPass "Support Policy attached to $name"
         done
         # for user in $(echo "$POLICYUSERS" | grep UserName | cut -d'"' -f4) ; do
         #   textInfo "User $user has support access via $policyarn"


### PR DESCRIPTION
In our setup, developers belong to a specific group so it makes sense to attach the `AWSSupportAccess` policy to this group. This fails the check as it is explicitly filtering by role.

In v1.2 of `CIS Amazon Web Services Foundations` pdf, it states:

```
Check if the 'AWSSupportAccess' is attached to any IAM user, group or role:

aws iam list-entities-for-policy --policy-arn <iam_policy_arn>
```

The command given in the pdf doesn't have this filter and explicitly mentions that it can also be attached to a user or group. This change removes the filter by role and ensures that just the name of the AWS entity is returned.