### PR TITLE
Fix check26 - get the account ID from sts

### DIFF
--- a/checks/check26
+++ b/checks/check26
@@ -18,7 +18,6 @@ check26(){
   # "Ensure S3 bucket access logging is enabled on the CloudTrail S3 bucket (Scored)"
 
   CLOUDTRAILS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region "$REGION" --query 'trailList[*].Name' --output text| tr '\011' '\012' | awk -F: '{print $1}')
-  ACCOUNT_ID=$($AWSCLI sts get-caller-identity --output json $PROFILE_OPT --region $REGION --query "Account" | tr -d '"')
 
   if [[ $CLOUDTRAILS ]];then
     for trail in $CLOUDTRAILS; do
@@ -27,7 +26,7 @@ check26(){
 
       if [[ $CLOUDTRAILBUCKET ]];then
         bucket=$CLOUDTRAILBUCKET
-        if [ "$CLOUDTRAIL_ACCOUNT_ID" == "$ACCOUNT_ID" ];then
+        if [ "$CLOUDTRAIL_ACCOUNT_ID" == "$ACCOUNT_NUM" ];then
           CLOUDTRAILBUCKET_LOGENABLED=$($AWSCLI s3api get-bucket-logging --bucket $bucket $PROFILE_OPT --region $REGION --query 'LoggingEnabled.TargetBucket' --output text|grep -v None)
           if [[ $CLOUDTRAILBUCKET_LOGENABLED ]];then
             textPass "Bucket access logging enabled in CloudTrail S3 bucket $bucket for $trail"

--- a/checks/check26
+++ b/checks/check26
@@ -18,10 +18,10 @@ check26(){
   # "Ensure S3 bucket access logging is enabled on the CloudTrail S3 bucket (Scored)"
 
   CLOUDTRAILS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region "$REGION" --query 'trailList[*].Name' --output text| tr '\011' '\012' | awk -F: '{print $1}')
+  ACCOUNT_ID=$($AWSCLI sts get-caller-identity --output json $PROFILE_OPT --region $REGION --query "Account" | tr -d '"')
 
   if [[ $CLOUDTRAILS ]];then
     for trail in $CLOUDTRAILS; do
-      CLOUDTRAIL_LOGGROUP_REGION=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region "$REGION" --query 'trailList[*].TrailARN' --output text | tr '\011' '\012' | grep "$trail" | awk -F: '{ print $4 }'  | head -n 1)
       CLOUDTRAIL_ACCOUNT_ID=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region "$REGION" --query 'trailList[*].TrailARN' --output text | tr '\011' '\012' | grep "$trail" | awk -F: '{ print $5 }'  | head -n 1)
       CLOUDTRAILBUCKET=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].[Name, S3BucketName]' --output text  | tr '\011' ':' |  grep "$trail" | awk -F: '{ print $2 }' )
 
@@ -29,12 +29,12 @@ check26(){
         bucket=$CLOUDTRAILBUCKET
         if [ "$CLOUDTRAIL_ACCOUNT_ID" == "$ACCOUNT_ID" ];then
           CLOUDTRAILBUCKET_LOGENABLED=$($AWSCLI s3api get-bucket-logging --bucket $bucket $PROFILE_OPT --region $REGION --query 'LoggingEnabled.TargetBucket' --output text|grep -v None)
-        fi 
-        if [[ $CLOUDTRAILBUCKET_LOGENABLED ]];then
-          textPass "Bucket access logging enabled in CloudTrail S3 bucket $bucket for $trail"
-        elif [ "$CLOUDTRAIL_ACCOUNT_ID" == "$ACCOUNT_ID" ];then
-          textFail "Bucket access logging is not enabled in CloudTrail S3 bucket $bucket for $trail"
-        else 
+          if [[ $CLOUDTRAILBUCKET_LOGENABLED ]];then
+            textPass "Bucket access logging enabled in CloudTrail S3 bucket $bucket for $trail"
+          else
+            textFail "Bucket access logging is not enabled in CloudTrail S3 bucket $bucket for $trail"
+          fi
+        else
           textInfo "CloudTrail S3 bucket $bucket for trail $trail is not in current account"
         fi
         


### PR DESCRIPTION
Related to https://github.com/toniblyx/prowler/issues/434

Added a step which gets the current account ID from STS, to compare with the trail's account ID.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
