### PR TITLE
support arn:aws:s3::: on extra725

### DIFF
--- a/checks/check_extra725
+++ b/checks/check_extra725
@@ -41,7 +41,17 @@ extra725(){
   while IFS='' read -r LINE || [[ -n "${LINE}" ]]; do
     TRAIL_REGION=$(echo "${LINE}" | awk '{ print $2 }')
     TRAIL_NAME=$(echo "${LINE}" | awk '{ print $1 }')
-    BUCKETS_OBJECT_LOGGING_ENABLED=$($AWSCLI cloudtrail get-event-selectors --trail-name "${TRAIL_NAME}" $PROFILE_OPT --region $TRAIL_REGION --query "EventSelectors[*].DataResources[?Type == \`AWS::S3::Object\`].Values" --output text |xargs -n1 |cut -d: -f 6|sed 's/\///g')
+    BUCKETS_OBJECT_LOGGING_ENABLED_TEXT=$($AWSCLI cloudtrail get-event-selectors --trail-name "${TRAIL_NAME}" $PROFILE_OPT --region $TRAIL_REGION --query "EventSelectors[*].DataResources[?Type == \`AWS::S3::Object\`].Values" --output text)
+    for bucket_arn in $( echo $BUCKETS_OBJECT_LOGGING_ENABLED_TEXT |xargs -n1); do
+      if [[ "$bucket_arn" =~ ^arn:aws:s3(:::$|$) ]];then
+        textPass "$regx: All S3 buckets have Object-level logging enabled in trail $trail" "$regx"
+        # delete all temp files
+        rm -fr $TEMP_BUCKET_LIST_FILE $TEMP_TRAILS_LIST_FILE $TEMP_BUCKETS_LOGGING_LIST_FILE
+        # exit function
+        return
+      fi
+    done
+    BUCKETS_OBJECT_LOGGING_ENABLED=$(echo $BUCKETS_OBJECT_LOGGING_ENABLED_TEXT |xargs -n1 |cut -d: -f 6|sed 's/\///g')
     echo $BUCKETS_OBJECT_LOGGING_ENABLED |tr " " "\n"|sort >> $TEMP_BUCKETS_LOGGING_LIST_FILE
     if [[ $BUCKETS_OBJECT_LOGGING_ENABLED ]]; then
       for bucket in $BUCKETS_OBJECT_LOGGING_ENABLED; do


### PR DESCRIPTION
When the `arn:aws:s3:::` or `arn:aws:s3` configuration is in cloudtrail, skip diff with buckets list and pass.
Can fix this issue: [extra725 catch-all rule for all logging events](https://github.com/toniblyx/prowler/issues/402)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
