### PR TITLE
reworked check740 to consider all snapshots, use JMESPath query, and …

### DIFF
--- a/checks/check_extra740
+++ b/checks/check_extra740
@@ -20,20 +20,64 @@ CHECK_ALTERNATE_check740="extra740"
 CHECK_ASFF_COMPLIANCE_TYPE_extra740="ens-mp.info.3.aws.ebs.3"
 
 extra740(){
-  textInfo "Looking for EBS Snapshots in all regions...  "
-  for regx in $REGIONS; do
-    LIST_OF_EBS_SNAPSHOTS=$($AWSCLI ec2 describe-snapshots $PROFILE_OPT --region $regx --owner-ids $ACCOUNT_NUM --output text --query 'Snapshots[*].{ID:SnapshotId}' --max-items $MAXITEMS | grep -v None 2> /dev/null)
-    if [[ $LIST_OF_EBS_SNAPSHOTS ]];then
-      for snapshot in $LIST_OF_EBS_SNAPSHOTS; do
-        SNAPSHOT_IS_ENCRYPTED=$($AWSCLI ec2 describe-snapshots $PROFILE_OPT --region $regx --output text --snapshot-id $snapshot --query Snapshots[*].Encrypted|grep False)
-        if [[ $SNAPSHOT_IS_ENCRYPTED ]];then
-          textFail "$regx: $snapshot is currently not encrypted!" "$regx"
-        else
-          textPass "$regx: $snapshot is encrypted" "$regx"
-        fi
+  textInfo "Examining EBS Volume Snapshots ..."
+  # This does NOT use max-items, which would limit the number of items
+  # considered. It considers all snapshots, but only reports at most 
+  # max-items passing and max-items failing.
+  for regx in ${REGIONS}; do
+    UNENCRYPTED_SNAPSHOTS=$(${AWSCLI} ec2 describe-snapshots ${PROFILE_OPT} \
+    --region ${regx} --owner-ids ${ACCOUNT_NUM} --output text \
+    --query 'Snapshots[?Encrypted==`false`]|[*].{Id:SnapshotId}' \
+     | grep -v None 2> /dev/null)
+    ENCRYPTED_SNAPSHOTS=$(${AWSCLI} ec2 describe-snapshots ${PROFILE_OPT} \
+    --region ${regx} --owner-ids ${ACCOUNT_NUM} --output text \
+    --query 'Snapshots[?Encrypted==`true`]|[*].{Id:SnapshotId}' \
+     | grep -v None 2> /dev/null)
+    typeset -i unencrypted
+    typeset -i encrypted
+    unencrypted=0
+    encrypted=0
+
+    if [[ ${UNENCRYPTED_SNAPSHOTS} ]]; then
+      for snapshot in ${UNENCRYPTED_SNAPSHOTS}; do
+          unencrypted=${unencrypted}+1
+          if [ "${unencrypted}" -le "${MAXITEMS}" ]; then
+            textFail "${regx}: ${snapshot} is not encrypted!" "${regx}"
+          fi
       done
+    fi
+    if [[ ${ENCRYPTED_SNAPSHOTS} ]]; then
+      for snapshot in ${ENCRYPTED_SNAPSHOTS}; do
+          encrypted=${encrypted}+1
+          if [ "${encrypted}" -le "${MAXITEMS}" ]; then
+            textPass "${regx}: ${snapshot} is encrypted." "${regx}"
+          fi
+      done
+    fi
+    if [[ "${encrypted}" = "0" ]] && [[ "${unencrypted}" = "0" ]] ; then
+      textInfo "${regx}: No EBS volume snapshots" "${regx}"
     else
-      textInfo "$regx: No EBS Snapshots found" "$regx"
+      typeset -i total
+      total=${encrypted}+${unencrypted}
+      if [[ "${unencrypted}" -ge "${MAXITEMS}" ]]; then
+        textFail "${unencrypted} unencrypted snapshots out of ${total} snapshots found. Only the first ${MAXITEMS} unencrypted snapshots are reported!"
+      fi
+      if [[ "${encrypted}" -ge "${MAXITEMS}" ]]; then
+        textPass "${encrypted} encrypted snapshots out of ${total} snapshots found. Only the first ${MAXITEMS} encrypted snapshots are reported."
+      fi
+      # Bit of 'bc' magic to print something like 10.42% or 0.85% or similar. 'bc' has a
+      # bug where it will never print leading zeros. So 0.5 is output as ".5". This has a
+      # little extra clause to print a 0 if 0 < x < 1.
+      ratio=$(echo "scale=2; p=(100*${encrypted}/(${encrypted}+${unencrypted})); if(p<1 && p>0) print 0;print p, \"%\";" | bc 2>/dev/null)
+      exit=$?
+
+      # maybe 'bc' doesn't exist, or it exits with an error
+      if [[ "${exit}" = "0" ]]
+      then
+        textInfo "${regx}: ${ratio} encrypted EBS volumes (${encrypted} out of ${total})" "${regx}"
+      else
+        textInfo "${regx}: ${unencrypted} unencrypted EBS volume snapshots out of ${total} total snapshots" "${regx}"
+      fi
     fi
   done
 }


### PR DESCRIPTION
This rework to check740 does several things:

- It uses JMESPath queries to fetch the IDs of unencrypted snapshots and the IDs of encrypted snapshots. This means it gets both lists with 2 EC `describe-snapshots` calls.
- It no longer uses `--max-items` on the `aws ec2 describe-snapshots` call. Instead, it limits its output. This is a big deal because, in the past, if you had 100,000 snapshots, `max-items` was 100 by default and you would only inspect the first 100 snapshots of your 100,000. Now, the tool will inspect all 100,000 snapshots, and return the first 100 that comply/don't comply. For very large accounts, this is a significant change. For small accounts, it is not going to make a big difference.
- This code actually uses the `bc` command to calculate a handy percentage. But it is graceful if `bc` doesn't exist or throws an error.

### Old Behaviour
In the past, if you ran this check with default options, you got the following behaviours:
- On an account with 100 unencrypted snapshots, you would make 101 `describe-snapshots` calls. 1 to get the list, then 1 per snapshot to get its ID.
- On an account with 100,000 unencrypted snapshots, you would make 101 `describe-snapshots` calls. 1 to get the first 100, then 1 per snapshot to get its ID.
- On an account with 100,000 mixed snapshots (some encrypted, some unencrypted), you would make 101 `describe-snapshots` calls. 1 to get the first 100, then 1 per snapshot to get its ID. But if unencrypted snapshots were not in the first 100 snapshots, they wouldn't be found at all. You could have 99,900 unencrypted snapshots and 100 encrypted snapshots, and this could actually report no unencrypted snapshots depending on the random ordering of the snapshots in response to the the `describe-snapshots` call.

### New Behaviour
- On an accounts with 1000 snapshots or less, it will make 2 `describe-snapshots` calls. 1 to get the list of unencrypted snapshots, then 1 to get the list of encrypted snapshots. We will report 100 unencrypted snapshots and an error about how many more exist, but were not reported.
- On an account with 100,000 unencrypted snapshots, it will make 100 calls to `describe-snapshots` to get the unencrypted snapshots because the [AWS CLI automatically paginates](https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-pagination.html) at 1000 items per call. Then it will probably make another 100 calls looking for the encrypted snapshots. It will report at most 100 in each category.
- On an account with 100,000 mixed snapshots, it will make 100 calls to `describe-snapshots` to get the unencrypted snapshots. Then it will make another 100 calls looking for the encrypted snapshots. It will report at most 100 in each category. Importantly, it will print out (as info) the actual total number (e.g., "42,867 out of 100,232").

> By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
