### PR TITLE
Add "access-analyzer:ListTagsForResource" to prowler-additions-policy…

### DIFF
--- a/iam/prowler-additions-policy.json
+++ b/iam/prowler-additions-policy.json
@@ -3,7 +3,7 @@
   "Statement": [
       {
           "Action": [
-              "access-analyzer:ListTagsForResource",
+              "access-analyzer:List*",
               "apigateway:get*",
               "apigatewayv2:get*",
               "aws-marketplace:viewsubscriptions",

--- a/iam/prowler-additions-policy.json
+++ b/iam/prowler-additions-policy.json
@@ -3,6 +3,7 @@
   "Statement": [
       {
           "Action": [
+              "access-analyzer:ListTagsForResource",
               "apigateway:get*",
               "apigatewayv2:get*",
               "aws-marketplace:viewsubscriptions",


### PR DESCRIPTION
….json

check extra769 (Check if IAM Access Analyzer is enabled and its findings) requires this IAM permission

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
