### PR TITLE
Extra 774 - Handle IAM credential report containing 'no_information' for a user's last console login date

### DIFF
--- a/checks/check_extra774
+++ b/checks/check_extra774
@@ -24,11 +24,23 @@ extra774(){
     user=$(cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$5 }' |grep "^$i " |awk '{ print $1 }')
     last_login_date=$(cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$5 }' |grep "^$i " |awk '{ print $2 }')
 
-    days_not_in_use=$(how_many_days_from_today ${last_login_date%T*})
-    if [ "$days_not_in_use" -lt "$MAX_DAYS" ];then
-        textFail "User $user has not used console login for more then ${MAX_DAYS#-} days"
+    # If the user has never logged into the console, their last login date is 'no_information'. See:
+    # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_getting-report.html#id_credentials_understanding_the_report_format
+    if [[ "${last_login_date}" == "no_information" ]]; then
+      user_created_date=$(cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$3 }' |grep "^$i " |awk '{ print $2 }')
+      days_since_user_created=$(how_many_days_from_today ${user_created_date%T*})
+      if [ "$days_since_user_created" -lt "$MAX_DAYS" ];then
+        textFail "User $user has never used console login since they were created ${days_since_user_created} days ago"
+      else
+        textInfo "User $user has not used console login since they were created ${days_since_user_created} days ago"
+      fi
+    else
+      days_not_in_use=$(how_many_days_from_today ${last_login_date%T*})
+      if [ "$days_not_in_use" -lt "$MAX_DAYS" ];then
+        textFail "User $user has not used console login for more than ${MAX_DAYS#-} days"
       else
         textPass "User $user has used console login in the past ${MAX_DAYS#-} days"
+      fi
     fi
   done
 }

--- a/checks/check_extra774
+++ b/checks/check_extra774
@@ -30,9 +30,9 @@ extra774(){
       user_created_date=$(cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$3 }' |grep "^$i " |awk '{ print $2 }')
       days_since_user_created=$(how_many_days_from_today ${user_created_date%T*})
       if [ "$days_since_user_created" -lt "$MAX_DAYS" ];then
-        textFail "User $user has never used console login since they were created ${days_since_user_created} days ago"
+        textFail "User $user has never used console login since they were created over ${MAX_DAYS#-} days ago"
       else
-        textInfo "User $user has not used console login since they were created ${days_since_user_created} days ago"
+        textInfo "User $user has not used console login since they were created"
       fi
     else
       days_not_in_use=$(how_many_days_from_today ${last_login_date%T*})


### PR DESCRIPTION
A user who has never logged into the console, or not logged in since Oct 2014 will present as 'no_information' in the
'password_last_used' column of the credential report. Handle this scenario and output a failed message if it has been
more than MAX_DAYS days since the user was created, or an info message if it is less than MAX_DAYS

Fixes #501

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
