### PR TITLE
Fix quotes in check for public RDS instances

### DIFF
--- a/checks/check_extra78
+++ b/checks/check_extra78
@@ -24,7 +24,7 @@ extra78(){
   # "Ensure there are no Public Accessible RDS instances (Not Scored) (Not part of CIS benchmark)"
   textInfo "Looking for RDS instances in all regions...  "
   for regx in $REGIONS; do
-    LIST_OF_RDS_PUBLIC_INSTANCES=$($AWSCLI rds describe-db-instances $PROFILE_OPT --region $regx --query 'DBInstances[?PubliclyAccessible==`true` && DBInstanceStatus=="available"].[DBInstanceIdentifier,Endpoint.Address]' --output text)
+    LIST_OF_RDS_PUBLIC_INSTANCES=$($AWSCLI rds describe-db-instances $PROFILE_OPT --region $regx --query 'DBInstances[?PubliclyAccessible==`true` && DBInstanceStatus==`"available"`].[DBInstanceIdentifier,Endpoint.Address]' --output text)
     if [[ $LIST_OF_RDS_PUBLIC_INSTANCES ]];then
       while read -r rds_instance;do
         RDS_NAME=$(echo $rds_instance | awk '{ print $1; }')


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

While running prowler, we noticed it was failing to find some public RDS instances. Digging into it, it appears that the quoting in the `query` was causing the condition to always evaluate to false.

I was able to verify that public RDS instances show up in the results now with this change.