### PR TITLE
Add check23 to group17_internetexposed group

### DIFF
--- a/groups/group17_internetexposed
+++ b/groups/group17_internetexposed
@@ -15,8 +15,9 @@ GROUP_ID[17]='internet-exposed'
 GROUP_NUMBER[17]='17.0'
 GROUP_TITLE[17]='Find resources exposed to the internet - [internet-exposed] ***'
 GROUP_RUN_BY_DEFAULT[17]='N' # run it when execute_all is called
-GROUP_CHECKS[17]='check41,check42,extra72,extra73,extra74,extra76,extra77,extra78,extra79,extra710,extra711,extra716,extra723,extra727,extra731,extra736,extra738,extra745,extra748,extra749,extra750,extra751,extra752,extra753,extra754,extra755,extra756,extra770,extra771,extra778,extra779,extra787,extra788,extra795,extra796,extra798,extra7102'
+GROUP_CHECKS[17]='check23,check41,check42,extra72,extra73,extra74,extra76,extra77,extra78,extra79,extra710,extra711,extra716,extra723,extra727,extra731,extra736,extra738,extra745,extra748,extra749,extra750,extra751,extra752,extra753,extra754,extra755,extra756,extra770,extra771,extra778,extra779,extra787,extra788,extra795,extra796,extra798,extra7102'
 
+# 2.3 [check23] Ensure the S3 bucket CloudTrail logs to is not publicly accessible (Scored)   [group2, cislevel1, cislevel2, forensics-ready, gdpr, hipaa, pci, iso27001, ffiec, ens]
 # 4.1 [check41] Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to port 22 (Scored)  [group4, cislevel1, cislevel2]
 # 4.2 [check42] Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to port 3389 (Scored)  [group4, cislevel1, cislevel2]
 # 7.2 [extra72] Ensure there are no EBS Snapshots set as Public (Not Scored) (Not part of CIS benchmark)   [extras, forensics-ready, gdpr, hipaa, apigateway, rds]


### PR DESCRIPTION
This add's the following check to group17.

* 2.3 [check23] Ensure the S3 bucket CloudTrail logs to is not publicly accessible (Scored)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
