### PR TITLE
Fixing profile and region settings for check_extra792 - ELB SSL ciphers

### DIFF
--- a/checks/check_extra792
+++ b/checks/check_extra792
@@ -30,7 +30,7 @@ extra792(){
         ELBSECURECIPHERS=("Protocol-TLSv1.2" "Protocol-TLSv1.1" "Protocol-TLSv1" "ECDHE-ECDSA-AES128-GCM-SHA256" "ECDHE-RSA-AES128-GCM-SHA256" "ECDHE-ECDSA-AES128-SHA256" "ECDHE-RSA-AES128-SHA256" "ECDHE-ECDSA-AES128-SHA" "ECDHE-RSA-AES128-SHA" "ECDHE-ECDSA-AES256-GCM-SHA384" "ECDHE-RSA-AES256-GCM-SHA384" "ECDHE-ECDSA-AES256-SHA384" "ECDHE-RSA-AES256-SHA384" "ECDHE-RSA-AES256-SHA" "ECDHE-ECDSA-AES256-SHA" "AES128-GCM-SHA256" "AES128-SHA256" "AES128-SHA" "AES256-GCM-SHA384" "AES256-SHA256" "AES256-SHA" "Server-Defined-Cipher-Order")
 
         for elb in $LIST_OF_ELBS; do
-          ELB_POLICIES=$($AWSCLI elb describe-load-balancers --load-balancer-name $elb --query "LoadBalancerDescriptions[0].ListenerDescriptions[*].PolicyNames" --output text) 
+          ELB_POLICIES=$($AWSCLI elb describe-load-balancers $PROFILE_OPT --region $regx --load-balancer-name $elb --query "LoadBalancerDescriptions[0].ListenerDescriptions[*].PolicyNames" --output text) 
           passed=true
           for policy in $ELB_POLICIES; do
             # Check for secure default policy 


### PR DESCRIPTION
A region and profile was missed on one of the API calls.  This PR corrects that.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
