### PR TITLE
Push image to Docker Hub on releases and pushes to master

### DIFF
--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -1,0 +1,20 @@
+# This action builds an image and pushes it to Docker Hub when a new release is published
+name: Push Releases to Docker Hub
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Publish Docker
+        uses: elgohr/Publish-Docker-Github-Action@2.12
+        with:
+            name: myDocker/repository
+            username: ${{ secrets.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
+            dockerfile: "./util/Dockerfile"
+            tags: latest

--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Publish Docker
         uses: elgohr/Publish-Docker-Github-Action@2.12
         with:
-            name: st0nez/prowler
+            name: toniblyx/prowler
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
             dockerfile: "./util/Dockerfile"

--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Publish Docker
         uses: elgohr/Publish-Docker-Github-Action@2.12
         with:
-            name: myDocker/repository
+            name: st0nez/prowler
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
             dockerfile: "./util/Dockerfile"

--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -1,4 +1,4 @@
-# This action builds an image and pushes it to Docker Hub when a new release is published
+# This action builds an image and pushes it to Docker Hub on each commit to master
 name: Push Releases to Docker Hub
 on:
   push:

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -16,4 +16,4 @@ jobs:
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
             dockerfile: "./util/Dockerfile"
-            tags: ${ github.ref/refs\/tag\//}
+            tags: ${{ github.ref/refs\/tag\// }}

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -1,9 +1,8 @@
-# This action builds an image and pushes it to Docker Hub on each commit to master
-name: Push Latest to Docker Hub
+# This action builds an image and pushes it to Docker Hub when a new release is published
+name: Push Releases to Docker Hub
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
 
 jobs:
   build-and-push:
@@ -17,4 +16,4 @@ jobs:
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
             dockerfile: "./util/Dockerfile"
-            tags: latest
+            tags: ${{ github.ref }}

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -1,5 +1,5 @@
 # This action builds an image and pushes it to Docker Hub when a new release is published
-name: Push Releases to Docker Hub
+name: Push Release to Docker Hub
 on:
   release:
     types: [published]

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Get release version
+        id: get_version
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${github.ref:9})
       - name: Publish Docker
         uses: elgohr/Publish-Docker-Github-Action@2.12
         with:
@@ -16,4 +19,4 @@ jobs:
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
             dockerfile: "./util/Dockerfile"
-            tags: ${{ github.ref/refs\/tag\// }}
+            tags: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Get release version
         id: get_version
-        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:9})
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
       - name: Publish Docker
         uses: elgohr/Publish-Docker-Github-Action@2.12
         with:

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Publish Docker
         uses: elgohr/Publish-Docker-Github-Action@2.12
         with:
-            name: st0nez/prowler
+            name: toniblyx/prowler
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
             dockerfile: "./util/Dockerfile"

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Get release version
         id: get_version
-        run: echo ::set-env name=RELEASE_VERSION::$(echo ${github.ref:9})
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:9})
       - name: Publish Docker
         uses: elgohr/Publish-Docker-Github-Action@2.12
         with:

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -16,4 +16,4 @@ jobs:
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
             dockerfile: "./util/Dockerfile"
-            tags: ${{ github.ref }}
+            tags: ${ github.ref/refs\/tag\//}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Re: https://github.com/toniblyx/prowler/issues/476
This adds github actions for building and pushing the image to Docker Hub. One action for releases and one for latest.

To use: add the `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets to your GitHub repo settings
