### PR TITLE
Show failures that are ignored due to whitelisting as skipped checks in JUnit output

### DIFF
--- a/include/junit_integration
+++ b/include/junit_integration
@@ -76,6 +76,10 @@ output_junit_failure() {
   output_junit_test_case "$1" "<failure message=\"$(xml_escape "$1")\"/>"
 }
 
+output_junit_skipped() {
+  output_junit_test_case "$1" "<skipped message=\"$(xml_escape "$1")\"/>"
+}
+
 get_junit_classname() {
   # <section>.<check_id> naturally follows a Java package structure, so it is suitable as a package name
   echo "$TITLE_ID"

--- a/include/outputs
+++ b/include/outputs
@@ -106,13 +106,13 @@ textFail(){
     FAIL_COUNTER=$((FAIL_COUNTER+1))
     EXITCODE=3
   fi
-  
+
   if [[ $2 ]]; then
     REPREGION=$2
   else
     REPREGION=$REGION
   fi
-  
+
   if [[ "${MODES[@]}" =~ "csv" ]]; then
     echo "$PROFILE${SEP}$ACCOUNT_NUM${SEP}$REPREGION${SEP}$TITLE_ID${SEP}${level}${SEP}$ITEM_SCORED${SEP}$ITEM_LEVEL${SEP}$TITLE_TEXT${SEP}$1" | tee -a ${OUTPUT_FILE_NAME}.${EXTENSION_CSV}
   fi
@@ -126,8 +126,12 @@ textFail(){
       sendToSecurityHub "${JSON_ASFF_OUTPUT}"
     fi
   fi
-  if is_junit_output_enabled && [[ "$level" == "FAIL" ]]; then
-    output_junit_failure "$1"
+  if is_junit_output_enabled; then
+    if [[ "${level}" == "FAIL" ]]; then
+      output_junit_failure "$1"
+    elif [[ "${level}" == "WARNING" ]]; then
+      output_junit_skipped "$1"
+    fi
   fi
   if [[ "${MODES[@]}" =~ "mono" ]]; then
     echo "      $colorcode ${level}! $1 $NORMAL" | tee -a ${OUTPUT_FILE_NAME}.$EXTENSION_TEXT


### PR DESCRIPTION
Continue to show (unwhitelisted) failed checks as failures in JUnit output, but rather than exclude failing whitelisted checks from JUnit, mark them as skipped

#### Test output from this branch

Whitelist file contains:
```
check14:marcjay
```
JUnit XML generated:
```
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="1.4" timestamp="2020-05-06T23:51:23Z">
  <properties>
    <property name="prowler.version" value="2.3.0RC"/>
    <property name="aws.profile" value=""/>
    <property name="aws.accountNumber" value="123456789012"/>
    <property name="check.id" value="1.4"/>
    <property name="check.scored" value="Scored"/>
    <property name="check.level" value="Level 1"/>
    <property name="check.asff.type" value="Software and Configuration Checks/Industry and Regulatory Standards/CIS AWS Foundations Benchmark"/>
    <property name="check.asff.resourceType" value="AwsIamUser"/>
  </properties>
  <testcase name="[check14] Ensure access keys are rotated every 90 days or less (Scored) (1)" classname="1.4" time="0.053">
    <skipped message="marcjay has not rotated access key 1 in over 90 days"/>
  </testcase>
  <testcase name="[check14] Ensure access keys are rotated every 90 days or less (Scored) (2)" classname="1.4" time="0.019">
    <system-out>No users with access key 2</system-out>
  </testcase>
</testsuite>
```

#### Whitelisted failure appears in Jenkins as Skipped:
![image](https://user-images.githubusercontent.com/580744/81240188-a1f6e980-8ffe-11ea-8fb6-88a0be69f146.png)
-----
![image](https://user-images.githubusercontent.com/580744/81240306-f4d0a100-8ffe-11ea-90e0-fc2639cf5d9a.png)

Fixes #590

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
