### PR TITLE
Misc fixes to check extra764

### DIFF
--- a/checks/check_extra764
+++ b/checks/check_extra764
@@ -34,7 +34,7 @@ extra764(){
       fi
 
       # https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-policy-for-config-rule/
-      CHECK_BUCKET_STP_POLICY_PRESENT=$(cat $TEMP_STP_POLICY_FILE | jq --arg arn "arn:aws:s3:::${bucket}/*" '.Statement[]|select((((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and .Action=="s3:*" and (.Resource|type == "array") and (.Resource|map({(.):0})[]|has($arn)) and (.Resource|map({(.):0})[]|has($arn+"/*")) and .Condition.Bool."aws:SecureTransport" == "false")')
+      CHECK_BUCKET_STP_POLICY_PRESENT=$(cat $TEMP_STP_POLICY_FILE | jq --arg arn "arn:aws:s3:::${bucket}" '.Statement[]|select(((.Principal|type == "string") and .Principal == "*") and .Action=="s3:*" and (.Resource|type == "array") and (.Resource|map({(.):0})[]|has($arn)) and (.Resource|map({(.):0})[]|has($arn+"/*")) and .Condition.Bool."aws:SecureTransport" == "false")')
       if [[ $CHECK_BUCKET_STP_POLICY_PRESENT ]]; then
         textPass "Bucket $bucket has S3 bucket policy to deny requests over insecure transport"
       else


### PR DESCRIPTION
I double checked this with AWS support -- Principal: {AWS: *} refers to all AWS users and Principal: * refers to everybody both in and out of AWS. So the secure transport policy should only use the later. This follows what AWS does for their check in AWS Config: https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-policy-for-config-rule/

While testing this change I found a mistake in the arg to the JQ statement, pretty sure I'm responsible, so I've fixed it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
