### PR TITLE
Fix execute_group_by_id

### DIFF
--- a/prowler
+++ b/prowler
@@ -395,11 +395,10 @@ execute_group() {
 
 # Function to execute group by name
 execute_group_by_id() {
-  if [ "${GROUP_ID[$1]}" == "group1" ]; then
+  
     genCredReport
     saveReport
-  fi
-	for i in "${!GROUP_ID[@]}"; do
+  	for i in "${!GROUP_ID[@]}"; do
 		if [ "${GROUP_ID[$i]}" == "$1" ]; then
 			execute_group ${i} $2
 		fi

--- a/prowler
+++ b/prowler
@@ -396,8 +396,6 @@ execute_group() {
 # Function to execute group by name
 execute_group_by_id() {
   
-    genCredReport
-    saveReport
   	for i in "${!GROUP_ID[@]}"; do
 		if [ "${GROUP_ID[$i]}" == "$1" ]; then
 			execute_group ${i} $2


### PR DESCRIPTION
* ${GROUP_ID[$1]} is invalid as first parameter is group_id
* All other group checks may require IAM credential report (PCI, CIS, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
