### PR TITLE
Add check extra798 to gdpr and pci group

### DIFF
--- a/groups/group15_pci
+++ b/groups/group15_pci
@@ -15,7 +15,7 @@ GROUP_ID[15]='pci'
 GROUP_NUMBER[15]='15.0'
 GROUP_TITLE[15]='PCI-DSS v3.2.1 Readiness - ONLY AS REFERENCE - [pci] **********'
 GROUP_RUN_BY_DEFAULT[15]='N' # run it when execute_all is called
-GROUP_CHECKS[15]='check11,check12,check13,check14,check15,check16,check17,check18,check19,check110,check112,check113,check114,check116,check21,check23,check25,check26,check27,check28,check29,check314,check36,check38,check43,extra713,extra717,extra718,extra72,extra729,extra735,extra738,extra740,extra744,extra748,extra75,extra750,extra751,extra753,extra754,extra755,extra756,extra773,extra78,extra780,extra781,extra782,extra783,extra784,extra785,extra787,extra788'
+GROUP_CHECKS[15]='check11,check12,check13,check14,check15,check16,check17,check18,check19,check110,check112,check113,check114,check116,check21,check23,check25,check26,check27,check28,check29,check314,check36,check38,check43,extra713,extra717,extra718,extra72,extra729,extra735,extra738,extra740,extra744,extra748,extra75,extra750,extra751,extra753,extra754,extra755,extra756,extra773,extra78,extra780,extra781,extra782,extra783,extra784,extra785,extra787,extra788,extra798'
 
 # Resources:
 # https://github.com/toniblyx/prowler/issues/296
@@ -40,6 +40,7 @@ GROUP_CHECKS[15]='check11,check12,check13,check14,check15,check16,check17,check1
 #     Remove unused security groups extra75
 #     RDS should not have Public interface open to a public scope extra78
 #     Check for Publicly Accessible Redshift Clusters extra756
+#     Ensure Lambda Functions are not publicly accessible   extra798
 
 # 3.2 Requirement 2: Do Not Use Vendor-Supplied Defaults for System Passwords and Other Security Parameters
 

--- a/groups/group9_gdpr
+++ b/groups/group9_gdpr
@@ -15,7 +15,7 @@ GROUP_ID[9]='gdpr'
 GROUP_NUMBER[9]='9.0'
 GROUP_TITLE[9]='GDPR Readiness - ONLY AS REFERENCE - [gdpr] ********************'
 GROUP_RUN_BY_DEFAULT[9]='N' # run it when execute_all is called
-GROUP_CHECKS[9]='extra718,extra725,extra727,check12,check113,check114,extra71,extra731,extra732,extra733,check25,check39,check21,check22,check23,check24,check26,check27,check35,extra726,extra714,extra715,extra717,extra719,extra720,extra721,extra722,check43,check25,extra714,extra729,extra734,extra735,extra736,extra738,extra740,extra761,check11,check110,check111,check112,check116,check120,check122,check13,check14,check15,check16,check17,check18,check19,check28,check29,check31,check310,check311,check312,check313,check314,check32,check33,check34,check36,check37,check38,check41,check42,extra711,extra72,extra723,extra730,extra739,extra76,extra763,extra778,extra78,extra792'
+GROUP_CHECKS[9]='extra718,extra725,extra727,check12,check113,check114,extra71,extra731,extra732,extra733,check25,check39,check21,check22,check23,check24,check26,check27,check35,extra726,extra714,extra715,extra717,extra719,extra720,extra721,extra722,check43,check25,extra714,extra729,extra734,extra735,extra736,extra738,extra740,extra761,check11,check110,check111,check112,check116,check120,check122,check13,check14,check15,check16,check17,check18,check19,check28,check29,check31,check310,check311,check312,check313,check314,check32,check33,check34,check36,check37,check38,check41,check42,extra711,extra72,extra723,extra730,extra739,extra76,extra763,extra778,extra78,extra792,extra798'
 
 # Resources:
 # https://d1.awsstatic.com/whitepapers/compliance/GDPR_Compliance_on_AWS.pdf


### PR DESCRIPTION
Added check extra798 to pci and gdpr group. This maps as below:

[+] GDPR:
| Article | Req. ID | Requirement summary | Prowler check ID | Check Summary |
|-|-|-|-|-|
| Article 25 - Data Protection by Design & Default | 25.2 | Data Access | extra798 | Ensure Lambda Functions are not publicly accessible |

[+] PCI:
| Category | Requirement ID | Requirement Summary | Prowler check ID | Check Summary |
|-|-|-|-|-|
| Secure Network and Systems | 1.3 | Prohibit direct public access between the Internet and any system component in the cardholder data environment | extra798 | Ensure Lambda Functions are not publicly accessible |

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
