### PR TITLE
Filter for only available rds instances

### DIFF
--- a/checks/check_extra78
+++ b/checks/check_extra78
@@ -22,7 +22,8 @@ extra78(){
   # "Ensure there are no Public Accessible RDS instances (Not Scored) (Not part of CIS benchmark)"
   textInfo "Looking for RDS instances in all regions...  "
   for regx in $REGIONS; do
-    LIST_OF_RDS_PUBLIC_INSTANCES=$($AWSCLI rds describe-db-instances $PROFILE_OPT --region $regx --query 'DBInstances[?PubliclyAccessible==`true`].[DBInstanceIdentifier,Endpoint.Address]' --output text)
+    LIST_OF_RDS_PUBLIC_INSTANCES=$($AWSCLI rds describe-db-instances $PROFILE_OPT --region $regx --query 'DBInstances[?PubliclyAccessible==`true` && DBInstanceStatus=="available"].[DBInstanceIdentifier,Endpoint.Address]' --output text)
+    echo $LIST_OF_RDS_PUBLIC_INSTANCES
     if [[ $LIST_OF_RDS_PUBLIC_INSTANCES ]];then
       while read -r rds_instance;do
         RDS_NAME=$(echo $rds_instance | awk '{ print $1; }')

--- a/checks/check_extra78
+++ b/checks/check_extra78
@@ -23,7 +23,6 @@ extra78(){
   textInfo "Looking for RDS instances in all regions...  "
   for regx in $REGIONS; do
     LIST_OF_RDS_PUBLIC_INSTANCES=$($AWSCLI rds describe-db-instances $PROFILE_OPT --region $regx --query 'DBInstances[?PubliclyAccessible==`true` && DBInstanceStatus=="available"].[DBInstanceIdentifier,Endpoint.Address]' --output text)
-    echo $LIST_OF_RDS_PUBLIC_INSTANCES
     if [[ $LIST_OF_RDS_PUBLIC_INSTANCES ]];then
       while read -r rds_instance;do
         RDS_NAME=$(echo $rds_instance | awk '{ print $1; }')


### PR DESCRIPTION
We noticed RDS instances which are not available are marked as violating - so I added this to the predicate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
