### PR TITLE
Write output files to a directory relative to Prowler

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git/
+
+# Ignore output directories
+output/
+junit-reports/

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ tags
 *.DS_Store
 
 # Prowler output
-prowler-output-*
+output/
 
 # JUnit Reports
 junit-reports/

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ This script has been written in bash using AWS-CLI and it works in Linux and OSX
     ./prowler -g gdpr -M csv,json,json-asff
     ```
 
-    Now `-M` creates a file inside the prowler root directory named `prowler-output-AWSACCOUNTID-YYYYMMDDHHMMSS.format`. You don't have to specify anything else, no pipes, no redirects.
+    Now `-M` creates a file inside the prowler `output` directory named `prowler-output-AWSACCOUNTID-YYYYMMDDHHMMSS.format`. You don't have to specify anything else, no pipes, no redirects.
 
     or just saving the output to a file like below:
 
@@ -211,10 +211,16 @@ This script has been written in bash using AWS-CLI and it works in Linux and OSX
 
     >Note about output formats to use with `-M`: "text" is the default one with colors, "mono" is like default one but monochrome, "csv" is comma separated values, "json" plain basic json (without comma between lines) and "json-asff" is also json with Amazon Security Finding Format that you can ship to Security Hub using `-S`.
 
-    or save your report in a S3 bucket (this only works for text or mono, for csv, json or json-asff it has to be copied afterwards):
+    or save your report in an S3 bucket (this only works for text or mono. For csv, json or json-asff it has to be copied afterwards):
 
     ```sh
     ./prowler -M mono | aws s3 cp - s3://bucket-name/prowler-report.txt
+    ```
+
+    When generating multiple formats and running using Docker, to retrieve the reports, bind a local directory to the container, e.g.:
+
+    ```sh
+    docker run -ti --rm --name prowler --volume "$(pwd)":/prowler/output --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN toniblyx/prowler:latest -M csv,json
     ```
 
 1. To perform an assessment based on CIS Profile Definitions you can use cislevel1 or cislevel2 with `-g` flag, more information about this [here, page 8](https://d0.awsstatic.com/whitepapers/compliance/AWS_CIS_Foundations_Benchmark.pdf):

--- a/include/outputs
+++ b/include/outputs
@@ -19,7 +19,11 @@ EXTENSION_ASFF="asff-json"
 EXTENSION_TEXT="txt"
 EXTENSION_HTML="html" # not implemented yet, use ansi2html as in documentation
 OUTPUT_DATE=$(date -u +"%Y%m%d%H%M%S")
-OUTPUT_FILE_NAME="prowler-output-${ACCOUNT_NUM}-${OUTPUT_DATE}"
+OUTPUT_DIR="${PROWLER_DIR}/output"
+OUTPUT_FILE_NAME="${OUTPUT_DIR}/prowler-output-${ACCOUNT_NUM}-${OUTPUT_DATE}"
+
+# Ensure that output directory always exists
+mkdir -p "${OUTPUT_DIR}"
 
 textPass(){
   if [[ "$QUIET" == 1 ]]; then

--- a/util/Dockerfile
+++ b/util/Dockerfile
@@ -9,10 +9,12 @@ RUN addgroup -g ${USERID} ${USERNAME} && \
     pip3 install --upgrade pip && \
     pip install awscli ansi2html boto3 detect-secrets
 
-ADD . /prowler
+WORKDIR /prowler
 
-RUN chown -R prowler /prowler/
+COPY . ./
+
+RUN chown -R prowler .
 
 USER ${USERNAME}
 
-ENTRYPOINT ["/prowler/prowler"]
+ENTRYPOINT ["./prowler"]


### PR DESCRIPTION
Write output files (CSV, JSON, etc.) to an `output` directory that is relative to prowler itself, no matter where prowler is invoked from.
Simplify Dockerfile by specifying a WORKDIR
Replace ADD command with the more recommended COPY command
Update README to cover how to run in Docker and access saved reports
Add a .dockerignore file to ignore .git and output directories

This partially addresses #570 - previously, within Docker, Prowler was attempting to write
reports to the root `/` directory in the container, which it did not have permission to do.
Instead, reports are now written to a path relative to Prowler

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
