### PR TITLE
Fix PROFILE_OPT arg

### DIFF
--- a/prowler
+++ b/prowler
@@ -113,7 +113,7 @@ while getopts ":hlLkqp:r:c:g:f:m:M:E:x:enbVsSI:A:R:T:w:" OPTION; do
         KEEPCREDREPORT=1
         ;;
      p )
-        PROFILE=$OPTARG
+        PROFILE_OPT=$OPTARG
         ;;
      r )
         REGION_OPT=$OPTARG


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

It looks like Prowler makes lots of references to the $PROFILE_OPT arg throughout the codebase, but the actual argument is never set. Unless I'm missing something, I think this means that the `-p` flag hasn't been working at all for quite a while.