### PR TITLE
Checks/find security groups with wide open non rfc1918 IPv4 addresses

### DIFF
--- a/checks/check_extra777
+++ b/checks/check_extra777
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Prowler - the handy cloud security tool (copyright 2019) by Toni de la Fuente
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+CHECK_ID_extra777="7.77"
+CHECK_TITLE_extra777="[extra777] Find VPC security groups with wide-open public IPv4 CIDR ranges (non-RFC1918) (Not Scored) (Not part of CIS benchmark)"
+CHECK_SCORED_extra777="NOT_SCORED"
+CHECK_TYPE_extra777="EXTRA"
+CHECK_ALTERNATE_check776="extra777"
+
+extra777(){
+    CIDR_THRESHOLD=24
+    RFC1918_REGEX="(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)"
+    textInfo "Looking for VPC security groups with wide-open (</${CIDR_THRESHOLD}) non-RFC1918 IPv4 address ranges in all regions...  "
+
+    check_cidr() {
+        CIDR_IP_LIST=$1
+        DIRECTION=$2
+        regx=$3
+        case ${DIRECTION} in
+            inbound)
+                DIRECTION_FILTER="IpPermissions"
+                DIRECTION_NAME="inbound"
+                ;;
+            outbound)
+                DIRECTION_FILTER="IpPermissionsEgress"
+                DIRECTION_NAME="outbound"
+                ;;
+        esac
+
+        CIDR_IP_LIST=$(aws ec2 describe-security-groups \
+                        --filter "Name=group-id,Values=${SECURITY_GROUP}" \
+                        --query "SecurityGroups[*].IpPermissions[*].IpRanges[*].CidrIp" \
+                        --region ${regx} \
+                        --output text | xargs
+                        )
+        
+        for CIDR_IP in ${CIDR_IP_LIST}; do
+            if [[ ! ${CIDR_IP} =~ ${RFC1918_REGEX} ]]; then
+                CIDR=$(echo ${CIDR_IP} | cut -d"/" -f2 | xargs)
+                if [[ ${CIDR} < ${CIDR_THRESHOLD} ]]; then
+                    textFail "${regx}: ${SECURITY_GROUP} has potential wide-open non-RFC1918 address ${CIDR_IP} in ${DIRECTION_NAME} rule." "${regx}"
+                fi
+            fi
+        done
+    }
+
+    for regx in ${REGIONS}; do
+        SECURITY_GROUP_IDS=$(${AWSCLI} ec2 describe-security-groups --region ${regx} --query 'SecurityGroups[*].GroupId' --output text | xargs)
+        for SECURITY_GROUP in ${SECURITY_GROUP_IDS}; do
+            check_cidr "${SECURITY_GROUP_IDS}" "inbound" "${regx}"
+            check_cidr "${SECURITY_GROUP_IDS}" "outbound" "${regx}"
+        done
+    done
+}

--- a/checks/check_extra777
+++ b/checks/check_extra777
@@ -15,7 +15,7 @@ CHECK_ID_extra777="7.77"
 CHECK_TITLE_extra777="[extra777] Find VPC security groups with wide-open public IPv4 CIDR ranges (non-RFC1918) (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra777="NOT_SCORED"
 CHECK_TYPE_extra777="EXTRA"
-CHECK_ALTERNATE_check776="extra777"
+CHECK_ALTERNATE_check777="extra777"
 
 extra777(){
     CIDR_THRESHOLD=24

--- a/checks/check_extra778
+++ b/checks/check_extra778
@@ -11,7 +11,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-CHECK_ID_extra778="7.77"
+CHECK_ID_extra778="7.78"
 CHECK_TITLE_extra778="[extra778] Find VPC security groups with wide-open public IPv4 CIDR ranges (non-RFC1918) (Not Scored) (Not part of CIS benchmark)"
 CHECK_SCORED_extra778="NOT_SCORED"
 CHECK_TYPE_extra778="EXTRA"

--- a/checks/check_extra778
+++ b/checks/check_extra778
@@ -47,6 +47,9 @@ extra778(){
         for CIDR_IP in ${CIDR_IP_LIST}; do
             if [[ ! ${CIDR_IP} =~ ${RFC1918_REGEX} ]]; then
                 CIDR=$(echo ${CIDR_IP} | cut -d"/" -f2 | xargs)
+
+                # Edge case "0.0.0.0/0" for RDP and SSH are checked already by check41 and check42
+                if [[ ${CIDR} < ${CIDR_THRESHOLD} && 0 < ${CIDR} ]]; then
                     textFail "${REGION}: ${SECURITY_GROUP} has potential wide-open non-RFC1918 address ${CIDR_IP} in ${DIRECTION} rule." "${REGION}"
                 fi
             fi

--- a/checks/check_extra778
+++ b/checks/check_extra778
@@ -11,13 +11,13 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-CHECK_ID_extra777="7.77"
-CHECK_TITLE_extra777="[extra777] Find VPC security groups with wide-open public IPv4 CIDR ranges (non-RFC1918) (Not Scored) (Not part of CIS benchmark)"
-CHECK_SCORED_extra777="NOT_SCORED"
-CHECK_TYPE_extra777="EXTRA"
-CHECK_ALTERNATE_check777="extra777"
+CHECK_ID_extra778="7.77"
+CHECK_TITLE_extra778="[extra778] Find VPC security groups with wide-open public IPv4 CIDR ranges (non-RFC1918) (Not Scored) (Not part of CIS benchmark)"
+CHECK_SCORED_extra778="NOT_SCORED"
+CHECK_TYPE_extra778="EXTRA"
+CHECK_ALTERNATE_check778="extra778"
 
-extra777(){
+extra778(){
     CIDR_THRESHOLD=24
     RFC1918_REGEX="(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)"
     textInfo "Looking for VPC security groups with wide-open (</${CIDR_THRESHOLD}) non-RFC1918 IPv4 address ranges in all regions...  "

--- a/checks/check_extra778
+++ b/checks/check_extra778
@@ -23,32 +23,31 @@ extra778(){
     textInfo "Looking for VPC security groups with wide-open (</${CIDR_THRESHOLD}) non-RFC1918 IPv4 address ranges in all regions...  "
 
     check_cidr() {
-        CIDR_IP_LIST=$1
-        DIRECTION=$2
-        regx=$3
+        local SECURITY_GROUP=$1
+        local DIRECTION=$2
+        local DIRECTION_FILTER=""
+        local REGION=$3
+        
         case ${DIRECTION} in
-            inbound)
+            "inbound")
                 DIRECTION_FILTER="IpPermissions"
-                DIRECTION_NAME="inbound"
                 ;;
-            outbound)
+            "outbound")
                 DIRECTION_FILTER="IpPermissionsEgress"
-                DIRECTION_NAME="outbound"
                 ;;
         esac
 
         CIDR_IP_LIST=$(aws ec2 describe-security-groups \
                         --filter "Name=group-id,Values=${SECURITY_GROUP}" \
-                        --query "SecurityGroups[*].IpPermissions[*].IpRanges[*].CidrIp" \
-                        --region ${regx} \
+                        --query "SecurityGroups[*].${DIRECTION_FILTER}[*].IpRanges[*].CidrIp" \
+                        --region ${REGION} \
                         --output text | xargs
                         )
         
         for CIDR_IP in ${CIDR_IP_LIST}; do
             if [[ ! ${CIDR_IP} =~ ${RFC1918_REGEX} ]]; then
                 CIDR=$(echo ${CIDR_IP} | cut -d"/" -f2 | xargs)
-                if [[ ${CIDR} < ${CIDR_THRESHOLD} ]]; then
-                    textFail "${regx}: ${SECURITY_GROUP} has potential wide-open non-RFC1918 address ${CIDR_IP} in ${DIRECTION_NAME} rule." "${regx}"
+                    textFail "${REGION}: ${SECURITY_GROUP} has potential wide-open non-RFC1918 address ${CIDR_IP} in ${DIRECTION} rule." "${REGION}"
                 fi
             fi
         done
@@ -57,8 +56,8 @@ extra778(){
     for regx in ${REGIONS}; do
         SECURITY_GROUP_IDS=$(${AWSCLI} ec2 describe-security-groups --region ${regx} --query 'SecurityGroups[*].GroupId' --output text | xargs)
         for SECURITY_GROUP in ${SECURITY_GROUP_IDS}; do
-            check_cidr "${SECURITY_GROUP_IDS}" "inbound" "${regx}"
-            check_cidr "${SECURITY_GROUP_IDS}" "outbound" "${regx}"
+            check_cidr "${SECURITY_GROUP}" "inbound" "${regx}"
+            check_cidr "${SECURITY_GROUP}" "outbound" "${regx}"
         done
     done
 }

--- a/checks/check_extra778
+++ b/checks/check_extra778
@@ -37,7 +37,8 @@ extra778(){
                 ;;
         esac
 
-        CIDR_IP_LIST=$(aws ec2 describe-security-groups \
+        CIDR_IP_LIST=$(${AWSCLI} ec2 describe-security-groups \
+                        ${PROFILE_OPT} \
                         --filter "Name=group-id,Values=${SECURITY_GROUP}" \
                         --query "SecurityGroups[*].${DIRECTION_FILTER}[*].IpRanges[*].CidrIp" \
                         --region ${REGION} \
@@ -57,7 +58,12 @@ extra778(){
     }
 
     for regx in ${REGIONS}; do
-        SECURITY_GROUP_IDS=$(${AWSCLI} ec2 describe-security-groups --region ${regx} --query 'SecurityGroups[*].GroupId' --output text | xargs)
+        SECURITY_GROUP_IDS=$(${AWSCLI} ec2 describe-security-groups \
+                              ${PROFILE_OPT} \
+                              --region ${regx} \
+                              --query 'SecurityGroups[*].GroupId' \
+                              --output text | xargs
+                              )
         for SECURITY_GROUP in ${SECURITY_GROUP_IDS}; do
             check_cidr "${SECURITY_GROUP}" "inbound" "${regx}"
             check_cidr "${SECURITY_GROUP}" "outbound" "${regx}"

--- a/groups/group7_extras
+++ b/groups/group7_extras
@@ -15,7 +15,7 @@ GROUP_ID[7]='extras'
 GROUP_NUMBER[7]='7.0'
 GROUP_TITLE[7]='Extras - [extras] **********************************************'
 GROUP_RUN_BY_DEFAULT[7]='Y' # run it when execute_all is called
-GROUP_CHECKS[7]='extra71,extra72,extra73,extra74,extra75,extra76,extra77,extra78,extra79,extra710,extra711,extra712,extra713,extra714,extra715,extra716,extra717,extra718,extra719,extra720,extra721,extra722,extra723,extra724,extra725,extra726,extra727,extra728,extra729,extra730,extra731,extra732,extra733,extra734,extra735,extra736,extra737,extra738,extra739,extra740,extra741,extra742,extra743,extra744,extra745,extra746,extra747,extra748,extra749,extra750,extra751,extra752,extra753,extra754,extra755,extra756,extra757,extra758,extra761,extra762,extra763,extra764,extra765,extra767,extra768,extra769,extra770,extra771,extra772,extra773,extra774,extra775'
+GROUP_CHECKS[7]='extra71,extra72,extra73,extra74,extra75,extra76,extra77,extra78,extra79,extra710,extra711,extra712,extra713,extra714,extra715,extra716,extra717,extra718,extra719,extra720,extra721,extra722,extra723,extra724,extra725,extra726,extra727,extra728,extra729,extra730,extra731,extra732,extra733,extra734,extra735,extra736,extra737,extra738,extra739,extra740,extra741,extra742,extra743,extra744,extra745,extra746,extra747,extra748,extra749,extra750,extra751,extra752,extra753,extra754,extra755,extra756,extra757,extra758,extra761,extra762,extra763,extra764,extra765,extra767,extra768,extra769,extra770,extra771,extra772,extra773,extra774,extra775,extra777'
 
 # Extras 759 and 760 (lambda variables and code secrets finder are not included)
 # to run detect-secrets use `./prowler -g secrets`

--- a/groups/group7_extras
+++ b/groups/group7_extras
@@ -15,7 +15,7 @@ GROUP_ID[7]='extras'
 GROUP_NUMBER[7]='7.0'
 GROUP_TITLE[7]='Extras - [extras] **********************************************'
 GROUP_RUN_BY_DEFAULT[7]='Y' # run it when execute_all is called
-GROUP_CHECKS[7]='extra71,extra72,extra73,extra74,extra75,extra76,extra77,extra78,extra79,extra710,extra711,extra712,extra713,extra714,extra715,extra716,extra717,extra718,extra719,extra720,extra721,extra722,extra723,extra724,extra725,extra726,extra727,extra728,extra729,extra730,extra731,extra732,extra733,extra734,extra735,extra736,extra737,extra738,extra739,extra740,extra741,extra742,extra743,extra744,extra745,extra746,extra747,extra748,extra749,extra750,extra751,extra752,extra753,extra754,extra755,extra756,extra757,extra758,extra761,extra762,extra763,extra764,extra765,extra767,extra768,extra769,extra770,extra771,extra772,extra773,extra774,extra775,extra777'
+GROUP_CHECKS[7]='extra71,extra72,extra73,extra74,extra75,extra76,extra77,extra78,extra79,extra710,extra711,extra712,extra713,extra714,extra715,extra716,extra717,extra718,extra719,extra720,extra721,extra722,extra723,extra724,extra725,extra726,extra727,extra728,extra729,extra730,extra731,extra732,extra733,extra734,extra735,extra736,extra737,extra738,extra739,extra740,extra741,extra742,extra743,extra744,extra745,extra746,extra747,extra748,extra749,extra750,extra751,extra752,extra753,extra754,extra755,extra756,extra757,extra758,extra761,extra762,extra763,extra764,extra765,extra767,extra768,extra769,extra770,extra771,extra772,extra773,extra774,extra775,extra778'
 
 # Extras 759 and 760 (lambda variables and code secrets finder are not included)
 # to run detect-secrets use `./prowler -g secrets`


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This is another check to raise attention to security groups that are potentially much opened to public IPv4 addresses (non RFC1918). 

Currently the default is >/24, but I'm open for a discussion and your experiences to find a better default.
