### PR TITLE
Fix extra734 - handle us-east-1

### DIFF
--- a/checks/check_extra734
+++ b/checks/check_extra734
@@ -27,6 +27,12 @@ extra734(){
       #  OR
       # - Have bucket policy denying s3:PutObject when s3:x-amz-server-side-encryption is absent
 
+      if [[ $BUCKET_LOCATION == "None" ]]; then
+        BUCKET_LOCATION="us-east-1"
+      fi
+      if [[ $BUCKET_LOCATION == "EU" ]]; then
+        BUCKET_LOCATION="eu-west-1"
+      fi
       # query to get if has encryption enabled or not
       RESULT=$($AWSCLI s3api get-bucket-encryption $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --query ServerSideEncryptionConfiguration.Rules[].ApplyServerSideEncryptionByDefault[].SSEAlgorithm --output text 2>&1)
       if [[ $(echo "$RESULT" | grep AccessDenied) ]]; then


### PR DESCRIPTION
(cherry picked from commit 5f2eb7f82e3814478b380ae5fbb6c8a69536e043)

Lately I used this check and found it failed for all buckets located in us-east-1. That's because [get-bucket-location returns null for us-east-1](https://docs.aws.amazon.com/cli/latest/reference/s3api/get-bucket-location.html).

This handles it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
