### PR TITLE
Fix check12's grep to find users who really have password access

### DIFF
--- a/checks/check12
+++ b/checks/check12
@@ -19,7 +19,7 @@ CHECK_ALTERNATE_check102="check12"
 check12(){
   # "Ensure multi-factor authentication (MFA) is enabled for all IAM users that have a console password (Scored)"
   # List users with password enabled
-  COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED=$(cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$4 }' |grep true | awk '{ print $1 }')
+  COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED=$(cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$4 }' |grep -F ' true' | awk '{ print $1 }')
   COMMAND12=$(
     for i in $COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED; do
       cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$8 }' |grep "^$i " |grep false | awk '{ print $1 }'

--- a/checks/check12
+++ b/checks/check12
@@ -19,7 +19,7 @@ CHECK_ALTERNATE_check102="check12"
 check12(){
   # "Ensure multi-factor authentication (MFA) is enabled for all IAM users that have a console password (Scored)"
   # List users with password enabled
-  COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED=$(cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$4 }' |grep -F ' true' | awk '{ print $1 }')
+  COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED=$(cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$4 }' |grep -F ' true$' | awk '{ print $1 }')
   COMMAND12=$(
     for i in $COMMAND12_LIST_USERS_WITH_PASSWORD_ENABLED; do
       cat $TEMP_REPORT_FILE|awk -F, '{ print $1,$8 }' |grep "^$i " |grep false | awk '{ print $1 }'


### PR DESCRIPTION
Hey!
Ran into an account with a user named `truedy`. He came up positive in this check because the of the grep... Fixed by searching for ` true` explicitly, which is what the output of `awk` is

(cherry picked from commit 4006c581a06c449b66ede8892b9ae18c735ad34c)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
