### PR TITLE
fix(securityhub): other os/check fixes + batch in 100 findings

### DIFF
--- a/include/os_detector
+++ b/include/os_detector
@@ -121,7 +121,7 @@ bsd_get_iso8601_hundred_days_ago() {
 }
 
 bsd_get_iso8601_one_minute_ago() {
-  "$DATE_CMD" -v-1m -u +"%Y-%m-%dT%H:%M:%SZ"
+  "$DATE_CMD" -v-1M -u +"%Y-%m-%dT%H:%M:%SZ"
 }
 
 gnu_test_tcp_connectivity() {

--- a/include/securityhub_integration
+++ b/include/securityhub_integration
@@ -41,15 +41,19 @@ resolveSecurityHubPreviousFails(){
 
     PREVIOUS_DATE=$(get_iso8601_hundred_days_ago)
 
-    FILTER="{\"UpdatedAt\":[{\"Start\":\"$PREVIOUS_DATE\",\"End\":\"$OLD_TIMESTAMP\"}],\"GeneratorId\":[{\"Value\": \"prowler-$check\",\"Comparison\":\"PREFIX\"}],\"ComplianceStatus\":[{\"Value\": \"FAILED\",\"Comparison\":\"EQUALS\"}]}"
+    FILTER="{\"UpdatedAt\":[{\"Start\":\"$PREVIOUS_DATE\",\"End\":\"$OLD_TIMESTAMP\"}],\"GeneratorId\":[{\"Value\": \"prowler-$check\",\"Comparison\":\"PREFIX\"}],\"ComplianceStatus\":[{\"Value\": \"FAILED\",\"Comparison\":\"EQUALS\"}],\"RecordState\":[{\"Value\": \"ACTIVE\",\"Comparison\":\"EQUALS\"}]}"
     SECURITY_HUB_PREVIOUS_FINDINGS=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT get-findings --filters "${FILTER}" | jq -c --arg updated_at $NEW_TIMESTAMP  '[ .Findings[] | .RecordState = "ARCHIVED" | .UpdatedAt = $updated_at ]')
     if [[ $SECURITY_HUB_PREVIOUS_FINDINGS != "[]" ]]; then
-      BATCH_IMPORT_RESULT=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT batch-import-findings --findings "${SECURITY_HUB_PREVIOUS_FINDINGS}")
-
-    # Check for success if imported
-      if [[ -z "${BATCH_IMPORT_RESULT}" ]] || ! jq -e '.SuccessCount == 1' <<< "${BATCH_IMPORT_RESULT}" > /dev/null 2>&1; then
-        echo -e "\n$RED ERROR!$NORMAL Failed to send check output to AWS Security Hub\n"
-      fi
+      FINDINGS_COUNT=$(echo $SECURITY_HUB_PREVIOUS_FINDINGS | jq '. | length')
+      for i in `seq 0 100 $FINDINGS_COUNT`; 
+      do 
+        # Import in batches of 100
+        BATCH_FINDINGS=$(echo $SECURITY_HUB_PREVIOUS_FINDINGS | jq '.['"$i:$i+100"']')
+        BATCH_IMPORT_RESULT=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT batch-import-findings --findings "${BATCH_FINDINGS}")
+        if [[ -z "${BATCH_IMPORT_RESULT}" ]] || jq -e '.FailedCount >= 1' <<< "${BATCH_IMPORT_RESULT}" > /dev/null 2>&1; then
+          echo -e "\n$RED ERROR!$NORMAL Failed to send check output to AWS Security Hub\n"
+        fi
+      done
     fi
   done
 

--- a/prowler
+++ b/prowler
@@ -352,6 +352,10 @@ execute_check() {
     if is_junit_output_enabled; then
       finalise_junit_check_output "$1"
     fi
+
+    if [[ "$SEND_TO_SECURITY_HUB" -eq 1 ]]; then
+      resolveSecurityHubPreviousFails "$1"
+    fi
   else
     # Check to see if this is a real check
     local check_id_var=CHECK_ID_$1
@@ -370,14 +374,14 @@ execute_check() {
       # Execute the check
       IGNORES="${ignores}" CHECK_NAME="$1" $1
 
+      if is_junit_output_enabled; then
+        finalise_junit_check_output "$1"
+      fi
 
       if [[ "$SEND_TO_SECURITY_HUB" -eq 1 ]]; then
         resolveSecurityHubPreviousFails "$1"
       fi
 
-      if is_junit_output_enabled; then
-        finalise_junit_check_output "$1"
-      fi
     else
       textFail "ERROR! Use a valid check name (i.e. check41 or extra71)";
       exit $EXITCODE


### PR DESCRIPTION
### Changed 
Fix: bsd_get_iso8601_one_minute_ago change to minute
Fix: Call resolveSecurityHubPreviousFails when using check alternative name + reorder to avoid affecting junit time results
Fix: resolveSecurityHubPreviousFails error handler
Fix: resolveSecurityHubPreviousFails batch-import-findings by 100 findings (large accounts)
Improvement: Only re-import non-archived findings

### Notes
Add coreutils to apk Dockerfile ("-d" flag is not supported in busybox alpine default).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
