### PR TITLE
Catch errors assuming role and describing regions

### DIFF
--- a/include/assume_role
+++ b/include/assume_role
@@ -11,13 +11,13 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-# both variables are mandatory to be set together 
+# both variables are mandatory to be set together
 assume_role(){
     if [[ -z $ROLE_TO_ASSUME ]]; then
         echo "$OPTRED ERROR!$OPTNORMAL - Both Account ID (-A) and IAM Role to assume (-R) must be set"
         exit 1
-    fi 
-    # if not session duration set with -T, then will be 1h. 
+    fi
+    # if not session duration set with -T, then will be 1h.
     # In some cases you will need more than 1h.
     if [[ -z $SESSION_DURATION_TO_ASSUME ]]; then
         SESSION_DURATION_TO_ASSUME="3600"
@@ -25,31 +25,37 @@ assume_role(){
 
     # temporary file where to store credentials
     TEMP_STS_ASSUMED_FILE=$(mktemp -t prowler.sts_assumed-XXXXXX)
-    
+
     #Check if external ID has bee provided if so execute with external ID if not ignore
     if [[ -z $ROLE_EXTERNAL_ID ]]; then
         # assume role command
         $AWSCLI $PROFILE_OPT sts assume-role --role-arn arn:${AWS_PARTITION}:iam::$ACCOUNT_TO_ASSUME:role/$ROLE_TO_ASSUME \
             --role-session-name ProwlerAssessmentSession \
             --region $REGION_FOR_STS \
-            --duration-seconds $SESSION_DURATION_TO_ASSUME > $TEMP_STS_ASSUMED_FILE 
-    else 
+            --duration-seconds $SESSION_DURATION_TO_ASSUME > $TEMP_STS_ASSUMED_FILE 2>&1
+    else
         $AWSCLI $PROFILE_OPT sts assume-role --role-arn arn:${AWS_PARTITION}:iam::$ACCOUNT_TO_ASSUME:role/$ROLE_TO_ASSUME \
             --role-session-name ProwlerAssessmentSession \
             --duration-seconds $SESSION_DURATION_TO_ASSUME \
             --region $REGION_FOR_STS \
-            --external-id $ROLE_EXTERNAL_ID > $TEMP_STS_ASSUMED_FILE 
-    fi 
+            --external-id $ROLE_EXTERNAL_ID > $TEMP_STS_ASSUMED_FILE 2>&1
+    fi
+    if [[ $(grep AccessDenied $TEMP_STS_ASSUMED_FILE) ]]; then
+      textFail "Access Denied assuming role arn:${AWS_PARTITION}:iam::${ACCOUNT_TO_ASSUME}:role/${ROLE_TO_ASSUME}"
+      rm -f $TEMP_STS_ASSUMED_FILE
+      EXITCODE=1
+      exit $EXITCODE
+    fi
 
     # assume role command
     #$AWSCLI $PROFILE_OPT sts assume-role --role-arn arn:${AWS_PARTITION}:iam::$ACCOUNT_TO_ASSUME:role/$ROLE_TO_ASSUME \
     #    --role-session-name ProwlerAssessmentSession \
-    #    --duration-seconds $SESSION_DURATION_TO_ASSUME > $TEMP_STS_ASSUMED_FILE 
+    #    --duration-seconds $SESSION_DURATION_TO_ASSUME > $TEMP_STS_ASSUMED_FILE
 
     # if previous command fails exit with the given error from aws-cli
-    # this is likely to be due to session duration limit of 1h in case 
+    # this is likely to be due to session duration limit of 1h in case
     # of assume role chaining:
-    # "The requested DurationSeconds exceeds the 1 hour session limit 
+    # "The requested DurationSeconds exceeds the 1 hour session limit
     # for roles assumed by role chaining."
     # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html
     if [[ $? != 0 ]];then

--- a/prowler
+++ b/prowler
@@ -237,7 +237,12 @@ trap handle_ctrl_c INT
 . $PROWLER_DIR/include/junit_integration
 
 # Get list of regions based on include/whoami
-REGIONS=$($AWSCLI ec2 describe-regions --query 'Regions[].RegionName' --output text $PROFILE_OPT --region $REGION_FOR_STS --region-names $FILTERREGION)
+REGIONS=$($AWSCLI ec2 describe-regions --query 'Regions[].RegionName' --output text $PROFILE_OPT --region $REGION_FOR_STS --region-names $FILTERREGION 2>&1)
+if [[ $(echo "$REGIONS" | grep AccessDenied) ]]; then
+  echo "Access Denied trying to describe regions"
+  EXITCODE=1
+  exit $EXITCODE
+fi
 
 # Pre-process whitelist file if supplied
 if [[ -n "$WHITELIST_FILE" ]]; then
@@ -339,7 +344,7 @@ execute_check() {
 
 
   local severity_var=CHECK_SEVERITY_$1
-  
+
   CHECK_SEVERITY="${!severity_var}"
 
   CHECK_ID="$1"
@@ -437,7 +442,6 @@ execute_group() {
 
 # Function to execute group by name
 execute_group_by_id() {
-  
   	for i in "${!GROUP_ID[@]}"; do
 		if [ "${GROUP_ID[$i]}" == "$1" ]; then
 			execute_group ${i} $2
@@ -447,14 +451,14 @@ execute_group_by_id() {
 
 # Function to execute all checks in all groups except extras if -e is invoked
 execute_all() {
-	for i in "${!GROUP_TITLE[@]}"; do
+  for i in "${!GROUP_TITLE[@]}"; do
     if [[ $EXTRAS ]]; then
       GROUP_RUN_BY_DEFAULT[7]='N'
     fi
     if [ "${GROUP_RUN_BY_DEFAULT[$i]}" == "Y" ]; then
       execute_group $i
     fi
-	done
+  done
 }
 
 # Function to show the titles of either all checks or only those in the specified group


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

@toniblyx In this change I'm trying to detect AccessDenied errors when doing describe-regions or sts assume-role. If describe-regions fails then the REGIONS variable is empty and that can lead do checks silently failing. If assume-role fails then checks will still run but produce errors.
