### PR TITLE
Wrap all mode checks with whitespace, along with comparison strings to ensure correct outputs are selected

### DIFF
--- a/include/junit_integration
+++ b/include/junit_integration
@@ -16,7 +16,7 @@
 JUNIT_OUTPUT_DIRECTORY="junit-reports"
 
 is_junit_output_enabled() {
-  if [[ ${MODES[@]} =~ "junit-xml" ]]; then
+  if [[ " ${MODES[@]} " =~ " junit-xml " ]]; then
     true
   else
     false

--- a/include/outputs
+++ b/include/outputs
@@ -32,13 +32,13 @@ textPass(){
   else
     REPREGION=$REGION
   fi
-  if [[ "${MODES[@]}" =~ "csv" ]]; then
+  if [[ " ${MODES[@]} " =~ " csv " ]]; then
     echo "$PROFILE${SEP}$ACCOUNT_NUM${SEP}$REPREGION${SEP}$TITLE_ID${SEP}PASS${SEP}$ITEM_SCORED${SEP}$ITEM_LEVEL${SEP}$TITLE_TEXT${SEP}$1" | tee -a ${OUTPUT_FILE_NAME}.$EXTENSION_CSV
   fi
-  if [[ "${MODES[@]}" =~ "json" ]]; then
+  if [[ " ${MODES[@]} " =~ " json " ]]; then
     generateJsonOutput "$1" "Pass" | tee -a ${OUTPUT_FILE_NAME}.$EXTENSION_JSON
   fi
-  if [[ "${MODES[@]}" =~ "json-asff" ]]; then
+  if [[ " ${MODES[@]} " =~ " json-asff " ]]; then
     JSON_ASFF_OUTPUT=$(generateJsonAsffOutput "$1" "PASSED" "INFORMATIONAL")
     echo "${JSON_ASFF_OUTPUT}" | tee -a $OUTPUT_FILE_NAME.$EXTENSION_ASFF
     if [[ "${SEND_TO_SECURITY_HUB}" -eq 1 ]]; then
@@ -48,10 +48,10 @@ textPass(){
   if is_junit_output_enabled; then
     output_junit_success "$1"
   fi
-  if [[ "${MODES[@]}" =~ "mono" ]]; then
+  if [[ " ${MODES[@]} " =~ " mono " ]]; then
     echo "      $OK PASS!$NORMAL $1" | tee -a ${OUTPUT_FILE_NAME}.$EXTENSION_TEXT
   fi
-  if [[ "${MODES[@]}" =~ "text" || "${MODES[@]}" =~ "mono" ]]; then
+  if [[ " ${MODES[@]} " =~ " text " || " ${MODES[@]} " =~ " mono " ]]; then
     echo "      $OK PASS!$NORMAL $1"
   fi
 }
@@ -66,19 +66,19 @@ textInfo(){
   else
     REPREGION=$REGION
   fi
-  if [[ "${MODES[@]}" =~ "csv" ]]; then
+  if [[ " ${MODES[@]} " =~ " csv " ]]; then
     echo "$PROFILE${SEP}$ACCOUNT_NUM${SEP}$REPREGION${SEP}$TITLE_ID${SEP}INFO${SEP}$ITEM_SCORED${SEP}$ITEM_LEVEL${SEP}$TITLE_TEXT${SEP}$1" | tee -a ${OUTPUT_FILE_NAME}.${EXTENSION_CSV}
   fi
-  if [[ "${MODES[@]}" =~ "json" ]]; then
+  if [[ " ${MODES[@]} " =~ " json " ]]; then
     generateJsonOutput "$1" "Info" | tee -a ${OUTPUT_FILE_NAME}.${EXTENSION_JSON}
   fi
   if is_junit_output_enabled; then
     output_junit_info "$1"
   fi
-  if [[ "${MODES[@]}" =~ "mono" ]]; then
+  if [[ " ${MODES[@]} " =~ " mono " ]]; then
     echo "      $NOTICE INFO! $1 $NORMAL" | tee -a ${OUTPUT_FILE_NAME}.$EXTENSION_TEXT
   fi
-  if [[ "${MODES[@]}" =~ "text" ]]; then
+  if [[ " ${MODES[@]} " =~ " text " ]]; then
     echo "      $NOTICE INFO! $1 $NORMAL"
   fi
 }
@@ -91,13 +91,13 @@ textFail(){
   else
     REPREGION=$REGION
   fi
-  if [[ "${MODES[@]}" =~ "csv" ]]; then
+  if [[ " ${MODES[@]} " =~ " csv " ]]; then
     echo "$PROFILE${SEP}$ACCOUNT_NUM${SEP}$REPREGION${SEP}$TITLE_ID${SEP}FAIL${SEP}$ITEM_SCORED${SEP}$ITEM_LEVEL${SEP}$TITLE_TEXT${SEP}$1" | tee -a ${OUTPUT_FILE_NAME}.${EXTENSION_CSV}
   fi
-  if [[ "${MODES[@]}" =~ "json" ]]; then
+  if [[ " ${MODES[@]} " =~ " json " ]]; then
     generateJsonOutput "$1" "Fail" | tee -a ${OUTPUT_FILE_NAME}.${EXTENSION_JSON}
   fi
-  if [[ "${MODES[@]}" =~ "json-asff" ]]; then
+  if [[ " ${MODES[@]} " =~ " json-asff " ]]; then
     JSON_ASFF_OUTPUT=$(generateJsonAsffOutput "$1" "FAILED" "HIGH")
     echo "${JSON_ASFF_OUTPUT}" | tee -a ${OUTPUT_FILE_NAME}.${EXTENSION_ASFF}
     if [[ "${SEND_TO_SECURITY_HUB}" -eq 1 ]]; then
@@ -107,10 +107,10 @@ textFail(){
   if is_junit_output_enabled; then
     output_junit_failure "$1"
   fi
-  if [[ "${MODES[@]}" =~ "mono" ]]; then
+  if [[ " ${MODES[@]} " =~ " mono " ]]; then
     echo "      $BAD FAIL! $1 $NORMAL" | tee -a ${OUTPUT_FILE_NAME}.$EXTENSION_TEXT
   fi
-  if [[ "${MODES[@]}" =~ "text" ]]; then
+  if [[ " ${MODES[@]} " =~ " text " ]]; then
     echo "      $BAD FAIL! $1 $NORMAL"
   fi
 }
@@ -150,9 +150,9 @@ textTitle(){
     group_ids="$CYAN [$5] $NORMAL"
   fi
 
-  if [[ "${MODES[@]}" =~ "csv" ]]; then
+  if [[ " ${MODES[@]} " =~ " csv " ]]; then
       >&2 echo "$TITLE_ID $TITLE_TEXT" | tee -a ${OUTPUT_FILE_NAME}.${EXTENSION_CSV}
-  elif [[ "${MODES[@]}" =~ "json" || "${MODES[@]}" =~ "json-asff" ]]; then
+  elif [[ " ${MODES[@]} " =~ " json " || " ${MODES[@]} " =~ " json-asff " ]]; then
     :
   else
     if [[ "$ITEM_SCORED" == "Scored" ]]; then

--- a/prowler
+++ b/prowler
@@ -445,7 +445,7 @@ get_all_checks_without_exclusion() {
 }
 
 ### All functions defined above ... run the workflow
-if [[ ${MODES[@]} =~ "mono" || ${MODES[@]} =~ "text" ]]; then
+if [[ " ${MODES[@]} " =~ " mono " || " ${MODES[@]} " =~ " text " ]]; then
   prowlerBanner
 fi
 
@@ -462,7 +462,7 @@ if [[ $PRINTGROUPSONLY == "1" ]]; then
 fi
 
 # Check that jq is installed for JSON outputs
-if [[ ${MODES[@]} =~ "json" || ${MODES[@]} =~ "json-asff" ]]; then
+if [[ " ${MODES[@]} " =~ " json " || " ${MODES[@]} " =~ " json-asff " ]]; then
   . $PROWLER_DIR/include/jq_detector
 fi
 


### PR DESCRIPTION
Only exact string matches are allowed, preventing clashes when output modes are named similarly, e.g. 'json' and 'json-asff'

Fixes #571

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
