### PR TITLE
added parameters and made the template parameterised.

### DIFF
--- a/iam/create_role_to_assume_cfn.yaml
+++ b/iam/create_role_to_assume_cfn.yaml
@@ -1,5 +1,31 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'This template creates a custom policy and role to be assumed by account 123456789012 (change it in line 12 as needed) to run Prowler from and perform a security assessment with a command like: ./prowler -A <THIS_ACCOUNT_ID> -R ProwlerExecRole'
+#
+# You can invoke CloudFormation and pass the principal ARN from a command line like this:
+# aws cloudformation create-stack \
+#  --capabilities CAPABILITY_IAM --capabilities CAPABILITY_NAMED_IAM \
+#  --template-body "file://create_role_to_assume_cfn.yaml" \
+#  --stack-name "ProwlerExecRole" \
+#  --parameters "ParameterKey=AuthorisedARN,ParameterValue=arn:aws:iam::123456789012:root"
+#
+Description: | 
+  This template creates an AWS IAM Role with an inline policy and two AWS managed policies
+  attached. It sets the trust policy on that IAM Role to permit a named ARN in another AWS
+  account to assume that role. The role name and the ARN of the trusted user can all be passed
+  to the CloudFormation stack as parameters. Then you can run Prowler to perform a security
+  assessment with a command like:
+  ./prowler -A <THIS_ACCOUNT_ID> -R ProwlerExecRole
+Parameters:
+  AuthorisedARN:
+    Description: |
+      ARN of user who is authorised to assume the role that is created by this template.
+      E.g., arn:aws:iam::123456789012:root
+    Type: String
+  ProwlerRoleName:
+    Description: |
+      Name of the IAM role that will have these policies attached. Default: ProwlerExecRole
+    Type: String
+    Default: 'ProwlerExecRole'
+
 Resources:
   ProwlerExecRole:
     Type: AWS::IAM::Role
@@ -9,7 +35,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: arn:aws:iam::123456789012:root
+              AWS: !Sub ${AuthorisedARN}
             Action: 'sts:AssumeRole'
             ## In case MFA is required uncomment lines below 
             ## and read https://github.com/toniblyx/prowler#run-prowler-with-mfa-protected-credentials
@@ -19,7 +45,7 @@ Resources:
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/SecurityAudit'
         - 'arn:aws:iam::aws:policy/job-function/ViewOnlyAccess'
-      RoleName: ProwlerExecRole
+      RoleName: !Sub ${ProwlerRoleName}
       Policies: 
         - PolicyName: ProwlerExecRoleAdditionalViewPrivileges
           PolicyDocument:


### PR DESCRIPTION
This change to the template includes the following:
1. The template now accepts the role name as an optional parameter (not everyone will be happy with our default name)
2. The template now requires the authorised ARN to be provided as a parameter.
3. I added documentation to the top of the template showing how to call it from the command line, passing the parameters.

This means that this template could be hosted in a publicly accessible bucket (_hint, hint_) and then people could just launch the template this way without ever downloading or editing the template.

```
aws cloudformation create-stack \
 --capabilities CAPABILITY_IAM --capabilities CAPABILITY_NAMED_IAM \
 --template-url "https://well-known-s3-bucket/create_role_to_assume_cfn.yaml" \
 --stack-name "ProwlerExecRole" \
 --parameters "ParameterKey=AuthorisedARN,ParameterValue=arn:aws:iam::123456789012:root"
```

> By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
