### PR TITLE
Adding 4 EKS checks

### DIFF
--- a/checks/check_extra794
+++ b/checks/check_extra794
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Prowler - the handy cloud security tool (copyright 2019) by Toni de la Fuente
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+CHECK_ID_extra794="7.94"
+CHECK_TITLE_extra794="[extra794] Ensure EKS Control Plane Audit Logging is enabled for all log types"
+CHECK_SCORED_extra794="NOT_SCORED"
+CHECK_TYPE_extra794="EXTRA"
+CHECK_ASFF_RESOURCE_TYPE_extra794="AwsEksCluster"
+CHECK_ALTERNATE_check794="extra794"
+
+extra794(){
+  textInfo "Looking for control plane logging enabled for EKS clusters across all regions... "
+  for regx in $REGIONS; do
+    # Get a list of EKS clusters (Unless us-west-1 which doesn't support EKS):
+    if [[ $regx == "us-west-1" ]]; then
+      textInfo "$regx: EKS not supported in this region" "$regx"
+    else
+      CLUSTERS=$($AWSCLI eks list-clusters $PROFILE_OPT --region $regx --query 'clusters[]' --output text)
+    fi
+    if [[ $CLUSTERS ]]; then
+      for CLUSTER in $CLUSTERS;do
+        CLUSTERDEF=$($AWSCLI eks describe-cluster $PROFILE_OPT --region $regx --name $CLUSTER --query 'cluster.logging.clusterLogging[0]')
+        LOGGING_ENABLED=$(echo $CLUSTERDEF | jq -r '.enabled')
+        TYPES=$(echo $CLUSTERDEF | jq -r '.types[]')
+        if [[ $LOGGING_ENABLED == "true" ]]; then
+           if [[ $(echo $TYPES | egrep "api.*audit.*authenticator.*controllerManager.*scheduler") ]]; then
+              textPass "$regx: Control plane logging enabled and correctly configured for EKS cluster $CLUSTER" "$regx"
+           else
+              textFail "$regx: Control plane logging enabled, but not all log types collected for EKS cluster $CLUSTER" "$regx"
+           fi
+        else
+              textFail "$regx: Control plane logging is not enabled for EKS cluster $CLUSTER" "$regx"
+        fi
+      done
+    else
+      if [[ $regx != "us-west-1" ]]; then
+        textInfo "$regx: No EKS clusters found" "$regx"
+      fi
+    fi
+  done
+}

--- a/checks/check_extra795
+++ b/checks/check_extra795
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Prowler - the handy cloud security tool (copyright 2019) by Toni de la Fuente
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+CHECK_ID_extra795="7.95"
+CHECK_TITLE_extra795="[extra795] Ensure EKS Clusters are created with Private Endpoint Enabled and Public Access Disabled"
+CHECK_SCORED_extra795="NOT_SCORED"
+CHECK_TYPE_extra795="EXTRA"
+CHECK_ASFF_RESOURCE_TYPE_extra795="AwsEksCluster"
+CHECK_ALTERNATE_check795="extra795"
+
+extra795(){
+  textInfo "Looking for public access enabled for EKS clusters across all regions... "
+  for regx in $REGIONS; do
+    # Get a list of EKS clusters (Unless us-west-1 which doesn't support EKS):
+    if [[ $regx == "us-west-1" ]]; then
+      textInfo "$regx: EKS not supported in this region" "$regx"
+    else
+      CLUSTERS=$($AWSCLI eks list-clusters $PROFILE_OPT --region $regx --query 'clusters[]' --output text)
+    fi
+    if [[ $CLUSTERS ]]; then
+      for CLUSTER in $CLUSTERS;do
+        CLUSTERDEF=$($AWSCLI eks describe-cluster $PROFILE_OPT --region $regx --name $CLUSTER --query 'cluster.resourcesVpcConfig')
+        PUB_ENABLED=$(echo $CLUSTERDEF | jq -r '.endpointPublicAccess')
+        PRIV_ENABLED=$(echo $CLUSTERDEF | jq -r '.endpointPrivateAccess')
+
+        if [[ $PUB_ENABLED == "false" ]] && [[ $PRIV_ENABLED == "true" ]] ; then
+          textPass "$regx: Cluster endpoint access is private for EKS cluster $CLUSTER" "$regx"
+        else
+              textFail "$regx: Cluster endpoint access is public for EKS cluster $CLUSTER" "$regx"
+        fi
+      done
+    else
+      if [[ $regx != "us-west-1" ]]; then
+        textInfo "$regx: No EKS clusters found" "$regx"
+      fi
+    fi
+  done
+}

--- a/checks/check_extra796
+++ b/checks/check_extra796
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Prowler - the handy cloud security tool (copyright 2019) by Toni de la Fuente
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+CHECK_ID_extra796="7.96"
+CHECK_TITLE_extra796="[extra796] Restrict Access to the EKS Control Plane Endpoint"
+CHECK_SCORED_extra796="NOT_SCORED"
+CHECK_TYPE_extra796="EXTRA"
+CHECK_ASFF_RESOURCE_TYPE_extra796="AwsEksCluster"
+CHECK_ALTERNATE_check796="extra796"
+
+extra796(){
+  textInfo "Looking for public access CIDRs for EKS clusters across all regions... "
+  for regx in $REGIONS; do
+    # Get a list of EKS clusters (Unless us-west-1 which doesn't support EKS):
+    if [[ $regx == "us-west-1" ]]; then
+      textInfo "$regx: EKS not supported in this region" "$regx"
+    else
+      CLUSTERS=$($AWSCLI eks list-clusters $PROFILE_OPT --region $regx --query 'clusters[]' --output text)
+    fi
+    if [[ $CLUSTERS ]]; then
+      for CLUSTER in $CLUSTERS;do
+        CLUSTERDEF=$($AWSCLI eks describe-cluster $PROFILE_OPT --region $regx --name $CLUSTER --query 'cluster.resourcesVpcConfig')
+        PUB_ENABLED=$(echo $CLUSTERDEF | jq -r '.endpointPublicAccess')
+        PRIV_ENABLED=$(echo $CLUSTERDEF | jq -r '.endpointPrivateAccess')
+        PUB_ACCESS_CIDRS=$(echo $CLUSTERDEF | jq -r '.publicAccessCidrs')
+
+        if [[ $PUB_ENABLED == "false" ]] && [[ $PRIV_ENABLED == "true" ]] ; then
+          textPass "$regx: Cluster endpoint access is private for EKS cluster $CLUSTER" "$regx"
+        else
+          if [[ $(echo $PUB_ACCESS_CIDRS | grep "0.0.0.0/0") ]] ; then
+            textFail "$regx: Cluster control plane access is not restricted for EKS cluster $CLUSTER" "$regx"
+          else
+            textPass "$regx: Cluster control plane access is restricted for EKS cluster $CLUSTER" "$regx"
+          fi
+        fi
+      done
+    else
+      if [[ $regx != "us-west-1" ]]; then
+        textInfo "$regx: No EKS clusters found" "$regx"
+      fi
+    fi
+  done
+}

--- a/checks/check_extra797
+++ b/checks/check_extra797
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Prowler - the handy cloud security tool (copyright 2019) by Toni de la Fuente
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+CHECK_ID_extra797="7.97"
+CHECK_TITLE_extra797="[extra797] Ensure Kubernetes Secrets are encrypted using Customer Master Keys (CMKs)"
+CHECK_SCORED_extra797="NOT_SCORED"
+CHECK_TYPE_extra797="EXTRA"
+CHECK_ASFF_RESOURCE_TYPE_extra797="AwsEksCluster"
+CHECK_ALTERNATE_check797="extra797"
+
+extra797(){
+  textInfo "Looking for encryption config for EKS clusters across all regions... "
+  for regx in $REGIONS; do
+    # Get a list of EKS clusters (Unless us-west-1 which doesn't support EKS):
+    if [[ $regx == "us-west-1" ]]; then
+      textInfo "$regx: EKS not supported in this region" "$regx"
+    else
+      CLUSTERS=$($AWSCLI eks list-clusters $PROFILE_OPT --region $regx --query 'clusters[]' --output text)
+    fi
+    if [[ $CLUSTERS ]]; then
+      for CLUSTER in $CLUSTERS;do
+        ENC_CONFIG=$($AWSCLI eks describe-cluster $PROFILE_OPT --region $regx --name $CLUSTER --query 'cluster.encryptionConfig')
+
+        if [[ $ENC_CONFIG == "null" ]]; then
+           textFail "$regx: Encryption for Kubernetes secrets is not configured for EKS cluster $CLUSTER" "$regx"
+        else
+           textPass "$regx: Encryption for Kubernetes secrets is configured for EKS cluster $CLUSTER" "$regx"
+        fi
+      done
+    else
+      if [[ $regx != "us-west-1" ]]; then
+        textInfo "$regx: No EKS clusters found" "$regx"
+      fi
+    fi
+  done
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Adding 4 checks related to EKS cluster settings: 
* Ensure EKS Control Plane Logging is Enabled
* Ensure EKS Clusters are created with Private Endpoint Enabled and Public Access Disabled
* Restrict Access to the EKS Control Plane Endpoint
* Ensure Kubernetes Secrets are encrypted using Customer Master Keys (CMKs)