### PR TITLE
fix regex in check43

### DIFF
--- a/checks/check43
+++ b/checks/check43
@@ -23,7 +23,7 @@ check43(){
   for regx in $REGIONS; do
     CHECK_SGDEFAULT_IDS=$($AWSCLI ec2 describe-security-groups $PROFILE_OPT --region $regx --filters Name=group-name,Values='default' --query 'SecurityGroups[*].GroupId[]' --output text)
     for CHECK_SGDEFAULT_ID in $CHECK_SGDEFAULT_IDS; do
-      CHECK_SGDEFAULT_ID_OPEN=$($AWSCLI ec2 describe-security-groups $PROFILE_OPT --region $regx --group-ids $CHECK_SGDEFAULT_ID --query 'SecurityGroups[*].{IpPermissions:IpPermissions,IpPermissionsEgress:IpPermissionsEgress,GroupId:GroupId}' --output text |egrep '0.0.0.0|\:\:\/0')
+      CHECK_SGDEFAULT_ID_OPEN=$($AWSCLI ec2 describe-security-groups $PROFILE_OPT --region $regx --group-ids $CHECK_SGDEFAULT_ID --query 'SecurityGroups[*].{IpPermissions:IpPermissions,IpPermissionsEgress:IpPermissionsEgress,GroupId:GroupId}' --output text |egrep ' 0.0.0.0|\:\:\/0')
       if [[ $CHECK_SGDEFAULT_ID_OPEN ]];then
         textFail "Default Security Groups ($CHECK_SGDEFAULT_ID) found that allow 0.0.0.0 IN or OUT traffic in Region $regx" "$regx"
       else


### PR DESCRIPTION
Let's say you have a rule like 10.0.0.0/8 in a default security group, the check fails when it should not.

The output from aws ec2 command is like this:

```
IPPERMISSIONS   2181    tcp     2181
IPRANGES        10.0.0.0/8
IPPERMISSIONS   9092    tcp     9092
IPRANGES        10.0.0.0/8
```

Simply changing the expression by adding a space fixes this problem
```
egrep ' 0.0.0.0|\:\:\/0'
```
