### PR TITLE
Split ignores by newline instead of spaces only

### DIFF
--- a/include/outputs
+++ b/include/outputs
@@ -111,19 +111,19 @@ textFail(){
   ## ignore whitelists for current check
   level="FAIL"
   colorcode="$BAD"
-  for i in $IGNORES; do
+  while read -r i; do
     ignore_check_name="${i%:*}"
     ignore_value="${i#*${CHECK_NAME}:}"
     if [[ ${ignore_check_name} != "${CHECK_NAME}" ]]; then
       # not for this check
       continue
     fi
-    if [[ $1 =~ ${ignore_value} ]]; then
+    if [[ $1 =~ .*"${ignore_value}".* ]]; then
       level="WARNING"
       colorcode="$WARNING"
       break
     fi
-  done
+  done <<< "$IGNORES"
 
   # only set non-0 exit code on FAIL mode, WARN is ok
   if [[ "$level" == "FAIL" ]]; then


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I was looking at https://github.com/toniblyx/prowler/issues/598 and realized that whitelist didn't match properly on spaces.
This should help support something like `check121:User foo is not setup properly` vs just `check121:foo`