### PR TITLE
Run assume_role before aws commands

### DIFF
--- a/prowler
+++ b/prowler
@@ -232,13 +232,6 @@ trap handle_ctrl_c INT
 . $PROWLER_DIR/include/securityhub_integration
 . $PROWLER_DIR/include/junit_integration
 
-# Get a list of all available AWS Regions
-REGIONS=$($AWSCLI ec2 describe-regions --query 'Regions[].RegionName' \
-  --output text \
-  $PROFILE_OPT \
-  --region $REGION \
-  --region-names $FILTERREGION)
-
 # Pre-process whitelist file if supplied
 if [[ -n "$WHITELIST_FILE" ]]; then
   # ignore lines starting with # (comments)
@@ -319,7 +312,7 @@ execute_check() {
   local asff_type_var=CHECK_ASFF_TYPE_$1
 
   local severity_var=CHECK_SEVERITY_$1
-  
+
   CHECK_SEVERITY="${!severity_var}"
 
   CHECK_ID="$1"
@@ -416,7 +409,7 @@ execute_group() {
 
 # Function to execute group by name
 execute_group_by_id() {
-  
+
   	for i in "${!GROUP_ID[@]}"; do
 		if [ "${GROUP_ID[$i]}" == "$1" ]; then
 			execute_group ${i} $2
@@ -518,18 +511,25 @@ if [[ " ${MODES[@]} " =~ " json " || " ${MODES[@]} " =~ " json-asff " ]]; then
   . $PROWLER_DIR/include/jq_detector
 fi
 
+# Gather account data / test aws cli connectivity
+getWhoami
+if [[ $ACCOUNT_TO_ASSUME ]]; then
+  assume_role
+fi
+
+# Get a list of all available AWS Regions
+REGIONS=$($AWSCLI ec2 describe-regions --query 'Regions[].RegionName' \
+  --output text \
+  $PROFILE_OPT \
+  --region $REGION \
+  --region-names $FILTERREGION)
+
 if [[ "$SEND_TO_SECURITY_HUB" -eq 1 ]]; then
   checkSecurityHubCompatibility
 fi
 
 if is_junit_output_enabled; then
   prepare_junit_output
-fi
-
-# Gather account data / test aws cli connectivity
-getWhoami
-if [[ $ACCOUNT_TO_ASSUME ]]; then
-  assume_role
 fi
 
 # Execute group of checks if called with -g


### PR DESCRIPTION
I used such command to run Prowler

```
/opt/prowler/prowler -A **** -R 'prowler-runner-role' -T 10800 -r ap-southeast-2
```

but it failed to get `REGIONS` and got such error

```shell
++ /bin/aws ec2 describe-regions --query 'Regions[].RegionName' --output text --region ap-southeast-2 --region-names

An error occurred (UnauthorizedOperation) when calling the DescribeRegions operation: You are not authorized to perform this operation.
+ REGIONS=
```

`ec2:DescribeRegions` is defined in the IAM role `prowler-runner-role`, so `assume-role` function should be run before any other `aws` commands.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
