### PR TITLE
Improved error handling when listing regions

### DIFF
--- a/checks/check_extra747
+++ b/checks/check_extra747
@@ -33,7 +33,7 @@ extra747(){
         if [[ $ENABLED_CLOUDWATCHLOGS_EXPORTS ]]; then
           textPass "$regx: RDS instance $rdsinstance is shipping $ENABLED_CLOUDWATCHLOGS_EXPORTS to CloudWatch Logs" "$regx"
         else
-          textFail "$regx: RDS instance $rdsinstance has not CloudWatch Logs enabled!" "$regx"
+          textFail "$regx: RDS instance $rdsinstance has no CloudWatch Logs enabled!" "$regx"
         fi
       done
     else

--- a/include/assume_role
+++ b/include/assume_role
@@ -70,7 +70,7 @@ assume_role(){
     export AWS_ACCESS_KEY_ID=$(cat $TEMP_STS_ASSUMED_FILE | jq -r '.Credentials.AccessKeyId')
     export AWS_SECRET_ACCESS_KEY=$(cat $TEMP_STS_ASSUMED_FILE | jq -r '.Credentials.SecretAccessKey')
     export AWS_SESSION_TOKEN=$(cat $TEMP_STS_ASSUMED_FILE | jq -r '.Credentials.SessionToken')
-    export AWS_SESSION_EXPIRATION=$(convert_date_to_timestamp "$(cat $TEMP_STS_ASSUMED_FILE | jq -r '.Credentials.Expiration'| sed 's/+00:00//g')")
+    export AWS_SESSION_EXPIRATION=$(convert_date_to_timestamp "$(cat $TEMP_STS_ASSUMED_FILE | jq -r '.Credentials.Expiration'| sed 's/+00:00//g;s/Z//g')")
     rm -fr $TEMP_STS_ASSUMED_FILE
 }
 

--- a/include/assume_role
+++ b/include/assume_role
@@ -70,7 +70,7 @@ assume_role(){
     export AWS_ACCESS_KEY_ID=$(cat $TEMP_STS_ASSUMED_FILE | jq -r '.Credentials.AccessKeyId')
     export AWS_SECRET_ACCESS_KEY=$(cat $TEMP_STS_ASSUMED_FILE | jq -r '.Credentials.SecretAccessKey')
     export AWS_SESSION_TOKEN=$(cat $TEMP_STS_ASSUMED_FILE | jq -r '.Credentials.SessionToken')
-    export AWS_SESSION_EXPIRATION=$(convert_date_to_timestamp "$(cat $TEMP_STS_ASSUMED_FILE | jq -r '.Credentials.Expiration'| sed 's/+00:00//g;s/Z//g')")
+    export AWS_SESSION_EXPIRATION=$(cat $TEMP_STS_ASSUMED_FILE | jq -r '.Credentials.Expiration | sub("\\+00:00";"Z") | fromdateiso8601')
     rm -fr $TEMP_STS_ASSUMED_FILE
 }
 

--- a/include/outputs
+++ b/include/outputs
@@ -22,7 +22,6 @@ OUTPUT_DATE=$(date -u +"%Y%m%d%H%M%S")
 OUTPUT_DIR="${PROWLER_DIR}/output" # default output if none 
 OUTPUT_FILE_NAME="${OUTPUT_DIR}/prowler-output-${ACCOUNT_NUM}-${OUTPUT_DATE}"
 HTML_LOGO_URL="https://github.com/toniblyx/prowler/"
-#HTML_LOGO_IMG="https://raw.githubusercontent.com/toniblyx/prowler/master/util/html/prowler-logo.png"
 HTML_LOGO_IMG="https://github.com/toniblyx/prowler/raw/2.4/util/html/prowler-logo-new.png"
 TIMESTAMP=$(get_iso8601_timestamp)
 PROWLER_PARAMETERS=$@
@@ -303,7 +302,7 @@ generateJsonAsffOutput(){
   --arg CHECK_ID "$CHECK_ID" \
   --arg TYPE "$CHECK_ASFF_COMPLIANCE_TYPE" \
   --arg COMPLIANCE_RELATED_REQUIREMENTS "$CHECK_ASFF_COMPLIANCE_TYPE" \
-  --arg RESOURCE_TYPE "$ASFF_RESOURCE_TYPE" \
+  --arg RESOURCE_TYPE "$CHECK_ASFF_RESOURCE_TYPE" \
   --arg REPREGION "$REPREGION" \
   --arg TIMESTAMP "$(get_iso8601_timestamp)" \
   --arg PROWLER_VERSION "$PROWLER_VERSION" \

--- a/prowler
+++ b/prowler
@@ -295,7 +295,8 @@ TOTAL_CHECKS=($(echo "${TOTAL_CHECKS[*]}" | tr ' ' '\n' | awk '!seen[$0]++' | so
 get_regions() {
   # Get list of regions based on include/whoami
   REGIONS=$($AWSCLI ec2 describe-regions --query 'Regions[].RegionName' --output text $PROFILE_OPT --region $REGION_FOR_STS --region-names $FILTERREGION 2>&1)
-  if [[ $(echo "$REGIONS" | grep 'AccessDenied\|UnauthorizedOperation') ]]; then
+  ret=$?
+  if [[ $ret -ne 0 ]]; then
     echo "$OPTRED Access Denied trying to describe regions! Review permissions as described here: https://github.com/toniblyx/prowler/#requirements-and-installation $OPTNORMAL"
     EXITCODE=1
     exit $EXITCODE


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Instead of looking for a fixed error string, it uses error codes from aws cli
Previos condition was not catching this error message:
An error occurred (ExpiredToken) when calling the GetCallerIdentity operation: The security token included in the request is expired
