### PR TITLE
Include missing AWS function policy to check AWS Lambda

### DIFF
--- a/iam/prowler-additions-policy.json
+++ b/iam/prowler-additions-policy.json
@@ -9,7 +9,8 @@
                 "ec2:GetEbsEncryptionByDefault",
                 "ecr:Describe*",
                 "support:Describe*",
-                "tag:GetTagKeys"
+                "tag:GetTagKeys",
+		"lambda:GetFunction"
             ],
             "Resource": "*",
             "Effect": "Allow",


### PR DESCRIPTION
Hi!

There is a missing function in `prowler-additions-policy.json`. 

To check AWS Lambda related controls included in Prowler: 

- extra720
- extra759
- extra760
- extra762
- extra798

it is necessary to allow in `prowler-additions-policy.json` the AWS function `lambda:GetFunction` otherwise it will fail with the following error:
```
An error occurred (AccessDeniedException) when calling the GetFunction operation: User: arn:aws:sts::<account-id>:assumed-role/<role>/botocore-session-<ID> is not authorized to perform: lambda:GetFunction on resource: arn:aws:lambda:<region>:<account-id>:function:<lambda-function-name>
``` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
