### PR TITLE
Fix: Security Hub eventual consistency + PREFIX query bug + Archive PASSED

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Lint Code Base
+        uses: github/super-linter@v3
+        env:
+          #Change to false to only check new files  
+          VALIDATE_ALL_CODEBASE: true
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          ./prowler -v


### PR DESCRIPTION
* **Feature:** resolveSecurityHubPreviousFails -  Also archive PASSED findings (in case -q is not used).
* **Bug:** resolveSecurityHubPreviousFails - Security Hub is eventual consistent. GetFindings filtered by UpdatedAt can return old finding versions resulting in findings being ARCHIVED incorrectly. Refactored integration to use "Read-Your-Own-Writes". 
* **Bug:** resolveSecurityHubPreviousFails - GeneratorId matched using EQUALS, not PREFIX (extra7100 matches extra71)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
