### PR TITLE
Replace empty space with '\s' in check43 regex

### DIFF
--- a/checks/check43
+++ b/checks/check43
@@ -24,7 +24,7 @@ check43(){
   for regx in $REGIONS; do
     CHECK_SGDEFAULT_IDS=$($AWSCLI ec2 describe-security-groups $PROFILE_OPT --region $regx --filters Name=group-name,Values='default' --query 'SecurityGroups[*].GroupId[]' --output text)
     for CHECK_SGDEFAULT_ID in $CHECK_SGDEFAULT_IDS; do
-      CHECK_SGDEFAULT_ID_OPEN=$($AWSCLI ec2 describe-security-groups $PROFILE_OPT --region $regx --group-ids $CHECK_SGDEFAULT_ID --query 'SecurityGroups[*].{IpPermissions:IpPermissions,IpPermissionsEgress:IpPermissionsEgress,GroupId:GroupId}' --output text |egrep ' 0.0.0.0|\:\:\/0')
+      CHECK_SGDEFAULT_ID_OPEN=$($AWSCLI ec2 describe-security-groups $PROFILE_OPT --region $regx --group-ids $CHECK_SGDEFAULT_ID --query 'SecurityGroups[*].{IpPermissions:IpPermissions,IpPermissionsEgress:IpPermissionsEgress,GroupId:GroupId}' --output text |egrep '\s0.0.0.0|\:\:\/0')
       if [[ $CHECK_SGDEFAULT_ID_OPEN ]];then
         textFail "Default Security Groups ($CHECK_SGDEFAULT_ID) found that allow 0.0.0.0 IN or OUT traffic in Region $regx" "$regx"
       else


### PR DESCRIPTION
The output from aws ec2 includes tabs and the regex it is not matching as expected.

```
$ aws ec2 describe-security-groups $PROFILE_OPT --region $regx --group-ids $CHECK_SGDEFAULT_ID --query 'SecurityGroups[*].{IpPermissions:IpPermissions,IpPermissionsEgress:IpPermissionsEgress,GroupId:GroupId}' --output text >  CHECK_SGDEFAULT_ID_OPEN.output
$ cat CHECK_SGDEFAULT_ID_OPEN.output | tr " \t" "_@"
IPRANGES@0.0.0.0/0
```

Replacing the space with '\s' fixes the issue.

```
egrep '\s0.0.0.0|\:\:\/0'
```


