### PR TITLE
Improved error handling sts get-caller-identity

### DIFF
--- a/include/whoami
+++ b/include/whoami
@@ -29,8 +29,9 @@ case "$REGION" in
   ;;
 esac
 
-GETCALLER=$($AWSCLI sts get-caller-identity $PROFILE_OPT --region $REGION_FOR_STS 2>&1)
-if [[ $(echo "$GETCALLER" | grep 'Unable') ]]; then
+GETCALLER=$($AWSCLI sts get-caller-identity $PROFILE_OPT --output json --region $REGION_FOR_STS 2>&1)
+ret=$?
+if [[ $ret -ne 0 ]]; then
   if [[ $PRINTCHECKSONLY || $PRINTGROUPSONLY ]]; then
     echo Listing... 
   else


### PR DESCRIPTION
Instead of looking for a fixed error string, it uses error codes from aws cli
Previos condition was not catching this error message:
An error occurred (ExpiredToken) when calling the GetCallerIdentity operation: The security token included in the request is expired
Also forced the output of the command to json. In some tests I was doing was failing becuase it was sending output as text

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
