### PR TITLE
Fix: Security Hub eventual consistency + PREFIX query bug + Archive PASSED

### DIFF
--- a/include/os_detector
+++ b/include/os_detector
@@ -104,24 +104,8 @@ gnu_get_iso8601_timestamp() {
   "$DATE_CMD" -u +"%Y-%m-%dT%H:%M:%SZ"
 }
 
-gsu_get_iso8601_one_minute_ago() {
-  "$DATE_CMD" -d "1 minute ago" -u +"%Y-%m-%dT%H:%M:%SZ"
-}
-
-gsu_get_iso8601_hundred_days_ago() {
-  "$DATE_CMD" -d "100 days ago" -u +"%Y-%m-%dT%H:%M:%SZ"
-}
-
 bsd_get_iso8601_timestamp() {
   "$DATE_CMD" -u +"%Y-%m-%dT%H:%M:%SZ"
-}
-
-bsd_get_iso8601_hundred_days_ago() {
-  "$DATE_CMD" -v-100d -u +"%Y-%m-%dT%H:%M:%SZ"
-}
-
-bsd_get_iso8601_one_minute_ago() {
-  "$DATE_CMD" -v-1M -u +"%Y-%m-%dT%H:%M:%SZ"
 }
 
 gnu_test_tcp_connectivity() {
@@ -166,12 +150,6 @@ if [ "$OSTYPE" == "linux-gnu" ] || [ "$OSTYPE" == "linux-musl" ]; then
   }
   get_iso8601_timestamp() {
     gnu_get_iso8601_timestamp
-  }
-  get_iso8601_one_minute_ago() {
-    gsu_get_iso8601_one_minute_ago
-  }
-  get_iso8601_hundred_days_ago() {
-    gsu_get_iso8601_hundred_days_ago
   }
   test_tcp_connectivity() {
     gnu_test_tcp_connectivity "$1" "$2" "$3"
@@ -229,12 +207,6 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     }
     get_iso8601_timestamp() {
       bsd_get_iso8601_timestamp
-    }
-    get_iso8601_one_minute_ago() {
-      bsd_get_iso8601_one_minute_ago
-    }
-    get_iso8601_hundred_days_ago() {
-      bsd_get_iso8601_hundred_days_ago
     }
   fi
   if "$BASE64_CMD" --version >/dev/null 2>&1 ; then

--- a/include/securityhub_integration
+++ b/include/securityhub_integration
@@ -14,7 +14,6 @@
 # Checks that the correct mode (json-asff) has been specified if wanting to send check output to AWS Security Hub
 # and that Security Hub is enabled in the chosen region
 checkSecurityHubCompatibility(){
-  OLD_TIMESTAMP=$(get_iso8601_one_minute_ago)
 
   local regx
   if [[ "${MODE}" != "json-asff" ]]; then
@@ -48,16 +47,16 @@ resolveSecurityHubPreviousFails(){
     local check="$1"
     NEW_TIMESTAMP=$(get_iso8601_timestamp)
 
-    PREVIOUS_DATE=$(get_iso8601_hundred_days_ago)
+    FILTER="{\"GeneratorId\":[{\"Value\": \"prowler-$check\",\"Comparison\":\"EQUALS\"}],\"RecordState\":[{\"Value\": \"ACTIVE\",\"Comparison\":\"EQUALS\"}]}"
 
-    FILTER="{\"UpdatedAt\":[{\"Start\":\"$PREVIOUS_DATE\",\"End\":\"$OLD_TIMESTAMP\"}],\"GeneratorId\":[{\"Value\": \"prowler-$check\",\"Comparison\":\"PREFIX\"}],\"ComplianceStatus\":[{\"Value\": \"FAILED\",\"Comparison\":\"EQUALS\"}],\"RecordState\":[{\"Value\": \"ACTIVE\",\"Comparison\":\"EQUALS\"}]}"
-    SECURITY_HUB_PREVIOUS_FINDINGS=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT get-findings --filters "${FILTER}" | jq -c --arg updated_at $NEW_TIMESTAMP  '[ .Findings[] | .RecordState = "ARCHIVED" | .UpdatedAt = $updated_at ]')
+    NEW_FINDING_IDS=$(echo -n "${SECURITYHUB_NEW_FINDINGS_IDS[@]}" | jq -cRs 'split(" ")')
+    SECURITY_HUB_PREVIOUS_FINDINGS=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT get-findings --filters "${FILTER}" | jq -c --argjson ids "$NEW_FINDING_IDS" --arg updated_at $NEW_TIMESTAMP  '[ .Findings[] | select( .Id| first(select($ids[] == .)) // false | not) | .RecordState = "ARCHIVED" | .UpdatedAt = $updated_at ]')
+
     if [[ $SECURITY_HUB_PREVIOUS_FINDINGS != "[]" ]]; then
       FINDINGS_COUNT=$(echo $SECURITY_HUB_PREVIOUS_FINDINGS | jq '. | length')
       for i in `seq 0 100 $FINDINGS_COUNT`; 
       do 
-        # Import in batches of 100
-        BATCH_FINDINGS=$(echo $SECURITY_HUB_PREVIOUS_FINDINGS | jq '.['"$i:$i+100"']')
+        BATCH_FINDINGS=$(echo $SECURITY_HUB_PREVIOUS_FINDINGS | jq -c '.['"$i:$i+100"']')
         BATCH_IMPORT_RESULT=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT batch-import-findings --findings "${BATCH_FINDINGS}")
         if [[ -z "${BATCH_IMPORT_RESULT}" ]] || jq -e '.FailedCount >= 1' <<< "${BATCH_IMPORT_RESULT}" > /dev/null 2>&1; then
           echo -e "\n$RED ERROR!$NORMAL Failed to send check output to AWS Security Hub\n"
@@ -73,6 +72,8 @@ sendToSecurityHub(){
   local findings="$1"
   local region="$2"
 
+  local finding_id=$(echo ${findings} | jq -r .Id )
+  SECURITYHUB_NEW_FINDINGS_IDS+=( "$finding_id" )
   BATCH_IMPORT_RESULT=$($AWSCLI securityhub --region "$region" $PROFILE_OPT batch-import-findings --findings "${findings}")
   
   # Check for success if imported

--- a/prowler
+++ b/prowler
@@ -331,6 +331,8 @@ execute_check() {
 
   ASFF_RESOURCE_TYPE="${!asff_resource_type_var:-AwsAccount}"
 
+  SECURITYHUB_NEW_FINDINGS_IDS=()
+
   # Generate the credential report, only if it is group1 related which checks we
   # run so that the checks can safely assume it's available
   # set the custom ignores list for this check


### PR DESCRIPTION
* **Feature:** resolveSecurityHubPreviousFails -  Also archive PASSED findings (in case -q is not used).
* **Bug:** resolveSecurityHubPreviousFails - Security Hub is eventual consistent. GetFindings filtered by UpdatedAt can return old finding versions resulting in findings being ARCHIVED incorrectly. Refactored integration to use "Read-Your-Own-Writes". 
* **Bug:** resolveSecurityHubPreviousFails - GeneratorId matched using EQUALS, not PREFIX (extra7100 matches extra71)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.