### PR TITLE
Ignore imported ACM Certificate in check_extra724

### DIFF
--- a/checks/check_extra724
+++ b/checks/check_extra724
@@ -24,10 +24,16 @@ extra724(){
       for cert_arn in $LIST_OF_CERTS;do
         CT_ENABLED=$($AWSCLI acm describe-certificate $PROFILE_OPT --region $regx --certificate-arn $cert_arn --query Certificate.Options.CertificateTransparencyLoggingPreference --output text)
         CERT_DOMAIN_NAME=$(aws acm describe-certificate $PROFILE_OPT --region $regx --certificate-arn $cert_arn --query Certificate.DomainName --output text)
-        if [[ $CT_ENABLED == "ENABLED" ]];then
-          textPass "$regx: ACM Certificate $CERT_DOMAIN_NAME has Certificate Transparency logging enabled!" "$regx"
+        CERT_TYPE=$(aws acm describe-certificate $PROFILE_OPT --region $regx --certificate-arn $cert_arn --query Certificate.Type --output text)
+        if [[ $CERT_TYPE == "IMPORTED" ]];then
+          # Ignore imported certificate
+          textInfo "$regx: ACM Certificate $CERT_DOMAIN_NAME is imported." "$regx"
         else
-          textFail "$regx: ACM Certificate $CERT_DOMAIN_NAME has Certificate Transparency logging disabled!" "$regx"
+          if [[ $CT_ENABLED == "ENABLED" ]];then
+            textPass "$regx: ACM Certificate $CERT_DOMAIN_NAME has Certificate Transparency logging enabled!" "$regx"
+          else
+            textFail "$regx: ACM Certificate $CERT_DOMAIN_NAME has Certificate Transparency logging disabled!" "$regx"
+          fi
         fi
       done
     else


### PR DESCRIPTION
The `UpdateCertificateOptions` command is not permitted for imported certificates, so certificate transparency logging of imported certificates should not be checked. I think it should be enabled by the issuer of imported certificates.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
