### PR TITLE
Change value of FAIL to FAILED for jsonAsff output type 

### DIFF
--- a/include/outputs
+++ b/include/outputs
@@ -222,6 +222,11 @@ generateJsonAsffOutput(){
   # Replace any successive non-conforming characters with a single underscore
   local message=$1
   local status=$2
+
+  if [[ "$status" == "FAIL" ]]; then
+    status="FAILED"
+  fi
+
   local severity=$3
   jq -M -c \
   --arg ACCOUNT_NUM "$ACCOUNT_NUM" \


### PR DESCRIPTION
`FAIL` status is incompatible…with AWS Security Hub submission

https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-findings-format.html#asff-compliance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
