### PR TITLE
Small check fixes to extra716 & extra731

### DIFF
--- a/checks/check_extra716
+++ b/checks/check_extra716
@@ -37,8 +37,9 @@ extra716(){
           textPass "$regx: $domain is in a VPC" "$regx"
         fi
       done
+    else
+      textInfo "$regx: No Elasticsearch Service domain found" "$regx"
     fi
-    textInfo "$regx: No Elasticsearch Service domain found" "$regx"
     rm -fr $TEMP_POLICY_FILE
   done
 }

--- a/checks/check_extra731
+++ b/checks/check_extra731
@@ -32,9 +32,9 @@ extra731(){
           if [[ $SNS_POLICY_ALLOW_ALL_WITHOUT_CONDITION ]]; then
             SNS_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS=$(echo $SNS_POLICY_ALLOW_ALL_WITHOUT_CONDITION \
               | jq '"[Principal: " + (.Principal|tostring) + " Action: " + (.Action|tostring) + "]"' )
-            textFail "$regx: SNS topic policy with public access: $SNS_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS" "$SHORT_TOPIC" "$regx"
+            textFail "$regx: SNS topic $SHORT_TOPIC's policy with public access: $SNS_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS" "$SHORT_TOPIC" "$regx"
           else
-            textPass "$regx: SNS topic policy with public access but has a Condition" "$SHORT_TOPIC" "$regx"
+            textPass "$regx: SNS topic $SHORT_TOPIC's policy with public access but has a Condition" "$SHORT_TOPIC" "$regx"
           fi
         else
           textPass "$regx: SNS topic without public access" "$SHORT_TOPIC" "$regx"


### PR DESCRIPTION
When running these checks, I noticed:
1. extra716 outputs `No Elasticsearch Service domain found` even if the scan found ES domains.
2. extra731 did not print out the name of the topic that has the bad policy.

This fixes these prints :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
