### PR TITLE
add check for unsupported lambda runtimes

### DIFF
--- a/checks/check_extra762
+++ b/checks/check_extra762
@@ -32,7 +32,7 @@ extra762(){
         runtime=$(echo "$lambdafunction" | cut -d'%' -f2)
         if echo "$lambdafunction" | grep -Eq $OBSOLETE  ; then
           # obselete runtime found
-          textFail "Obselete ${runtime} runtime found in Lambda funtion ${fname}" "$regx"
+          textFail "Obsolete ${runtime} runtime found in Lambda funtion ${fname}" "$regx"
         else
           textPass "Supported ${runtime} runtime found in Lambda function ${fname}" "$regx"
         fi

--- a/checks/check_extra762
+++ b/checks/check_extra762
@@ -25,7 +25,7 @@ extra762(){
   textInfo "Looking for deprecated runtimes used by Lambda functions across all regions... "
   textInfo "This check may take a while depending on the number of functions. "
   for regx in $REGIONS; do
-    LIST_OF_FUNCTIONS=$($AWSCLI lambda list-functions "$PROFILE_OPT" --region "$regx" --output text --query 'Functions[*].{R:Runtime,N:FunctionName}' | tr "\t" "%")
+    LIST_OF_FUNCTIONS=$($AWSCLI lambda list-functions $PROFILE_OPT --region $regx --output text --query 'Functions[*].{R:Runtime,N:FunctionName}' | tr "\t" "%")
     if [[ $LIST_OF_FUNCTIONS ]]; then
       for lambdafunction in $LIST_OF_FUNCTIONS;do
         fname=$(echo "$lambdafunction" | cut -d'%' -f1)

--- a/checks/check_extra762
+++ b/checks/check_extra762
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Prowler - the handy cloud security tool (copyright 2019) by Toni de la Fuente
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+CHECK_ID_extra762="7.62"
+CHECK_TITLE_extra762="[extra762] Find obsolete Lambda runtimes (Not Scored) (Not part of CIS benchmark)"
+CHECK_SCORED_extra762="NOT_SCORED"
+CHECK_TYPE_extra762="EXTRA"
+CHECK_ALTERNATE_check762="extra762"
+
+extra762(){
+
+  # regex to match OBSOLETE runtimes in string functionName%runtime
+  # https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html
+  OBSOLETE='%(nodejs4.3|nodejs4.3-edge|nodejs6.10|nodejs8.10|dotnetcore1.0|dotnetcore2.0)'
+
+  textInfo "Looking for deprecated runtimes used by Lambda functions across all regions... "
+  textInfo "This check may take a while depending on the number of functions. "
+  for regx in $REGIONS; do
+    LIST_OF_FUNCTIONS=$($AWSCLI lambda list-functions "$PROFILE_OPT" --region "$regx" --output text --query 'Functions[*].{R:Runtime,N:FunctionName}' | tr "\t" "%")
+    if [[ $LIST_OF_FUNCTIONS ]]; then
+      for lambdafunction in $LIST_OF_FUNCTIONS;do
+        fname=$(echo "$lambdafunction" | cut -d'%' -f1)
+        runtime=$(echo "$lambdafunction" | cut -d'%' -f2)
+        if echo "$lambdafunction" | grep -Eq $OBSOLETE  ; then
+          # obselete runtime found
+          textFail "Obselete ${runtime} runtime found in Lambda funtion ${fname}" "$regx"
+        else
+          textPass "Supported ${runtime} runtime found in Lambda function ${fname}" "$regx"
+        fi
+      done
+    else
+      textInfo "$regx: No Lambda functions found" "$regx"
+    fi
+  done
+}

--- a/checks/check_extra762
+++ b/checks/check_extra762
@@ -32,9 +32,9 @@ extra762(){
         runtime=$(echo "$lambdafunction" | cut -d'%' -f2)
         if echo "$lambdafunction" | grep -Eq $OBSOLETE  ; then
           # obselete runtime found
-          textFail "Obsolete ${runtime} runtime found in Lambda funtion ${fname}" "$regx"
+          textFail "$regx: Obsolete ${runtime} runtime found in Lambda funtion ${fname}" "$regx"
         else
-          textPass "Supported ${runtime} runtime found in Lambda function ${fname}" "$regx"
+          textPass "$regx: Supported ${runtime} runtime found in Lambda function ${fname}" "$regx"
         fi
       done
     else

--- a/groups/group7_extras
+++ b/groups/group7_extras
@@ -15,7 +15,7 @@ GROUP_ID[7]='extras'
 GROUP_NUMBER[7]='7.0'
 GROUP_TITLE[7]='Extras - [extras] **********************************************'
 GROUP_RUN_BY_DEFAULT[7]='Y' # run it when execute_all is called
-GROUP_CHECKS[7]='extra71,extra72,extra73,extra74,extra75,extra76,extra77,extra78,extra79,extra710,extra711,extra712,extra713,extra714,extra715,extra716,extra717,extra718,extra719,extra720,extra721,extra722,extra723,extra724,extra725,extra726,extra727,extra728,extra729,extra730,extra731,extra732,extra733,extra734,extra735,extra736,extra737,extra738,extra739,extra740,extra741,extra742,extra743,extra744,extra745,extra746,extra747,extra748,extra749,extra750,extra751,extra752,extra753,extra754,extra755,extra756,extra757,extra758,extra761'
+GROUP_CHECKS[7]='extra71,extra72,extra73,extra74,extra75,extra76,extra77,extra78,extra79,extra710,extra711,extra712,extra713,extra714,extra715,extra716,extra717,extra718,extra719,extra720,extra721,extra722,extra723,extra724,extra725,extra726,extra727,extra728,extra729,extra730,extra731,extra732,extra733,extra734,extra735,extra736,extra737,extra738,extra739,extra740,extra741,extra742,extra743,extra744,extra745,extra746,extra747,extra748,extra749,extra750,extra751,extra752,extra753,extra754,extra755,extra756,extra757,extra758,extra761,extra762'
 
 # Extras 759 and 760 (lambda variables and code secrets finder are not included)
 # to run detect-secrets use `./prowler -g secrets`


### PR DESCRIPTION
check lambda function runtimes for deprecated configurations based on the list published at https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html

Include in the "extras" check group.