### PR TITLE
Fix finding customer kms keys in cli v2 for checks extra737 extra736

### DIFF
--- a/checks/check_extra736
+++ b/checks/check_extra736
@@ -19,7 +19,7 @@ CHECK_ALTERNATE_check736="extra736"
 extra736(){
   textInfo "Looking for KMS keys in all regions...  "
   for regx in $REGIONS; do
-    LIST_OF_CUSTOMER_KMS_KEYS=$($AWSCLI kms list-aliases $PROFILE_OPT --region $regx --output text |grep -v :alias/aws/ |awk '{ print $4 }')
+    LIST_OF_CUSTOMER_KMS_KEYS=$($AWSCLI kms list-aliases $PROFILE_OPT --region $regx --query "Aliases[].[AliasName,TargetKeyId]" --output text |grep -v ^alias/aws/ |awk '{ print $2 }')
     if [[ $LIST_OF_CUSTOMER_KMS_KEYS ]];then
       for key in $LIST_OF_CUSTOMER_KMS_KEYS; do
         CHECK_POLICY=$($AWSCLI kms get-key-policy --key-id $key --policy-name default $PROFILE_OPT --region $regx  --output text|awk '/Principal/{n=NR+1} n>=NR' |grep AWS\"\ :\ \"\\*\"$)

--- a/checks/check_extra737
+++ b/checks/check_extra737
@@ -19,7 +19,7 @@ CHECK_ALTERNATE_check737="extra737"
 extra737(){
   textInfo "Looking for KMS keys in all regions...  "
   for regx in $REGIONS; do
-    LIST_OF_CUSTOMER_KMS_KEYS=$($AWSCLI kms list-aliases $PROFILE_OPT --region $regx --output text |grep -v :alias/aws/ |awk '{ print $4 }')
+    LIST_OF_CUSTOMER_KMS_KEYS=$($AWSCLI kms list-aliases $PROFILE_OPT --region $regx --query "Aliases[].[AliasName,TargetKeyId]" --output text |grep -v ^alias/aws/ |awk '{ print $2 }')
     if [[ $LIST_OF_CUSTOMER_KMS_KEYS ]];then
       for key in $LIST_OF_CUSTOMER_KMS_KEYS; do
         CHECK_ROTATION=$($AWSCLI kms get-key-rotation-status --key-id $key $PROFILE_OPT --region $regx  --output text)


### PR DESCRIPTION
Key id is in position 6 in aws cli version 2.2.5, but in position 4 in aws cli 1.x
Use --query to select only the data necessary and output in a consistent format

See previous discussion in https://github.com/toniblyx/prowler/pull/802

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
