### PR TITLE
improve check25

### DIFF
--- a/checks/check25
+++ b/checks/check25
@@ -16,12 +16,21 @@ CHECK_ALTERNATE_check205="check25"
 
 check25(){
   # "Ensure AWS Config is enabled in all regions (Scored)"
+  result=false
   for regx in $REGIONS; do
-    CHECK_AWSCONFIG_STATUS=$($AWSCLI configservice get-status $PROFILE_OPT --region $regx --output json| grep "recorder: ON")
-    if [[ $CHECK_AWSCONFIG_STATUS ]];then
-      textPass "Region $regx has AWS Config recorder: ON" "$regx"
-    else
-      textFail "Region $regx has AWS Config disabled or not configured" "$regx"
+    CHECK_AWSCONFIG_STATUS=$($AWSCLI configservice describe-configuration-recorders $PROFILE_OPT --region $regx --output json)
+    
+    if [[ $CHECK_AWSCONFIG_STATUS == *'"allSupported": true'* ]] && [[ $CHECK_AWSCONFIG_STATUS == *'"includeGlobalResourceTypes": true'* ]]; then
+        CHECK_AWSCONFIG_STATUS2=$($AWSCLI configservice get-status $PROFILE_OPT --region $regx --output json| grep "recorder: ON")
+        if [[ $CHECK_AWSCONFIG_STATUS2 ]];then
+            textPass "AWS Config is enabled in all regions"
+            result=true
+            break
+        fi
+    fi
+    done
+    if [[ $result == false ]];then
+        textFail "AWS Config is not enabled in all regions"
     fi
   done
 }


### PR DESCRIPTION
CIS Amazon Web Services Foundations v1.2.0 - 05-23-2018 

Via AWS Command Line Interface:
1. Run this command to show all AWS Config recorders and their properties:
```
aws configservice describe-configuration-recorders
```
2. Evaluate the output to ensure that there's at least one recorder for which
recordingGroup object includes ```"allSupported": true ``` AND ``` "includeGlobalResourceTypes": true ```

Note: There is one more parameter "ResourceTypes" in recordingGroup object. We don't
need to check the same as whenever we set "allSupported": true, AWS enforces resource
types to be empty ("ResourceTypes":[])

3. Run this command to show the status for all AWS Config recorders
```
aws configservice describe-configuration-recorder-status
```
4. In the output, find recorders with name key matching the recorders that met criteria
in step 2. Ensure that at least one of them includes ``` "recording": true ``` and
``` "lastStatus": "SUCCESS" ```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
