### PR TITLE
Prevent colorization on Failed and Info

### DIFF
--- a/include/outputs
+++ b/include/outputs
@@ -76,7 +76,7 @@ textInfo(){
     else
       REPREGION=$REGION
     fi
-    jq -c \
+    jq -M -c \
     --arg PROFILE "$PROFILE" \
     --arg ACCOUNT_NUM "$ACCOUNT_NUM" \
     --arg TITLE_TEXT "$TITLE_TEXT" \
@@ -119,7 +119,7 @@ textFail(){
     else
       REPREGION=$REGION
     fi
-    jq -c \
+    jq -M -c \
     --arg PROFILE "$PROFILE" \
     --arg ACCOUNT_NUM "$ACCOUNT_NUM" \
     --arg TITLE_TEXT "$TITLE_TEXT" \


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Make the decolorization changes in #363 consistent for all lines.