### PR TITLE
Add conditions check for extra716

### DIFF
--- a/checks/check_extra716
+++ b/checks/check_extra716
@@ -27,7 +27,7 @@ extra716(){
           TEMP_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-es-domain.policy.XXXXXXXXXX)
           $AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query DomainConfig.AccessPolicies.Options --output text > $TEMP_POLICY_FILE 2> /dev/null
           # check if the policy has Principal as *
-          CHECK_ES_DOMAIN_ALLUSERS_POLICY=$(cat $TEMP_POLICY_FILE | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | awk '/Principal/ && !skip { print } { skip = /Deny/} '|grep \"Principal|grep \*)
+          CHECK_ES_DOMAIN_ALLUSERS_POLICY=$(cat $TEMP_POLICY_FILE | jq -r '. | .Statement[] | select(.Effect == "Allow" and (((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and .Condition == null)')
           if [[ $CHECK_ES_DOMAIN_ALLUSERS_POLICY ]];then
             textFail "$regx: $domain policy \"may\" allow Anonymous users to perform actions (Principal: \"*\")" "$regx"
           else


### PR DESCRIPTION
Only checking for principal = "*" isn't enough - we started using IP addresses as conditions. Added this to the predicate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
