### PR TITLE
ECR Scanning imageDigest issues

### DIFF
--- a/checks/check_extra776
+++ b/checks/check_extra776
@@ -42,44 +42,46 @@ extra776(){
       for repo in $LIST_ECR_REPOS; do
         SCAN_ENABLED=$($AWSCLI ecr describe-repositories $PROFILE_OPT --region $region --query "repositories[?repositoryName==\`$repo\`].[imageScanningConfiguration.scanOnPush]" --output text 2>&1)
         if [[ "$SCAN_ENABLED" == "True" ]]; then
-          IMAGE_DIGEST=$($AWSCLI ecr describe-images $PROFILE_OPT --region $region --repository-name "$repo" --query "sort_by(imageDetails,& imagePushedAt)[-1].imageDigest" --output text 2>&1)
-          IMAGE_TAG=$($AWSCLI ecr describe-images $PROFILE_OPT --region $region --repository-name "$repo" --query "sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]" --output text 2>&1)
-          if [[ ! -z "$LIST_ECR_REPOS" ]]; then
-            IMAGE_SCAN_STATUS=$($AWSCLI ecr describe-image-scan-findings $PROFILE_OPT --region $region --repository-name "$repo" --image-id imageDigest="$IMAGE_DIGEST" --query "imageScanStatus.status" 2>&1)
-            if [[ $IMAGE_SCAN_STATUS == *"ScanNotFoundException"* ]]; then
-              textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG without a scan" "$region"
-            else
-              if [[ $IMAGE_SCAN_STATUS == *"FAILED"* ]]; then
-                textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with scan status $IMAGE_SCAN_STATUS" "$region"
+          IMAGE_DIGEST=$($AWSCLI ecr describe-images $PROFILE_OPT --region $region --repository-name "$repo" --query "sort_by(imageDetails,& imagePushedAt)[-1].imageDigest" --output text | head -n 1 2>&1)
+          if [[ $IMAGE_DIGEST != *"None"* ]]; then
+            IMAGE_TAG=$($AWSCLI ecr describe-images $PROFILE_OPT --region $region --repository-name "$repo" --query "sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]" --output text 2>&1)
+            if [[ ! -z "$LIST_ECR_REPOS" ]]; then
+              IMAGE_SCAN_STATUS=$($AWSCLI ecr describe-image-scan-findings $PROFILE_OPT --region $region --repository-name "$repo" --image-id imageDigest="$IMAGE_DIGEST" --query "imageScanStatus.status" 2>&1)
+              if [[ $IMAGE_SCAN_STATUS == *"ScanNotFoundException"* ]]; then
+                textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG without a scan" "$region"
               else
-                FINDINGS_COUNT=$($AWSCLI ecr describe-image-scan-findings $PROFILE_OPT --region $region --repository-name "$repo" --image-id imageDigest="$IMAGE_DIGEST" --query "imageScanFindings.findingSeverityCounts" 2>&1)
-                if [[ ! -z "$FINDINGS_COUNT" ]]; then
-                    SEVERITY_CRITICAL=$(echo "$FINDINGS_COUNT" | jq -r '.CRITICAL' )
-                    if [[ "$SEVERITY_CRITICAL" != "null" ]]; then
-                      textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with CRITICAL ($SEVERITY_CRITICAL) findings" "$region"
-                    fi
-                    SEVERITY_HIGH=$(echo "$FINDINGS_COUNT" | jq -r '.HIGH' )
-                    if [[ "$SEVERITY_HIGH" != "null" ]]; then
-                      textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with HIGH ($SEVERITY_HIGH) findings" "$region"
-                    fi
-                    SEVERITY_MEDIUM=$(echo "$FINDINGS_COUNT" | jq -r '.MEDIUM' )
-                    if [[ "$SEVERITY_MEDIUM" != "null" ]]; then
-                      textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with MEDIUM ($SEVERITY_MEDIUM) findings" "$region"
-                    fi
-                    SEVERITY_LOW=$(echo "$FINDINGS_COUNT" | jq -r '.LOW' )
-                    if [[ "$SEVERITY_LOW" != "null" ]]; then
-                      textInfo "$region: ECR repository $repo has imageTag $IMAGE_TAG with LOW ($SEVERITY_LOW) findings" "$region"
-                    fi
-                    SEVERITY_INFORMATIONAL=$(echo "$FINDINGS_COUNT" | jq -r '.INFORMATIONAL' )
-                    if [[ "$SEVERITY_INFORMATIONAL" != "null" ]]; then
-                      textInfo "$region: ECR repository $repo has imageTag $IMAGE_TAG with INFORMATIONAL ($SEVERITY_INFORMATIONAL) findings" "$region"
-                    fi
-                    SEVERITY_UNDEFINED=$(echo "$FINDINGS_COUNT" | jq -r '.UNDEFINED' )
-                    if [[ "$SEVERITY_UNDEFINED" != "null" ]]; then
-                      textInfo "$region: ECR repository $repo has imageTag $IMAGE_TAG with UNDEFINED ($SEVERITY_UNDEFINED) findings" "$region"
-                    fi
+                if [[ $IMAGE_SCAN_STATUS == *"FAILED"* ]]; then
+                  textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with scan status $IMAGE_SCAN_STATUS" "$region"
                 else
-                  textPass "$region: ECR repository $repo has imageTag $IMAGE_TAG without findings" "$region"
+                  FINDINGS_COUNT=$($AWSCLI ecr describe-image-scan-findings $PROFILE_OPT --region $region --repository-name "$repo" --image-id imageDigest="$IMAGE_DIGEST" --query "imageScanFindings.findingSeverityCounts" 2>&1)
+                  if [[ ! -z "$FINDINGS_COUNT" ]]; then
+                      SEVERITY_CRITICAL=$(echo "$FINDINGS_COUNT" | jq -r '.CRITICAL' )
+                      if [[ "$SEVERITY_CRITICAL" != "null" ]]; then
+                        textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with CRITICAL ($SEVERITY_CRITICAL) findings" "$region"
+                      fi
+                      SEVERITY_HIGH=$(echo "$FINDINGS_COUNT" | jq -r '.HIGH' )
+                      if [[ "$SEVERITY_HIGH" != "null" ]]; then
+                        textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with HIGH ($SEVERITY_HIGH) findings" "$region"
+                      fi
+                      SEVERITY_MEDIUM=$(echo "$FINDINGS_COUNT" | jq -r '.MEDIUM' )
+                      if [[ "$SEVERITY_MEDIUM" != "null" ]]; then
+                        textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with MEDIUM ($SEVERITY_MEDIUM) findings" "$region"
+                      fi
+                      SEVERITY_LOW=$(echo "$FINDINGS_COUNT" | jq -r '.LOW' )
+                      if [[ "$SEVERITY_LOW" != "null" ]]; then
+                        textInfo "$region: ECR repository $repo has imageTag $IMAGE_TAG with LOW ($SEVERITY_LOW) findings" "$region"
+                      fi
+                      SEVERITY_INFORMATIONAL=$(echo "$FINDINGS_COUNT" | jq -r '.INFORMATIONAL' )
+                      if [[ "$SEVERITY_INFORMATIONAL" != "null" ]]; then
+                        textInfo "$region: ECR repository $repo has imageTag $IMAGE_TAG with INFORMATIONAL ($SEVERITY_INFORMATIONAL) findings" "$region"
+                      fi
+                      SEVERITY_UNDEFINED=$(echo "$FINDINGS_COUNT" | jq -r '.UNDEFINED' )
+                      if [[ "$SEVERITY_UNDEFINED" != "null" ]]; then
+                        textInfo "$region: ECR repository $repo has imageTag $IMAGE_TAG with UNDEFINED ($SEVERITY_UNDEFINED) findings" "$region"
+                      fi
+                  else
+                    textPass "$region: ECR repository $repo has imageTag $IMAGE_TAG without findings" "$region"
+                  fi
                 fi
               fi
             fi


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

With the ECR scanning check I found a couple of issues in my environment that would return:

An error occurred (InvalidParameterException) when calling the DescribeImageScanFindings operation: Invalid parameter at 'imageDigest' failed to satisfy constraint: 'must satisfy regular expression '[a-zA-Z0-9-_+.]+:[a-fA-F0-9]+''
parse error: Invalid numeric literal at line 2, column 3

1. If the IMAGE_DIGEST var returned "None" (i.e. there was no image) the script would continue and generate these errors since `imageDigest` was "None". Added an if statement to skip this scenario
2. For reasons I have not yet been able to isolate, in some ECR repos, the IMAGE_DIGEST query would return 2 image digest values, I have added the `| head -n 1` command to always return the first value

These changes have resolved the errors I was getting from AWS