### PR TITLE
Added check_extra770, which checks for internet facing instances with an instance profile attached

### DIFF
--- a/checks/check_extra770
+++ b/checks/check_extra770
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Prowler - the handy cloud security tool (copyright 2018) by Toni de la Fuente
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+CHECK_ID_extra770="7.70"
+CHECK_TITLE_extra770="[extra770] Check for internet facing EC2 instances with Instance Profiles attached (Not Scored) (Not part of CIS benchmark)"
+CHECK_SCORED_extra770="NOT_SCORED"
+CHECK_TYPE_extra770="EXTRA"
+CHECK_ALTERNATE_check770="extra770"
+
+extra770(){
+  # "Check for internet facing EC2 Instances (Not Scored) (Not part of CIS benchmark)"
+  textInfo "Looking for instances in all regions...  "
+  for regx in $REGIONS; do
+    LIST_OF_PUBLIC_INSTANCES_WITH_INSTANCE_PROFILES=$($AWSCLI ec2 describe-instances $PROFILE_OPT --region $regx --query 'Reservations[*].Instances[?((IamInstanceProfile!=`null` && PublicIpAddress!=`null`))].[InstanceId,PublicIpAddress,IamInstanceProfile.Arn]' --output text)
+    if [[ $LIST_OF_PUBLIC_INSTANCES_WITH_INSTANCE_PROFILES ]];then
+      while read -r instance;do
+        INSTANCE_ID=$(echo $instance | awk '{ print $1; }')
+        PUBLIC_IP=$(echo $instance | awk '{ print $2; }')
+        INSTANCE_PROFILE=$(echo $instance | awk '{ print $3; }')
+        textFail "$regx: Instance: $INSTANCE_ID at IP: $PUBLIC_IP is internet-facing with Instance Profile $INSTANCE_PROFILE" "$regx"
+      done <<< "$LIST_OF_PUBLIC_INSTANCES_WITH_INSTANCE_PROFILES"
+      else
+        textPass "$regx: no Internet Facing EC2 Instances with Instance Profiles found" "$regx"
+    fi
+  done
+}


### PR DESCRIPTION
@toniblyx - this is what we discussed.

The purpose of this check is to identify public-facing instances that have instance profiles attached. While the presence of an instance profile on a public facing instance is not inherently a security issue, it is definitely worth discovering and triaging, given the higher impact that could come with compromise. For reference, the Capital One situation - a public facing EC2 instance with `s3:*`.

Note: We don't evaluate the actual contents of the policies attached to those instance profiles, as that kind of analysis becomes very robust to the point where it has its own subcategory of tools (see [Parliament](https://github.com/duo-labs/parliament) and [Policy Sentry](https://policy-sentry.readthedocs.io/en/latest/)).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
