### PR TITLE
Whitelist improvements

### DIFF
--- a/include/outputs
+++ b/include/outputs
@@ -114,13 +114,8 @@ textFail(){
   while read -r i; do
     ignore_check_name="${i%%:*}" # Check name is everything up to the first :
     ignore_value="${i#*${CHECK_NAME}:}" # Ignore value is everything after the first :
-    if [[ ${ignore_value} =~ .*:f ]]; then
-      # Fuzzy search - if this pattern appears anywhere in the line, it matches.
-      resource_value=".*${ignore_value%:*}.*"
-    else
-      # Strict search - pattern has to be its own word.
-      resource_value="[[:space:]^]${ignore_value}[[:space:]$]"
-    fi
+    # Check to see if ignore value appears anywhere within log message.
+    resource_value=".*${ignore_value}.*"
     if [[ ${ignore_check_name} != "${CHECK_NAME}" ]]; then
       # not for this check
       continue

--- a/include/outputs
+++ b/include/outputs
@@ -112,13 +112,20 @@ textFail(){
   level="FAIL"
   colorcode="$BAD"
   while read -r i; do
-    ignore_check_name="${i%:*}"
-    ignore_value="${i#*${CHECK_NAME}:}"
+    ignore_check_name="${i%%:*}" # Check name is everything up to the first :
+    ignore_value="${i#*${CHECK_NAME}:}" # Ignore value is everything after the first :
+    if [[ ${ignore_value} =~ .*:f ]]; then
+      # Fuzzy search - if this pattern appears anywhere in the line, it matches.
+      resource_value=".*${ignore_value%:*}.*"
+    else
+      # Strict search - pattern has to be its own word.
+      resource_value="[[:space:]^]${ignore_value}[[:space:]$]"
+    fi
     if [[ ${ignore_check_name} != "${CHECK_NAME}" ]]; then
       # not for this check
       continue
     fi
-    if [[ $1 =~ .*"${ignore_value}".* ]]; then
+    if [[ $1 =~ ${resource_value} ]]; then
       level="WARNING"
       colorcode="$WARNING"
       break

--- a/whitelist_sample.txt
+++ b/whitelist_sample.txt
@@ -3,12 +3,10 @@
 # Example: Will not consider a myignoredbucket failures as full failure. (Still printed as a warning)
 check26:myignoredbucket
 
-# By default, whitelisting something (e.g. "ci-logs") will only whitelist resources specifically called 
-# "ci-logs". However, if you put ":f" at the end of the line, it will do a fuzzy match, and will
-# whitelist all resources with "ci-logs" in their name.
+# Note that by default, this searches for the string appearing *anywhere* in the resource name.
 # For example:
-#   extra718:ci-logs    # Will block bucket "ci-logs" but not bucket "ci-logs-replica"
-#   extra718:ci-logs:f  # Will block any bucket containing the term "ci-logs"
+#   extra718:ci-logs  # Will block bucket "ci-logs" AND ALSO bucket "ci-logs-replica"
+#   extra718:logs     # Will block EVERY BUCKET containing the string "logs"
 
 # line starting with # are ignored as comments
 # add a line per resource as here:
@@ -20,4 +18,4 @@ check26:myignoredbucket
 # REGEXES
 # This whitelist works with regexes (ERE, the same style of regex as grep -E and bash's =~ use)
 # therefore:
-# extra718:[[:alnum:]]+-logs:f # will ignore all buckets containing the terms ci-logs, qa-logs, etc.
+# extra718:[[:alnum:]]+-logs # will ignore all buckets containing the terms ci-logs, qa-logs, etc.

--- a/whitelist_sample.txt
+++ b/whitelist_sample.txt
@@ -3,6 +3,13 @@
 # Example: Will not consider a myignoredbucket failures as full failure. (Still printed as a warning)
 check26:myignoredbucket
 
+# By default, whitelisting something (e.g. "ci-logs") will only whitelist resources specifically called 
+# "ci-logs". However, if you put ":f" at the end of the line, it will do a fuzzy match, and will
+# whitelist all resources with "ci-logs" in their name.
+# For example:
+#   extra718:ci-logs    # Will block bucket "ci-logs" but not bucket "ci-logs-replica"
+#   extra718:ci-logs:f  # Will block any bucket containing the term "ci-logs"
+
 # line starting with # are ignored as comments
 # add a line per resource as here:
 #<checkid1>:<resource to ignore 1>
@@ -10,3 +17,7 @@ check26:myignoredbucket
 # checkid2
 #<checkid2>:<resource to ignore 1>
 
+# REGEXES
+# This whitelist works with regexes (ERE, the same style of regex as grep -E and bash's =~ use)
+# therefore:
+# extra718:[[:alnum:]]+-logs:f # will ignore all buckets containing the terms ci-logs, qa-logs, etc.


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This allows you to use regexes in the whitelist file - my company was in a situation where we wanted to ignore all buckets called <something>-logs, and didn't want to write out every one individually.