### PR TITLE
add extra761 EBS default encryption

### DIFF
--- a/checks/check_extra761
+++ b/checks/check_extra761
@@ -19,7 +19,7 @@ CHECK_ALTERNATE_check761="extra761"
 extra761(){
   textInfo "Looking for EBS Default Encryption activation in all regions...  "
   for regx in $REGIONS; do
-    EBS_DEFAULT_ENCRYPTION=$($AWSCLI ec2 get-ebs-encryption-by-default --query 'EbsEncryptionByDefault')
+    EBS_DEFAULT_ENCRYPTION=$($AWSCLI ec2 get-ebs-encryption-by-default $PROFILE_OPT --region $regx --query 'EbsEncryptionByDefault')
     if [[ $EBS_DEFAULT_ENCRYPTION == "true" ]];then
       textPass "$regx: EBS Default Encryption is activated" "$regx"
     else

--- a/checks/check_extra761
+++ b/checks/check_extra761
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Prowler - the handy cloud security tool (copyright 2019) by Toni de la Fuente
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+CHECK_ID_extra761="7.61"
+CHECK_TITLE_extra761="[extra761] Check if EBS Default Encryption is activated (Not Scored) (Not part of CIS benchmark)"
+CHECK_SCORED_extra761="NOT_SCORED"
+CHECK_TYPE_extra761="EXTRA"
+CHECK_ALTERNATE_check761="extra761"
+
+extra761(){
+  textInfo "Looking for EBS Default Encryption activation in all regions...  "
+  for regx in $REGIONS; do
+    EBS_DEFAULT_ENCRYPTION=$($AWSCLI ec2 get-ebs-encryption-by-default --query 'EbsEncryptionByDefault')
+    if [[ $EBS_DEFAULT_ENCRYPTION == "true" ]];then
+      textPass "$regx: EBS Default Encryption is activated" "$regx"
+    else
+      textFail "$regx: EBS Default Encryption is not activated" "$regx"
+    fi
+    done
+}

--- a/groups/group7_extras
+++ b/groups/group7_extras
@@ -15,7 +15,7 @@ GROUP_ID[7]='extras'
 GROUP_NUMBER[7]='7.0'
 GROUP_TITLE[7]='Extras - [extras] **********************************************'
 GROUP_RUN_BY_DEFAULT[7]='Y' # run it when execute_all is called
-GROUP_CHECKS[7]='extra71,extra72,extra73,extra74,extra75,extra76,extra77,extra78,extra79,extra710,extra711,extra712,extra713,extra714,extra715,extra716,extra717,extra718,extra719,extra720,extra721,extra722,extra723,extra724,extra725,extra726,extra727,extra728,extra729,extra730,extra731,extra732,extra733,extra734,extra735,extra736,extra737,extra738,extra739,extra740,extra741,extra742,extra743,extra744,extra745,extra746,extra747,extra748,extra749,extra750,extra751,extra752,extra753,extra754,extra755,extra756,extra757,extra758'
+GROUP_CHECKS[7]='extra71,extra72,extra73,extra74,extra75,extra76,extra77,extra78,extra79,extra710,extra711,extra712,extra713,extra714,extra715,extra716,extra717,extra718,extra719,extra720,extra721,extra722,extra723,extra724,extra725,extra726,extra727,extra728,extra729,extra730,extra731,extra732,extra733,extra734,extra735,extra736,extra737,extra738,extra739,extra740,extra741,extra742,extra743,extra744,extra745,extra746,extra747,extra748,extra749,extra750,extra751,extra752,extra753,extra754,extra755,extra756,extra757,extra758,extra761'
 
 # Extras 759 and 760 (lambda variables and code secrets finder are not included)
 # to run detect-secrets use `./prowler -g secrets`

--- a/groups/group9_gdpr
+++ b/groups/group9_gdpr
@@ -15,7 +15,7 @@ GROUP_ID[9]='gdpr'
 GROUP_NUMBER[9]='9.0'
 GROUP_TITLE[9]='GDPR Readiness - ONLY AS REFERENCE - [gdpr] ********************'
 GROUP_RUN_BY_DEFAULT[9]='N' # run it when execute_all is called
-GROUP_CHECKS[9]='extra718,extra725,extra727,check12,check113,check114,extra71,extra731,extra732,extra733,check25,check39,check21,check22,check23,check24,check26,check27,check35,extra726,extra714,extra715,extra717,extra719,extra720,extra721,extra722,check43,check25,extra714,extra729,extra734,extra735,extra736,extra738,extra740'
+GROUP_CHECKS[9]='extra718,extra725,extra727,check12,check113,check114,extra71,extra731,extra732,extra733,check25,check39,check21,check22,check23,check24,check26,check27,check35,extra726,extra714,extra715,extra717,extra719,extra720,extra721,extra722,check43,check25,extra714,extra729,extra734,extra735,extra736,extra738,extra740,extra761'
 
 # Resources:
 # https://d1.awsstatic.com/whitepapers/compliance/GDPR_Compliance_on_AWS.pdf


### PR DESCRIPTION
As it is now possible to create EBS volumes encrypted by default (https://aws.amazon.com/fr/blogs/aws/new-opt-in-to-default-encryption-for-new-ebs-volumes/), let's check if it is activated.