### PR TITLE
Remove --output text in CLOUDTRAILBUCKET_LOGENABLED

### DIFF
--- a/checks/check26
+++ b/checks/check26
@@ -27,7 +27,7 @@ check26(){
       if [[ $CLOUDTRAILBUCKET ]]; then
         bucket=$CLOUDTRAILBUCKET
         if [ "$CLOUDTRAIL_ACCOUNT_ID" == "$ACCOUNT_NUM" ]; then
-          CLOUDTRAILBUCKET_LOGENABLED=$($AWSCLI s3api get-bucket-logging --bucket $bucket $PROFILE_OPT --region $REGION --query 'LoggingEnabled.TargetBucket' --output text 2>&1)
+          CLOUDTRAILBUCKET_LOGENABLED=$($AWSCLI s3api get-bucket-logging --bucket $bucket $PROFILE_OPT --region $REGION --query 'LoggingEnabled.TargetBucket' 2>&1)
           if [[ $(echo "$CLOUDTRAILBUCKET_LOGENABLED" | grep AccessDenied) ]]; then
             textFail "Access Denied Trying to Get Bucket Logging for $bucket"
             continue


### PR DESCRIPTION
I am not sure is there anyone has the same issue as mine. If server access log is not enabled for one bucket, the output of following command is `None` instead of `null`.

```
s3api get-bucket-logging --bucket $bucket $PROFILE_OPT --region $REGION --query 'LoggingEnabled.TargetBucket' --output text
```

Probably caused by different version of `aws-cli` or `boto`. Here is my version

```
aws --version
aws-cli/2.0.4 Python/3.8.2 Darwin/19.4.0 botocore/2.0.0dev8
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
