### PR TITLE
check23 - on failure, output info and not failure

### DIFF
--- a/checks/check23
+++ b/checks/check23
@@ -21,7 +21,7 @@ check23(){
     for bucket in $CLOUDTRAILBUCKET;do
       CLOUDTRAILBUCKET_HASALLPERMISIONS=$($AWSCLI s3api get-bucket-acl --bucket $bucket --query 'Grants[?Grantee.URI==`http://acs.amazonaws.com/groups/global/AllUsers`]' $PROFILE_OPT --region $REGION --output text 2>&1)
       if [[ $(echo "$CLOUDTRAILBUCKET_HASALLPERMISIONS" | grep AccessDenied) ]]; then
-        textFail "Access Denied Trying to Get Bucket Acl for $bucket"
+        textInfo "Access Denied Trying to Get Bucket Acl for $bucket"
         continue
       fi
       if [[ $CLOUDTRAILBUCKET_HASALLPERMISIONS ]]; then


### PR DESCRIPTION
CloudTrail bucket can be in another account, which will result if failing to get bucket ACL.
Therefore, IMO, errors should be handled as `Info` and not as `Fail`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
