### PR TITLE
Fix listing configurations if default output format is not JSON

### DIFF
--- a/checks/check119
+++ b/checks/check119
@@ -18,7 +18,7 @@ CHECK_ALTERNATE_check119="check119"
 
 check119(){
   for regx in $REGIONS; do
-    EC2_DATA=$($AWSCLI ec2 describe-instances $PROFILE_OPT --region $regx --query 'Reservations[].Instances[].[InstanceId, IamInstanceProfile.Arn, State.Name]')
+    EC2_DATA=$($AWSCLI ec2 describe-instances $PROFILE_OPT --region $regx --query 'Reservations[].Instances[].[InstanceId, IamInstanceProfile.Arn, State.Name]' --output json)
     EC2_DATA=$(echo $EC2_DATA | jq '.[]|{InstanceId: .[0], ProfileArn: .[1], StateName: .[2]}')
     INSTANCE_LIST=$(echo $EC2_DATA | jq -r '.InstanceId')
     if [[ $INSTANCE_LIST ]]; then

--- a/checks/check_extra742
+++ b/checks/check_extra742
@@ -26,7 +26,7 @@ extra742(){
 
   textInfo "Looking for secrets in CloudFormation output across all regions... "
   for regx in $REGIONS; do
-    CFN_STACKS=$($AWSCLI cloudformation describe-stacks $PROFILE_OPT --region $regx)
+    CFN_STACKS=$($AWSCLI cloudformation describe-stacks $PROFILE_OPT --region $regx --output json)
     LIST_OF_CFN_STACKS=$(echo $CFN_STACKS | jq -r '.Stacks[].StackName')
     if [[ $LIST_OF_CFN_STACKS ]];then
       for stack in $LIST_OF_CFN_STACKS; do

--- a/checks/check_extra75
+++ b/checks/check_extra75
@@ -24,7 +24,7 @@ extra75(){
   textInfo "Looking for Security Groups in all regions...  "
 
   for regx in $REGIONS; do
-    SECURITYGROUPS=$($AWSCLI ec2 describe-security-groups $PROFILE_OPT --region $regx --max-items $MAXITEMS | jq '.SecurityGroups|map({(.GroupId): (.GroupName)})|add')
+    SECURITYGROUPS=$($AWSCLI ec2 describe-security-groups $PROFILE_OPT --region $regx --max-items $MAXITEMS --output json | jq '.SecurityGroups|map({(.GroupId): (.GroupName)})|add')
     if [[ $SECURITYGROUPS == "null" ]];
     then
       continue

--- a/checks/check_extra772
+++ b/checks/check_extra772
@@ -19,7 +19,7 @@ CHECK_ALTERNATE_check772="extra772"
 
 extra772(){
   for region in $REGIONS; do
-    EIP_DUMP=$($AWSCLI ec2 describe-addresses ${PROFILE_OPT} --region $region)
+    EIP_DUMP=$($AWSCLI ec2 describe-addresses ${PROFILE_OPT} --region $region --output json)
     EIP_LIST=$(echo $EIP_DUMP | jq -r '.Addresses[].AllocationId')
     if [[ $EIP_LIST ]]; then
       for eip in $EIP_LIST; do


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This prevents errors like:
```
parse error: Invalid numeric literal at line 1, column 2 
```