### PR TITLE
Additional check for location of awscli

### DIFF
--- a/include/awscli_detector
+++ b/include/awscli_detector
@@ -12,8 +12,11 @@
 # specific language governing permissions and limitations under the License.
 
 # AWS-CLI detector variable
-AWSCLI=$(which aws)
-if [ -z "${AWSCLI}" ]; then
+if [ ! -z $(which aws) ]; then
+  AWSCLI=$(which aws)
+elif [ ! -z $(type -p aws) ]; then
+  AWSCLI=$(type -p aws)
+else
   echo -e "\n$RED ERROR!$NORMAL AWS-CLI (aws command) not found. Make sure it is installed correctly and in your \$PATH\n"
   EXITCODE=1
   exit $EXITCODE


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

@toniblyx I've encountered the most bizarre situation on MacOS. The aws client is in my path, works when I run it, but the which command doesn't report its location. It is not an alias, hash bang is valid, python interpreter is valid. The type command does report its location, so this patch adds it as a fallback in case someone else has the same issue. Both type and which are bash builtins, so this should be very low overhead.
