### PR TITLE
Fix -E flag no longer excluding checks

### DIFF
--- a/prowler
+++ b/prowler
@@ -425,7 +425,6 @@ show_all_group_titles() {
 get_all_checks_without_exclusion() {
   CHECKS_EXCLUDED=()
   local CHECKS_TO_EXCLUDE=()
-  local TOTAL_CHECKS=()
   # Get a list of checks to exclude
   IFS=',' read -ra E_CHECKS <<< "$1"
   for E_CHECK in "${E_CHECKS[@]}"; do


### PR DESCRIPTION
Remove re-declaration of TOTAL_CHECKS variable

Bug introduced by #561

Fixes #566

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
