### PR TITLE
UPDATE README.md - fix incorrect group flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ This script has been written in bash using AWS-CLI and it works in Linux and OSX
     ./prowler -M mono | aws s3 cp - s3://bucket-name/prowler-report.txt
     ```
 
-1. To perform an assessment based on CIS Profile Definitions you can use cislevel1 or cislevel2 with `-c` flag, more information about this [here, page 8](https://d0.awsstatic.com/whitepapers/compliance/AWS_CIS_Foundations_Benchmark.pdf):
+1. To perform an assessment based on CIS Profile Definitions you can use cislevel1 or cislevel2 with `-g` flag, more information about this [here, page 8](https://d0.awsstatic.com/whitepapers/compliance/AWS_CIS_Foundations_Benchmark.pdf):
 
     ```sh
     ./prowler -g cislevel1


### PR DESCRIPTION
To run prowler with the cislevelx group you use '-g', not '-c'

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
