### PR TITLE
Fix - EKS California

### DIFF
--- a/checks/check_extra794
+++ b/checks/check_extra794
@@ -21,12 +21,7 @@ CHECK_ALTERNATE_check794="extra794"
 extra794(){
   textInfo "Looking for control plane logging enabled for EKS clusters across all regions... "
   for regx in $REGIONS; do
-    # Get a list of EKS clusters (Unless us-west-1 which doesn't support EKS):
-    if [[ $regx == "us-west-1" ]]; then
-      textInfo "$regx: EKS not supported in this region" "$regx"
-    else
-      CLUSTERS=$($AWSCLI eks list-clusters $PROFILE_OPT --region $regx --query 'clusters[]' --output text)
-    fi
+    CLUSTERS=$($AWSCLI eks list-clusters $PROFILE_OPT --region $regx --query 'clusters[]' --output text)
     if [[ $CLUSTERS ]]; then
       for CLUSTER in $CLUSTERS;do
         CLUSTERDEF=$($AWSCLI eks describe-cluster $PROFILE_OPT --region $regx --name $CLUSTER --query 'cluster.logging.clusterLogging[0]')
@@ -43,9 +38,7 @@ extra794(){
         fi
       done
     else
-      if [[ $regx != "us-west-1" ]]; then
-        textInfo "$regx: No EKS clusters found" "$regx"
-      fi
+      textInfo "$regx: No EKS clusters found" "$regx"
     fi
   done
 }

--- a/checks/check_extra795
+++ b/checks/check_extra795
@@ -21,12 +21,7 @@ CHECK_ALTERNATE_check795="extra795"
 extra795(){
   textInfo "Looking for public access enabled for EKS clusters across all regions... "
   for regx in $REGIONS; do
-    # Get a list of EKS clusters (Unless us-west-1 which doesn't support EKS):
-    if [[ $regx == "us-west-1" ]]; then
-      textInfo "$regx: EKS not supported in this region" "$regx"
-    else
-      CLUSTERS=$($AWSCLI eks list-clusters $PROFILE_OPT --region $regx --query 'clusters[]' --output text)
-    fi
+    CLUSTERS=$($AWSCLI eks list-clusters $PROFILE_OPT --region $regx --query 'clusters[]' --output text)
     if [[ $CLUSTERS ]]; then
       for CLUSTER in $CLUSTERS;do
         CLUSTERDEF=$($AWSCLI eks describe-cluster $PROFILE_OPT --region $regx --name $CLUSTER --query 'cluster.resourcesVpcConfig')
@@ -40,9 +35,7 @@ extra795(){
         fi
       done
     else
-      if [[ $regx != "us-west-1" ]]; then
-        textInfo "$regx: No EKS clusters found" "$regx"
-      fi
+      textInfo "$regx: No EKS clusters found" "$regx"
     fi
   done
 }

--- a/checks/check_extra796
+++ b/checks/check_extra796
@@ -21,12 +21,7 @@ CHECK_ALTERNATE_check796="extra796"
 extra796(){
   textInfo "Looking for public access CIDRs for EKS clusters across all regions... "
   for regx in $REGIONS; do
-    # Get a list of EKS clusters (Unless us-west-1 which doesn't support EKS):
-    if [[ $regx == "us-west-1" ]]; then
-      textInfo "$regx: EKS not supported in this region" "$regx"
-    else
-      CLUSTERS=$($AWSCLI eks list-clusters $PROFILE_OPT --region $regx --query 'clusters[]' --output text)
-    fi
+    CLUSTERS=$($AWSCLI eks list-clusters $PROFILE_OPT --region $regx --query 'clusters[]' --output text)
     if [[ $CLUSTERS ]]; then
       for CLUSTER in $CLUSTERS;do
         CLUSTERDEF=$($AWSCLI eks describe-cluster $PROFILE_OPT --region $regx --name $CLUSTER --query 'cluster.resourcesVpcConfig')
@@ -45,9 +40,7 @@ extra796(){
         fi
       done
     else
-      if [[ $regx != "us-west-1" ]]; then
-        textInfo "$regx: No EKS clusters found" "$regx"
-      fi
+      textInfo "$regx: No EKS clusters found" "$regx"
     fi
   done
 }

--- a/checks/check_extra797
+++ b/checks/check_extra797
@@ -21,12 +21,7 @@ CHECK_ALTERNATE_check797="extra797"
 extra797(){
   textInfo "Looking for encryption config for EKS clusters across all regions... "
   for regx in $REGIONS; do
-    # Get a list of EKS clusters (Unless us-west-1 which doesn't support EKS):
-    if [[ $regx == "us-west-1" ]]; then
-      textInfo "$regx: EKS not supported in this region" "$regx"
-    else
-      CLUSTERS=$($AWSCLI eks list-clusters $PROFILE_OPT --region $regx --query 'clusters[]' --output text)
-    fi
+    CLUSTERS=$($AWSCLI eks list-clusters $PROFILE_OPT --region $regx --query 'clusters[]' --output text)
     if [[ $CLUSTERS ]]; then
       for CLUSTER in $CLUSTERS;do
         ENC_CONFIG=$($AWSCLI eks describe-cluster $PROFILE_OPT --region $regx --name $CLUSTER --query 'cluster.encryptionConfig')
@@ -38,9 +33,7 @@ extra797(){
         fi
       done
     else
-      if [[ $regx != "us-west-1" ]]; then
-        textInfo "$regx: No EKS clusters found" "$regx"
-      fi
+      textInfo "$regx: No EKS clusters found" "$regx"
     fi
   done
 }


### PR DESCRIPTION
Hello,

As of September 2020 EKS is available in the California region and so there no longer needs to be a condition to check region within the EKS related checks. 

AWS Announcement: https://aws.amazon.com/about-aws/whats-new/2020/09/amazon-eks-now-available-n-california-region/

us-west-1 eks region ref: https://docs.aws.amazon.com/general/latest/gr/eks.html

**License**
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
