### PR TITLE
Adding fix to generate test summary so reports display graphs correctly

### DIFF
--- a/include/junit_integration
+++ b/include/junit_integration
@@ -14,6 +14,11 @@
 # Generates JUnit XML reports which can be read by Jenkins or other CI tools
 
 JUNIT_OUTPUT_DIRECTORY="junit-reports"
+JUNIT_TESTS_COUNT="0"
+JUNIT_SUCCESS_COUNT="0"
+JUNIT_FAILURES_COUNT="0"
+JUNIT_SKIPPED_COUNT="0"
+JUNIT_ERRORS_COUNT="0"
 
 is_junit_output_enabled() {
   if [[ " ${MODES[@]} " =~ " junit-xml " ]]; then
@@ -44,7 +49,7 @@ prepare_junit_check_output() {
   JUNIT_OUTPUT_FILE="$JUNIT_OUTPUT_DIRECTORY/TEST-$1.xml"
   printf '%s\n' \
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" \
-    "<testsuite name=\"$(xml_escape "$(get_junit_classname)")\" timestamp=\"$(get_iso8601_timestamp)\">" \
+    "<testsuite name=\"$(xml_escape "$(get_junit_classname)")\" tests=\"_TESTS_COUNT_\" failures=\"_FAILURES_COUNT_\" skipped=\"_SKIPPED_COUNT_\" errors=\"_ERRORS_COUNT_\" timestamp=\"$(get_iso8601_timestamp)\">" \
     "  <properties>" \
     "    <property name=\"prowler.version\" value=\"$(xml_escape "$PROWLER_VERSION")\"/>" \
     "    <property name=\"aws.profile\" value=\"$(xml_escape "$PROFILE")\"/>" \
@@ -60,24 +65,21 @@ prepare_junit_check_output() {
 }
 
 finalise_junit_check_output() {
+  # Calculate Total and populate summary info
+  JUNIT_TESTS_COUNT=$((JUNIT_SUCCESS_COUNT+$JUNIT_FAILURES_COUNT+$JUNIT_SKIPPED_COUNT+$JUNIT_ERRORS_COUNT))
+  sed "s/_TESTS_COUNT_/${JUNIT_TESTS_COUNT}/g;s/_FAILURES_COUNT_/${JUNIT_FAILURES_COUNT}/g;s/_SKIPPED_COUNT_/${JUNIT_SKIPPED_COUNT}/g;s/_ERRORS_COUNT_/${JUNIT_ERRORS_COUNT}/g" "$JUNIT_OUTPUT_FILE" > "$JUNIT_OUTPUT_FILE.$$"
+  mv "$JUNIT_OUTPUT_FILE.$$" "$JUNIT_OUTPUT_FILE"
   echo '</testsuite>' >> "$JUNIT_OUTPUT_FILE"
-  TEST_COUNT="0"
-  TEST_SUCCESS_COUNT="0"
-  TEST_FAILURE_COUNT="0"
-  TEST_SKIPPED_COUNT="0"
-  TEST_ERROR_COUNT="0"
-  TEST_COUNT=$(grep -c "testcase name=" "$JUNIT_OUTPUT_FILE")
-  TEST_SUCCESS_COUNT=$(grep -A1 "testcase name=" "$JUNIT_OUTPUT_FILE" | grep -c "<system-out>")
-  TEST_FAILURE_COUNT=$(grep -A1 "testcase name=" "$JUNIT_OUTPUT_FILE" | grep -c "<failure message")
-  TEST_SKIPPED_COUNT=$(grep -A1 "testcase name=" "$JUNIT_OUTPUT_FILE" | grep -c "<skipped message")
-  TEST_ERROR_COUNT=$(grep -A1 "testcase name=" "$JUNIT_OUTPUT_FILE" | grep -c "<error message")
-  EXTRACT_TESTSUITE_NAME=$(awk '/<testsuite name=/ { print $1,$2}' "$JUNIT_OUTPUT_FILE")
-  EXTRACT_TESTSUITE_TIME=$(awk '/<testsuite name=/ { print $3}' "$JUNIT_OUTPUT_FILE");
-  NEW_TESTSUITE_NAME=$(echo "$EXTRACT_TESTSUITE_NAME tests=\"$TEST_COUNT\" failures=\"$TEST_FAILURE_COUNT\" skipped=\"$TEST_SKIPPED_COUNT\" errors=\"$TEST_ERROR_COUNT\" $EXTRACT_TESTSUITE_TIME")
-  sed "s/<testsuite name=.*/$NEW_TESTSUITE_NAME/g" "$JUNIT_OUTPUT_FILE" > "$JUNIT_OUTPUT_FILE.$$" && mv "$JUNIT_OUTPUT_FILE.$$" "$JUNIT_OUTPUT_FILE"
+  # Reset global counters as test output closed
+  JUNIT_TESTS_COUNT="0"
+  JUNIT_SUCCESS_COUNT="0"
+  JUNIT_FAILURES_COUNT="0"
+  JUNIT_SKIPPED_COUNT="0"
+  JUNIT_ERRORS_COUNT="0"
 }
 
 output_junit_success() {
+  JUNIT_SUCCESS_COUNT=$(($JUNIT_SUCCESS_COUNT+1))
   output_junit_test_case "$1" "<system-out>$(xml_escape "$1")</system-out>"
 }
 
@@ -87,10 +89,12 @@ output_junit_info() {
 }
 
 output_junit_failure() {
+  JUNIT_FAILURES_COUNT=$(($JUNIT_FAILURES_COUNT+1))
   output_junit_test_case "$1" "<failure message=\"$(xml_escape "$1")\"/>"
 }
 
 output_junit_skipped() {
+  JUNIT_SKIPPED_COUNT=$(($UNIT_SKIPPED_COUNT+1))
   output_junit_test_case "$1" "<skipped message=\"$(xml_escape "$1")\"/>"
 }
 

--- a/include/junit_integration
+++ b/include/junit_integration
@@ -61,6 +61,20 @@ prepare_junit_check_output() {
 
 finalise_junit_check_output() {
   echo '</testsuite>' >> "$JUNIT_OUTPUT_FILE"
+  TEST_COUNT="0"
+  TEST_SUCCESS_COUNT="0"
+  TEST_FAILURE_COUNT="0"
+  TEST_SKIPPED_COUNT="0"
+  TEST_ERROR_COUNT="0"
+  TEST_COUNT=$(grep -c "testcase name=" "$JUNIT_OUTPUT_FILE")
+  TEST_SUCCESS_COUNT=$(grep -A1 "testcase name=" "$JUNIT_OUTPUT_FILE" | grep -c "<system-out>")
+  TEST_FAILURE_COUNT=$(grep -A1 "testcase name=" "$JUNIT_OUTPUT_FILE" | grep -c "<failure message")
+  TEST_SKIPPED_COUNT=$(grep -A1 "testcase name=" "$JUNIT_OUTPUT_FILE" | grep -c "<skipped message")
+  TEST_ERROR_COUNT=$(grep -A1 "testcase name=" "$JUNIT_OUTPUT_FILE" | grep -c "<error message")
+  EXTRACT_TESTSUITE_NAME=$(awk '/<testsuite name=/ { print $1,$2}' "$JUNIT_OUTPUT_FILE")
+  EXTRACT_TESTSUITE_TIME=$(awk '/<testsuite name=/ { print $3}' "$JUNIT_OUTPUT_FILE");
+  NEW_TESTSUITE_NAME=$(echo "$EXTRACT_TESTSUITE_NAME tests=\"$TEST_COUNT\" failures=\"$TEST_FAILURE_COUNT\" skipped=\"$TEST_SKIPPED_COUNT\" errors=\"$TEST_ERROR_COUNT\" $EXTRACT_TESTSUITE_TIME")
+  sed "s/<testsuite name=.*/$NEW_TESTSUITE_NAME/g" "$JUNIT_OUTPUT_FILE" > "$JUNIT_OUTPUT_FILE.$$" && mv "$JUNIT_OUTPUT_FILE.$$" "$JUNIT_OUTPUT_FILE"
 }
 
 output_junit_success() {

--- a/include/junit_integration
+++ b/include/junit_integration
@@ -79,7 +79,7 @@ finalise_junit_check_output() {
 }
 
 output_junit_success() {
-  JUNIT_SUCCESS_COUNT=$(($JUNIT_SUCCESS_COUNT+1))
+  ((JUNIT_SUCCESS_COUNT++))
   output_junit_test_case "$1" "<system-out>$(xml_escape "$1")</system-out>"
 }
 
@@ -89,12 +89,12 @@ output_junit_info() {
 }
 
 output_junit_failure() {
-  JUNIT_FAILURES_COUNT=$(($JUNIT_FAILURES_COUNT+1))
+  ((JUNIT_FAILURES_COUNT++))
   output_junit_test_case "$1" "<failure message=\"$(xml_escape "$1")\"/>"
 }
 
 output_junit_skipped() {
-  JUNIT_SKIPPED_COUNT=$(($UNIT_SKIPPED_COUNT+1))
+  ((JUNIT_SKIPPED_COUNT++))
   output_junit_test_case "$1" "<skipped message=\"$(xml_escape "$1")\"/>"
 }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

When using the junit outputs tests get recorded correctly however there is a slight issue with the following line.

<testsuite name="7.31" timestamp="2020-10-21T15:11:59Z">

When passing the output in tools like Azure Devops or AWS CodeBuild the engine expects a summary of all tests within the junit file like the following:-

<testsuite name="7.31" tests="4" failures="0" skipped="0" errors="0" timestamp="2020-10-21T15:11:59Z">

This PR addresses the creation of this line after enumerating the test cases within. So in the case of AWS CodeBuild the following graph should then populate.

![image](https://user-images.githubusercontent.com/45608674/96741041-230b3700-140d-11eb-9331-4d495f9ec7b7.png)

Thanks!