### PR TITLE
Add check for AccessDenied when calling GetBucketLocation

### DIFF
--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -80,18 +80,17 @@ extra73(){
     # must be made to S3 endpoints in the same region as the bucket was
     # created.
     #
-    BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location --bucket $bucket $PROFILE_OPT --output text 2>&1)
+    BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location $PROFILE_OPT --region $REGION --bucket $bucket --output text 2>&1)
     if [[ $(echo "$BUCKET_LOCATION" | grep AccessDenied) ]]; then
       textFail "Access Denied Trying to Get Bucket Location for $bucket"
       continue
     fi
-    if [[ "None" == $BUCKET_LOCATION ]]; then
+    if [[ $BUCKET_LOCATION == "None" ]]; then
       BUCKET_LOCATION="us-east-1"
     fi
-    if [[ "EU" == $BUCKET_LOCATION ]]; then
+    if [[ $BUCKET_LOCATION == "EU" ]]; then
       BUCKET_LOCATION="eu-west-1"
     fi
-
     #
     # If public ACLs disabled at bucket level then look no further
     #

--- a/checks/check_extra734
+++ b/checks/check_extra734
@@ -23,18 +23,21 @@ extra734(){
   LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets $PROFILE_OPT --region $REGION --query Buckets[*].Name --output text|xargs -n1)
   if [[ $LIST_OF_BUCKETS ]]; then
     for bucket in $LIST_OF_BUCKETS;do
-      BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location $PROFILE_OPT --region $REGION --bucket $bucket --output text)
-      # For this test to pass one of the following must be present:
-      # - Configure ServerSideEncryptionConfiguration rule for AES256 or aws:kms
-      #  OR
-      # - Have bucket policy denying s3:PutObject when s3:x-amz-server-side-encryption is absent
-
+      BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location $PROFILE_OPT --region $REGION --bucket $bucket --output text 2>&1)
+      if [[ $(echo "$BUCKET_LOCATION" | grep AccessDenied) ]]; then
+        textFail "Access Denied Trying to Get Bucket Location for $bucket"
+        continue
+      fi
       if [[ $BUCKET_LOCATION == "None" ]]; then
         BUCKET_LOCATION="us-east-1"
       fi
       if [[ $BUCKET_LOCATION == "EU" ]]; then
         BUCKET_LOCATION="eu-west-1"
       fi
+      # For this test to pass one of the following must be present:
+      # - Configure ServerSideEncryptionConfiguration rule for AES256 or aws:kms
+      #  OR
+      # - Have bucket policy denying s3:PutObject when s3:x-amz-server-side-encryption is absent
       # query to get if has encryption enabled or not
       RESULT=$($AWSCLI s3api get-bucket-encryption $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --query ServerSideEncryptionConfiguration.Rules[].ApplyServerSideEncryptionByDefault[].SSEAlgorithm --output text 2>&1)
       if [[ $(echo "$RESULT" | grep AccessDenied) ]]; then

--- a/checks/check_extra764
+++ b/checks/check_extra764
@@ -24,11 +24,15 @@ extra764(){
   if [[ $LIST_OF_BUCKETS ]]; then
     for bucket in $LIST_OF_BUCKETS;do
       TEMP_STP_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-${bucket}.policy.XXXXXXXXXX)
-      BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location $PROFILE_OPT --region $REGION --bucket $bucket --output text)
-      if [[ "None" == $BUCKET_LOCATION ]]; then
+      BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location $PROFILE_OPT --region $REGION --bucket $bucket --output text 2>&1)
+      if [[ $(echo "$BUCKET_LOCATION" | grep AccessDenied) ]]; then
+        textFail "Access Denied Trying to Get Bucket Location for $bucket"
+        continue
+      fi
+      if [[ $BUCKET_LOCATION == "None" ]]; then
         BUCKET_LOCATION="us-east-1"
       fi
-      if [[ "EU" == $BUCKET_LOCATION ]]; then
+      if [[ $BUCKET_LOCATION == "EU" ]]; then
         BUCKET_LOCATION="eu-west-1"
       fi
       # get bucket policy


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

@toniblyx This adds a couple checks for AccessDenied when calling get-bucket-location
