### PR TITLE
Add GetFindings action to example IAM policy for Security Hub

### DIFF
--- a/iam/prowler-security-hub.json
+++ b/iam/prowler-security-hub.json
@@ -3,7 +3,8 @@
     "Statement": [
         {
             "Action": [
-                "securityhub:BatchImportFindings"
+                "securityhub:BatchImportFindings",
+                "securityhub:GetFindings"
             ],
             "Effect": "Allow",
             "Resource": "*"


### PR DESCRIPTION
Following the merge of #651, prowler now calls the GetFindings API when using Security Hub integration - this action needs to be added to the required policy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
