### PR TITLE
Fix extra764 - handle us-east-1 & check validity of policy

### DIFF
--- a/checks/check_extra764
+++ b/checks/check_extra764
@@ -23,6 +23,12 @@ extra764(){
     for bucket in $LIST_OF_BUCKETS;do
       TEMP_STP_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-${bucket}.policy.XXXXXXXXXX)
       BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location $PROFILE_OPT --region $REGION --bucket $bucket --output text)
+      if [[ "None" == $BUCKET_LOCATION ]]; then
+        BUCKET_LOCATION="us-east-1"
+      fi
+      if [[ "EU" == $BUCKET_LOCATION ]]; then
+        BUCKET_LOCATION="eu-west-1"
+      fi
       # get bucket policy
       $AWSCLI s3api get-bucket-policy $PROFILE_OPT --bucket $bucket --output text --query Policy --region $BUCKET_LOCATION > $TEMP_STP_POLICY_FILE 2>&1
       if [[ $(grep AccessDenied $TEMP_STP_POLICY_FILE) ]]; then
@@ -37,11 +43,17 @@ extra764(){
       fi
 
       # https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-policy-for-config-rule/
-      CHECK_BUCKET_STP_POLICY_PRESENT=$(cat $TEMP_STP_POLICY_FILE | jq --arg arn "arn:${AWS_PARTITION}:s3:::${bucket}" '.Statement[]|select((((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and .Action=="s3:*" and (.Resource|type == "array") and (.Resource|map({(.):0})[]|has($arn)) and (.Resource|map({(.):0})[]|has($arn+"/*")) and .Condition.Bool."aws:SecureTransport" == "false")')
-      if [[ $CHECK_BUCKET_STP_POLICY_PRESENT ]]; then
-        textPass "Bucket $bucket has S3 bucket policy to deny requests over insecure transport"
+      # checking if $TEMP_STP_POLICY_FILE is a valid json before converting it to json with jq
+      policy_str=$(cat "$TEMP_STP_POLICY_FILE")
+      if jq -e . >/dev/null 2>&1 <<< "$policy_str"; then
+        CHECK_BUCKET_STP_POLICY_PRESENT=$(cat $TEMP_STP_POLICY_FILE | jq --arg arn "arn:${AWS_PARTITION}:s3:::${bucket}" '.Statement[]|select((((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and .Action=="s3:*" and (.Resource|type == "array") and (.Resource|map({(.):0})[]|has($arn)) and (.Resource|map({(.):0})[]|has($arn+"/*")) and .Condition.Bool."aws:SecureTransport" == "false")')
+        if [[ $CHECK_BUCKET_STP_POLICY_PRESENT ]]; then
+          textPass "Bucket $bucket has S3 bucket policy to deny requests over insecure transport"
+        else
+          textFail "Bucket $bucket allows requests over insecure transport"
+        fi
       else
-        textFail "Bucket $bucket allows requests over insecure transport"
+          textInfo "Unknown Error occurred: $policy_str"
       fi
       rm -fr $TEMP_STP_POLICY_FILE
     done


### PR DESCRIPTION
(cherry picked from commit 89bd8a90d5767c70a59ab29928501bad3be6ad84)
Found 2 minor bugs in this check:
1. It failed for all buckets located in us-east-1. That's because [get-bucket-location returns null for us-east-1](https://docs.aws.amazon.com/cli/latest/reference/s3api/get-bucket-location.html). This handles it.
2. If the get-bucket-policy fails, something which isn't a JSON string is returned and that causes prowler to fail. This avoids the failure by graciously noting the error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
