### PR TITLE
Workaround for tr error with json-asff output mode in CentOS

### DIFF
--- a/include/outputs
+++ b/include/outputs
@@ -201,7 +201,7 @@ generateJsonAsffOutput(){
   --arg ACCOUNT_NUM "$ACCOUNT_NUM" \
   --arg TITLE_TEXT "$TITLE_TEXT" \
   --arg MESSAGE "$(echo -e "${message}" | sed -e 's/^[[:space:]]*//')" \
-  --arg UNIQUE_ID "$(LC_ALL=C echo -e "${message}" | tr -cs '[:alnum:]._~-\n' '_')" \
+  --arg UNIQUE_ID "$(LC_ALL=C echo -e "${message}" | tr -cs '[:alnum:]._~-\n' '_' 2> /dev/null)" \
   --arg STATUS "$status" \
   --arg SEVERITY "$severity" \
   --arg TITLE_ID "$TITLE_ID" \

--- a/include/outputs
+++ b/include/outputs
@@ -35,7 +35,7 @@ textPass(){
   if [[ "${MODES[@]}" =~ "csv" ]]; then
     echo "$PROFILE${SEP}$ACCOUNT_NUM${SEP}$REPREGION${SEP}$TITLE_ID${SEP}PASS${SEP}$ITEM_SCORED${SEP}$ITEM_LEVEL${SEP}$TITLE_TEXT${SEP}$1" | tee -a ${OUTPUT_FILE_NAME}.$EXTENSION_CSV
   fi
-  if [[ "${MODES[@]}" =~ "json" ]]; then
+  if [[ " ${MODES[@]} " =~ " json " ]]; then
     generateJsonOutput "$1" "Pass" | tee -a ${OUTPUT_FILE_NAME}.$EXTENSION_JSON
   fi
   if [[ "${MODES[@]}" =~ "json-asff" ]]; then
@@ -69,7 +69,7 @@ textInfo(){
   if [[ "${MODES[@]}" =~ "csv" ]]; then
     echo "$PROFILE${SEP}$ACCOUNT_NUM${SEP}$REPREGION${SEP}$TITLE_ID${SEP}INFO${SEP}$ITEM_SCORED${SEP}$ITEM_LEVEL${SEP}$TITLE_TEXT${SEP}$1" | tee -a ${OUTPUT_FILE_NAME}.${EXTENSION_CSV}
   fi
-  if [[ "${MODES[@]}" =~ "json" ]]; then
+  if [[ " ${MODES[@]} " =~ " json " ]]; then
     generateJsonOutput "$1" "Info" | tee -a ${OUTPUT_FILE_NAME}.${EXTENSION_JSON}
   fi
   if is_junit_output_enabled; then
@@ -94,7 +94,7 @@ textFail(){
   if [[ "${MODES[@]}" =~ "csv" ]]; then
     echo "$PROFILE${SEP}$ACCOUNT_NUM${SEP}$REPREGION${SEP}$TITLE_ID${SEP}FAIL${SEP}$ITEM_SCORED${SEP}$ITEM_LEVEL${SEP}$TITLE_TEXT${SEP}$1" | tee -a ${OUTPUT_FILE_NAME}.${EXTENSION_CSV}
   fi
-  if [[ "${MODES[@]}" =~ "json" ]]; then
+  if [[ " ${MODES[@]} " =~ " json " ]]; then
     generateJsonOutput "$1" "Fail" | tee -a ${OUTPUT_FILE_NAME}.${EXTENSION_JSON}
   fi
   if [[ "${MODES[@]}" =~ "json-asff" ]]; then
@@ -152,7 +152,7 @@ textTitle(){
 
   if [[ "${MODES[@]}" =~ "csv" ]]; then
       >&2 echo "$TITLE_ID $TITLE_TEXT" | tee -a ${OUTPUT_FILE_NAME}.${EXTENSION_CSV}
-  elif [[ "${MODES[@]}" =~ "json" || "${MODES[@]}" =~ "json-asff" ]]; then
+  elif [[ " ${MODES[@]} " =~ " json " || "${MODES[@]}" =~ "json-asff" ]]; then
     :
   else
     if [[ "$ITEM_SCORED" == "Scored" ]]; then


### PR DESCRIPTION
Workaround for issue 573: seeing error "tr: range-endpoints of '~-\012' are in reverse collating sequence order" when there are failures in CentOS and the output mode is "json-asff"
https://github.com/toniblyx/prowler/issues/573

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.