### PR TITLE
Check for errors generating credential report, limit loop iterations

### DIFF
--- a/include/credentials_report
+++ b/include/credentials_report
@@ -14,9 +14,19 @@
 # Generate Credential Report
 genCredReport() {
   textTitle "0.1" "Generating AWS IAM Credential Report..." "NOT_SCORED" "SUPPORT"
-  until $( $AWSCLI iam generate-credential-report --output text --query 'State' $PROFILE_OPT --region $REGION |grep -q -m 1 "COMPLETE") ; do
+  for i in $(seq 1 60); do
+    GENERATECREDENTIALREPORTOUTPUT=$($AWSCLI iam generate-credential-report --output text --query 'State' $PROFILE_OPT --region $REGION 2>&1)
+    if [[ $(echo "$GENERATECREDENTIALREPORTOUTPUT" | grep AccessDenied) ]]; then
+      textFail "Access Denied trying to generate credential report"
+      exit 1
+    fi
+    if [[ "$GENERATECREDENTIALREPORTOUTPUT" == "COMPLETE" ]]; then
+      return
+    fi
     sleep 1
   done
+  textFail "Generate credential report unsuccessful"
+  exit 1
 }
 
 # Save report to a file, decode it, deletion at finish and after every single check


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

@toniblyx This is to address the endless loop in genCredReport reported in issue 617
