### PR TITLE
Extra741 - Check if User Data is a valid GZIP file before attempting to gunzip

### DIFF
--- a/checks/check_extra741
+++ b/checks/check_extra741
@@ -31,31 +31,23 @@ extra741(){
       for instance in $LIST_OF_EC2_INSTANCES; do
         EC2_USERDATA_FILE="$SECRETS_TEMP_FOLDER/extra741-$instance-userData.decoded"
         EC2_USERDATA=$($AWSCLI ec2 describe-instance-attribute --attribute userData $PROFILE_OPT --region $regx --instance-id $instance --query UserData.Value --output text| grep -v ^None | decode_report > $EC2_USERDATA_FILE)
-        if [ -s $EC2_USERDATA_FILE ];then
-          FILE_FORMAT_ASCII=$(file -b $EC2_USERDATA_FILE|grep ASCII)
+        if [ -s "$EC2_USERDATA_FILE" ];then
           # This finds ftp or http URLs with credentials and common keywords
           # FINDINGS=$(egrep -i '[[:alpha:]]*://[[:alnum:]]*:[[:alnum:]]*@.*/|key|secret|token|pass' $EC2_USERDATA_FILE |wc -l|tr -d '\ ')
           # New implementation using https://github.com/Yelp/detect-secrets
-          if [[ $FILE_FORMAT_ASCII ]]; then
-          FINDINGS=$(secretsDetector file $EC2_USERDATA_FILE)
-            if [[ $FINDINGS -eq 0 ]]; then
-              textPass "$regx: No secrets found in $instance" "$regx"
-              # delete file if nothing interesting is there
-              rm -f $EC2_USERDATA_FILE
-            else
-              textFail "$regx: Potential secret found in $instance" "$regx"
-              # delete file to not leave trace, user must look at the instance User Data
-              rm -f $EC2_USERDATA_FILE
-            fi
+          # Test if user data is a valid GZIP file, if so gunzip first
+          if gunzip -t "$EC2_USERDATA_FILE" > /dev/null 2>&1; then
+            mv "$EC2_USERDATA_FILE" "$EC2_USERDATA_FILE.gz" ; gunzip "$EC2_USERDATA_FILE.gz"
+          fi
+          FINDINGS=$(secretsDetector file "$EC2_USERDATA_FILE")
+          if [[ $FINDINGS -eq 0 ]]; then
+            textPass "$regx: No secrets found in $instance" "$regx"
+            # delete file if nothing interesting is there
+            rm -f "$EC2_USERDATA_FILE"
           else
-            mv $EC2_USERDATA_FILE $EC2_USERDATA_FILE.gz ; gunzip $EC2_USERDATA_FILE.gz
-            FINDINGS=$(secretsDetector file $EC2_USERDATA_FILE)
-            if [[ $FINDINGS -eq 0 ]]; then
-              textPass "$regx: No secrets found in $instance User Data" "$regx"
-              rm -f $EC2_USERDATA_FILE
-            else
-              textFail "$regx: Potential secret found in $instance" "$regx"
-            fi
+            textFail "$regx: Potential secret found in $instance" "$regx"
+            # delete file to not leave trace, user must look at the instance User Data
+            rm -f "$EC2_USERDATA_FILE"
           fi
         else
           textPass "$regx: No secrets found in $instance User Data or it is empty" "$regx"

--- a/checks/check_extra741
+++ b/checks/check_extra741
@@ -41,11 +41,11 @@ extra741(){
           fi
           FINDINGS=$(secretsDetector file "$EC2_USERDATA_FILE")
           if [[ $FINDINGS -eq 0 ]]; then
-            textPass "$regx: No secrets found in $instance" "$regx"
+            textPass "$regx: No secrets found in $instance User Data" "$regx"
             # delete file if nothing interesting is there
             rm -f "$EC2_USERDATA_FILE"
           else
-            textFail "$regx: Potential secret found in $instance" "$regx"
+            textFail "$regx: Potential secret found in $instance User Data" "$regx"
             # delete file to not leave trace, user must look at the instance User Data
             rm -f "$EC2_USERDATA_FILE"
           fi


### PR DESCRIPTION
Test if the user data is a valid GZIP file using `gunzip -t` and only then attempt to gunzip it
Remove some code duplication

Fixes #535

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
