### PR TITLE
Feature: add support for IRSA

### DIFF
--- a/include/aws_profile_loader
+++ b/include/aws_profile_loader
@@ -31,6 +31,9 @@ elif [[ -n $AWS_CONTAINER_CREDENTIALS_RELATIVE_URI ]] && [[ -z $INSTANCE_PROFILE
     AWS_ACCESS_KEY_ID=$(curl -s 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI | grep AccessKeyId | cut -d':' -f2 | sed 's/[^0-9A-Z]*//g')
     AWS_SECRET_ACCESS_KEY_ID=$(curl -s 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI | grep SecretAccessKey | cut -d':' -f2 | sed 's/[^0-9A-Za-z/+=]*//g')
     AWS_SESSION_TOKEN=$(curl -s 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI  grep Token| cut -d':' -f2 | sed 's/[^0-9A-Za-z/+=]*//g')
+elif [[ $AWS_WEB_IDENTITY_TOKEN_FILE ]]
+    PROFILE=""
+    PROFILE_OPT=""
 elif [[ $INSTANCE_PROFILE ]];then
     PROFILE="INSTANCE-PROFILE"
     AWS_ACCESS_KEY_ID=$(curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/${INSTANCE_PROFILE} | grep AccessKeyId | cut -d':' -f2 | sed 's/[^0-9A-Z]*//g')


### PR DESCRIPTION
IAM roles for service accounts (IRSA) allows prowler to be used from
inside a kubernetes cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
