### PR TITLE
Fix log metric filter checks with multiple trails

### DIFF
--- a/include/check3x
+++ b/include/check3x
@@ -17,16 +17,19 @@ check3x(){
   # In order to make all these checks work properly logs and alarms have to 
   # be based only on CloudTrail tail with CloudWatchLog configuration.
   DESCRIBE_TRAILS_CACHE=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region "$REGION" --query 'trailList[?CloudWatchLogsLogGroupArn != `null`]')
-  TRAIL_LIST=$(echo $DESCRIBE_TRAILS_CACHE | jq -r '. |@base64')
+  TRAIL_LIST=$(echo $DESCRIBE_TRAILS_CACHE | jq -r -c '.[] |@base64') # this treats each array element as its own line
   CURRENT_ACCOUNT_ID=$($AWSCLI sts $PROFILE_OPT get-caller-identity --region "$REGION" --query Account --output text)
   CLOUDWATCH_LOGGROUP=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region "$REGION" --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text| tr '\011' '\012' | awk -F: '{print $7}')
 
   if [[ $CLOUDWATCH_LOGGROUP != "" ]]; then
     for group_obj_enc in $TRAIL_LIST; do
+
       group_obj_raw=$(echo $group_obj_enc | decode_report)
-      CLOUDWATCH_LOGGROUP_NAME=$(echo $group_obj_raw | jq -r '.[] | .CloudWatchLogsLogGroupArn|split(":")[6]')
-      CLOUDWATCH_LOGGROUP_REGION=$(echo $group_obj_raw | jq -r '.[] | .CloudWatchLogsLogGroupArn|split(":")[3]')
-      CLOUDWATCH_LOGGROUP_ACCOUNT=$(echo $group_obj_raw | jq -r '.[] | .CloudWatchLogsLogGroupArn|split(":")[4]')
+
+      CLOUDWATCH_LOGGROUP_NAME=$(echo $group_obj_raw | jq -r '.CloudWatchLogsLogGroupArn|split(":")[6]')
+      CLOUDWATCH_LOGGROUP_REGION=$(echo $group_obj_raw | jq -r '.CloudWatchLogsLogGroupArn|split(":")[3]')
+      CLOUDWATCH_LOGGROUP_ACCOUNT=$(echo $group_obj_raw | jq -r '.CloudWatchLogsLogGroupArn|split(":")[4]')
+
       if [ "$CLOUDWATCH_LOGGROUP_ACCOUNT" == "$CURRENT_ACCOUNT_ID" ];then
         # Filter control and whitespace from .metricFilters[*].filterPattern for easier matching later
         METRICFILTER_CACHE=$($AWSCLI logs describe-metric-filters --log-group-name "$CLOUDWATCH_LOGGROUP_NAME" $PROFILE_OPT --region "$CLOUDWATCH_LOGGROUP_REGION"|jq '.metricFilters|=map(.filterPattern|=gsub("[[:space:]]+"; " "))')
@@ -69,7 +72,7 @@ check3x(){
     fi
     if [[ $CHECK_CROSS_ACCOUNT_WARN ]]; then
       for group in $CHECK_CROSS_ACCOUNT_WARN; do
-        textInfo "CloudWatch group $group is not in this account"
+        textInfo "CloudWatch group $group is not in this account" 
       done
     fi
   else


### PR DESCRIPTION
There was an issue with how the check3x handled instances where there were multiple log groups. It attempted to loop through results, but it was treating a jq array as one element, and then parsing it as an array within the loop, which seems to indicate that it was being handled as an array but assumed to be length 1.

It's hard to explain, but check out this branch: https://github.com/bridgecrewio/prowler/tree/WIP-debug-check3x on an account having multiple trails. Here's an example of a value for `DESCRIBE_TRAILS_CACHE` that would generate this issue (sanitized):

```
[
  {
    "Name": "Default",
    "S3BucketName": "bucket1",
    "IncludeGlobalServiceEvents": true,
    "IsMultiRegionTrail": false,
    "HomeRegion": "us-east-1",
    "TrailARN": "arn:aws:cloudtrail:us-east-1:123456789012:trail/Default",
    "LogFileValidationEnabled": false,
    "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:CloudTrail/us-east-1:*",
    "CloudWatchLogsRoleArn": "arn:aws:iam::123456789012:role/CloudTrail_CloudWatchLogs_Role",
    "HasCustomEventSelectors": false,
    "HasInsightSelectors": false,
    "IsOrganizationTrail": false
  },
  {
    "Name": "cloudtrail2",
    "S3BucketName": "bucket2",
    "SnsTopicName": "arn:aws:sns:us-east-1:123456789012:cloudtrail-Topic",
    "SnsTopicARN": "arn:aws:sns:us-east-1:123456789012:cloudtrail-Topic",
    "IncludeGlobalServiceEvents": true,
    "IsMultiRegionTrail": true,
    "HomeRegion": "us-west-2",
    "TrailARN": "arn:aws:cloudtrail:us-west-2:123456789012:trail/cloudtrail2",
    "LogFileValidationEnabled": true,
    "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-west-2:123456789012:log-group:/loggroup:*",
    "CloudWatchLogsRoleArn": "arn:aws:iam::123456789012:role/service-role/cloudtrail2",
    "HasCustomEventSelectors": false,
    "HasInsightSelectors": false,
    "IsOrganizationTrail": false
  }
]
```

The result was false-negatives whenever there were multiple log groups. There were only `info` results so they didn't appear as a pass or fail.

This PR fixes it by properly handling multiple elements in a jq array as distinct lines of output that can be appropriately handled in bash.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
