### PR TITLE
check26 - on failure, output info and not failure

### DIFF
--- a/checks/check26
+++ b/checks/check26
@@ -29,7 +29,7 @@ check26(){
         if [ "$CLOUDTRAIL_ACCOUNT_ID" == "$ACCOUNT_NUM" ]; then
           CLOUDTRAILBUCKET_LOGENABLED=$($AWSCLI s3api get-bucket-logging --bucket $bucket $PROFILE_OPT --region $REGION --query 'LoggingEnabled.TargetBucket' --output text 2>&1)
           if [[ $(echo "$CLOUDTRAILBUCKET_LOGENABLED" | grep AccessDenied) ]]; then
-            textFail "Access Denied Trying to Get Bucket Logging for $bucket"
+            textInfo "Access Denied Trying to Get Bucket Logging for $bucket"
             continue
           fi
           if [[ $CLOUDTRAILBUCKET_LOGENABLED != "null" ]]; then


### PR DESCRIPTION
CloudTrail bucket can be in another account, which will result if failing to get bucket logging.
Therefore, IMO, errors should be handled as `Info` and not as `Fail`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
