### PR TITLE
Security Hub: Mark as ARCHIVED + fix race condition

### DIFF
--- a/include/os_detector
+++ b/include/os_detector
@@ -104,6 +104,10 @@ gnu_get_iso8601_timestamp() {
   "$DATE_CMD" -u +"%Y-%m-%dT%H:%M:%SZ"
 }
 
+gsu_get_iso8601_one_minute_ago() {
+  "$DATE_CMD" -d "1 minute ago" -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
 gsu_get_iso8601_hundred_days_ago() {
   "$DATE_CMD" -d "100 days ago" -u +"%Y-%m-%dT%H:%M:%SZ"
 }
@@ -114,6 +118,10 @@ bsd_get_iso8601_timestamp() {
 
 bsd_get_iso8601_hundred_days_ago() {
   "$DATE_CMD" -v-100d -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+bsd_get_iso8601_one_minute_ago() {
+  "$DATE_CMD" -v-1m -u +"%Y-%m-%dT%H:%M:%SZ"
 }
 
 gnu_test_tcp_connectivity() {
@@ -158,6 +166,9 @@ if [ "$OSTYPE" == "linux-gnu" ] || [ "$OSTYPE" == "linux-musl" ]; then
   }
   get_iso8601_timestamp() {
     gnu_get_iso8601_timestamp
+  }
+  get_iso8601_one_minute_ago() {
+    gsu_get_iso8601_one_minute_ago
   }
   get_iso8601_hundred_days_ago() {
     gsu_get_iso8601_hundred_days_ago
@@ -218,6 +229,9 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     }
     get_iso8601_timestamp() {
       bsd_get_iso8601_timestamp
+    }
+    get_iso8601_one_minute_ago() {
+      bsd_get_iso8601_one_minute_ago
     }
     get_iso8601_hundred_days_ago() {
       bsd_get_iso8601_hundred_days_ago

--- a/include/outputs
+++ b/include/outputs
@@ -112,13 +112,15 @@ textFail(){
   level="FAIL"
   colorcode="$BAD"
   while read -r i; do
-    ignore_check_name="${i%:*}"
-    ignore_value="${i#*${CHECK_NAME}:}"
+    ignore_check_name="${i%%:*}" # Check name is everything up to the first :
+    ignore_value="${i#*${CHECK_NAME}:}" # Ignore value is everything after the first :
+    # Check to see if ignore value appears anywhere within log message.
+    resource_value=".*${ignore_value}.*"
     if [[ ${ignore_check_name} != "${CHECK_NAME}" ]]; then
       # not for this check
       continue
     fi
-    if [[ $1 =~ .*"${ignore_value}".* ]]; then
+    if [[ $1 =~ ${resource_value} ]]; then
       level="WARNING"
       colorcode="$WARNING"
       break
@@ -274,7 +276,7 @@ generateJsonAsffOutput(){
       "SchemaVersion": "2018-10-08",
       "Id": "prowler-\($TITLE_ID)-\($ACCOUNT_NUM)-\($REPREGION)-\($UNIQUE_ID)",
       "ProductArn": "arn:\($AWS_PARTITION):securityhub:\($REPREGION):\($ACCOUNT_NUM):product/\($ACCOUNT_NUM)/default",
-      "RecordState": "ACTIVE",
+      "RecordState": "ACTIVE"
       "ProductFields": {
           "ProviderName": "Prowler",
           "ProviderVersion": $PROWLER_VERSION
@@ -282,7 +284,7 @@ generateJsonAsffOutput(){
       "GeneratorId": "prowler-\($CHECK_ID)",
       "AwsAccountId": $ACCOUNT_NUM,
       "Types": [
-          "\($TYPE)-Policy:\($TITLE_TEXT)"
+          $TYPE
       ],
       "FirstObservedAt": $TIMESTAMP,
       "UpdatedAt": $TIMESTAMP,

--- a/include/outputs
+++ b/include/outputs
@@ -112,15 +112,13 @@ textFail(){
   level="FAIL"
   colorcode="$BAD"
   while read -r i; do
-    ignore_check_name="${i%%:*}" # Check name is everything up to the first :
-    ignore_value="${i#*${CHECK_NAME}:}" # Ignore value is everything after the first :
-    # Check to see if ignore value appears anywhere within log message.
-    resource_value=".*${ignore_value}.*"
+    ignore_check_name="${i%:*}"
+    ignore_value="${i#*${CHECK_NAME}:}"
     if [[ ${ignore_check_name} != "${CHECK_NAME}" ]]; then
       # not for this check
       continue
     fi
-    if [[ $1 =~ ${resource_value} ]]; then
+    if [[ $1 =~ .*"${ignore_value}".* ]]; then
       level="WARNING"
       colorcode="$WARNING"
       break
@@ -276,6 +274,7 @@ generateJsonAsffOutput(){
       "SchemaVersion": "2018-10-08",
       "Id": "prowler-\($TITLE_ID)-\($ACCOUNT_NUM)-\($REPREGION)-\($UNIQUE_ID)",
       "ProductArn": "arn:\($AWS_PARTITION):securityhub:\($REPREGION):\($ACCOUNT_NUM):product/\($ACCOUNT_NUM)/default",
+      "RecordState": "ACTIVE",
       "ProductFields": {
           "ProviderName": "Prowler",
           "ProviderVersion": $PROWLER_VERSION
@@ -283,7 +282,7 @@ generateJsonAsffOutput(){
       "GeneratorId": "prowler-\($CHECK_ID)",
       "AwsAccountId": $ACCOUNT_NUM,
       "Types": [
-          $TYPE
+          "\($TYPE)-Policy:\($TITLE_TEXT)"
       ],
       "FirstObservedAt": $TIMESTAMP,
       "UpdatedAt": $TIMESTAMP,

--- a/include/securityhub_integration
+++ b/include/securityhub_integration
@@ -35,13 +35,15 @@ resolveSecurityHubPreviousFails(){
   for regx in $REGIONS; do
 
     local check="$1"
-    
+    OLD_TIMESTAMP=$(get_iso8601_one_minute_ago)
     NEW_TIMESTAMP=$(get_iso8601_timestamp)
 
     PREVIOUS_DATE=$(get_iso8601_hundred_days_ago)
-    FILTER="{\"UpdatedAt\":[{\"Start\":\"$PREVIOUS_DATE\",\"End\":\"$TIMESTAMP\"}],\"GeneratorId\":[{\"Value\": \"prowler-$check\",\"Comparison\":\"PREFIX\"}],\"ComplianceStatus\":[{\"Value\": \"FAILED\",\"Comparison\":\"EQUALS\"}]}"
-    SECURITY_HUB_PREVIOUS_FINDINGS=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT get-findings --filters "${FILTER}" | jq -c --arg updated_at $NEW_TIMESTAMP  '[ .Findings[] | .RecordState="ARCHIVED" | .UpdatedAt = $updated_at ]')
+
+    FILTER="{\"UpdatedAt\":[{\"Start\":\"$PREVIOUS_DATE\",\"End\":\"$OLD_TIMESTAMP\"}],\"GeneratorId\":[{\"Value\": \"prowler-$check\",\"Comparison\":\"PREFIX\"}],\"ComplianceStatus\":[{\"Value\": \"FAILED\",\"Comparison\":\"EQUALS\"}]}"
+    SECURITY_HUB_PREVIOUS_FINDINGS=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT get-findings --filters "${FILTER}" | jq -c --arg updated_at $NEW_TIMESTAMP  '[ .Findings[] | .RecordState = "ARCHIVED" | .UpdatedAt = $updated_at ]')
     if [[ $SECURITY_HUB_PREVIOUS_FINDINGS != "[]" ]]; then
+      echo "$SECURITY_HUB_PREVIOUS_FINDINGS"
       BATCH_IMPORT_RESULT=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT batch-import-findings --findings "${SECURITY_HUB_PREVIOUS_FINDINGS}")
 
     # Check for success if imported

--- a/include/securityhub_integration
+++ b/include/securityhub_integration
@@ -31,7 +31,7 @@ checkSecurityHubCompatibility(){
 }
 
 resolveSecurityHubPreviousFails(){
-  # Move previous check findings to Workflow to PASSED (as prowler didn't re-detect them)
+  # Move previous check findings RecordState to ARCHIVED (as prowler didn't re-detect them)
   for regx in $REGIONS; do
 
     local check="$1"
@@ -40,7 +40,7 @@ resolveSecurityHubPreviousFails(){
 
     PREVIOUS_DATE=$(get_iso8601_hundred_days_ago)
     FILTER="{\"UpdatedAt\":[{\"Start\":\"$PREVIOUS_DATE\",\"End\":\"$TIMESTAMP\"}],\"GeneratorId\":[{\"Value\": \"prowler-$check\",\"Comparison\":\"PREFIX\"}],\"ComplianceStatus\":[{\"Value\": \"FAILED\",\"Comparison\":\"EQUALS\"}]}"
-    SECURITY_HUB_PREVIOUS_FINDINGS=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT get-findings --filters "${FILTER}" | jq -c --arg updated_at $NEW_TIMESTAMP  '[ .Findings[] | .Compliance = {"Status":"PASSED"} | .UpdatedAt = $updated_at ]')
+    SECURITY_HUB_PREVIOUS_FINDINGS=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT get-findings --filters "${FILTER}" | jq -c --arg updated_at $NEW_TIMESTAMP  '[ .Findings[] | .RecordState="ARCHIVED" | .UpdatedAt = $updated_at ]')
     if [[ $SECURITY_HUB_PREVIOUS_FINDINGS != "[]" ]]; then
       BATCH_IMPORT_RESULT=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT batch-import-findings --findings "${SECURITY_HUB_PREVIOUS_FINDINGS}")
 

--- a/include/securityhub_integration
+++ b/include/securityhub_integration
@@ -43,7 +43,6 @@ resolveSecurityHubPreviousFails(){
     FILTER="{\"UpdatedAt\":[{\"Start\":\"$PREVIOUS_DATE\",\"End\":\"$OLD_TIMESTAMP\"}],\"GeneratorId\":[{\"Value\": \"prowler-$check\",\"Comparison\":\"PREFIX\"}],\"ComplianceStatus\":[{\"Value\": \"FAILED\",\"Comparison\":\"EQUALS\"}]}"
     SECURITY_HUB_PREVIOUS_FINDINGS=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT get-findings --filters "${FILTER}" | jq -c --arg updated_at $NEW_TIMESTAMP  '[ .Findings[] | .RecordState = "ARCHIVED" | .UpdatedAt = $updated_at ]')
     if [[ $SECURITY_HUB_PREVIOUS_FINDINGS != "[]" ]]; then
-      echo "$SECURITY_HUB_PREVIOUS_FINDINGS"
       BATCH_IMPORT_RESULT=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT batch-import-findings --findings "${SECURITY_HUB_PREVIOUS_FINDINGS}")
 
     # Check for success if imported


### PR DESCRIPTION
* Fix race condition when resolveSecurityHubPreviousFails's TIMESTAMP is the same second as initial TIMESTAMP
* Security Hub AWS native integrations (such as IAM Access Analyzer) use RecordState to filter current findings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
