### PR TITLE
fix: check119 needs to ignore terminated instances

### DIFF
--- a/checks/check119
+++ b/checks/check119
@@ -16,16 +16,19 @@ CHECK_ALTERNATE_check119="check119"
 
 check119(){
   for regx in $REGIONS; do
-    EC2_DATA=$($AWSCLI ec2 describe-instances $PROFILE_OPT --region $regx --query 'Reservations[].Instances[].[InstanceId, IamInstanceProfile.Arn]')
-    EC2_DATA=$(echo $EC2_DATA | jq '.[]|{InstanceId: .[0], ProfileArn: .[1]}')
+    EC2_DATA=$($AWSCLI ec2 describe-instances $PROFILE_OPT --region $regx --query 'Reservations[].Instances[].[InstanceId, IamInstanceProfile.Arn, State.Name]')
+    EC2_DATA=$(echo $EC2_DATA | jq '.[]|{InstanceId: .[0], ProfileArn: .[1], StateName: .[2]}')
     INSTANCE_LIST=$(echo $EC2_DATA | jq -r '.InstanceId')
     if [[ $INSTANCE_LIST ]]; then
       for instance in $INSTANCE_LIST; do
-        PROFILEARN=$(echo $EC2_DATA | jq -r --arg i "$instance" 'select(.InstanceId==$i)|.ProfileArn')
-        if [[ $PROFILEARN == "null" ]]; then
-          textFail "$regx: Instance $instance not associated with an instance role." $regx
-        else
-          textPass "$regx: Instance $instance associated with role ${PROFILEARN##*/}." $regx
+        STATE_NAME=$(echo $EC2_DATA | jq -r --arg i "$instance" 'select(.InstanceId==$i)|.StateName')
+        if [[ $STATE_NAME != "terminated" ]]; then
+          PROFILEARN=$(echo $EC2_DATA | jq -r --arg i "$instance" 'select(.InstanceId==$i)|.ProfileArn')
+          if [[ $PROFILEARN == "null" ]]; then
+            textFail "$regx: Instance $instance not associated with an instance role." $regx
+          else
+            textPass "$regx: Instance $instance associated with role ${PROFILEARN##*/}." $regx
+          fi
         fi
       done
     else


### PR DESCRIPTION
Terminated does not seem to have an instance profile (At least when they are managed by an autoscaling group). And its not
possible to start a terminated instance again.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
