### PR TITLE
Support setting entropy limit for detect-secrets from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,16 @@ In order to remove noise and get only FAIL findings there is a `-q` flag that ma
 ./prowler -q -M csv -b
 ```
 
+### Set the entropy limit for detect-secrets
+
+Sets the entropy limit for high entropy base64 strings from environment variable `BASE64_LIMIT`. Value must be between 0.0 and 8.0, defaults is 4.5.
+Sets the entropy limit for high entropy hex strings from environment variable `HEX_LIMIT`. Value must be between 0.0 and 8.0, defaults is 3.0.
+
+```sh
+export BASE64_LIMIT=4.5
+export HEX_LIMIT=3.0
+```
+
 ## Security Hub integration
 
 Since version v2.3, Prowler supports natively sending findings to [AWS Security Hub](https://aws.amazon.com/security-hub). This integration allows Prowler to import its findings to AWS Security Hub. With Security Hub, you now have a single place that aggregates, organizes, and prioritizes your security alerts, or findings, from multiple AWS services, such as Amazon GuardDuty, Amazon Inspector, Amazon Macie, AWS Identity and Access Management (IAM) Access Analyzer, and AWS Firewall Manager, as well as from AWS Partner solutions and now from Prowler. It is as simple as running the command below:

--- a/include/secrets_detector
+++ b/include/secrets_detector
@@ -20,35 +20,35 @@ secretsDetector(){
         exit $EXITCODE
     else
         SECRETS_TEMP_FOLDER="$PROWLER_DIR/secrets-$ACCOUNT_NUM"
-        if [[ ! -d $SECRETS_TEMP_FOLDER ]]; then 
+        if [[ ! -d $SECRETS_TEMP_FOLDER ]]; then
             mkdir $SECRETS_TEMP_FOLDER
-        fi 
+        fi
         PYTHON_PIP_DETECTSECRETS_INSTALLED=1
-        # Sets the entropy limit for high entropy base64 strings. Value
-        # must be between 0.0 and 8.0, defaults is 4.5.
-        BASE64_LIMIT=3.0
-        # Sets the entropy limit for high entropy hex strings. Value
-        # must be between 0.0 and 8.0, defaults is 3.0.
-        HEX_LIMIT=3.0
+        # Sets the entropy limit for high entropy base64 strings from
+        # environment variable BASE64_LIMIT.
+        # Value must be between 0.0 and 8.0, defaults is 4.5.
+        # Sets the entropy limit for high entropy hex strings from
+        # environment variable HEX_LIMIT.
+        # Value must be between 0.0 and 8.0, defaults is 3.0.
         case $1 in
             file )
                 # this is to scan a file
-                detect-secrets scan --hex-limit $HEX_LIMIT --base64-limit $BASE64_LIMIT $2 | \
-                jq -r '.results[]|.[] | [.line_number, .type]|@csv' | wc -l 
+                detect-secrets scan --hex-limit ${HEX_LIMIT:-3.0} --base64-limit ${BASE64_LIMIT:-4.5} $2 | \
+                jq -r '.results[]|.[] | [.line_number, .type]|@csv' | wc -l
                 #jq -r '.results[] | .[] | "\(.line_number)\t\(.type)"'
                 # this command must return values in two colums:
                 # line in file and type of secrets found
                 ;;
             string )
-                # this is to scan a given string 
-                detect-secrets scan --hex-limit $HEX_LIMIT --base64-limit $BASE64_LIMIT --string $2 | \
+                # this is to scan a given string
+                detect-secrets scan --hex-limit ${HEX_LIMIT:-3.0} --base64-limit ${BASE64_LIMIT:-4.5} --string $2 | \
                 grep True| wc -l
             ;;
             folder )
-                # this is to scan a given folder with all lambda files 
-                detect-secrets scan --hex-limit $HEX_LIMIT --base64-limit $BASE64_LIMIT --all-files $2 | \
+                # this is to scan a given folder with all lambda files
+                detect-secrets scan --hex-limit ${HEX_LIMIT:-3.0} --base64-limit ${BASE64_LIMIT:-4.5} --all-files $2 | \
                 jq -r '.results[]|.[] | [.line_number, .type]|@csv' | wc -l
             ;;
-        esac 
-    fi  
+        esac
+    fi
 }


### PR DESCRIPTION
Support customizing entropy limit from environment variables `BASE64_LIMIT` and `HEX_LIMIT`.
If environment variables are not set, use the default values

It can help to resolve issues like #498

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
