### PR TITLE
adapt check119 to exclude instances shutting down... this time with correct check...

### DIFF
--- a/checks/check119
+++ b/checks/check119
@@ -25,7 +25,7 @@ check119(){
     if [[ $INSTANCE_LIST ]]; then
       for instance in $INSTANCE_LIST; do
         STATE_NAME=$(echo $EC2_DATA | jq -r --arg i "$instance" 'select(.InstanceId==$i)|.StateName')
-        if [[ $STATE_NAME != "terminated" || $STATE_NAME != "shutting-down" ]]; then
+        if [[ $STATE_NAME != "terminated" && $STATE_NAME != "shutting-down" ]]; then
           PROFILEARN=$(echo $EC2_DATA | jq -r --arg i "$instance" 'select(.InstanceId==$i)|.ProfileArn')
           if [[ $PROFILEARN == "null" ]]; then
             textFail "$regx: Instance $instance not associated with an instance role" $regx


### PR DESCRIPTION
brain fart: used logical 'or' instead of correct '&&'. Sorry about that.
this really fixes issue https://github.com/toniblyx/prowler/issues/689

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
