### PR TITLE
Fix for busybox date command

### DIFF
--- a/include/os_detector
+++ b/include/os_detector
@@ -109,7 +109,11 @@ bsd_get_iso8601_timestamp() {
 }
 
 gnu_convert_date_to_timestamp() {
-  date -d "$1" +%s
+  if [ "$OSTYPE" == "linux-musl" ]; then
+    date -D "%Y-%m-%dT%H:%M:%SZ" -d "$1" +%s
+  else
+    date -d "$1" +%s
+  fi
 }
 
 bsd_convert_date_to_timestamp() {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

@toniblyx I noticed when using the -A -R -T parameters with Prowler running on Alpine Linux 3.12.3 (which uses busybox) there is an reoccurring error in the Prowler output because the date command doesn't understand RFC3339 format dates by default - but date can parse them if you combine the -D parameter with the -d parameter. Really odd that the date command is one of the most non-standard between different OS, you think that would be a solved problem after sixty years.
