### PR TITLE
Add python2.7 to obsolete Lambda runtimes

### DIFF
--- a/checks/check_extra762
+++ b/checks/check_extra762
@@ -23,7 +23,7 @@ extra762(){
 
   # regex to match OBSOLETE runtimes in string functionName%runtime
   # https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html
-  OBSOLETE='%(nodejs4.3|nodejs4.3-edge|nodejs6.10|nodejs8.10|dotnetcore1.0|dotnetcore2.0)'
+  OBSOLETE='%(nodejs4.3|nodejs4.3-edge|nodejs6.10|nodejs8.10|dotnetcore1.0|dotnetcore2.0|python2.7)'
 
   for regx in $REGIONS; do
     LIST_OF_FUNCTIONS=$($AWSCLI lambda list-functions $PROFILE_OPT --region $regx --output text --query 'Functions[*].{R:Runtime,N:FunctionName}' | tr "\t" "%")


### PR DESCRIPTION
Since python version 2.7 is already deprecated we should also cover that within the obsolete Lambda runtimes check. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
