### PR TITLE
Check org Cloudtrail first and pass if enabled

### DIFF
--- a/checks/check21
+++ b/checks/check21
@@ -17,8 +17,13 @@ CHECK_ASFF_RESOURCE_TYPE_check21="AwsCloudTrailTrail"
 CHECK_ALTERNATE_check201="check21"
 
 check21(){
-  trail_count=0
-  # "Ensure CloudTrail is enabled in all regions (Scored)"
+	ORG_TRAIL=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region us-east-1 | jq '.trailList[] | select(.IsMultiRegionTrail and .IsOrganizationTrail) | .Name' | sed 's/"//g')
+	if [[ $ORG_TRAIL != "" ]]; then
+		textPass "$ORG_TRAIL trail in us-east-1 is enabled for all regions"
+		return
+	fi
+	trail_count=0
+	# "Ensure CloudTrail is enabled in all regions (Scored)"
 	for regx in $REGIONS; do
 		LIST_OF_TRAILS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query 'trailList[*].Name' --output text --no-include-shadow-trails)
 		if [[ $LIST_OF_TRAILS ]];then
@@ -35,11 +40,6 @@ check21(){
 	done
 
 	if [[ $trail_count == 0 ]]; then
-	  ORG_TRAIL=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region us-east-1 | jq '.trailList[] | select(.IsMultiRegionTrail and .IsOrganizationTrail) | .Name' | sed 's/"//g')
-	  if [[ $ORG_TRAIL != "" ]]; then
-      textPass "$ORG_TRAIL trail in $regx is enabled for all regions"
-    else
       textFail "No CloudTrail trails were found in the account"
     fi
-  fi
 }


### PR DESCRIPTION
Hi @toniblyx 

We changed the Cloudtrail check implementation to first check if an organizational trail is enabled and if so we stop and report PASS. Without this change the check would fail at the first single region trail, even if there is an organizational / other trail with multi region enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
