### PR TITLE
Fix getops OPTARG for custom checks

### DIFF
--- a/prowler
+++ b/prowler
@@ -96,7 +96,7 @@ USAGE:
   exit
 }
 
-while getopts ":hlLkqp:r:c:g:f:m:M:E:enbVsSxI:A:R:T:w:" OPTION; do
+while getopts ":hlLkqp:r:c:g:f:m:M:E:x:enbVsSI:A:R:T:w:" OPTION; do
    case $OPTION in
      h )
         usage


### PR DESCRIPTION
Custom checks in folder are not being sourced. `./prowler -c extra800 -x custom` results in empty EXTERNAL_CHECKS_PATH variables due to missing colon.

The fix was tested in both OSX and toniblyx/prowler:latest Docker.

Regards,

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
