### PR TITLE
Ensure that hyphen is at end of tr string to prevent 'reverse collating sequence order' error in GNU tr

### DIFF
--- a/include/outputs
+++ b/include/outputs
@@ -201,7 +201,7 @@ generateJsonAsffOutput(){
   --arg ACCOUNT_NUM "$ACCOUNT_NUM" \
   --arg TITLE_TEXT "$TITLE_TEXT" \
   --arg MESSAGE "$(echo -e "${message}" | sed -e 's/^[[:space:]]*//')" \
-  --arg UNIQUE_ID "$(LC_ALL=C echo -e "${message}" | tr -cs '[:alnum:]._~-\n' '_')" \
+  --arg UNIQUE_ID "$(LC_ALL=C echo -e -n "${message}" | tr -cs '[:alnum:]._~-' '_')" \
   --arg STATUS "$status" \
   --arg SEVERITY "$severity" \
   --arg TITLE_ID "$TITLE_ID" \


### PR DESCRIPTION
Also stop echo from adding newlines using `-n`, removing the need to stop replacing new-line characters with underscores

Fixes #573

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
