### PR TITLE
Import Security Hub finding into the same region as the related resource

### DIFF
--- a/include/outputs
+++ b/include/outputs
@@ -27,13 +27,13 @@ TIMESTAMP=$(get_iso8601_timestamp)
 PROWLER_PARAMETERS=$@
 
 # Ensure that output directory always exists when -M is used
-if [[ $MODE ]];then 
+if [[ $MODE ]];then
   mkdir -p "${OUTPUT_DIR}"
   if [[ "${MODES[@]}" =~ "html" ]]; then
     addHtmlHeader > ${OUTPUT_FILE_NAME}.$EXTENSION_HTML
     HTML_REPORT_INIT="1"
   fi
-fi 
+fi
 
 if [[ $PROFILE == "" ]];then
   PROFILE="ENV"
@@ -60,7 +60,7 @@ textPass(){
     JSON_ASFF_OUTPUT=$(generateJsonAsffOutput "$1" "PASSED" "INFORMATIONAL")
     echo "${JSON_ASFF_OUTPUT}" | tee -a $OUTPUT_FILE_NAME.$EXTENSION_ASFF
     if [[ "${SEND_TO_SECURITY_HUB}" -eq 1 ]]; then
-      sendToSecurityHub "${JSON_ASFF_OUTPUT}"
+      sendToSecurityHub "${JSON_ASFF_OUTPUT}" "${REPREGION}"
     fi
   fi
   if is_junit_output_enabled; then
@@ -147,7 +147,7 @@ textFail(){
     JSON_ASFF_OUTPUT=$(generateJsonAsffOutput "$1" "${level}" "HIGH")
     echo "${JSON_ASFF_OUTPUT}" | tee -a ${OUTPUT_FILE_NAME}.${EXTENSION_ASFF}
     if [[ "${SEND_TO_SECURITY_HUB}" -eq 1 ]]; then
-      sendToSecurityHub "${JSON_ASFF_OUTPUT}"
+      sendToSecurityHub "${JSON_ASFF_OUTPUT}" "${REPREGION}"
     fi
   fi
   if is_junit_output_enabled; then
@@ -318,7 +318,7 @@ generateHtmlOutput(){
       echo '<td>'$TITLE_TEXT'</td>' >> ${OUTPUT_FILE_NAME}.$EXTENSION_HTML
       echo '<td>'$message'</td>' >> ${OUTPUT_FILE_NAME}.$EXTENSION_HTML
     echo '</tr>' >> ${OUTPUT_FILE_NAME}.$EXTENSION_HTML
-  fi 
+  fi
   if [[ $status == "PASS" ]];then
     echo '<tr class="p-3 mb-2 bg-success">' >> ${OUTPUT_FILE_NAME}.$EXTENSION_HTML
       echo '<td><i class="fas fa-thumbs-up"></i></td>' >> ${OUTPUT_FILE_NAME}.$EXTENSION_HTML

--- a/include/securityhub_integration
+++ b/include/securityhub_integration
@@ -14,21 +14,26 @@
 # Checks that the correct mode (json-asff) has been specified if wanting to send check output to AWS Security Hub
 # and that Security Hub is enabled in the chosen region
 checkSecurityHubCompatibility(){
+  local regx
   if [[ "${MODE}" != "json-asff" ]]; then
     echo -e "\n$RED ERROR!$NORMAL Output can only be sent to Security Hub when the output mode is json-asff, i.e. -M json-asff -S\n"
     EXITCODE=1
     exit $EXITCODE
   fi
-  SECURITY_HUB_ENABLED=$($AWSCLI securityhub --region $REGION $PROFILE_OPT describe-hub)
-  if [[ -z "${SECURITY_HUB_ENABLED}" ]]; then
-    echo -e "\n$RED ERROR!$NORMAL Security Hub is not enabled in $REGION. Enable it by calling '$AWSCLI securityhub --region $REGION $PROFILE_OPT enable-security-hub'\n"
-    EXITCODE=1
-    exit $EXITCODE
-  fi
+  for regx in $REGIONS; do
+    SECURITY_HUB_ENABLED=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT describe-hub)
+    if [[ -z "${SECURITY_HUB_ENABLED}" ]]; then
+      echo -e "\n$RED ERROR!$NORMAL Security Hub is not enabled in $regx. Enable it by calling '$AWSCLI securityhub --region $regx $PROFILE_OPT enable-security-hub'\n"
+      EXITCODE=1
+      exit $EXITCODE
+    fi
+  done
 }
 
 sendToSecurityHub(){
-  BATCH_IMPORT_RESULT=$($AWSCLI securityhub --region $REGION $PROFILE_OPT batch-import-findings --findings "$1")
+  local findings="$1"
+  local region="$2"
+  BATCH_IMPORT_RESULT=$($AWSCLI securityhub --region "$region" $PROFILE_OPT batch-import-findings --findings "${findings}")
   # A successful CLI response is: {"SuccessCount": 1,"FailedFindings": [],"FailedCount": 0}
   # Therefore, check that SuccessCount is indeed 1
   if [[ -z "${BATCH_IMPORT_RESULT}" ]] || ! jq -e '.SuccessCount == 1' <<< "${BATCH_IMPORT_RESULT}" > /dev/null 2>&1; then


### PR DESCRIPTION
Force the batch-import-findings AWS CLI call to be directed at the region the currently reporting resource is located in, as Security Hub enforces this requirement

When checking that Security Hub is enabled, check for all regions that are in scope, e.g. all regions, unless '-f \<region>' is used

Fixes #618

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
