### PR TITLE
Add error checking to checks extra77 and extra765

### DIFF
--- a/checks/check_extra765
+++ b/checks/check_extra765
@@ -19,7 +19,6 @@
 #     --region <value> \
 #     --repository-name <value> \
 #     --image-scanning-configuration scanOnPush=true
-  
 
 CHECK_ID_extra765="7.65"
 CHECK_TITLE_extra765="[extra765] Check if ECR image scan on push is enabled (Not Scored) (Not part of CIS benchmark)"
@@ -28,19 +27,32 @@ CHECK_TYPE_extra765="EXTRA"
 CHECK_ALTERNATE_check765="extra765"
 
 extra765(){
-  for regx in $REGIONS; do
-    LIST_ECR_REPOS=$($AWSCLI ecr describe-repositories $PROFILE_OPT --region $regx --query "repositories[*].[repositoryName]" --output text 2>&1)
-    if [[ $LIST_ECR_REPOS ]]; then 
+  for region in $REGIONS; do
+    LIST_ECR_REPOS=$($AWSCLI ecr describe-repositories $PROFILE_OPT --region $region --query "repositories[*].[repositoryName]" --output text 2>&1)
+    if [[ $(echo "$LIST_ECR_REPOS" | grep AccessDenied) ]]; then
+      textFail "Access Denied Trying to describe ECR repositories"
+      continue
+    fi
+    if [[ ! -z "$LIST_ECR_REPOS" ]]; then
       for repo in $LIST_ECR_REPOS; do
-        SCAN_ENABLED=$($AWSCLI ecr describe-repositories $PROFILE_OPT --region $regx --query "repositories[?repositoryName==\`$repo\`].[imageScanningConfiguration.scanOnPush]" --output text|grep True)
-        if [[ $SCAN_ENABLED ]];then
-          textPass "$regx: ECR repository $repo has scan on push enabled" "$regx"
-        else
-          textFail "$regx: ECR repository $repo has scan on push disabled!" "$regx"
-        fi
-      done 
+        SCAN_ENABLED=$($AWSCLI ecr describe-repositories $PROFILE_OPT --region $region --query "repositories[?repositoryName==\`$repo\`].[imageScanningConfiguration.scanOnPush]" --output text 2>&1)
+        case "$SCAN_ENABLED" in
+          "True")
+            textPass "$region: ECR repository $repo has scan on push enabled" "$region"
+            ;;
+          "False")
+            textFail "$region: ECR repository $repo has scan on push disabled!" "$region"
+            ;;
+          "None")
+            textInfo "$region: ECR repository $repo hs no scanOnPush status, newer awscli needed" "$region"
+            ;;
+          "*")
+            textInfo "$region: ECR repository $repo has unknown scanOnPush status \"$SCAN_ENABLED\"" "$region"
+            ;;
+        esac
+      done
     else
-      textInfo "$regx: No ECR repositories found" "$regx"
-    fi 
-  done 
+      textInfo "$region: No ECR repositories found" "$region"
+    fi
+  done
 }

--- a/checks/check_extra77
+++ b/checks/check_extra77
@@ -10,6 +10,7 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+
 CHECK_ID_extra77="7.7,7.07"
 CHECK_TITLE_extra77="[extra77] Ensure there are no ECR repositories set as Public (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra77="NOT_SCORED"
@@ -20,20 +21,36 @@ CHECK_ALTERNATE_check707="extra77"
 
 extra77(){
   # "Ensure there are no ECR repositories set as Public (Not Scored) (Not part of CIS benchmark)"
-  textInfo "Looking for ECR repos in all regions...  "
-  for regx in $REGIONS; do
-    LIST_OF_ECR_REPOS=$($AWSCLI ecr describe-repositories $PROFILE_OPT --region $regx --query 'repositories[*].{Name:repositoryName}' --output text)
-    for ecr_repo in $LIST_OF_ECR_REPOS; do
+  for region in $REGIONS; do
+    LIST_ECR_REPOS=$($AWSCLI ecr describe-repositories $PROFILE_OPT --region $region --query "repositories[*].[repositoryName]" --output text 2>&1)
+    if [[ $(echo "$LIST_ECR_REPOS" | grep AccessDenied) ]]; then
+      textFail "Access Denied Trying to describe ECR repositories"
+      continue
+    fi
+    if [[ ! -z "$LIST_ECR_REPOS" ]]; then
       TEMP_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-ecr-repo.policy.XXXXXXXXXX)
-      $AWSCLI ecr get-repository-policy --repository-name $ecr_repo $PROFILE_OPT --region $regx --output text > $TEMP_POLICY_FILE 2> /dev/null
-      # check if the policy has Principal as *
-      CHECK_ECR_REPO_ALLUSERS_POLICY=$(cat $TEMP_POLICY_FILE | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | awk '/Principal/ && !skip { print } { skip = /Deny/} '|grep \"Principal|grep \*)
-      if [[ $CHECK_ECR_REPO_ALLUSERS_POLICY ]];then
-        textFail "$regx: $ecr_repo policy \"may\" allow Anonymous users to perform actions (Principal: \"*\")" "$regx"
-      else
-        textPass "$regx: $ecr_repo is not open" "$regx"
-      fi
-    done
-    rm -fr $TEMP_POLICY_FILE
+      for repo in $LIST_ECR_REPOS; do
+        $AWSCLI ecr get-repository-policy $PROFILE_OPT --region $region --repository-name $repo --query "policyText" --output text > $TEMP_POLICY_FILE 2>&1
+        if [[ $(grep AccessDenied $TEMP_POLICY_FILE) ]]; then
+          textFail "$region: $repo Access Denied for get-repository-policy"
+          continue
+        fi
+        # https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policies.html - "By default, only the repository owner has access to a repository."
+        if [[ $(grep RepositoryPolicyNotFoundException $TEMP_POLICY_FILE) ]]; then
+          textPass "$region: $repo is not open" "$region"
+          continue
+        fi
+        # check if the policy has Principal as *
+        CHECK_ECR_REPO_ALLUSERS_POLICY=$(cat $TEMP_POLICY_FILE | jq '.Statement[]|select(.Effect=="Allow" and (((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")))')
+        if [[ $CHECK_ECR_REPO_ALLUSERS_POLICY ]]; then
+          textFail "$region: $repo policy \"may\" allow Anonymous users to perform actions (Principal: \"*\")" "$region"
+        else
+          textPass "$region: $repo is not open" "$region"
+        fi
+      done
+      rm -f $TEMP_POLICY_FILE
+    else
+      textInfo "$region: No ECR repositories found" "$region"
+    fi
   done
 }


### PR DESCRIPTION
Check extra765 - Add additional error checking, a recent awscli is required to run this check successfully.

Check extra77 - Add additional error checking, use jq for policy parsing instead of awk

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
