### PR TITLE
Update extra764 and extra734, add .gitignore rules for vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~

--- a/checks/check_extra734
+++ b/checks/check_extra734
@@ -21,14 +21,21 @@ extra734(){
   if [[ $LIST_OF_BUCKETS ]]; then
     for bucket in $LIST_OF_BUCKETS;do
 
+      # For this test to pass one of the following must be present:
+      # - Configure ServerSideEncryptionConfiguration rule for AES256 or aws:kms
+      #  OR
+      # - Have bucket policy denying s3:PutObject when s3:x-amz-server-side-encryption is absent
+
       # query to get if has encryption enabled or not
       RESULT=$($AWSCLI s3api get-bucket-encryption $PROFILE_OPT --bucket $bucket --query ServerSideEncryptionConfiguration.Rules[].ApplyServerSideEncryptionByDefault[].SSEAlgorithm --output text 2>&1)
       if [[ $(echo "$RESULT" | grep AccessDenied) ]]; then
         textFail "Access Denied Trying to Get Encryption for $bucket"
         continue
       fi
-      if [[ $(echo "$RESULT" | grep ServerSideEncryptionConfigurationNotFoundError) ]]; then
-        textFail "Bucket $bucket does not enforce encryption!"
+
+      if [[ $RESULT == "AES256" || $RESULT == "aws:kms" ]];
+      then
+        textPass "Bucket $bucket is enabled for default encryption with $RESULT"
         continue
       fi
 
@@ -48,7 +55,7 @@ extra734(){
       fi
 
       # check if the S3 policy forces SSE s3:x-amz-server-side-encryption:true
-      CHECK_BUCKET_SSE_POLICY_PRESENT=$(cat $TEMP_SSE_POLICY_FILE | jq --arg arn "arn:aws:s3:::${bucket}/*" '.Statement[]|select(.Effect=="Deny" and (.Principal|type == "object") and .Principal.AWS == "*" and .Action=="s3:PutObject" and .Resource==$arn and .Condition.StringNotEquals."s3:x-amz-server-side-encryption" != null)')
+      CHECK_BUCKET_SSE_POLICY_PRESENT=$(cat $TEMP_SSE_POLICY_FILE | jq --arg arn "arn:aws:s3:::${bucket}/*" '.Statement[]|select(.Effect=="Deny" and ((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*") and .Action=="s3:PutObject" and .Resource==$arn and .Condition.StringEquals."s3:x-amz-server-side-encryption" != null)')
       if [[ $CHECK_BUCKET_SSE_POLICY_PRESENT == "" ]]; then
         textFail "Bucket $bucket does not enforce encryption!"
         rm -fr $TEMP_SSE_POLICY_FILE

--- a/checks/check_extra764
+++ b/checks/check_extra764
@@ -33,8 +33,8 @@ extra764(){
         continue
       fi
 
-      # check if the S3 policy denies all actions by all principals when aws:SecureTransport:false
-      CHECK_BUCKET_STP_POLICY_PRESENT=$(cat $TEMP_STP_POLICY_FILE | jq --arg arn "arn:aws:s3:::${bucket}/*" '.Statement[]|select(.Effect=="Deny" and (.Principal|type == "object") and .Principal.AWS == "*" and .Action=="s3:*" and .Resource==$arn and .Condition.Bool."aws:SecureTransport" == "false")')
+      # https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-policy-for-config-rule/
+      CHECK_BUCKET_STP_POLICY_PRESENT=$(cat $TEMP_STP_POLICY_FILE | jq --arg arn "arn:aws:s3:::${bucket}/*" '.Statement[]|select(((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and .Action=="s3:*" and (.Resource|type == "array") and (.Resource|map({(.):0})[]|has($arn)) and (.Resource|map({(.):0})[]|has($arn+"/*")) and .Condition.Bool."aws:SecureTransport" == "false")')
       if [[ $CHECK_BUCKET_STP_POLICY_PRESENT ]]; then
         textPass "Bucket $bucket has S3 bucket policy to deny requests over insecure transport"
       else


### PR DESCRIPTION
Extra734 - verified with AWS support that S3 server side encryption requires only the ServerSideEncryptionConfiguration rule OR the IAM policy rule but not both.  Changed check to match.  Avoids call to get-bucket-policy if ServerSideEncryptionConfiguration is set.

Extra764 - found reference to the secure transport policy which AWS Config looks for in default s3-bucket-ssl-requests-only rule and updated the jq call to look for the same signature. Provided link to AWS resource in comments in case someone is wondering why the check is written the way it is.

.gitignore - added vim rules from https://github.com/github/gitignore/blob/master/Global/Vim.gitignore 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
