### PR TITLE
Add access checks for several checks

### DIFF
--- a/checks/check21
+++ b/checks/check21
@@ -23,7 +23,11 @@ check21(){
   trail_count=0
   # "Ensure CloudTrail is enabled in all regions (Scored)"
   for regx in $REGIONS; do
-    TRAILS_AND_REGIONS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query 'trailList[*].{Name:TrailARN, HomeRegion:HomeRegion}' --output text | tr "	" ',')
+    TRAILS_AND_REGIONS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query 'trailList[*].{Name:TrailARN, HomeRegion:HomeRegion}' --output text 2>&1 | tr "	" ',')
+    if [[ $(echo "$TRAILS_AND_REGIONS" | grep AccessDenied) ]]; then
+      textFail "Access Denied trying to describe trails in $regx"
+      continue
+    fi
     if [[ $TRAILS_AND_REGIONS ]]; then
       for reg_trail in $TRAILS_AND_REGIONS; do
         TRAIL_REGION=$(echo $reg_trail | cut -d',' -f1)

--- a/checks/check22
+++ b/checks/check22
@@ -23,7 +23,11 @@ check22(){
   trail_count=0
   # "Ensure CloudTrail log file validation is enabled (Scored)"
   for regx in $REGIONS; do
-    TRAILS_AND_REGIONS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query 'trailList[*].{Name:TrailARN, HomeRegion:HomeRegion}' --output text | tr "	" ',')
+    TRAILS_AND_REGIONS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query 'trailList[*].{Name:TrailARN, HomeRegion:HomeRegion}' --output text 2>&1 | tr "	" ',')
+    if [[ $(echo "$TRAILS_AND_REGIONS" | grep AccessDenied) ]]; then
+      textFail "Access Denied trying to describe trails in $regx"
+      continue
+    fi
     if [[ $TRAILS_AND_REGIONS ]]; then
       for reg_trail in $TRAILS_AND_REGIONS; do
         TRAIL_REGION=$(echo $reg_trail | cut -d',' -f1)
@@ -35,9 +39,9 @@ check22(){
 
         LOGFILEVALIDATION_TRAIL_STATUS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $TRAIL_REGION --query 'trailList[*].LogFileValidationEnabled' --output text --trail-name-list $trail)
         if [[ "$LOGFILEVALIDATION_TRAIL_STATUS" == 'False' ]];then
-          textFail "Trail $trail in $regx has not log file validation enabled"
+          textFail "Trail $trail in $regx log file validation disabled"
         else
-          textPass "Trail $trail in $regx has log file validation enabled"
+          textPass "Trail $trail in $regx log file validation enabled"
         fi
 
       done

--- a/checks/check23
+++ b/checks/check23
@@ -20,22 +20,68 @@ CHECK_ASFF_COMPLIANCE_TYPE_check23="ens-op.exp.10.aws.trail.3 ens-op.exp.10.aws.
 CHECK_SERVICENAME_check23="cloudtrail"
 
 check23(){
+  trail_count=0
   # "Ensure the S3 bucket CloudTrail logs to is not publicly accessible (Scored)"
-  CLOUDTRAILBUCKET=$($AWSCLI cloudtrail describe-trails --query 'trailList[*].S3BucketName' --output text $PROFILE_OPT --region $REGION)
-  if [[ $CLOUDTRAILBUCKET ]]; then
-    for bucket in $CLOUDTRAILBUCKET;do
-      CLOUDTRAILBUCKET_HASALLPERMISIONS=$($AWSCLI s3api get-bucket-acl --bucket $bucket --query 'Grants[?Grantee.URI==`http://acs.amazonaws.com/groups/global/AllUsers`]' $PROFILE_OPT --region $REGION --output text 2>&1)
-      if [[ $(echo "$CLOUDTRAILBUCKET_HASALLPERMISIONS" | grep AccessDenied) ]]; then
-        textInfo "Access Denied Trying to Get Bucket Acl for $bucket"
-        continue
-      fi
-      if [[ $CLOUDTRAILBUCKET_HASALLPERMISIONS ]]; then
-        textFail "check your $bucket CloudTrail bucket ACL and Policy!"
-      else
-        textPass "Bucket $bucket is set correctly"
-      fi
-    done
-  else
-    textFail "No CloudTrail bucket found!"
+  for regx in $REGIONS; do
+    TRAILS_AND_REGIONS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query 'trailList[*].{Name:TrailARN, HomeRegion:HomeRegion}' --output text 2>&1 | tr "	" ',')
+    if [[ $(echo "$TRAILS_AND_REGIONS" | grep AccessDenied) ]]; then
+      textFail "Access Denied trying to describe trails in $regx"
+      continue
+    fi
+    if [[ $TRAILS_AND_REGIONS ]]; then
+      for reg_trail in $TRAILS_AND_REGIONS; do
+        TRAIL_REGION=$(echo $reg_trail | cut -d',' -f1)
+        if [ $TRAIL_REGION != $regx ]; then # Only report trails once in home region
+          continue
+        fi
+        trail=$(echo $reg_trail | cut -d',' -f2)
+        trail_count=$((trail_count + 1))
+
+        CLOUDTRAILBUCKET=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $TRAIL_REGION --query 'trailList[*].[S3BucketName]' --output text --trail-name-list $trail)
+        if [[ -z $CLOUDTRAILBUCKET ]]; then
+          textFail "Trail $trail in $TRAIL_REGION does not publish to S3"
+          continue
+        fi
+
+        CLOUDTRAIL_ACCOUNT_ID=$(echo $trail | awk -F: '{ print $5 }')
+        if [ "$CLOUDTRAIL_ACCOUNT_ID" != "$ACCOUNT_NUM" ]; then
+          textInfo "Trail $trail in $TRAIL_REGION S3 logging bucket $CLOUDTRAILBUCKET is not in current account"
+          continue
+        fi
+
+        #
+        # LOCATION - requests referencing buckets created after March 20, 2019
+        # must be made to S3 endpoints in the same region as the bucket was
+        # created.
+        #
+        BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location $PROFILE_OPT --region $regx --bucket $CLOUDTRAILBUCKET --output text 2>&1)
+        if [[ $(echo "$BUCKET_LOCATION" | grep AccessDenied) ]]; then
+          textFail "Trail $trail in $TRAIL_REGION Access Denied getting bucket location for $CLOUDTRAILBUCKET"
+          continue
+        fi
+        if [[ $BUCKET_LOCATION == "None" ]]; then
+          BUCKET_LOCATION="us-east-1"
+        fi
+        if [[ $BUCKET_LOCATION == "EU" ]]; then
+          BUCKET_LOCATION="eu-west-1"
+        fi
+
+        CLOUDTRAILBUCKET_HASALLPERMISIONS=$($AWSCLI s3api get-bucket-acl --bucket $CLOUDTRAILBUCKET $PROFILE_OPT --region $BUCKET_LOCATION --query 'Grants[?Grantee.URI==`http://acs.amazonaws.com/groups/global/AllUsers`]' --output text 2>&1)
+        if [[ $(echo "$CLOUDTRAILBUCKET_HASALLPERMISIONS" | grep AccessDenied) ]]; then
+          textInfo "Trail $trail in $TRAIL_REGION Access Denied getting bucket acl for $CLOUDTRAILBUCKET"
+          continue
+        fi
+
+        if [[ -z $CLOUDTRAILBUCKET_HASALLPERMISIONS ]]; then
+          textPass "Trail $trail in $TRAIL_REGION S3 logging bucket $CLOUDTRAILBUCKET is not publicly accessible"
+        else
+          textFail "Trail $trail in $TRAIL_REGION S3 logging bucket $CLOUDTRAILBUCKET is publicly accessible"
+        fi
+
+      done
+    fi
+  done
+  if [[ $trail_count == 0 ]]; then
+    textFail "No CloudTrail trails were found in the account"
   fi
 }

--- a/checks/check24
+++ b/checks/check24
@@ -23,7 +23,11 @@ check24(){
   trail_count=0
   # "Ensure CloudTrail trails are integrated with CloudWatch Logs (Scored)"
   for regx in $REGIONS; do
-    TRAILS_AND_REGIONS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query 'trailList[*].{Name:TrailARN, HomeRegion:HomeRegion}' --output text | tr "	" ',')
+    TRAILS_AND_REGIONS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query 'trailList[*].{Name:TrailARN, HomeRegion:HomeRegion}' --output text 2>&1 | tr "	" ',')
+    if [[ $(echo "$TRAILS_AND_REGIONS" | grep AccessDenied) ]]; then
+      textFail "Access Denied trying to describe trails in $regx"
+      continue
+    fi
     if [[ $TRAILS_AND_REGIONS ]]; then
       for reg_trail in $TRAILS_AND_REGIONS; do
         TRAIL_REGION=$(echo $reg_trail | cut -d',' -f1)

--- a/checks/check25
+++ b/checks/check25
@@ -21,11 +21,20 @@ CHECK_SERVICENAME_check25="configservice"
 check25(){
   # "Ensure AWS Config is enabled in all regions (Scored)"
   for regx in $REGIONS; do
-    CHECK_AWSCONFIG_STATUS=$($AWSCLI configservice get-status $PROFILE_OPT --region $regx --output json| grep "recorder: ON")
-    if [[ $CHECK_AWSCONFIG_STATUS ]];then
-      textPass "Region $regx has AWS Config recorder: ON" "$regx"
+    CHECK_AWSCONFIG_RECORDING=$($AWSCLI configservice describe-configuration-recorder-status $PROFILE_OPT --region $regx --query 'ConfigurationRecordersStatus[*].recording' --output text 2>&1)
+    CHECK_AWSCONFIG_STATUS=$($AWSCLI configservice describe-configuration-recorder-status $PROFILE_OPT --region $regx --query 'ConfigurationRecordersStatus[*].lastStatus' --output text 2>&1)
+    if [[ $(echo "$CHECK_AWSCONFIG_STATUS" | grep AccessDenied) ]]; then
+      textFail "Access Denied trying to describe configuration recorder status in $regx"
+      continue
+    fi
+    if [[ $CHECK_AWSCONFIG_RECORDING == "True" ]]; then
+      if [[ $CHECK_AWSCONFIG_STATUS == "SUCCESS" ]]; then
+        textPass "Region $regx AWS Config recorder enabled"
+      else
+        textFail "Region $regx AWS Config recorder in failure state"
+      fi
     else
-      textFail "Region $regx has AWS Config disabled or not configured" "$regx"
+      textFail "Region $regx AWS Config recorder disabled"
     fi
   done
 }

--- a/checks/check26
+++ b/checks/check26
@@ -19,37 +19,68 @@ CHECK_ALTERNATE_check206="check26"
 CHECK_SERVICENAME_check26="s3"
 
 check26(){
+  trail_count=0
   # "Ensure S3 bucket access logging is enabled on the CloudTrail S3 bucket (Scored)"
-
-  CLOUDTRAILS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region "$REGION" --query 'trailList[*].Name' --output text| tr '\011' '\012' | awk -F: '{print $1}')
-
-  if [[ $CLOUDTRAILS ]]; then
-    for trail in $CLOUDTRAILS; do
-      CLOUDTRAIL_ACCOUNT_ID=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region "$REGION" --query 'trailList[*].TrailARN' --output text | tr '\011' '\012' | grep "$trail" | awk -F: '{ print $5 }'  | head -n 1)
-      CLOUDTRAILBUCKET=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[*].[Name, S3BucketName]' --output text  | tr '\011' ':' |  grep "$trail" | awk -F: '{ print $2 }' )
-
-      if [[ $CLOUDTRAILBUCKET ]]; then
-        bucket=$CLOUDTRAILBUCKET
-        if [ "$CLOUDTRAIL_ACCOUNT_ID" == "$ACCOUNT_NUM" ]; then
-          CLOUDTRAILBUCKET_LOGENABLED=$($AWSCLI s3api get-bucket-logging --bucket $bucket $PROFILE_OPT --region $REGION --query 'LoggingEnabled.TargetBucket' 2>&1)
-          if [[ $(echo "$CLOUDTRAILBUCKET_LOGENABLED" | grep AccessDenied) ]]; then
-            textInfo "Access Denied Trying to Get Bucket Logging for $bucket"
-            continue
-          fi
-          if [[ $CLOUDTRAILBUCKET_LOGENABLED != "null" ]]; then
-            textPass "Bucket access logging enabled in CloudTrail S3 bucket $bucket for $trail"
-          else
-            textFail "Bucket access logging is not enabled in CloudTrail S3 bucket $bucket for $trail"
-          fi
-        else
-          textInfo "CloudTrail S3 bucket $bucket for trail $trail is not in current account"
+  for regx in $REGIONS; do
+    TRAILS_AND_REGIONS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query 'trailList[*].{Name:TrailARN, HomeRegion:HomeRegion}' --output text 2>&1 | tr "	" ',')
+    if [[ $(echo "$TRAILS_AND_REGIONS" | grep AccessDenied) ]]; then
+      textFail "Access Denied trying to describe trails in $regx"
+      continue
+    fi
+    if [[ $TRAILS_AND_REGIONS ]]; then
+      for reg_trail in $TRAILS_AND_REGIONS; do
+        TRAIL_REGION=$(echo $reg_trail | cut -d',' -f1)
+        if [ $TRAIL_REGION != $regx ]; then # Only report trails once in home region
+          continue
         fi
-      else
-        textFail "CloudTrail bucket not found!"
-      fi
-    done
+        trail=$(echo $reg_trail | cut -d',' -f2)
+        trail_count=$((trail_count + 1))
 
-  else
-    textFail "No CloudWatch group found and no CloudTrail bucket"
+        CLOUDTRAILBUCKET=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $TRAIL_REGION --query 'trailList[*].[S3BucketName]' --output text --trail-name-list $trail)
+        if [[ -z $CLOUDTRAILBUCKET ]]; then
+          textFail "Trail $trail in $TRAIL_REGION does not publish to S3"
+          continue
+        fi
+
+        CLOUDTRAIL_ACCOUNT_ID=$(echo $trail | awk -F: '{ print $5 }')
+        if [ "$CLOUDTRAIL_ACCOUNT_ID" != "$ACCOUNT_NUM" ]; then
+          textInfo "Trail $trail in $TRAIL_REGION S3 logging bucket $CLOUDTRAILBUCKET is not in current account"
+          continue
+        fi
+
+        #
+        # LOCATION - requests referencing buckets created after March 20, 2019
+        # must be made to S3 endpoints in the same region as the bucket was
+        # created.
+        #
+        BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location $PROFILE_OPT --region $regx --bucket $CLOUDTRAILBUCKET --output text 2>&1)
+        if [[ $(echo "$BUCKET_LOCATION" | grep AccessDenied) ]]; then
+          textFail "Trail $trail in $TRAIL_REGION Access Denied getting bucket location for $CLOUDTRAILBUCKET"
+          continue
+        fi
+        if [[ $BUCKET_LOCATION == "None" ]]; then
+          BUCKET_LOCATION="us-east-1"
+        fi
+        if [[ $BUCKET_LOCATION == "EU" ]]; then
+          BUCKET_LOCATION="eu-west-1"
+        fi
+
+        CLOUDTRAILBUCKET_LOGENABLED=$($AWSCLI s3api get-bucket-logging --bucket $CLOUDTRAILBUCKET $PROFILE_OPT --region $BUCKET_LOCATION --query 'LoggingEnabled.TargetBucket' --output text 2>&1)
+        if [[ $(echo "$CLOUDTRAILBUCKET_LOGENABLED" | grep AccessDenied) ]]; then
+          textInfo "Trail $trail in $TRAIL_REGION Access Denied getting bucket logging for $CLOUDTRAILBUCKET"
+          continue
+        fi
+
+        if [[ $CLOUDTRAILBUCKET_LOGENABLED != "None" ]]; then
+          textPass "Trail $trail in $TRAIL_REGION S3 bucket access logging is enabled for $CLOUDTRAILBUCKET"
+        else
+          textFail "Trail $trail in $TRAIL_REGION S3 bucket access logging is not enabled for $CLOUDTRAILBUCKET"
+        fi
+
+      done
+    fi
+  done
+  if [[ $trail_count == 0 ]]; then
+    textFail "No CloudTrail trails were found in the account"
   fi
 }

--- a/checks/check27
+++ b/checks/check27
@@ -23,7 +23,11 @@ check27(){
   trail_count=0
   # "Ensure CloudTrail logs are encrypted at rest using KMS CMKs (Scored)"
   for regx in $REGIONS; do
-    TRAILS_AND_REGIONS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query 'trailList[*].{Name:TrailARN, HomeRegion:HomeRegion}' --output text | tr "	" ',')
+    TRAILS_AND_REGIONS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query 'trailList[*].{Name:TrailARN, HomeRegion:HomeRegion}' --output text 2>&1 | tr "	" ',')
+    if [[ $(echo "$TRAILS_AND_REGIONS" | grep AccessDenied) ]]; then
+      textFail "Access Denied trying to describe trails in $regx"
+      continue
+    fi
     if [[ $TRAILS_AND_REGIONS ]]; then
       for reg_trail in $TRAILS_AND_REGIONS; do
         TRAIL_REGION=$(echo $reg_trail | cut -d',' -f1)

--- a/checks/check28
+++ b/checks/check28
@@ -21,31 +21,53 @@ CHECK_SERVICENAME_check28="kms"
 check28(){
   # "Ensure rotation for customer created CMKs is enabled (Scored)"
   for regx in $REGIONS; do
-  CHECK_KMS_KEYLIST=$($AWSCLI kms list-keys $PROFILE_OPT --region $regx --output text --query 'Keys[*].KeyId')
-    if [[ $CHECK_KMS_KEYLIST ]];then
-      CHECK_KMS_KEYLIST_NO_DEFAULT=$(
-        for key in $CHECK_KMS_KEYLIST; do
-          $AWSCLI kms describe-key --key-id $key $PROFILE_OPT --region $regx --query 'KeyMetadata.{key:KeyId,state:KeyState,man:KeyManager}' --output text|grep Enabled$|grep -v AWS| awk '{ print $1 }'
-        done )
-      if [[ $CHECK_KMS_KEYLIST_NO_DEFAULT ]]; then
-        for key in $CHECK_KMS_KEYLIST_NO_DEFAULT; do
-          CHECK_KMS_KEY_TYPE=$($AWSCLI kms describe-key --key-id $key $PROFILE_OPT --region $regx --query 'KeyMetadata.Origin' | sed 's/["]//g')
-            if [[ "$CHECK_KMS_KEY_TYPE" == "EXTERNAL" ]];then
-              textPass "$regx: Key $key in Region $regx Customer Uploaded Key Material" "$regx"
-            else
-              CHECK_KMS_KEY_ROTATION=$($AWSCLI kms get-key-rotation-status --key-id $key $PROFILE_OPT --region $regx --output text)
-              if [[ "$CHECK_KMS_KEY_ROTATION" == "True" ]];then
-                textPass "$regx: Key $key is set correctly" "$regx"
-              else
-                textFail "$regx: Key $key is not set to rotate!" "$regx"
-              fi
-            fi
-        done
-      else
-        textInfo "$regx: This region doesn't have CUSTOM encryption keys" "$regx"
+    CHECK_KMS_KEYLIST=$($AWSCLI kms list-keys $PROFILE_OPT --region $regx --output text --query 'Keys[*].KeyId' --output text 2>&1)
+    if [[ $(echo "$CHECK_KMS_KEYLIST" | grep AccessDenied) ]]; then
+      textFail "Access Denied trying to list keys in $regx"
+      continue
+    fi
+    if [[ $CHECK_KMS_KEYLIST ]]; then
+      cmk_count=0
+      for key in $CHECK_KMS_KEYLIST; do
+        KMSDETAILS=$($AWSCLI kms describe-key --key-id $key $PROFILE_OPT --region $regx --query 'KeyMetadata.{key:KeyId,man:KeyManager,origin:Origin,state:KeyState}' --output text 2>&1)
+        if [[ $(echo "$KMSDETAILS" | grep AccessDenied) ]]; then
+           textFail "$regx: Key $key Access Denied describing key"
+           continue
+        fi
+
+        KEYID=$(echo $KMSDETAILS | awk '{print $1}')
+        KEYMANAGER=$(echo $KMSDETAILS | awk '{print $2}')
+        KEYORIGIN=$(echo $KMSDETAILS | awk '{print $3}')
+        KEYSTATE=$(echo $KMSDETAILS | awk '{print $4}')
+
+        if [[ "$KEYMANAGER" == "AWS" ]]; then
+          continue
+        fi
+        if [[ "$KEYSTATE" != "Enabled" ]]; then
+          continue
+        fi
+        cmk_count=$((cmk_count + 1))
+
+        if [[ "$KEYORIGIN" == "EXTERNAL" ]]; then
+          textPass "$regx: Key $key uses imported key material"
+        else
+          CHECK_KMS_KEY_ROTATION=$($AWSCLI kms get-key-rotation-status --key-id $key $PROFILE_OPT --region $regx --output text 2>&1)
+          if [[ $(echo "$CHECK_KMS_KEY_ROTATION" | grep AccessDenied) ]]; then
+            textFail "$regx: Key $key Access Denied getting key rotation status"
+            continue
+          fi
+          if [[ "$CHECK_KMS_KEY_ROTATION" == "True" ]];then
+            textPass "$regx: Key $key automatic rotation of the key material is enabled"
+          else
+            textFail "$regx: Key $key automatic rotation of the key material is disabled"
+          fi
+        fi
+      done
+      if [[ $cmk_count == 0 ]]; then
+        textInfo "$regx: This region has no customer managed keys"
       fi
     else
-      textInfo "$regx: This region doesn't have ANY encryption keys" "$regx"
+      textInfo "$regx: This region has no KMS keys"
     fi
   done
 }

--- a/checks/check29
+++ b/checks/check29
@@ -22,15 +22,23 @@ CHECK_SERVICENAME_check29="vpc"
 check29(){
   # "Ensure VPC Flow Logging is Enabled in all VPCs (Scored)"
   for regx in $REGIONS; do
-    AVAILABLE_VPC=$($AWSCLI ec2 describe-vpcs $PROFILE_OPT --region $regx --query 'Vpcs[?State==`available`].VpcId' --output text)
+    AVAILABLE_VPC=$($AWSCLI ec2 describe-vpcs $PROFILE_OPT --region $regx --query 'Vpcs[?State==`available`].VpcId' --output text 2>&1)
+    if [[ $(echo "$AVAILABLE_VPC" | grep AccessDenied) ]]; then
+      textFail "$regx: Access Denied trying to describe VPCs"
+      continue
+    fi
     for vpcx in $AVAILABLE_VPC; do
-      CHECK_FL=$($AWSCLI ec2 describe-flow-logs $PROFILE_OPT --region $regx --filter Name="resource-id",Values="${vpcx}" --query 'FlowLogs[?FlowLogStatus==`ACTIVE`].FlowLogId' --output text)
-      if [[ $CHECK_FL ]];then
-        for FL in $CHECK_FL;do
-          textPass "VPC $vpcx: VPCFlowLog is enabled for LogGroupName: $FL in Region $regx" "$regx"
+      CHECK_FL=$($AWSCLI ec2 describe-flow-logs $PROFILE_OPT --region $regx --filter Name="resource-id",Values="${vpcx}" --query 'FlowLogs[?FlowLogStatus==`ACTIVE`].FlowLogId' --output text 2>&1)
+      if [[ $(echo "$CHECK_FL" | grep AccessDenied) ]]; then
+        textFail "$regx: VPC $vpcx Access Denied trying to describe flow logs"
+        continue
+      fi
+      if [[ $CHECK_FL ]]; then
+        for FL in $CHECK_FL; do
+          textPass "$regx: VPC $vpcx VPCFlowLog is enabled for LogGroupName: $FL"
         done
       else
-        textFail "VPC $vpcx: No VPCFlowLog has been found in Region $regx" "$regx"
+        textFail "$regx: VPC $vpcx VPCFlowLog is disabled"
       fi
     done
   done

--- a/checks/check_extra720
+++ b/checks/check_extra720
@@ -22,10 +22,18 @@ CHECK_SERVICENAME_extra720="lambda"
 extra720(){
   # "Check if Lambda functions invoke API operations are being recorded by CloudTrail (Not Scored) (Not part of CIS benchmark)"
   for regx in $REGIONS; do
-    LIST_OF_FUNCTIONS=$($AWSCLI lambda list-functions $PROFILE_OPT --region $regx --query Functions[*].FunctionName --output text)
+    LIST_OF_FUNCTIONS=$($AWSCLI lambda list-functions $PROFILE_OPT --region $regx --query 'Functions[*].FunctionName' --output text 2>&1)
+    if [[ $(echo "$LIST_OF_FUNCTIONS" | grep AccessDenied) ]]; then
+      textFail "$regx: Access Denied trying to list functions"
+      continue
+    fi
     if [[ $LIST_OF_FUNCTIONS ]]; then
-      for lambdafunction in $LIST_OF_FUNCTIONS;do
-        LIST_OF_TRAILS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query trailList[].TrailARN --output text)
+      LIST_OF_TRAILS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query 'trailList[*].TrailARN' --output text 2>&1)
+      if [[ $(echo "$LIST_OF_TRAILS" | grep AccessDenied) ]]; then
+        textFail "$regx: Access Denied trying to describe trails"
+        continue
+      fi
+      for lambdafunction in $LIST_OF_FUNCTIONS; do
         if [[ $LIST_OF_TRAILS ]]; then
           for trail in $LIST_OF_TRAILS; do
             FUNCTION_ENABLED_IN_TRAIL=$($AWSCLI cloudtrail get-event-selectors $PROFILE_OPT --trail-name $trail --region $regx --query "EventSelectors[*].DataResources[?Type == \`AWS::Lambda::Function\`].Values" --output text |xargs -n1| grep -E "^arn:${AWS_PARTITION}:lambda.*function:$lambdafunction$|^arn:${AWS_PARTITION}:lambda$")
@@ -52,7 +60,7 @@ extra720(){
         else
           textFail "$regx: Lambda function $lambdafunction is not being recorded no CloudTrail found!" "$regx"
         fi
-      done
+     done
     else
       textInfo "$regx: No Lambda functions found" "$regx"
     fi

--- a/checks/check_extra725
+++ b/checks/check_extra725
@@ -26,19 +26,25 @@ extra725(){
   # "Check if S3 buckets have Object-level logging enabled in CloudTrail (Not Scored) (Not part of CIS benchmark)"
   textInfo "Looking for S3 Buckets Object-level logging information in all trails...  "
 
-  LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets $PROFILE_OPT --region $REGION --query 'Buckets[*].{Name:Name}'  --output text)
-  LIST_OF_TRAILS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[].TrailARN' --output text)
+  LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets $PROFILE_OPT --region $REGION --query 'Buckets[*].{Name:Name}' --output text 2>&1)
+  if [[ $(echo "$LIST_OF_BUCKETS" | grep AccessDenied) ]]; then
+    textFail "Access Denied trying to list buckets"
+    return
+  fi
+  LIST_OF_TRAILS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $REGION --query 'trailList[].TrailARN' --output text 2>&1)
+  if [[ $(echo "$LIST_OF_TRAILS" | grep AccessDenied) ]]; then
+    textFail "Access Denied trying to describe trails"
+    return
+  fi
   if [[ $LIST_OF_BUCKETS ]]; then
-    for bucketName in $LIST_OF_BUCKETS;do
+    for bucketName in $LIST_OF_BUCKETS; do
       if [[ $LIST_OF_TRAILS ]]; then
         BUCKET_ENABLED_TRAILS=()
+
         for trail in $LIST_OF_TRAILS; do
           BUCKET_ENABLED_IN_TRAIL=$($AWSCLI cloudtrail get-event-selectors --region $REGION $PROFILE_OPT --trail-name $trail --query "EventSelectors[*].DataResources[?Type == \`AWS::S3::Object\`].Values" --output text |xargs -n1| grep -E "^arn:${AWS_PARTITION}:s3:::$bucketName/\S*$|^arn:${AWS_PARTITION}:s3$|^arn:${AWS_PARTITION}:s3:::$")
           if [[ $BUCKET_ENABLED_IN_TRAIL ]]; then
             BUCKET_ENABLED_TRAILS+=($trail)
-            # textPass "$regx: S3 bucket $bucketName has Object-level logging enabled in trail $trail" "$regx"
-          #else
-            # textFail "$regx: S3 bucket $bucketName has Object-level logging disabled" "$regx"
           fi
         done
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

@toniblyx The other issue raised in issue 617 is that the reporter was using a policy that didn't allow cloudtrail describe-trails and that led to unexpected results. That seems to be a common theme in the issues section and I think the only real fix is to be defensive and look for access denied errors whenever an aws cli command is run. This adds a number of AccessDenied checks in the check_2x checks and a couple extra_7xx checks that happen to call describe-trails.
