### PR TITLE
Add quiet mode that only logs failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ This script has been written in bash using AWS-CLI and it works in Linux and OSX
         -b                  do not print Prowler banner
         -V                  show version number & exit
         -s                  show scoring report
+        -q                  suppress info messages and passing test output
         -h                  this help
     ```
 

--- a/include/outputs
+++ b/include/outputs
@@ -13,6 +13,10 @@
 
 # Output formatting functions
 textPass(){
+  if [[ "$QUIET" == 1 ]]; then
+    return
+  fi
+
   PASS_COUNTER=$((PASS_COUNTER+1))
   if [[ "$MODE" == "csv" ]]; then
     if [[ $2 ]]; then
@@ -55,6 +59,10 @@ textPass(){
 }
 
 textInfo(){
+  if [[ "$QUIET" == 1 ]]; then
+    return
+  fi
+
   if [[ "$MODE" == "csv" ]]; then
     if [[ $2 ]]; then
       REPREGION=$2

--- a/prowler
+++ b/prowler
@@ -40,6 +40,7 @@ FILTERREGION=""
 MAXITEMS=100
 MONOCHROME=0
 MODE="text"
+QUIET=0
 SEP=','
 KEEPCREDREPORT=0
 EXITCODE=0
@@ -75,12 +76,13 @@ USAGE:
       -V                  show version number & exit
       -s                  show scoring report
       -x                  specify external directory with custom checks (i.e. /my/own/checks, files must start by "check")
+      -q                  suppress info messages and passing test output
       -h                  this help
   "
   exit
 }
 
-while getopts ":hlLkp:r:c:g:f:m:M:E:enbVsx:" OPTION; do
+while getopts ":hlLkqp:r:c:g:f:m:M:E:enbVsx:" OPTION; do
    case $OPTION in
      h )
         usage
@@ -139,6 +141,9 @@ while getopts ":hlLkp:r:c:g:f:m:M:E:enbVsx:" OPTION; do
         ;;
      x )
         EXTERNAL_CHECKS_PATH=$OPTARG
+        ;;
+     q )
+        QUIET=1
         ;;
      : )
         echo ""


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Quiet mode turns off output for textPass and textInfo