### PR TITLE
Remove `ses:sendemails`

### DIFF
--- a/iam/prowler-additions-policy.json
+++ b/iam/prowler-additions-policy.json
@@ -92,7 +92,6 @@
               "secretsmanager:listsecretversionids",
               "servicecatalog:list*",
               "ses:list*",
-              "ses:sendemail",
               "sns:list*",
               "sqs:listqueuetags",
               "ssm:listassociations",


### PR DESCRIPTION
Prowler should only require permissions which are readonly. The additional policy, recommended byt the readme, adds the ability to send emails via SES. There is even a closed issue where it was described as not needed: https://github.com/toniblyx/prowler/issues/124

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
