### PR TITLE
Smarter extra73 (S3 Public Buckets)

### DIFF
--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -74,7 +74,7 @@ extra73(){
       BUCKET_PUBLIC_BLOCK_BLOCKPUBLICACLS=$($AWSCLI s3api get-public-access-block --bucket $bucket $PROFILE_OPT --region $BUCKET_LOCATION --output text --query PublicAccessBlockConfiguration.BlockPublicAcls 2>/dev/null)
       BUCKET_PUBLIC_BLOCK_RESTRICPUBLICBUCKET=$($AWSCLI s3api get-public-access-block --bucket $bucket $PROFILE_OPT --region $BUCKET_LOCATION --output text --query PublicAccessBlockConfiguration.RestrictPublicBuckets 2>/dev/null)
       if [[ $BUCKET_PUBLIC_BLOCK_IGNOREPUBLICACL == "True" ]] && [[ $BUCKET_PUBLIC_BLOCK_BLOCKPUBLICPOLICY == "True" ]] &&  [[ $BUCKET_PUBLIC_BLOCK_BLOCKPUBLICACLS == "True" ]] &&  [[ $BUCKET_PUBLIC_BLOCK_RESTRICPUBLICBUCKET == "True" ]]; then
-        textPass "$BUCKET_LOCATION: $bucket is public blocked (public-access-block)" "$BUCKET_LOCATION"
+        textPass "$BUCKET_LOCATION: $bucket bucket is public blocked (public-access-block)" "$BUCKET_LOCATION"
       else
         ## ACL
         # check if AllUsers is in the ACL as Grantee
@@ -95,10 +95,11 @@ extra73(){
             fi
           fi
           if [[ $BUCKET_PUBLIC_BLOCK_RESTRICPUBLICBUCKET != "True" ]] && [[ $BUCKET_POLICY_STATUS == "True" ]]; then
-            # Look Statement Allow, Principal * and No Condition
+            # Here comes the magic: Look Statement Allow, Principal * and No Condition
             BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION=$($AWSCLI s3api get-bucket-policy $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket \
               | jq '.Policy | fromjson' | jq '.Statement[] | select(.Effect=="Allow") | select(.Principal=="*" or .Principal.AWS=="*" or .Principal.CanonicalUser=="*") | select(has("Condition") | not)')
             if [[ $BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION ]]; then
+              # Let's do more magic and identify who can do what
               BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS=$($AWSCLI s3api get-bucket-policy $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket \
                 | jq '.Policy | fromjson' | jq '.Statement[] | select(.Effect=="Allow") | select(.Principal=="*" or .Principal.AWS=="*" or .Principal.CanonicalUser=="*") | select(has("Condition") | not)' | jq '"[Principal: " + (.Principal|tostring) + " Action: " + .Action + "]"' )
               S3_FINDING_POLICY="$bucket bucket policy allow perform actions: $BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS"

--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -88,10 +88,10 @@ extra73(){
         if [[ $CHECK_BUCKET_ALLUSERS_ACL || $CHECK_BUCKET_AUTHUSERS_ACL || $CHECK_BUCKET_ALLUSERS_POLICY == "True" ]]; then
           if [[ $CHECK_BUCKET_ALLUSERS_ACL || $CHECK_BUCKET_AUTHUSERS_ACL ]] && [[ $BUCKET_PUBLIC_BLOCK_IGNOREPUBLICACL != "True" ]];then
             if [[ $CHECK_BUCKET_ALLUSERS_ACL ]];then
-              S3_FINDING_ALLUSERS_ACL="$bucket bucket ACL is open to the Internet (Everyone) with permissions: $CHECK_BUCKET_ALLUSERS_ACL_SINGLE_LINE"
+              S3_FINDING_ALLUSERS_ACL="bucket ACL is open to the Internet (Everyone) with permissions: $CHECK_BUCKET_ALLUSERS_ACL_SINGLE_LINE"
             fi
             if [[ $CHECK_BUCKET_AUTHUSERS_ACL ]];then
-              S3_FINDING_AUTHUSERS_ACL="$bucket bucket ACL is open to Authenticated users (Any AWS user) with permissions: $CHECK_BUCKET_AUTHUSERS_ACL_SINGLE_LINE"
+              S3_FINDING_AUTHUSERS_ACL="bucket ACL is open to Authenticated users (Any AWS user) with permissions: $CHECK_BUCKET_AUTHUSERS_ACL_SINGLE_LINE"
             fi
           fi
           if [[ $BUCKET_PUBLIC_BLOCK_RESTRICPUBLICBUCKET != "True" ]] && [[ $BUCKET_POLICY_STATUS == "True" ]]; then
@@ -102,7 +102,7 @@ extra73(){
               # Let's do more magic and identify who can do what
               BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS=$($AWSCLI s3api get-bucket-policy $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket \
                 | jq '.Policy | fromjson' | jq '.Statement[] | select(.Effect=="Allow") | select(.Principal=="*" or .Principal.AWS=="*" or .Principal.CanonicalUser=="*") | select(has("Condition") | not)' | jq '"[Principal: " + (.Principal|tostring) + " Action: " + .Action + "]"' )
-              S3_FINDING_POLICY="$bucket bucket policy allow perform actions: $BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS"
+              S3_FINDING_POLICY="bucket policy allow perform actions: $BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS"
             else
               textPass "$BUCKET_LOCATION: $bucket bucket policy with conditions" "$BUCKET_LOCATION"
             fi
@@ -113,7 +113,7 @@ extra73(){
       fi
     fi
     if [[ $S3_FINDING_ALLUSERS_ACL != "Ok" ]] || [[ $S3_FINDING_AUTHUSERS_ACL != "Ok" ]] || [[ $S3_FINDING_POLICY != "Ok" ]] ; then
-        textFail "$BUCKET_LOCATION: ALLUSERS_ACL: $S3_FINDING_ALLUSERS_ACL | AUTHUSERS_ACL: $S3_FINDING_AUTHUSERS_ACL | BUCKET_POLICY: $S3_FINDING_POLICY" "$BUCKET_LOCATION"
+        textFail "$BUCKET_LOCATION: (bucket: $bucket) ALLUSERS_ACL: $S3_FINDING_ALLUSERS_ACL | AUTHUSERS_ACL: $S3_FINDING_AUTHUSERS_ACL | BUCKET_POLICY: $S3_FINDING_POLICY" "$BUCKET_LOCATION"
     fi
   done
 }

--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -69,11 +69,12 @@ extra73(){
     else
       # PUBLIC BLOCK
       # https://docs.aws.amazon.com/cli/latest/reference/s3api/get-public-access-block.html
-      BUCKET_PUBLIC_BLOCK_IGNOREPUBLICACL=$($AWSCLI s3api get-public-access-block --bucket $bucket $PROFILE_OPT --region $BUCKET_LOCATION --output text --query PublicAccessBlockConfiguration.IgnorePublicAcls 2>/dev/null)
-      BUCKET_PUBLIC_BLOCK_BLOCKPUBLICPOLICY=$($AWSCLI s3api get-public-access-block --bucket $bucket $PROFILE_OPT --region $BUCKET_LOCATION --output text --query PublicAccessBlockConfiguration.BlockPublicPolicy 2>/dev/null)
-      BUCKET_PUBLIC_BLOCK_BLOCKPUBLICACLS=$($AWSCLI s3api get-public-access-block --bucket $bucket $PROFILE_OPT --region $BUCKET_LOCATION --output text --query PublicAccessBlockConfiguration.BlockPublicAcls 2>/dev/null)
-      BUCKET_PUBLIC_BLOCK_RESTRICPUBLICBUCKET=$($AWSCLI s3api get-public-access-block --bucket $bucket $PROFILE_OPT --region $BUCKET_LOCATION --output text --query PublicAccessBlockConfiguration.RestrictPublicBuckets 2>/dev/null)
-      if [[ $BUCKET_PUBLIC_BLOCK_IGNOREPUBLICACL == "True" ]] && [[ $BUCKET_PUBLIC_BLOCK_BLOCKPUBLICPOLICY == "True" ]] &&  [[ $BUCKET_PUBLIC_BLOCK_BLOCKPUBLICACLS == "True" ]] &&  [[ $BUCKET_PUBLIC_BLOCK_RESTRICPUBLICBUCKET == "True" ]]; then
+      BUCKET_PUBLIC_BLOCK=$($AWSCLI s3api get-public-access-block --bucket $bucket $PROFILE_OPT --region $BUCKET_LOCATION 2>/dev/null)
+      BUCKET_PUBLIC_BLOCK_IGNOREPUBLICACL=$(echo $BUCKET_PUBLIC_BLOCK | jq .PublicAccessBlockConfiguration.BlockPublicAcls 2>/dev/null)
+      BUCKET_PUBLIC_BLOCK_BLOCKPUBLICPOLICY=$(echo $BUCKET_PUBLIC_BLOCK | jq  .PublicAccessBlockConfiguration.BlockPublicPolicy 2>/dev/null)
+      BUCKET_PUBLIC_BLOCK_BLOCKPUBLICACLS=$(echo $BUCKET_PUBLIC_BLOCK | jq  .PublicAccessBlockConfiguration.BlockPublicAcls 2>/dev/null)
+      BUCKET_PUBLIC_BLOCK_RESTRICPUBLICBUCKET=$(echo $BUCKET_PUBLIC_BLOCK | jq  .PublicAccessBlockConfiguration.RestrictPublicBuckets 2>/dev/null)
+      if [[ $BUCKET_PUBLIC_BLOCK_IGNOREPUBLICACL == "true" ]] && [[ $BUCKET_PUBLIC_BLOCK_BLOCKPUBLICPOLICY == "true" ]] &&  [[ $BUCKET_PUBLIC_BLOCK_BLOCKPUBLICACLS == "true" ]] &&  [[ $BUCKET_PUBLIC_BLOCK_RESTRICPUBLICBUCKET == "true" ]]; then
         textPass "$BUCKET_LOCATION: $bucket bucket is public blocked (public-access-block)" "$BUCKET_LOCATION"
       else
         ## ACL
@@ -86,7 +87,7 @@ extra73(){
         ## POLICY
         BUCKET_POLICY_STATUS=$($AWSCLI s3api get-bucket-policy-status $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --query PolicyStatus.IsPublic --output text 2>/dev/null)
         if [[ $CHECK_BUCKET_ALLUSERS_ACL || $CHECK_BUCKET_AUTHUSERS_ACL || $CHECK_BUCKET_ALLUSERS_POLICY == "True" ]]; then
-          if [[ $CHECK_BUCKET_ALLUSERS_ACL || $CHECK_BUCKET_AUTHUSERS_ACL ]] && [[ $BUCKET_PUBLIC_BLOCK_IGNOREPUBLICACL != "True" ]];then
+          if [[ $CHECK_BUCKET_ALLUSERS_ACL || $CHECK_BUCKET_AUTHUSERS_ACL ]] && [[ $BUCKET_PUBLIC_BLOCK_IGNOREPUBLICACL != "true" ]];then
             if [[ $CHECK_BUCKET_ALLUSERS_ACL ]];then
               S3_FINDING_ALLUSERS_ACL="bucket ACL is open to the Internet (Everyone) with permissions: $CHECK_BUCKET_ALLUSERS_ACL_SINGLE_LINE"
             fi
@@ -94,14 +95,14 @@ extra73(){
               S3_FINDING_AUTHUSERS_ACL="bucket ACL is open to Authenticated users (Any AWS user) with permissions: $CHECK_BUCKET_AUTHUSERS_ACL_SINGLE_LINE"
             fi
           fi
-          if [[ $BUCKET_PUBLIC_BLOCK_RESTRICPUBLICBUCKET != "True" ]] && [[ $BUCKET_POLICY_STATUS == "True" ]]; then
+          if [[ $BUCKET_PUBLIC_BLOCK_RESTRICPUBLICBUCKET != "true" ]] && [[ $BUCKET_POLICY_STATUS == "True" ]]; then
             # Here comes the magic: Find Statement Allow, Principal * and No Condition
             BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION=$($AWSCLI s3api get-bucket-policy $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket \
               | jq '.Policy | fromjson' | jq '.Statement[] | select(.Effect=="Allow") | select(.Principal=="*" or .Principal.AWS=="*" or .Principal.CanonicalUser=="*") | select(has("Condition") | not)')
             if [[ $BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION ]]; then
               # Let's do more magic and identify who can do what
-              BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS=$($AWSCLI s3api get-bucket-policy $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket \
-                | jq '.Policy | fromjson' | jq '.Statement[] | select(.Effect=="Allow") | select(.Principal=="*" or .Principal.AWS=="*" or .Principal.CanonicalUser=="*") | select(has("Condition") | not)' | jq '"[Principal: " + (.Principal|tostring) + " Action: " + (.Action|tostring) + "]"' )
+              BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS=$(echo $BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION \
+                | jq '"[Principal: " + (.Principal|tostring) + " Action: " + (.Action|tostring) + "]"' )
               S3_FINDING_POLICY="bucket policy allow perform actions: $BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS"
             else
               textPass "$BUCKET_LOCATION: $bucket bucket policy with conditions" "$BUCKET_LOCATION"

--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -95,7 +95,7 @@ extra73(){
             fi
           fi
           if [[ $BUCKET_PUBLIC_BLOCK_RESTRICPUBLICBUCKET != "True" ]] && [[ $BUCKET_POLICY_STATUS == "True" ]]; then
-            # Here comes the magic: Look Statement Allow, Principal * and No Condition
+            # Here comes the magic: Find Statement Allow, Principal * and No Condition
             BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION=$($AWSCLI s3api get-bucket-policy $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket \
               | jq '.Policy | fromjson' | jq '.Statement[] | select(.Effect=="Allow") | select(.Principal=="*" or .Principal.AWS=="*" or .Principal.CanonicalUser=="*") | select(has("Condition") | not)')
             if [[ $BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION ]]; then

--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -48,7 +48,7 @@ extra73(){
 
   for bucket in $ALL_BUCKETS_LIST; do
 
-    # 3 DIFFERENT POSSIBLE, Let's show only 1 finding all together
+    # 3 Different problems, let's show only 1 finding all together
     S3_FINDING_ALLUSERS_ACL="Ok"
     S3_FINDING_AUTHUSERS_ACL="Ok"
     S3_FINDING_POLICY="Ok"

--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -104,7 +104,7 @@ extra73(){
                 | jq '.Policy | fromjson' | jq '.Statement[] | select(.Effect=="Allow") | select(.Principal=="*" or .Principal.AWS=="*" or .Principal.CanonicalUser=="*") | select(has("Condition") | not)' | jq '"[Principal: " + (.Principal|tostring) + " Action: " + .Action + "]"' )
               S3_FINDING_POLICY="$bucket bucket policy allow perform actions: $BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS"
             else
-              textPass "$BUCKET_LOCATION: $bucket bucket policy with conditions: $CHECK_BUCKET_ALLUSERS_POLICY_CONDITIONS" "$BUCKET_LOCATION"
+              textPass "$BUCKET_LOCATION: $bucket bucket policy with conditions" "$BUCKET_LOCATION"
             fi
           fi
         else

--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -45,7 +45,15 @@ CHECK_ALTERNATE_check703="extra73"
 extra73(){
   textInfo "Looking for open S3 Buckets (ACLs and Policies) in all regions...  "
   ALL_BUCKETS_LIST=$($AWSCLI s3api list-buckets --query 'Buckets[*].{Name:Name}' $PROFILE_OPT --output text)
+
   for bucket in $ALL_BUCKETS_LIST; do
+
+    # 3 DIFFERENT POSSIBLE, Let's show only 1 finding all together
+    S3_FINDING_ALLUSERS_ACL="Ok"
+    S3_FINDING_AUTHUSERS_ACL="Ok"
+    S3_FINDING_POLICY="Ok"
+
+    # LOCATION
     BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location --bucket $bucket $PROFILE_OPT --output text)
     if [[ "None" == $BUCKET_LOCATION ]]; then
       BUCKET_LOCATION="us-east-1"
@@ -53,36 +61,58 @@ extra73(){
     if [[ "EU" == $BUCKET_LOCATION ]]; then
       BUCKET_LOCATION="eu-west-1"
     fi
-    # Check Explicit Deny and Avoid Error
+
+    # EXPLICIT DENY
     CHEK_FOR_EXPLICIT_DENY=$($AWSCLI s3api get-bucket-acl $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --output text 2>&1)
     if [[ $(echo "$CHEK_FOR_EXPLICIT_DENY" | grep AccessDenied) ]] ; then
-      textPass "$BUCKET_LOCATION: bucket have an explicit Deny. Not possible to get ACL." "$BUCKET_LOCATION"
+      textInfo "$BUCKET_LOCATION: $bucket have an explicit Deny. Not possible to get ACL." "$bucket" "$BUCKET_LOCATION"
     else
-      # check if AllUsers is in the ACL as Grantee
-      CHECK_BUCKET_ALLUSERS_ACL=$($AWSCLI s3api get-bucket-acl $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --query "Grants[?Grantee.URI == 'http://acs.amazonaws.com/groups/global/AllUsers']" --output text |grep -v GRANTEE)
-      CHECK_BUCKET_ALLUSERS_ACL_SINGLE_LINE=$(echo -ne $CHECK_BUCKET_ALLUSERS_ACL)
-      # check if AuthenticatedUsers is in the ACL as Grantee, they will have access with sigened URL only
-      CHECK_BUCKET_AUTHUSERS_ACL=$($AWSCLI s3api get-bucket-acl $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --query "Grants[?Grantee.URI == 'http://acs.amazonaws.com/groups/global/AuthenticatedUsers']" --output text |grep -v GRANTEE)
-      CHECK_BUCKET_AUTHUSERS_ACL_SINGLE_LINE=$(echo -ne $CHECK_BUCKET_AUTHUSERS_ACL)
-      # to prevent error NoSuchBucketPolicy first clean the output controlling stderr
-      TEMP_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-${bucket}.policy.XXXXXXXXXX)
-      $AWSCLI s3api get-bucket-policy $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --output text --query Policy > $TEMP_POLICY_FILE 2> /dev/null
-      # check if the S3 policy has Principal as *
-      CHECK_BUCKET_ALLUSERS_POLICY=$(cat $TEMP_POLICY_FILE | sed -e 's/[{}]/''/g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}'|awk '/Principal/ && !skip { print } { skip = /Deny/} '|grep ^\"Principal|grep \*)
-      if [[ $CHECK_BUCKET_ALLUSERS_ACL || $CHECK_BUCKET_AUTHUSERS_ACL || $CHECK_BUCKET_ALLUSERS_POLICY ]];then
-        if [[ $CHECK_BUCKET_ALLUSERS_ACL ]];then
-          textFail "$BUCKET_LOCATION: $bucket bucket is open to the Internet (Everyone) with permissions: $CHECK_BUCKET_ALLUSERS_ACL_SINGLE_LINE" "$BUCKET_LOCATION"
-        fi
-        if [[ $CHECK_BUCKET_AUTHUSERS_ACL ]];then
-          textFail "$BUCKET_LOCATION: $bucket bucket is open to Authenticated users (Any AWS user) with permissions: $CHECK_BUCKET_AUTHUSERS_ACL_SINGLE_LINE" "$BUCKET_LOCATION"
-        fi
-        if [[ $CHECK_BUCKET_ALLUSERS_POLICY ]];then
-          textFail "$BUCKET_LOCATION: $bucket bucket policy \"may\" allow Anonymous users to perform actions (Principal: \"*\")" "$BUCKET_LOCATION"
-        fi
+      # PUBLIC BLOCK
+      # https://docs.aws.amazon.com/cli/latest/reference/s3api/get-public-access-block.html
+      BUCKET_PUBLIC_BLOCK_IGNOREPUBLICACL=$($AWSCLI s3api get-public-access-block --bucket $bucket $PROFILE_OPT --region $BUCKET_LOCATION --output text --query PublicAccessBlockConfiguration.IgnorePublicAcls 2>/dev/null)
+      BUCKET_PUBLIC_BLOCK_BLOCKPUBLICPOLICY=$($AWSCLI s3api get-public-access-block --bucket $bucket $PROFILE_OPT --region $BUCKET_LOCATION --output text --query PublicAccessBlockConfiguration.BlockPublicPolicy 2>/dev/null)
+      BUCKET_PUBLIC_BLOCK_BLOCKPUBLICACLS=$($AWSCLI s3api get-public-access-block --bucket $bucket $PROFILE_OPT --region $BUCKET_LOCATION --output text --query PublicAccessBlockConfiguration.BlockPublicAcls 2>/dev/null)
+      BUCKET_PUBLIC_BLOCK_RESTRICPUBLICBUCKET=$($AWSCLI s3api get-public-access-block --bucket $bucket $PROFILE_OPT --region $BUCKET_LOCATION --output text --query PublicAccessBlockConfiguration.RestrictPublicBuckets 2>/dev/null)
+      if [[ $BUCKET_PUBLIC_BLOCK_IGNOREPUBLICACL == "True" ]] && [[ $BUCKET_PUBLIC_BLOCK_BLOCKPUBLICPOLICY == "True" ]] &&  [[ $BUCKET_PUBLIC_BLOCK_BLOCKPUBLICACLS == "True" ]] &&  [[ $BUCKET_PUBLIC_BLOCK_RESTRICPUBLICBUCKET == "True" ]]; then
+        textPass "$BUCKET_LOCATION: $bucket is public blocked (public-access-block)" "$BUCKET_LOCATION"
       else
-        textPass "$BUCKET_LOCATION: $bucket bucket is not open" "$BUCKET_LOCATION"
+        ## ACL
+        # check if AllUsers is in the ACL as Grantee
+        CHECK_BUCKET_ALLUSERS_ACL=$($AWSCLI s3api get-bucket-acl $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --query "Grants[?Grantee.URI == 'http://acs.amazonaws.com/groups/global/AllUsers']" --output text |grep -v GRANTEE)
+        CHECK_BUCKET_ALLUSERS_ACL_SINGLE_LINE=$(echo -ne $CHECK_BUCKET_ALLUSERS_ACL)
+        # check if AuthenticatedUsers is in the ACL as Grantee, they will have access with sigened URL only
+        CHECK_BUCKET_AUTHUSERS_ACL=$($AWSCLI s3api get-bucket-acl $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --query "Grants[?Grantee.URI == 'http://acs.amazonaws.com/groups/global/AuthenticatedUsers']" --output text |grep -v GRANTEE)
+        CHECK_BUCKET_AUTHUSERS_ACL_SINGLE_LINE=$(echo -ne $CHECK_BUCKET_AUTHUSERS_ACL)
+        ## POLICY
+        BUCKET_POLICY_STATUS=$($AWSCLI s3api get-bucket-policy-status $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --query PolicyStatus.IsPublic --output text 2>/dev/null)
+        if [[ $CHECK_BUCKET_ALLUSERS_ACL || $CHECK_BUCKET_AUTHUSERS_ACL || $CHECK_BUCKET_ALLUSERS_POLICY == "True" ]]; then
+          if [[ $CHECK_BUCKET_ALLUSERS_ACL || $CHECK_BUCKET_AUTHUSERS_ACL ]] && [[ $BUCKET_PUBLIC_BLOCK_IGNOREPUBLICACL != "True" ]];then
+            if [[ $CHECK_BUCKET_ALLUSERS_ACL ]];then
+              S3_FINDING_ALLUSERS_ACL="$bucket bucket ACL is open to the Internet (Everyone) with permissions: $CHECK_BUCKET_ALLUSERS_ACL_SINGLE_LINE"
+            fi
+            if [[ $CHECK_BUCKET_AUTHUSERS_ACL ]];then
+              S3_FINDING_AUTHUSERS_ACL="$bucket bucket ACL is open to Authenticated users (Any AWS user) with permissions: $CHECK_BUCKET_AUTHUSERS_ACL_SINGLE_LINE"
+            fi
+          fi
+          if [[ $BUCKET_PUBLIC_BLOCK_RESTRICPUBLICBUCKET != "True" ]] && [[ $BUCKET_POLICY_STATUS == "True" ]]; then
+            # Look Statement Allow, Principal * and No Condition
+            BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION=$($AWSCLI s3api get-bucket-policy $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket \
+              | jq '.Policy | fromjson' | jq '.Statement[] | select(.Effect=="Allow") | select(.Principal=="*" or .Principal.AWS=="*" or .Principal.CanonicalUser=="*") | select(has("Condition") | not)')
+            if [[ $BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION ]]; then
+              BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS=$($AWSCLI s3api get-bucket-policy $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket \
+                | jq '.Policy | fromjson' | jq '.Statement[] | select(.Effect=="Allow") | select(.Principal=="*" or .Principal.AWS=="*" or .Principal.CanonicalUser=="*") | select(has("Condition") | not)' | jq '"[Principal: " + (.Principal|tostring) + " Action: " + .Action + "]"' )
+              S3_FINDING_POLICY="$bucket bucket policy allow perform actions: $BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS"
+            else
+              textPass "$BUCKET_LOCATION: $bucket bucket policy with conditions: $CHECK_BUCKET_ALLUSERS_POLICY_CONDITIONS" "$BUCKET_LOCATION"
+            fi
+          fi
+        else
+          textPass "$BUCKET_LOCATION: $bucket bucket is not open" "$bucket" "$BUCKET_LOCATION"
+        fi
       fi
-      rm -fr $TEMP_POLICY_FILE
+    fi
+    if [[ $S3_FINDING_ALLUSERS_ACL != "Ok" ]] || [[ $S3_FINDING_AUTHUSERS_ACL != "Ok" ]] || [[ $S3_FINDING_POLICY != "Ok" ]] ; then
+        textFail "$BUCKET_LOCATION: ALLUSERS_ACL: $S3_FINDING_ALLUSERS_ACL | AUTHUSERS_ACL: $S3_FINDING_AUTHUSERS_ACL | BUCKET_POLICY: $S3_FINDING_POLICY" "$BUCKET_LOCATION"
     fi
   done
 }

--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -101,7 +101,7 @@ extra73(){
             if [[ $BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION ]]; then
               # Let's do more magic and identify who can do what
               BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS=$($AWSCLI s3api get-bucket-policy $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket \
-                | jq '.Policy | fromjson' | jq '.Statement[] | select(.Effect=="Allow") | select(.Principal=="*" or .Principal.AWS=="*" or .Principal.CanonicalUser=="*") | select(has("Condition") | not)' | jq '"[Principal: " + (.Principal|tostring) + " Action: " + .Action + "]"' )
+                | jq '.Policy | fromjson' | jq '.Statement[] | select(.Effect=="Allow") | select(.Principal=="*" or .Principal.AWS=="*" or .Principal.CanonicalUser=="*") | select(has("Condition") | not)' | jq '"[Principal: " + (.Principal|tostring) + " Action: " + (.Action|tostring) + "]"' )
               S3_FINDING_POLICY="bucket policy allow perform actions: $BUCKET_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS"
             else
               textPass "$BUCKET_LOCATION: $bucket bucket policy with conditions" "$BUCKET_LOCATION"


### PR DESCRIPTION
I completely rethought this check, we were missing a lot of possible variables combinations. 

Improvements:
- Now check it's able to identify public-access-block configuration (ALL or by ACL and Policy). See https://docs.aws.amazon.com/cli/latest/reference/s3api/get-public-access-block.html
- Before checking Bucket Policy, let's first use `get-bucket-policy-status`
- Completely replaced awk search for *, with jq, now is more powerful, and we can analyze each statement individually
- Now we can identify conditions by statement
- Fail now is one by bucket, could be a combination of fails or just one, but it will show only one fail line, so only one count for metrics (before we were counting more than one fail by bucket if the case)
- Output with exact details of what we found

What do u think @toniblyx ?