### PR TITLE
check21 - scope variable to prevent clobbering and fix flag ordering …

### DIFF
--- a/checks/check21
+++ b/checks/check21
@@ -19,14 +19,14 @@ CHECK_ALTERNATE_check201="check21"
 check21(){
   trail_count=0
   # "Ensure CloudTrail is enabled in all regions (Scored)"
-    REGIONS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --query 'trailList[*].HomeRegion' --output text)
+    local REGIONS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --query 'trailList[*].HomeRegion' --output text)
     result='False'
 	for regx in $REGIONS; do
 		LIST_OF_TRAILS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query 'trailList[*].Name' --output text)
 		if [[ $LIST_OF_TRAILS ]];then
 			for trail in $LIST_OF_TRAILS;do
 				trail_count=$((trail_count + 1))
-				MULTIREGION_TRAIL_STATUS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query 'trailList[*].IsMultiRegionTrail' --output text --trail-name-list $trail)
+				MULTIREGION_TRAIL_STATUS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --trail-name-list $trail --query 'trailList[*].IsMultiRegionTrail' --output text)
 				ISLOGGING_STATUS=$($AWSCLI cloudtrail get-trail-status $PROFILE_OPT --region $regx --name $trail --query ['IsLogging'] --output text)
 				INCLUDEMANAGEMENTEVENTS_STATUS=$($AWSCLI cloudtrail  get-event-selectors $PROFILE_OPT --region $regx --trail-name $trail --query EventSelectors[*].IncludeManagementEvents --output text)
 				READWRITETYPE_STATUS=$($AWSCLI cloudtrail  get-event-selectors $PROFILE_OPT --region $regx --trail-name $trail --query EventSelectors[*].ReadWriteType --output text)


### PR DESCRIPTION
This is to fix the following issue:
https://github.com/toniblyx/prowler/issues/550

Currently after check21 runs, all subsequent checks may return false negatives because they aren't checking all regions. This is a simple change to scope the variable used in this check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
