### PR TITLE
Accept current most restrictive TLSv1.2-only ALB security policy as secure

### DIFF
--- a/checks/check_extra792
+++ b/checks/check_extra792
@@ -73,7 +73,8 @@ extra792(){
       if [[ $LIST_OF_ELBSV2 ]]; then
         # NOTE - ALBs do NOT support custom security policies 
         # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html
-        ELBV2SECUREPOLICIES=("ELBSecurityPolicy-2016-08" "ELBSecurityPolicy-TLS-1-1-2017-01" "ELBSecurityPolicy-TLS-1-2-2017-01" "ELBSecurityPolicy-TLS-1-2-Ext-2018-06" "ELBSecurityPolicy-FS-2018-06" "ELBSecurityPolicy-FS-1-1-2019-08" "ELBSecurityPolicy-FS-1-2-2019-08" "ELBSecurityPolicy-FS-1-2-Res-2019-08" "ELBSecurityPolicy-2015-05")
+        ELBV2SECUREPOLICIES=("ELBSecurityPolicy-2016-08" "ELBSecurityPolicy-TLS-1-1-2017-01" "ELBSecurityPolicy-TLS-1-2-2017-01" "ELBSecurityPolicy-TLS-1-2-Ext-2018-06" "ELBSecurityPolicy-FS-2018-06" "ELBSecurityPolicy-FS-1-1-2019-08" "ELBSecurityPolicy-FS-1-2-2019-08" "ELBSecurityPolicy-FS-1-2-Res-2019-08" "ELBSecurityPolicy-FS-1-2-Res-2020-10" "ELBSecurityPolicy-2015-05")
+
         for elbarn in $LIST_OF_ELBSV2; do
           passed=true
           if [[ $(echo $elbarn | grep "loadbalancer/app/") ]]; then


### PR DESCRIPTION
The `ELBSecurityPolicy-FS-1-2-Res-2020-10` policy is the most
restrictive TLS v1.2 only SSL/TLS security policy available, and is a
subset of the already accepted `ELBSecurityPolicy-FS-1-2-Res-2019-08`
policy - this commit adds `ELBSecurityPolicy-FS-1-2-Res-2020-10` to
the list of acceptable "secure" security policies.

`ELBSecurityPolicy-FS-1-2-Res-2020-10` has a very limited set of
ciphers, is TLS v1.2 only and supports Forward Secrecy.

Current SSL Labs tests gives it an "A" rating for another source of
confirmation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
