### PR TITLE
Don't fail check extra737 for keys scheduled for deletion

### DIFF
--- a/checks/check_extra737
+++ b/checks/check_extra737
@@ -24,7 +24,7 @@ extra737(){
     if [[ $LIST_OF_CUSTOMER_KMS_KEYS ]];then
       for key in $LIST_OF_CUSTOMER_KMS_KEYS; do
         CHECK_ROTATION=$($AWSCLI kms get-key-rotation-status --key-id $key $PROFILE_OPT --region $regx  --output text)
-        CHECK_STATUS=$($AWSCLI kms describe-key --key-id $key $PROFILE_OPT --region $regx | jq -r '.KeyMetadata.KeyState')
+        CHECK_STATUS=$($AWSCLI kms describe-key --key-id $key $PROFILE_OPT --region $regx --output json | jq -r '.KeyMetadata.KeyState')
         if [[ $CHECK_STATUS == "PendingDeletion" ]]; then
           textInfo "$regx: KMS key $key is pending deletion and cannot be rotated" "$regx"
         elif [[ $CHECK_ROTATION == "False" ]]; then

--- a/checks/check_extra737
+++ b/checks/check_extra737
@@ -24,7 +24,10 @@ extra737(){
     if [[ $LIST_OF_CUSTOMER_KMS_KEYS ]];then
       for key in $LIST_OF_CUSTOMER_KMS_KEYS; do
         CHECK_ROTATION=$($AWSCLI kms get-key-rotation-status --key-id $key $PROFILE_OPT --region $regx  --output text)
-        if [[ $CHECK_ROTATION == "False" ]]; then
+        CHECK_STATUS=$($AWSCLI kms describe-key --key-id $key $PROFILE_OPT --region $regx | jq -r '.KeyMetadata.KeyState')
+        if [[ $CHECK_STATUS == "PendingDeletion" ]]; then
+          textInfo "$regx: KMS key $key is pending deletion and cannot be rotated" "$regx"
+        elif [[ $CHECK_ROTATION == "False" ]]; then
           textFail "$regx: KMS key $key has rotation disabled!" "$regx"
         else
           textPass "$regx: KMS key $key has rotation enabled" "$regx"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

If a KMS key is scheduled for deletion, it can't have rotation enabled, but it still shouldn't cause the test to fail. This fixes that.