### PR TITLE
check21 - If no account cloudtrail trail is found, check org trail

### DIFF
--- a/checks/check21
+++ b/checks/check21
@@ -35,6 +35,11 @@ check21(){
 	done
 
 	if [[ $trail_count == 0 ]]; then
-    textFail "No CloudTrail trails were found in the account"
+	  ORG_TRAIL=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region us-east-1 | jq '.trailList[] | select(.IsMultiRegionTrail and .IsOrganizationTrail) | .Name' | sed 's/"//g')
+	  if [[ $ORG_TRAIL != "" ]]; then
+      textPass "$ORG_TRAIL trail in $regx is enabled for all regions"
+    else
+      textFail "No CloudTrail trails were found in the account"
+    fi
   fi
 }


### PR DESCRIPTION
This check started failing when we moved to an org trail...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
