### PR TITLE
Add ResourceID to all checks output for ASFF and other output formats

### DIFF
--- a/checks/check116
+++ b/checks/check116
@@ -30,12 +30,12 @@ check116(){
   for user in $LIST_USERS;do
     USER_POLICY=$($AWSCLI iam list-attached-user-policies --output text $PROFILE_OPT --region $REGION --user-name $user)
     if [[ $USER_POLICY ]]; then
-      textFail "$user has managed policy directly attached"
+      textFail "$user has managed policy directly attached" "us-east-1" "$user"
       C116_NUM_USERS=$(expr $C116_NUM_USERS + 1)
     fi
     USER_POLICY=$($AWSCLI iam list-user-policies --output text $PROFILE_OPT --region $REGION --user-name $user)
     if [[ $USER_POLICY ]]; then
-      textFail "$user has inline policy directly attached"
+      textFail "$user has inline policy directly attached" "us-east-1" "$user"
       C116_NUM_USERS=$(expr $C116_NUM_USERS + 1)
     fi
   done

--- a/checks/check119
+++ b/checks/check119
@@ -33,7 +33,7 @@ check119(){
         if [[ $STATE_NAME != "terminated" && $STATE_NAME != "shutting-down" ]]; then
           PROFILEARN=$(echo $EC2_DATA | jq -r --arg i "$instance" 'select(.InstanceId==$i)|.ProfileArn')
           if [[ $PROFILEARN == "null" ]]; then
-            textFail "$regx: Instance $instance not associated with an instance role" $regx
+            textFail "$regx: Instance $instance not associated with an instance role" "$regx" "$instance"
           else
             textPass "$regx: Instance $instance associated with role ${PROFILEARN##*/}" $regx
           fi

--- a/checks/check121
+++ b/checks/check121
@@ -32,7 +32,7 @@ check121(){
   LIST_USERS_KEY1_ACTIVE=$(for user in $LIST_USERS_KEY1_NA; do grep "^${user}," $TEMP_REPORT_FILE|awk -F, '{ print $1,$4,$9 }'|grep "true true$"|awk '{ print $1 }'|sed 's/[[:blank:]]+/,/g' ; done)
   if [[ $LIST_USERS_KEY1_ACTIVE ]]; then
     for user in $LIST_USERS_KEY1_ACTIVE; do
-      textFail "User $user has never used access key 1"
+      textFail "User $user has never used access key 1" "us-east-1" "$user"
     done
   else
     textPass "No users found with access key 1 never used"

--- a/checks/check122
+++ b/checks/check122
@@ -38,7 +38,7 @@ check122(){
     if [[ $POLICIES_ALLOW_LIST ]]; then
       textInfo "List of custom policies: "
       for policy in $POLICIES_ALLOW_LIST; do
-        textFail "Policy $policy allows \"*:*\""
+        textFail "Policy $policy allows \"*:*\"" "us-east-1" "$policy"
       done
     else
         textPass "No custom policy found that allow full \"*:*\" administrative privileges"

--- a/checks/check14
+++ b/checks/check14
@@ -37,7 +37,7 @@ check14(){
         HOWOLDER=$(how_older_from_today $DATEROTATED1)
 
         if [ $HOWOLDER -gt "90" ];then
-          textFail "$user has not rotated access key 1 in over 90 days"
+          textFail "$user has not rotated access key 1 in over 90 days" "us-east-1" "$user"
           C14_NUM_USERS1=$(expr $C14_NUM_USERS1 + 1)
         fi
       done
@@ -55,7 +55,7 @@ check14(){
         DATEROTATED2=$(cat $TEMP_REPORT_FILE | grep -v user_creation_time | grep "^${user},"| awk -F, '{ print $15 }' | grep -v "N/A" | awk -F"T" '{ print $1 }')
         HOWOLDER=$(how_older_from_today $DATEROTATED2)
         if [ $HOWOLDER -gt "90" ];then
-          textFail "$user has not rotated access key 2 in over 90 days"
+          textFail "$user has not rotated access key 2 in over 90 days" "us-east-1" "$user"
           C14_NUM_USERS2=$(expr $C14_NUM_USERS2 + 1)
         fi
       done

--- a/checks/check21
+++ b/checks/check21
@@ -43,9 +43,9 @@ check21(){
 
         MULTIREGION_TRAIL_STATUS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $TRAIL_REGION --query 'trailList[*].IsMultiRegionTrail' --output text --trail-name-list $trail)
         if [[ "$MULTIREGION_TRAIL_STATUS" == 'False' ]];then
-          textFail "Trail $trail in $regx is not enabled for all regions"
+          textFail "Trail $trail in $regx is not enabled for all regions" "$regx" "$trail"
         else
-          textPass "Trail $trail in $regx is enabled for all regions"
+          textPass "Trail $trail in $regx is enabled for all regions" "$regx" "$trail"
         fi
 
       done

--- a/checks/check22
+++ b/checks/check22
@@ -43,9 +43,9 @@ check22(){
 
         LOGFILEVALIDATION_TRAIL_STATUS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $TRAIL_REGION --query 'trailList[*].LogFileValidationEnabled' --output text --trail-name-list $trail)
         if [[ "$LOGFILEVALIDATION_TRAIL_STATUS" == 'False' ]];then
-          textFail "Trail $trail in $regx log file validation disabled"
+          textFail "Trail $trail in $regx log file validation disabled" "$regx" "$trail"
         else
-          textPass "Trail $trail in $regx log file validation enabled"
+          textPass "Trail $trail in $regx log file validation enabled" "$regx" "$trail"
         fi
 
       done

--- a/checks/check29
+++ b/checks/check29
@@ -34,15 +34,15 @@ check29(){
     for vpcx in $AVAILABLE_VPC; do
       CHECK_FL=$($AWSCLI ec2 describe-flow-logs $PROFILE_OPT --region $regx --filter Name="resource-id",Values="${vpcx}" --query 'FlowLogs[?FlowLogStatus==`ACTIVE`].FlowLogId' --output text 2>&1)
       if [[ $(echo "$CHECK_FL" | grep AccessDenied) ]]; then
-        textFail "$regx: VPC $vpcx Access Denied trying to describe flow logs"
+        textFail "$regx: VPC $vpcx Access Denied trying to describe flow logs" "$regx" "$vpcx"
         continue
       fi
       if [[ $CHECK_FL ]]; then
         for FL in $CHECK_FL; do
-          textPass "$regx: VPC $vpcx VPCFlowLog is enabled for LogGroupName: $FL"
+          textPass "$regx: VPC $vpcx VPCFlowLog is enabled for LogGroupName: $FL" "$regx" "$vpcx"
         done
       else
-        textFail "$regx: VPC $vpcx VPCFlowLog is disabled"
+        textFail "$regx: VPC $vpcx VPCFlowLog is disabled" "$regx" "$vpcx"
       fi
     done
   done

--- a/checks/check41
+++ b/checks/check41
@@ -29,7 +29,7 @@ check41(){
     SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`22` && ToPort>=`22`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
     if [[ $SG_LIST ]];then
       for SG in $SG_LIST;do
-        textFail "Found Security Group: $SG open to 0.0.0.0/0 in Region $regx" "$regx"
+        textFail "Found Security Group: $SG open to 0.0.0.0/0 in Region $regx" "$regx" "$SG"
       done
     else
       textPass "No Security Groups found in $regx with port 22 TCP open to 0.0.0.0/0" "$regx"

--- a/checks/check42
+++ b/checks/check42
@@ -29,7 +29,7 @@ check42(){
     SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`3389` && ToPort>=`3389`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
     if [[ $SG_LIST ]];then
       for SG in $SG_LIST;do
-        textFail "Found Security Group: $SG open to 0.0.0.0/0 in Region $regx" "$regx"
+        textFail "Found Security Group: $SG open to 0.0.0.0/0 in Region $regx" "$regx" "$SG"
       done
     else
       textPass "No Security Groups found in $regx with port 3389 TCP open to 0.0.0.0/0" "$regx"

--- a/checks/check43
+++ b/checks/check43
@@ -30,9 +30,9 @@ check43(){
     for CHECK_SGDEFAULT_ID in $CHECK_SGDEFAULT_IDS; do
       CHECK_SGDEFAULT_ID_OPEN=$($AWSCLI ec2 describe-security-groups $PROFILE_OPT --region $regx --group-ids $CHECK_SGDEFAULT_ID --query 'SecurityGroups[*].{IpPermissions:IpPermissions,IpPermissionsEgress:IpPermissionsEgress,GroupId:GroupId}' --output text |egrep '\s0.0.0.0|\:\:\/0')
       if [[ $CHECK_SGDEFAULT_ID_OPEN ]];then
-        textFail "Default Security Groups ($CHECK_SGDEFAULT_ID) found that allow 0.0.0.0 IN or OUT traffic in Region $regx" "$regx"
+        textFail "Default Security Groups ($CHECK_SGDEFAULT_ID) found that allow 0.0.0.0 IN or OUT traffic in Region $regx" "$regx" "$CHECK_SGDEFAULT_ID"
       else
-        textPass "No Default Security Groups ($CHECK_SGDEFAULT_ID) open to 0.0.0.0 found in Region $regx" "$regx"
+        textPass "No Default Security Groups ($CHECK_SGDEFAULT_ID) open to 0.0.0.0 found in Region $regx" "$regx" "$CHECK_SGDEFAULT_ID"
       fi
     done
   done

--- a/checks/check_extra71
+++ b/checks/check_extra71
@@ -44,9 +44,9 @@ extra71(){
         # check for user MFA device in credential report
         USER_MFA_ENABLED=$( cat $TEMP_REPORT_FILE | grep "^$auser," | cut -d',' -f8)
         if [[ "true" == $USER_MFA_ENABLED ]]; then
-          textPass "$auser / MFA Enabled / admin via group $grp"
+          textPass "$auser / MFA Enabled / admin via group $grp" "us-east-1" "$auser"
         else
-          textFail "$auser / MFA DISABLED / admin via group $grp"
+          textFail "$auser / MFA DISABLED / admin via group $grp" "us-east-1" "$auser"
         fi
       done
     else

--- a/checks/check_extra710
+++ b/checks/check_extra710
@@ -33,10 +33,10 @@ extra710(){
       while read -r instance;do
         INSTANCE_ID=$(echo $instance | awk '{ print $1; }')
         PUBLIC_IP=$(echo $instance | awk '{ print $2; }')
-        textFail "$regx: Instance: $INSTANCE_ID at IP: $PUBLIC_IP is internet-facing!" "$regx"
+        textFail "$regx: Instance: $INSTANCE_ID at IP: $PUBLIC_IP is internet-facing!" "$regx" "$INSTANCE_ID"
       done <<< "$LIST_OF_PUBLIC_INSTANCES"
       else
-        textPass "$regx: no Internet Facing EC2 Instances found" "$regx"
+        textPass "$regx: no Internet Facing EC2 Instances found" "$regx" "$INSTANCE_ID"
     fi
   done
 }

--- a/checks/check_extra7100
+++ b/checks/check_extra7100
@@ -72,7 +72,7 @@ extra7100(){
       textInfo "STS AssumeRole Policies should only include the complete ARNs for the Roles that the user needs"
       textInfo "Learn more: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_permissions-to-switch.html#roles-usingrole-createpolicy"
       for policy in $PERMISSIVE_POLICIES_LIST; do
-        textFail "Policy $policy allows permissive STS Role assumption"
+        textFail "Policy $policy allows permissive STS Role assumption" "us-east-1" "$policy"
       done
     else
       textPass "No custom policies found that allow permissive STS Role assumption"

--- a/checks/check_extra7101
+++ b/checks/check_extra7101
@@ -31,9 +31,9 @@ extra7101(){
       for domain in $LIST_OF_DOMAINS;do
         AUDIT_LOGS_ENABLED=$($AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query DomainConfig.LogPublishingOptions.Options.AUDIT_LOGS.Enabled --output text |grep -v ^None|grep -v ^False)
         if [[ $AUDIT_LOGS_ENABLED ]];then
-          textPass "$regx: Amazon ES domain $domain AUDIT_LOGS enabled" "$regx"
+          textPass "$regx: Amazon ES domain $domain AUDIT_LOGS enabled" "$regx" "$domain"
         else
-          textFail "$regx: Amazon ES domain $domain AUDIT_LOGS disabled!" "$regx"
+          textFail "$regx: Amazon ES domain $domain AUDIT_LOGS disabled!" "$regx" "$domain"
         fi
       done
     else

--- a/checks/check_extra7102
+++ b/checks/check_extra7102
@@ -47,7 +47,7 @@ extra7102(){
           else
             echo $SHODAN_QUERY > $OUTPUT_DIR/shodan-output-$ip.json
             IP_SHODAN_INFO=$(cat $OUTPUT_DIR/shodan-output-$ip.json | jq -r '. | { ports: .ports, org: .org, country: .country_name }| @text' | tr -d \"\{\}\}\]\[ | tr , '\ ' )
-            textFail "$regx: IP $ip is listed in Shodan with data $IP_SHODAN_INFO. More info https://www.shodan.io/host/$ip and $OUTPUT_DIR/shodan-output-$ip.json" "$regx"
+            textFail "$regx: IP $ip is listed in Shodan with data $IP_SHODAN_INFO. More info https://www.shodan.io/host/$ip and $OUTPUT_DIR/shodan-output-$ip.json" "$regx" "$ip"
           fi
         done
       else

--- a/checks/check_extra7103
+++ b/checks/check_extra7103
@@ -31,9 +31,9 @@ extra7103(){
             for nb_instance in $LIST_SM_NB_INSTANCES; do
                 SM_NB_ROOTACCESS=$($AWSCLI $PROFILE_OPT --region $regx sagemaker describe-notebook-instance --notebook-instance-name $nb_instance --query 'RootAccess' --output text)
                 if [[ "${SM_NB_ROOTACCESS}" == "Enabled" ]]; then
-                    textFail "${regx}: Sagemaker Notebook instance $nb_instance has root access enabled" "${regx}"
+                    textFail "${regx}: Sagemaker Notebook instance $nb_instance has root access enabled" "${regx}" "$nb_instance"
                 else
-                    textPass "${regx}: Sagemaker Notebook instance $nb_instance has root access disabled" "${regx}"                    
+                    textPass "${regx}: Sagemaker Notebook instance $nb_instance has root access disabled" "${regx}" "$nb_instance"                    
                 fi 
             done
         else 

--- a/checks/check_extra7104
+++ b/checks/check_extra7104
@@ -31,9 +31,9 @@ extra7104(){
             for nb_instance in $LIST_SM_NB_INSTANCES; do
                 SM_NB_SUBNETID=$($AWSCLI $PROFILE_OPT --region $regx sagemaker describe-notebook-instance --notebook-instance-name $nb_instance --query 'SubnetId' --output text)
                 if [[ "${SM_NB_SUBNETID}" == "None" ]]; then
-                    textFail "${regx}: Sagemaker Notebook instance $nb_instance has VPC settings disabled" "${regx}"
+                    textFail "${regx}: Sagemaker Notebook instance $nb_instance has VPC settings disabled" "${regx}" "$nb_instance"
                 else
-                    textPass "${regx}: Sagemaker Notebook instance $nb_instance is in a VPC" "${regx}"
+                    textPass "${regx}: Sagemaker Notebook instance $nb_instance is in a VPC" "${regx}" "$nb_instance"
                 fi 
             done
         else 

--- a/checks/check_extra7105
+++ b/checks/check_extra7105
@@ -31,9 +31,9 @@ extra7105(){
 			for nb_model_name in $LIST_SM_NB_MODELS; do
 				SM_NB_NETWORKISOLATION=$($AWSCLI $PROFILE_OPT --region $regx sagemaker describe-model --model-name $nb_model_name --query 'EnableNetworkIsolation' --output text)
 				if [[ $SM_NB_NETWORKISOLATION == False ]]; then
-					textFail "${regx}: SageMaker Model $nb_model_name has network isolation disabled" "${regx}"
+					textFail "${regx}: SageMaker Model $nb_model_name has network isolation disabled" "${regx}" "$nb_model_name"
 				else
-					textPass "${regx}: SageMaker Model $nb_model_name has network isolation enabled" "${regx}"
+					textPass "${regx}: SageMaker Model $nb_model_name has network isolation enabled" "${regx}" "$nb_model_name"
 				fi 
 			done
 		else 

--- a/checks/check_extra7106
+++ b/checks/check_extra7106
@@ -31,9 +31,9 @@ extra7106(){
             for nb_model_name in $LIST_SM_NB_MODELS; do
                 SM_NB_VPCCONFIG=$($AWSCLI $PROFILE_OPT --region $regx sagemaker describe-model --model-name $nb_model_name --query 'VpcConfig.Subnets' --output text)
                 if [[ $SM_NB_VPCCONFIG == "None" ]]; then
-                    textFail "${regx}: Amazon SageMaker Model $nb_model_name has VPC settings disabled" "${regx}"
+                    textFail "${regx}: Amazon SageMaker Model $nb_model_name has VPC settings disabled" "${regx}" "$nb_model_name"
                 else
-                    textPass "${regx}: Amazon SageMaker Model $nb_model_name has VPC settings enabled" "${regx}"
+                    textPass "${regx}: Amazon SageMaker Model $nb_model_name has VPC settings enabled" "${regx}" "$nb_model_name"
                 fi 
             done
         else 

--- a/checks/check_extra7107
+++ b/checks/check_extra7107
@@ -31,9 +31,9 @@ extra7107(){
             for nb_job_name in $LIST_SM_NB_JOBS; do
                 SM_NB_INTERCONTAINERENCRYPTION=$($AWSCLI $PROFILE_OPT --region $regx sagemaker describe-training-job --training-job-name $nb_job_name --query 'EnableInterContainerTrafficEncryption' --output text)
                 if [[ $SM_NB_INTERCONTAINERENCRYPTION == "False" ]]; then
-                    textFail "${regx}: SageMaker Training job $nb_job_name has intercontainer encryption disabled" "${regx}"
+                    textFail "${regx}: SageMaker Training job $nb_job_name has intercontainer encryption disabled" "${regx}" "$nb_job_name"
                 else
-                    textPass "${regx}: SageMaker Training jobs $nb_job_name has intercontainer encryption enabled" "${regx}"
+                    textPass "${regx}: SageMaker Training jobs $nb_job_name has intercontainer encryption enabled" "${regx}" "$nb_job_name"
                 fi 
             done
         else 

--- a/checks/check_extra7108
+++ b/checks/check_extra7108
@@ -31,9 +31,9 @@ extra7108(){
             for nb_job_name in $LIST_SM_NB_JOBS; do
                 SM_JOB_KMSENCRYPTION=$($AWSCLI $PROFILE_OPT --region $regx sagemaker describe-training-job --training-job-name $nb_job_name --query 'ResourceConfig.VolumeKmsKeyId' --output text)
                 if [[ "${SM_JOB_KMSENCRYPTION}" == "None" ]];then
-                    textFail "${regx}: Sagemaker Trainings job $nb_job_name has KMS encryption disabled" "${regx}"
+                    textFail "${regx}: Sagemaker Trainings job $nb_job_name has KMS encryption disabled" "${regx}" "$nb_job_name"
                 else
-                    textPass "${regx}: Sagemaker Trainings job $nb_job_name has KSM encryption enabled" "${regx}"
+                    textPass "${regx}: Sagemaker Trainings job $nb_job_name has KSM encryption enabled" "${regx}" "$nb_job_name"
                 fi 
             done
         else 

--- a/checks/check_extra7109
+++ b/checks/check_extra7109
@@ -31,9 +31,9 @@ extra7109(){
             for nb_job_name in $LIST_SM_NB_JOBS; do
                 SM_NB_NETWORKISOLATION=$($AWSCLI $PROFILE_OPT --region $regx sagemaker describe-training-job --training-job-name $nb_job_name --query 'EnableNetworkIsolation' --output text)
                 if [[ $SM_NB_NETWORKISOLATION == False ]]; then
-                    textFail "${regx}: Sagemaker Training job $nb_job_name has network isolation disabled" "${regx}"
+                    textFail "${regx}: Sagemaker Training job $nb_job_name has network isolation disabled" "${regx}" "$nb_job_name"
                 else
-                    textPass "${regx}: Sagemaker Training job $nb_job_name has network isolation enabled" "${regx}"
+                    textPass "${regx}: Sagemaker Training job $nb_job_name has network isolation enabled" "${regx}" "$nb_job_name"
                 fi 
             done
         else 

--- a/checks/check_extra711
+++ b/checks/check_extra711
@@ -32,10 +32,10 @@ extra711(){
       while read -r cluster;do
         CLUSTER_ID=$(echo $cluster | awk '{ print $1; }')
         CLUSTER_ENDPOINT=$(echo $cluster | awk '{ print $2; }')
-        textFail "$regx: Cluster: $CLUSTER_ID at Endpoint: $CLUSTER_ENDPOINT is publicly accessible!" "$regx"
+        textFail "$regx: Cluster: $CLUSTER_ID at Endpoint: $CLUSTER_ENDPOINT is publicly accessible!" "$regx" "$CLUSTER_ID"
       done <<< "$LIST_OF_PUBLIC_REDSHIFT_CLUSTERS"
       else
-        textPass "$regx: no Publicly Accessible Redshift Clusters found" "$regx"
+        textPass "$regx: no Publicly Accessible Redshift Clusters found" "$regx" "$CLUSTER_ID"
     fi
   done
 }

--- a/checks/check_extra7110
+++ b/checks/check_extra7110
@@ -31,9 +31,9 @@ extra7110(){
             for nb_job_name in $LIST_SM_NB_JOBS; do
                 SM_NB_SUBNETS=$($AWSCLI $PROFILE_OPT --region $regx sagemaker describe-training-job --training-job-name $nb_job_name --query 'VpcConfig.Subnets' --output text)
                 if [[ $SM_NB_SUBNETS == "None" ]]; then
-                    textFail "${regx}: Sagemaker Training job $nb_job_name has VPC settings for the training job volume and output disabled" "${regx}"
+                    textFail "${regx}: Sagemaker Training job $nb_job_name has VPC settings for the training job volume and output disabled" "${regx}" "$nb_job_name"
                 else
-                    textPass "${regx}: Sagemaker Training job $nb_job_name has VPC settings for the training job volume and output enabled" "${regx}"
+                    textPass "${regx}: Sagemaker Training job $nb_job_name has VPC settings for the training job volume and output enabled" "${regx}" "$nb_job_name"
                 fi 
             done
         else 

--- a/checks/check_extra7111
+++ b/checks/check_extra7111
@@ -31,9 +31,9 @@ extra7111(){
             for nb_instance in $LIST_SM_NB_INSTANCES; do
                 SM_NB_DIRECTINET=$($AWSCLI $PROFILE_OPT --region $regx sagemaker describe-notebook-instance --notebook-instance-name $nb_instance --query 'DirectInternetAccess' --output text)
                 if [[ "${SM_NB_DIRECTINET}" == "Enabled" ]]; then
-                    textFail "${regx}: Sagemaker Notebook instance $nb_instance has direct internet access enabled" "${regx}"
+                    textFail "${regx}: Sagemaker Notebook instance $nb_instance has direct internet access enabled" "${regx}" "$nb_instance"
                 else
-                    textPass "${regx}: Sagemaker Notebook instance $nb_instance has direct internet access disabled" "${regx}"
+                    textPass "${regx}: Sagemaker Notebook instance $nb_instance has direct internet access disabled" "${regx}" "$nb_instance"
                 fi 
             done
         else 

--- a/checks/check_extra7112
+++ b/checks/check_extra7112
@@ -31,9 +31,9 @@ extra7112(){
             for nb_instance in $LIST_SM_NB_INSTANCES; do
                 SM_NB_KMSKEY=$($AWSCLI $PROFILE_OPT --region $regx sagemaker describe-notebook-instance --notebook-instance-name $nb_instance --query 'KmsKeyId' --output text)
                 if [[ "${SM_NB_KMSKEY}" == "None" ]]; then
-                    textFail "${regx}: Sagemaker Notebook instance $nb_instance has data encryption disabled" "${regx}"
+                    textFail "${regx}: Sagemaker Notebook instance $nb_instance has data encryption disabled" "${regx}" "$nb_instance"
                 else
-                    textPass "${regx}: Sagemaker Notebook instance $nb_instance has data encryption enabled" "${regx}"
+                    textPass "${regx}: Sagemaker Notebook instance $nb_instance has data encryption enabled" "${regx}" "$nb_instance"
                 fi 
             done
         else 

--- a/checks/check_extra7114
+++ b/checks/check_extra7114
@@ -34,12 +34,12 @@ extra7114(){
         if [[ ! -z "$ENDPOINT_SC" ]]; then
           ENDPOINT_SC_ENCRYPTION=$($AWSCLI glue get-security-configuration --name "${ENDPOINT_SC}" $PROFILE_OPT --region $regx --query 'SecurityConfiguration.EncryptionConfiguration.S3Encryption[0].S3EncryptionMode' --output text)
           if [[ "$ENDPOINT_SC_ENCRYPTION" == "DISABLED" ]]; then
-            textFail "$regx: Glue development endpoint $ENDPOINT_NAME does not have S3 encryption enabled!" "$regx"
+            textFail "$regx: Glue development endpoint $ENDPOINT_NAME does not have S3 encryption enabled!" "$regx" "$ENDPOINT_NAME"
           else
-            textPass "$regx: Glue development endpoint $ENDPOINT_NAME has S3 encryption enabled" "$regx"
+            textPass "$regx: Glue development endpoint $ENDPOINT_NAME has S3 encryption enabled" "$regx" 
           fi
         else
-          textFail "$regx: Glue development endpoint $ENDPOINT_NAME does not have security configuration" "$regx"
+          textFail "$regx: Glue development endpoint $ENDPOINT_NAME does not have security configuration" "$regx" "$ENDPOINT_NAME"
         fi
       done
     else

--- a/checks/check_extra7115
+++ b/checks/check_extra7115
@@ -31,9 +31,9 @@ extra7115(){
           CONNECTION_NAME=$(echo $connection | base64 --decode   | jq -r '.Name' )
           CONNECTION_SSL_STATE=$(echo $connection | base64 --decode  | jq -r '.SSL')
           if [[ "$CONNECTION_SSL_STATE" == "false" ]]; then
-              textFail "$regx: Glue connection $CONNECTION_NAME has SSL connection disabled"  "$regx"
+              textFail "$regx: Glue connection $CONNECTION_NAME has SSL connection disabled"  "$regx" "$CONNECTION_NAME"
           else 
-              textPass "$regx: Glue connection $CONNECTION_NAME has SSL connection enabled"  "$regx"
+              textPass "$regx: Glue connection $CONNECTION_NAME has SSL connection enabled"  "$regx" "$CONNECTION_NAME"
           fi
       done
     else 

--- a/checks/check_extra7118
+++ b/checks/check_extra7118
@@ -35,9 +35,9 @@ extra7118(){
             S3_ENCRYPTION=$($AWSCLI glue get-security-configuration --name "${SECURITY_CONFIGURATION}" $PROFILE_OPT --region $regx --output text --query 'SecurityConfiguration.EncryptionConfiguration.S3Encryption[0].S3EncryptionMode')
             if [[ "$S3_ENCRYPTION" == "DISABLED" ]]; then
               if [[ ! -z "$JOB_ENCRYPTION" ]]; then
-                textPass "$regx: Glue job $JOB_NAME does have $JOB_ENCRYPTION for S3 encryption enabled" "$regx"
+                textPass "$regx: Glue job $JOB_NAME does have $JOB_ENCRYPTION for S3 encryption enabled" "$regx" "$JOB_NAME"
               else 
-                textFail "$regx: Glue job $JOB_NAME does not have S3 encryption enabled" "$regx"
+                textFail "$regx: Glue job $JOB_NAME does not have S3 encryption enabled" "$regx" "$JOB_NAME"
               fi 
             else
               textPass "$regx: Glue job $JOB_NAME does have $S3_ENCRYPTION for S3 encryption enabled" "$regx"
@@ -45,7 +45,7 @@ extra7118(){
           elif [[ ! -z "$JOB_ENCRYPTION" ]]; then
             textPass "$regx: Glue job $JOB_NAME does have $JOB_ENCRYPTION for S3 encryption enabled" "$regx"
           else 
-            textFail "$regx: Glue job $JOB_NAME does not have S3 encryption enabled" "$regx"
+            textFail "$regx: Glue job $JOB_NAME does not have S3 encryption enabled" "$regx" "$JOB_NAME"
           fi
       done
     else 

--- a/checks/check_extra7119
+++ b/checks/check_extra7119
@@ -34,12 +34,12 @@ extra7119(){
         if [[ ! -z "$ENDPOINT_SC" ]]; then
           ENDPOINT_SC_ENCRYPTION=$($AWSCLI glue get-security-configuration --name "${ENDPOINT_SC}" $PROFILE_OPT --region $regx --query 'SecurityConfiguration.EncryptionConfiguration.CloudWatchEncryption.CloudWatchEncryptionMode' --output text)
           if [[ $ENDPOINT_SC_ENCRYPTION == "DISABLED" ]]; then
-            textFail "$regx: Glue development endpoint $ENDPOINT_NAME does not have CloudWatch logs encryption enabled!" "$regx"
+            textFail "$regx: Glue development endpoint $ENDPOINT_NAME does not have CloudWatch logs encryption enabled!" "$regx" "$ENDPOINT_NAME"
           else
             textPass "$regx: Glue development endpoint $ENDPOINT_NAME has CloudWatch logs encryption enabled" "$regx"
           fi
         else
-          textFail "$regx: Glue development endpoint $ENDPOINT_NAME does not have security configuration" "$regx"
+          textFail "$regx: Glue development endpoint $ENDPOINT_NAME does not have security configuration" "$regx" "$ENDPOINT_NAME"
         fi
       done
     else

--- a/checks/check_extra7120
+++ b/checks/check_extra7120
@@ -33,12 +33,12 @@ extra7120(){
           if [[ ! -z "$SECURITY_CONFIGURATION" ]]; then
             CLOUDWATCH_ENCRYPTION=$($AWSCLI glue get-security-configuration --name "${SECURITY_CONFIGURATION}" $PROFILE_OPT --region $regx --output text --query 'SecurityConfiguration.EncryptionConfiguration.CloudWatchEncryption.CloudWatchEncryptionMode')
             if [[ "$CLOUDWATCH_ENCRYPTION" == "DISABLED" ]]; then
-              textFail "$regx: Glue job $JOB_NAME does not have CloudWatch Logs encryption enabled" "$regx"
+              textFail "$regx: Glue job $JOB_NAME does not have CloudWatch Logs encryption enabled" "$regx" "$JOB_NAME"
             else
-              textPass "$regx: Glue job $JOB_NAME does have $CLOUDWATCH_ENCRYPTION CloudWatch Logs encryption enabled" "$regx"
+              textPass "$regx: Glue job $JOB_NAME does have $CLOUDWATCH_ENCRYPTION CloudWatch Logs encryption enabled" "$regx" "$JOB_NAME"
             fi
           else
-            textFail "$regx: Glue job $JOB_NAME does not have CloudWatch Logs encryption enabled" "$regx"
+            textFail "$regx: Glue job $JOB_NAME does not have CloudWatch Logs encryption enabled" "$regx" "$JOB_NAME"
           fi
       done
     else 

--- a/checks/check_extra7121
+++ b/checks/check_extra7121
@@ -34,12 +34,12 @@ extra7121(){
         if [[ ! -z "$ENDPOINT_SC" ]]; then
           ENDPOINT_SC_ENCRYPTION=$($AWSCLI glue get-security-configuration --name "${ENDPOINT_SC}" $PROFILE_OPT --region $regx --query 'SecurityConfiguration.EncryptionConfiguration.JobBookmarksEncryption.JobBookmarksEncryptionMode' --output text)
           if [[ "$ENDPOINT_SC_ENCRYPTION" == "DISABLED" ]]; then
-            textFail "$regx: Glue development endpoint $ENDPOINT_NAME does not have Job Bookmark encryption enabled!" "$regx"
+            textFail "$regx: Glue development endpoint $ENDPOINT_NAME does not have Job Bookmark encryption enabled!" "$regx" "$ENDPOINT_NAME"
           else
-            textPass "$regx: Glue development endpoint $ENDPOINT_NAME has Job Bookmark encryption enabled" "$regx"
+            textPass "$regx: Glue development endpoint $ENDPOINT_NAME has Job Bookmark encryption enabled" "$regx" "$ENDPOINT_NAME"
           fi
         else
-          textFail "$regx: Glue development endpoint $ENDPOINT_NAME does not have security configuration" "$regx"
+          textFail "$regx: Glue development endpoint $ENDPOINT_NAME does not have security configuration" "$regx" "$ENDPOINT_NAME"
         fi
       done
     else

--- a/checks/check_extra7122
+++ b/checks/check_extra7122
@@ -33,12 +33,12 @@ extra7122(){
           if [[ ! -z "$SECURITY_CONFIGURATION" ]]; then
             JOB_BOOKMARK_ENCRYPTION=$($AWSCLI glue get-security-configuration --name "${SECURITY_CONFIGURATION}" $PROFILE_OPT --region $regx --output text --query 'SecurityConfiguration.EncryptionConfiguration.JobBookmarksEncryption.JobBookmarksEncryptionMode')
             if [[ "$JOB_BOOKMARK_ENCRYPTION" == "DISABLED" ]]; then
-              textFail "$regx: Glue job $JOB_NAME does not have Job bookmark encryption enabled" "$regx"
+              textFail "$regx: Glue job $JOB_NAME does not have Job bookmark encryption enabled" "$regx" "$JOB_NAME"
             else
               textPass "$regx: Glue job $JOB_NAME does have $JOB_BOOKMARK_ENCRYPTION for Job bookmark encryption enabled" "$regx"
             fi
           else
-            textFail "$regx: Glue job $JOB_NAME does not have Job bookmark encryption enabled" "$regx"
+            textFail "$regx: Glue job $JOB_NAME does not have Job bookmark encryption enabled" "$regx" "$JOB_NAME"
           fi
       done
     else 

--- a/checks/check_extra7123
+++ b/checks/check_extra7123
@@ -30,7 +30,7 @@ extra7123(){
   if [[ $LIST_OF_USERS_WITH_2ACCESS_KEYS ]]; then
     # textFail "Users with access key 1 older than 90 days:"
     for user in $LIST_OF_USERS_WITH_2ACCESS_KEYS; do
-      textFail "User $user has 2 active access keys" 
+      textFail "User $user has 2 active access keys" "us-east-1" "$user"
     done
   else
     textPass "No users with 2 active access keys"

--- a/checks/check_extra7124
+++ b/checks/check_extra7124
@@ -33,12 +33,12 @@ extra7124(){
       LIST_EC2_UNMANAGED=$(echo ${LIST_SSM_MANAGED_INSTANCES[@]} ${LIST_EC2_INSTANCES[@]} | tr ' ' '\n' | sort | uniq -u)
       if [[ $LIST_EC2_UNMANAGED ]]; then
         for instance in $LIST_EC2_UNMANAGED; do
-          textFail "$regx: EC2 instance $instance is not managed by Systems Manager" "$regx"
+          textFail "$regx: EC2 instance $instance is not managed by Systems Manager" "$regx" "$instance"
         done
       fi 
       if [[ $LIST_SSM_MANAGED_INSTANCES ]]; then
         for instance in $LIST_SSM_MANAGED_INSTANCES; do 
-          textPass "$regx: EC2 instance $instance is managed by Systems Manager" "$regx"
+          textPass "$regx: EC2 instance $instance is managed by Systems Manager" "$regx" "$instance"
         done 
       fi 
     else 

--- a/checks/check_extra7125
+++ b/checks/check_extra7125
@@ -34,9 +34,9 @@ extra7125(){
       if [[ $MFA_TYPE == "mfa" || $MFA_TYPE == "sms-mfa" ]]; then 
         textInfo "User $user has virtual MFA enabled" 
       elif [[ $MFA_TYPE == "" ]]; then 
-        textFail "User $user has not hardware MFA enabled"
+        textFail "User $user has not hardware MFA enabled" "us-east-1" "$user"
       else 
-        textPass "User $user has hardware MFA enabled"
+        textPass "User $user has hardware MFA enabled" "us-east-1" "$user"
       fi
     done
   else

--- a/checks/check_extra7127
+++ b/checks/check_extra7127
@@ -32,12 +32,12 @@ extra7127(){
     if [[ $NON_COMPLIANT_SSM_MANAGED_INSTANCES || $COMPLIANT_SSM_MANAGED_INSTANCES ]]; then
       if [[ $NON_COMPLIANT_SSM_MANAGED_INSTANCES ]]; then
         for instance in $NON_COMPLIANT_SSM_MANAGED_INSTANCES; do
-          textFail "$regx: EC2 managed instance $instance is non-compliant" "$regx"
+          textFail "$regx: EC2 managed instance $instance is non-compliant" "$regx" "$instance"
         done
       fi
       if [[ $COMPLIANT_SSM_MANAGED_INSTANCES ]]; then
         for instance in $COMPLIANT_SSM_MANAGED_INSTANCES; do
-          textPass "$regx: EC2 managed instance $instance is compliant" "$regx"
+          textPass "$regx: EC2 managed instance $instance is compliant" "$regx" "$instance"
         done
       fi 
     else 

--- a/checks/check_extra7129
+++ b/checks/check_extra7129
@@ -59,10 +59,10 @@ extra7129(){
               done
             fi
           else
-            textFail "$regx: Application Load Balancer $alb is not protected by WAF ACL" "$regx"
+            textFail "$regx: Application Load Balancer $alb is not protected by WAF ACL" "$regx" "$alb"
           fi
         else
-          textFail "$regx: Application Load Balancer $alb is not protected no WAF ACL found" "$regx"
+          textFail "$regx: Application Load Balancer $alb is not protected no WAF ACL found" "$regx" "$alb"
         fi
       done
     else

--- a/checks/check_extra713
+++ b/checks/check_extra713
@@ -34,9 +34,9 @@ extra713(){
         while read -r detector;do
           DETECTOR_ENABLED=$($AWSCLI guardduty get-detector --detector-id $detector $PROFILE_OPT --region $regx --query "Status" --output text|grep ENABLED)
           if [[ $DETECTOR_ENABLED ]]; then
-            textPass "$regx: GuardDuty detector $detector enabled" "$regx"
+            textPass "$regx: GuardDuty detector $detector enabled" "$regx" "$detector"
           else
-            textFail "$regx: GuardDuty detector $detector configured but suspended" "$regx"
+            textFail "$regx: GuardDuty detector $detector configured but suspended" "$regx" "$detector"
           fi
         done <<< "$LIST_OF_GUARDDUTY_DETECTORS"
         else

--- a/checks/check_extra7130
+++ b/checks/check_extra7130
@@ -33,9 +33,9 @@ extra7130(){
         SHORT_TOPIC=$(echo $topic | awk -F ":" '{print $NF}')
         SNS_ENCRYPTION=$($AWSCLI sns get-topic-attributes $PROFILE_OPT --region $regx --topic-arn $topic --query 'Attributes.KmsMasterKeyId' --output text)
         if [[ "None" == $SNS_ENCRYPTION ]]; then
-          textFail "$regx: $SHORT_TOPIC is not encrypted!" "$regx"
+          textFail "$regx: $SHORT_TOPIC is not encrypted!" "$regx" "$SHORT_TOPIC"
         else
-          textPass "$regx: $SHORT_TOPIC is encrypted" "$regx"
+          textPass "$regx: $SHORT_TOPIC is encrypted" "$regx" "$SHORT_TOPIC"
         fi
       done
     else

--- a/checks/check_extra7134
+++ b/checks/check_extra7134
@@ -28,10 +28,10 @@ extra7134(){
     SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort==`20` && ToPort==`21`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
     if [[ $SG_LIST ]];then
       for SG in $SG_LIST;do
-        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for FTP ports" "$regx"
+        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for FTP ports" "$regx" "$SG"
       done
     else
-      textPass "$regx: No Security Groups found with any port open to 0.0.0.0/0 for FTP ports" "$regx"
+      textPass "$regx: No Security Groups found with any port open to 0.0.0.0/0 for FTP ports" "$regx" "$SG"
     fi
   done
 }

--- a/checks/check_extra7135
+++ b/checks/check_extra7135
@@ -28,7 +28,7 @@ extra7135(){
     SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort==`9092` && ToPort==`9092`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
     if [[ $SG_LIST ]];then
       for SG in $SG_LIST;do
-        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Kafka ports" "$regx"
+        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Kafka ports" "$regx" "$SG"
       done
     else
       textPass "$regx: No Security Groups found with any port open to 0.0.0.0/0 for Kafka ports" "$regx"

--- a/checks/check_extra7136
+++ b/checks/check_extra7136
@@ -28,10 +28,10 @@ extra7136(){
     SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort==`23` && ToPort==`23`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
     if [[ $SG_LIST ]];then
       for SG in $SG_LIST;do
-        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Telnet ports" "$regx"
+        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Telnet ports" "$regx" "$SG"
       done
     else
-      textPass "$regx: No Security Groups found with any port open to 0.0.0.0/0 for Telnet ports" "$regx"
+      textPass "$regx: No Security Groups found with any port open to 0.0.0.0/0 for Telnet ports" "$regx" "$SG"
     fi
   done
 }

--- a/checks/check_extra7137
+++ b/checks/check_extra7137
@@ -28,7 +28,7 @@ extra7137(){
     SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort==`1433` && ToPort==`1434`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
     if [[ $SG_LIST ]];then
       for SG in $SG_LIST;do
-        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Microsoft SQL Server ports" "$regx"
+        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Microsoft SQL Server ports" "$regx" "$SG"
       done
     else
       textPass "$regx: No Security Groups found with any port open to 0.0.0.0/0 for Microsoft SQL Server ports" "$regx"

--- a/checks/check_extra7138
+++ b/checks/check_extra7138
@@ -29,10 +29,10 @@ extra7138(){
     NACL_LIST=$($AWSCLI ec2 describe-network-acls --query 'NetworkAcls[?Entries[?((!PortRange) && (CidrBlock == `0.0.0.0/0`) && (Egress == `false`) && (RuleAction == `allow`))]].{NetworkAclId:NetworkAclId}' $PROFILE_OPT --region $regx --output text)
     if [[ $NACL_LIST ]];then
       for NACL in $NACL_LIST;do
-        textInfo "$regx: Found Network ACL: $NACL open to 0.0.0.0/0 for any port" "$regx"
+        textInfo "$regx: Found Network ACL: $NACL open to 0.0.0.0/0 for any port" "$regx" "$NACL"
       done
     else
-      textPass "$regx: No Network ACL found with any port open to 0.0.0.0/0" "$regx"
+      textPass "$regx: No Network ACL found with any port open to 0.0.0.0/0" "$regx" "$NACL"
     fi
   done
 }

--- a/checks/check_extra714
+++ b/checks/check_extra714
@@ -30,9 +30,9 @@ extra714(){
     for dist in $LIST_OF_DISTRIBUTIONS; do
       LOG_ENABLED=$($AWSCLI cloudfront get-distribution $PROFILE_OPT --id "$dist" --query 'Distribution.DistributionConfig.Logging.Enabled' | grep true)
       if [[ $LOG_ENABLED ]]; then
-        textPass "CloudFront distribution $dist has logging enabled"
+        textPass "CloudFront distribution $dist has logging enabled" "us-east-1" "$dist"
       else
-        textFail "CloudFront distribution $dist has logging disabled"
+        textFail "CloudFront distribution $dist has logging disabled" "us-east-1" "$dist" 
       fi
     done
   else

--- a/checks/check_extra7140
+++ b/checks/check_extra7140
@@ -29,9 +29,9 @@ extra7140(){
       for ssmdoc in $SSM_DOCS; do 
         SSM_DOC_SHARED_ALL=$($AWSCLI $PROFILE_OPT --region $regx ssm describe-document-permission --name "$ssmdoc" --permission-type "Share" --query AccountIds[] --output text | grep all)
         if [[ $SSM_DOC_SHARED_ALL ]];then
-          textFail "$regx: SSM Document $ssmdoc is public." "$regx"
+          textFail "$regx: SSM Document $ssmdoc is public." "$regx" "$ssmdoc"
         else
-          textPass "$regx: SSM Document $ssmdoc is not public." "$regx"
+          textPass "$regx: SSM Document $ssmdoc is not public." "$regx" "$ssmdoc"
         fi
       done
     else

--- a/checks/check_extra715
+++ b/checks/check_extra715
@@ -30,15 +30,15 @@ extra715(){
       for domain in $LIST_OF_DOMAINS;do
         SEARCH_SLOWLOG_ENABLED=$($AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query DomainConfig.LogPublishingOptions.Options.SEARCH_SLOW_LOGS.Enabled --output text |grep -v ^None|grep -v ^False)
         if [[ $SEARCH_SLOWLOG_ENABLED ]];then
-          textPass "$regx: Amazon ES domain $domain SEARCH_SLOW_LOGS enabled" "$regx"
+          textPass "$regx: Amazon ES domain $domain SEARCH_SLOW_LOGS enabled" "$regx" "$domain"
         else
-          textFail "$regx: Amazon ES domain $domain SEARCH_SLOW_LOGS disabled!" "$regx"
+          textFail "$regx: Amazon ES domain $domain SEARCH_SLOW_LOGS disabled!" "$regx" "$domain"
         fi
         INDEX_SLOWLOG_ENABLED=$($AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query DomainConfig.LogPublishingOptions.Options.INDEX_SLOW_LOGS.Enabled --output text |grep -v ^None|grep -v ^False)
         if [[ $INDEX_SLOWLOG_ENABLED ]];then
-          textPass "$regx: Amazon ES domain $domain INDEX_SLOW_LOGS enabled" "$regx"
+          textPass "$regx: Amazon ES domain $domain INDEX_SLOW_LOGS enabled" "$regx" "$domain"
         else
-          textFail "$regx: Amazon ES domain $domain INDEX_SLOW_LOGS disabled!" "$regx"
+          textFail "$regx: Amazon ES domain $domain INDEX_SLOW_LOGS disabled!" "$regx" "$domain"
         fi
       done
     else

--- a/checks/check_extra716
+++ b/checks/check_extra716
@@ -40,7 +40,7 @@ extra716(){
           # check if the policy has a principal set up
           CHECK_ES_POLICY_PRINCIPAL=$(cat $TEMP_POLICY_FILE | jq -r '. | .Statement[] | select(.Effect == "Allow" and (((.Principal|type == "object") and .Principal.AWS != "*") or ((.Principal|type == "string") and .Principal != "*")) and select(has("Condition") | not))')
           if [[ $CHECK_ES_POLICY_PRINCIPAL ]]; then 
-            textPass "$regx: Amazon ES domain $domain does have a Principal set up" "$regx"
+            textPass "$regx: Amazon ES domain $domain does have a Principal set up" "$regx" "$domain"
           fi 
           CHECK_ES_DOMAIN_POLICY_OPEN=$(cat $TEMP_POLICY_FILE | jq -r '. | .Statement[] | select(.Effect == "Allow" and (((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and select(has("Condition") | not))')
           CHECK_ES_DOMAIN_POLICY_HAS_CONDITION=$(cat $TEMP_POLICY_FILE | jq -r '. | .Statement[] | select(.Effect == "Allow" and (((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and select(has("Condition")))' )
@@ -67,13 +67,13 @@ extra716(){
           fi
           if [[ $CHECK_ES_DOMAIN_POLICY_OPEN || $CHECK_ES_DOMAIN_POLICY_CONDITION_ZERO || $CHECK_ES_DOMAIN_POLICY_CONDITION_STAR || ${CHECK_ES_DOMAIN_POLICY_CONDITION_PUBLIC_IP[@]} ]];then
             if [[ $CHECK_ES_DOMAIN_POLICY_OPEN ]];then
-              textFail "$regx: Amazon ES domain $domain policy allows access (Principal: \"*\") - use extra788 to test AUTH" "$regx"
+              textFail "$regx: Amazon ES domain $domain policy allows access (Principal: \"*\") - use extra788 to test AUTH" "$regx" "$domain"
             fi
             if [[ $CHECK_ES_DOMAIN_POLICY_HAS_CONDITION && $CHECK_ES_DOMAIN_POLICY_CONDITION_ZERO ]];then
-              textFail "$regx: Amazon ES domain $domain policy allows access (Principal: \"*\" and network 0.0.0.0) - use extra788 to test AUTH" "$regx"
+              textFail "$regx: Amazon ES domain $domain policy allows access (Principal: \"*\" and network 0.0.0.0) - use extra788 to test AUTH" "$regx" "$domain"
             fi
             if [[ $CHECK_ES_DOMAIN_POLICY_HAS_CONDITION && $CHECK_ES_DOMAIN_POLICY_CONDITION_STAR ]];then
-              textFail "$regx: Amazon ES domain $domain policy allows access (Principal: \"*\" and network \"*\") - use extra788 to test AUTH" "$regx"
+              textFail "$regx: Amazon ES domain $domain policy allows access (Principal: \"*\" and network \"*\") - use extra788 to test AUTH" "$regx" "$domain"
             fi
             if [[ $CHECK_ES_DOMAIN_POLICY_HAS_CONDITION && ${CHECK_ES_DOMAIN_POLICY_CONDITION_PUBLIC_IP[@]} ]];then
               textInfo "$regx: Amazon ES domain $domain policy allows access (Principal: \"*\" and Public IP or Network $(echo ${CONDITION_HAS_PUBLIC_IP_ARRAY[@]})) - use extra788 to test AUTH" "$regx"
@@ -82,7 +82,7 @@ extra716(){
             if [[ $CHECK_ES_DOMAIN_POLICY_HAS_CONDITION && ${CHECK_ES_DOMAIN_POLICY_CONDITION_PRIVATE_IP[@]} ]];then
               textInfo "$regx: Amazon ES domain $domain policy allows access from a Private IP or CIDR RFC1918 $(echo ${CONDITION_HAS_PRIVATE_IP_ARRAY[@]})" "$regx"
             else
-              textPass "$regx: Amazon ES domain $domain does not allow anonymous access" "$regx"
+              textPass "$regx: Amazon ES domain $domain does not allow anonymous access" "$regx" "$domain"
             fi
           fi
           rm -f $TEMP_POLICY_FILE

--- a/checks/check_extra717
+++ b/checks/check_extra717
@@ -33,9 +33,9 @@ extra717(){
         for elb in $LIST_OF_ELBS; do
           CHECK_ELBS_LOG_ENABLED=$($AWSCLI elb describe-load-balancer-attributes $PROFILE_OPT --region $regx --load-balancer-name $elb --query 'LoadBalancerAttributes.AccessLog.Enabled'|grep "^true")
           if [[ $CHECK_ELBS_LOG_ENABLED ]]; then
-            textPass "$regx: $elb has access logs to S3 configured" "$regx"
+            textPass "$regx: $elb has access logs to S3 configured" "$regx" "$elb"
           else
-            textFail "$regx: $elb has not configured access logs" "$regx"
+            textFail "$regx: $elb has not configured access logs" "$regx" "$elb"
           fi
         done
       fi
@@ -44,9 +44,9 @@ extra717(){
           CHECK_ELBSV2_LOG_ENABLED=$($AWSCLI elbv2 describe-load-balancer-attributes $PROFILE_OPT --region $regx --load-balancer-arn $elbarn --query Attributes[*] --output text|grep "^access_logs.s3.enabled"|cut -f2|grep true)
           ELBV2_NAME=$(echo $elbarn|cut -d\/ -f3)
           if [[ $CHECK_ELBSV2_LOG_ENABLED ]]; then
-            textPass "$regx: $ELBV2_NAME has access logs to S3 configured" "$regx"
+            textPass "$regx: $ELBV2_NAME has access logs to S3 configured" "$regx" "$elb"
           else
-            textFail "$regx: $ELBV2_NAME has not configured access logs" "$regx"
+            textFail "$regx: $ELBV2_NAME has not configured access logs" "$regx" "$elb"
           fi
         done
       fi

--- a/checks/check_extra718
+++ b/checks/check_extra718
@@ -34,9 +34,9 @@ extra718(){
         continue
       fi
       if [[ $(echo "$BUCKET_SERVER_LOG_ENABLED" | grep "^None$") ]]; then
-        textFail "Bucket $bucket has server access logging disabled!"
+        textFail "Bucket $bucket has server access logging disabled!" "us-east-1" "$bucket"
       else
-        textPass "Bucket $bucket has server access logging enabled"
+        textPass "Bucket $bucket has server access logging enabled" "us-east-1" "$bucket"
       fi
     done
   else

--- a/checks/check_extra719
+++ b/checks/check_extra719
@@ -30,9 +30,9 @@ extra719(){
     for hostedzoneid in $LIST_OF_HOSTED_ZONES;do
       HOSTED_ZONE_QUERY_LOG_ENABLED=$($AWSCLI route53 list-query-logging-configs --hosted-zone-id $hostedzoneid $PROFILE_OPT --query QueryLoggingConfigs[*].CloudWatchLogsLogGroupArn --output text|cut -d: -f7)
       if [[ $HOSTED_ZONE_QUERY_LOG_ENABLED ]];then
-        textPass "Route53 public hosted zone Id $hostedzoneid has query logging enabled in Log Group $HOSTED_ZONE_QUERY_LOG_ENABLED"
+        textPass "Route53 public hosted zone Id $hostedzoneid has query logging enabled in Log Group $HOSTED_ZONE_QUERY_LOG_ENABLED" "us-east-1" "$hostedzoneid"
       else
-        textFail "Route53 public hosted zone Id $hostedzoneid has query logging disabled!"
+        textFail "Route53 public hosted zone Id $hostedzoneid has query logging disabled!" "us-east-1" "$hostedzoneid"
       fi
     done
   else

--- a/checks/check_extra72
+++ b/checks/check_extra72
@@ -33,9 +33,9 @@ extra72(){
     for snapshot in $LIST_OF_EBS_SNAPSHOTS; do
       SNAPSHOT_IS_PUBLIC=$($AWSCLI ec2 describe-snapshot-attribute $PROFILE_OPT --region $regx --output text --snapshot-id $snapshot --attribute createVolumePermission --query "CreateVolumePermissions[?Group=='all']")
       if [[ $SNAPSHOT_IS_PUBLIC ]];then
-        textFail "$regx: $snapshot is currently Public!" "$regx"
+        textFail "$regx: $snapshot is currently Public!" "$regx" "$snapshot"
       else
-        textPass "$regx: $snapshot is not Public" "$regx"
+        textPass "$regx: $snapshot is not Public" "$regx" "$snapshot"
       fi
     done
   done

--- a/checks/check_extra720
+++ b/checks/check_extra720
@@ -42,9 +42,9 @@ extra720(){
           for trail in $LIST_OF_TRAILS; do
             FUNCTION_ENABLED_IN_TRAIL=$($AWSCLI cloudtrail get-event-selectors $PROFILE_OPT --trail-name $trail --region $regx --query "EventSelectors[*].DataResources[?Type == \`AWS::Lambda::Function\`].Values" --output text |xargs -n1| grep -E "^arn:${AWS_PARTITION}:lambda.*function:$lambdafunction$|^arn:${AWS_PARTITION}:lambda$")
             if [[ $FUNCTION_ENABLED_IN_TRAIL ]]; then
-              textPass "$regx: Lambda function $lambdafunction enabled in trail $trail" "$regx"
+              textPass "$regx: Lambda function $lambdafunction enabled in trail $trail" "$regx" "$trail"
             else
-              textFail "$regx: Lambda function $lambdafunction NOT enabled in trail $trail" "$regx"
+              textFail "$regx: Lambda function $lambdafunction NOT enabled in trail $trail" "$regx" "$trail"
             fi
           done
           # LIST_OF_MULTIREGION_TRAILS=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region $regx --query "trailList[?IsMultiRegionTrail == \`true\`].Name" --output text)
@@ -62,7 +62,7 @@ extra720(){
           #   textFail "$regx: Lambda function $lambdafunction is not being recorded!" "$regx"
           # fi
         else
-          textFail "$regx: Lambda function $lambdafunction is not being recorded no CloudTrail found!" "$regx"
+          textFail "$regx: Lambda function $lambdafunction is not being recorded no CloudTrail found!" "$regx" "$trail"
         fi
      done
     else

--- a/checks/check_extra721
+++ b/checks/check_extra721
@@ -32,9 +32,9 @@ extra721(){
         REDSHIFT_LOG_ENABLED=$($AWSCLI redshift describe-logging-status $PROFILE_OPT --region $regx --cluster-identifier $redshiftcluster --query LoggingEnabled --output text | grep True)
         if [[ $REDSHIFT_LOG_ENABLED ]];then
           REDSHIFT_LOG_ENABLED_BUCKET=$($AWSCLI redshift describe-logging-status $PROFILE_OPT --region $regx --cluster-identifier $redshiftcluster --query BucketName --output text)
-          textPass "$regx: Redshift cluster $redshiftcluster has audit logging enabled to bucket $REDSHIFT_LOG_ENABLED_BUCKET" "$regx"
+          textPass "$regx: Redshift cluster $redshiftcluster has audit logging enabled to bucket $REDSHIFT_LOG_ENABLED_BUCKET" "$regx" "$redshiftcluster"
         else
-          textFail "$regx: Redshift cluster $redshiftcluster logging disabled!" "$regx"
+          textFail "$regx: Redshift cluster $redshiftcluster logging disabled!" "$regx" "$redshiftcluster"
         fi
       done
     else

--- a/checks/check_extra722
+++ b/checks/check_extra722
@@ -35,13 +35,13 @@ extra722(){
           for stagname in $CHECK_STAGES_NAME;do
             CHECK_STAGE_METHOD_LOGGING=$($AWSCLI apigateway get-stages $PROFILE_OPT --region $regx --rest-api-id $apigwid --query "item[?stageName == \`$stagname\` ].methodSettings" --output text |awk '{ print $6 }' |egrep 'ERROR|INFO')
             if [[ $CHECK_STAGE_METHOD_LOGGING ]];then
-              textPass "$regx: API Gateway $API_GW_NAME ID $apigwid in $stagname has logging enabled as $CHECK_STAGE_METHOD_LOGGING" "$regx"
+              textPass "$regx: API Gateway $API_GW_NAME ID $apigwid in $stagname has logging enabled as $CHECK_STAGE_METHOD_LOGGING" "$regx" "$API_GW_NAME"
             else
-              textFail "$regx: API Gateway $API_GW_NAME ID $apigwid in $stagname has logging disabled" "$regx"
+              textFail "$regx: API Gateway $API_GW_NAME ID $apigwid in $stagname has logging disabled" "$regx" "$API_GW_NAME"
             fi
           done
         else
-           textFail "$regx: No Stage name found for $API_GW_NAME" "$regx"
+           textFail "$regx: No Stage name found for $API_GW_NAME" "$regx" "$API_GW_NAME"
         fi
       done
     else

--- a/checks/check_extra724
+++ b/checks/check_extra724
@@ -34,12 +34,12 @@ extra724(){
         CERT_TYPE=$(aws acm describe-certificate $PROFILE_OPT --region $regx --certificate-arn $cert_arn --query Certificate.Type --output text)
         if [[ $CERT_TYPE == "IMPORTED" ]];then
           # Ignore imported certificate
-          textInfo "$regx: ACM Certificate $CERT_DOMAIN_NAME is imported." "$regx"
+          textInfo "$regx: ACM Certificate $CERT_DOMAIN_NAME is imported." "$regx" 
         else
           if [[ $CT_ENABLED == "ENABLED" ]];then
-            textPass "$regx: ACM Certificate $CERT_DOMAIN_NAME has Certificate Transparency logging enabled!" "$regx"
+            textPass "$regx: ACM Certificate $CERT_DOMAIN_NAME has Certificate Transparency logging enabled!" "$regx" "$CERT_DOMAIN_NAME"
           else
-            textFail "$regx: ACM Certificate $CERT_DOMAIN_NAME has Certificate Transparency logging disabled!" "$regx"
+            textFail "$regx: ACM Certificate $CERT_DOMAIN_NAME has Certificate Transparency logging disabled!" "$regx" "$CERT_DOMAIN_NAME"
           fi
         fi
       done

--- a/checks/check_extra725
+++ b/checks/check_extra725
@@ -53,14 +53,14 @@ extra725(){
 
         if [[ ${#BUCKET_ENABLED_TRAILS[@]} -gt 0 ]]; then
           for trail in "${BUCKET_ENABLED_TRAILS[@]}"; do
-            textPass "$regx: S3 bucket $bucketName has Object-level logging enabled in trail $trail" "$regx"
+            textPass "$regx: S3 bucket $bucketName has Object-level logging enabled in trail $trail" "$regx" "$bucketName"
           done
         else
-          textFail "$regx: S3 bucket $bucketName has Object-level logging disabled" "$regx"
+          textFail "$regx: S3 bucket $bucketName has Object-level logging disabled" "$regx" "$bucketName"
         fi
 
       else
-        textFail "$regx: S3 bucket $bucketName is not being recorded no CloudTrail found!" "$regx"
+        textFail "$regx: S3 bucket $bucketName is not being recorded no CloudTrail found!" "$regx" "$bucketName"
       fi
     done
   else

--- a/checks/check_extra726
+++ b/checks/check_extra726
@@ -38,19 +38,19 @@ extra726(){
     # Possible results - https://docs.aws.amazon.com/cli/latest/reference/support/describe-trusted-advisor-check-result.html
     case "$QUERY_TA_CHECK_RESULT" in
       "ok")
-        textPass "Trusted Advisor check $TA_CHECKS_NAME is in ok state $QUERY_TA_CHECK_RESULT"
+        textPass "Trusted Advisor check $TA_CHECKS_NAME is in ok state $QUERY_TA_CHECK_RESULT" "us-east-1" "$TA_CHECKS_NAME"
         ;;
       "error")
-        textFail "Trusted Advisor check $TA_CHECKS_NAME is in error state $QUERY_TA_CHECK_RESULT"
+        textFail "Trusted Advisor check $TA_CHECKS_NAME is in error state $QUERY_TA_CHECK_RESULT" "us-east-1" "$TA_CHECKS_NAME"
         ;;
       "warning")
-        textInfo "Trusted Advisor check $TA_CHECKS_NAME is in warning state $QUERY_TA_CHECK_RESULT"
+        textInfo "Trusted Advisor check $TA_CHECKS_NAME is in warning state $QUERY_TA_CHECK_RESULT" "us-east-1" "$TA_CHECKS_NAME"
         ;;
       "not_available")
-        textInfo "Trusted Advisor check $TA_CHECKS_NAME is in not_available state $QUERY_TA_CHECK_RESULT"
+        textInfo "Trusted Advisor check $TA_CHECKS_NAME is in not_available state $QUERY_TA_CHECK_RESULT" "us-east-1" "$TA_CHECKS_NAME"
         ;;
       "*")
-        textFail "Trusted Advisor check $TA_CHECKS_NAME is in unknown state $QUERY_TA_CHECK_RESULT"
+        textFail "Trusted Advisor check $TA_CHECKS_NAME is in unknown state $QUERY_TA_CHECK_RESULT" "us-east-1" "$TA_CHECKS_NAME"
         ;;
     esac
   done

--- a/checks/check_extra727
+++ b/checks/check_extra727
@@ -39,15 +39,15 @@ extra727(){
             if [[ $SQS_POLICY_ALLOW_ALL_WITHOUT_CONDITION ]]; then
               SQS_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS=$(echo $SQS_POLICY_ALLOW_ALL_WITHOUT_CONDITION \
                 | jq '"[Principal: " + (.Principal|tostring) + " Action: " + (.Action|tostring) + "]"' )
-              textFail "$regx: SQS $queue queue policy with public access: $SQS_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS" "$regx"
+              textFail "$regx: SQS $queue queue policy with public access: $SQS_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS" "$regx" "$queue"
             else
               textInfo "$regx: SQS $queue queue policy with public access but has a Condition" "$regx"
             fi
           else
-            textPass "$regx: SQS $queue queue without public access" "$regx"
+            textPass "$regx: SQS $queue queue without public access" "$regx" "$queue"
           fi
         else
-          textPass "$regx: SQS $queue queue without policy" "$regx"
+          textPass "$regx: SQS $queue queue without policy" "$regx" "$queue"
         fi
       done
     else

--- a/checks/check_extra728
+++ b/checks/check_extra728
@@ -33,9 +33,9 @@ extra728(){
         # check if the policy has KmsMasterKeyId therefore SSE enabled
         SSE_ENABLED_QUEUE=$($AWSCLI sqs get-queue-attributes --queue-url $queue $PROFILE_OPT --region $regx --attribute-names All --query Attributes.KmsMasterKeyId --output text|grep -v ^None)
         if [[ $SSE_ENABLED_QUEUE ]]; then
-          textPass "$regx: SQS queue $queue is using Server Side Encryption" "$regx"
+          textPass "$regx: SQS queue $queue is using Server Side Encryption" "$regx" "$queue"
         else
-          textFail "$regx: SQS queue $queue is not using Server Side Encryption" "$regx"
+          textFail "$regx: SQS queue $queue is not using Server Side Encryption" "$regx" "$queue"
         fi
       done
     else

--- a/checks/check_extra729
+++ b/checks/check_extra729
@@ -32,13 +32,13 @@ extra729(){
     LIST_OF_EBS_NON_ENC_VOLUMES=$($AWSCLI ec2 describe-volumes $PROFILE_OPT --region $regx --query 'Volumes[?Encrypted==`false`].VolumeId' --output text)
     if [[ $LIST_OF_EBS_NON_ENC_VOLUMES ]];then
       for volume in $LIST_OF_EBS_NON_ENC_VOLUMES; do
-        textFail "$regx: $volume is not encrypted!" "$regx"
+        textFail "$regx: $volume is not encrypted!" "$regx" "$volume"
       done
     fi
     LIST_OF_EBS_ENC_VOLUMES=$($AWSCLI ec2 describe-volumes $PROFILE_OPT --region $regx --query 'Volumes[?Encrypted==`true`].VolumeId' --output text)
     if [[ $LIST_OF_EBS_ENC_VOLUMES ]];then
       for volume in $LIST_OF_EBS_ENC_VOLUMES; do
-        textPass "$regx: $volume is encrypted" "$regx"
+        textPass "$regx: $volume is encrypted" "$regx" "$volume"
       done
     fi
   done

--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -127,13 +127,13 @@ extra73(){
 
     ALLUSERS_ACL=$(echo "$BUCKET_ACL" | jq '.Grants[]|select(.Grantee.URI != null)|select(.Grantee.URI | endswith("/AllUsers"))')
     if [[ $ALLUSERS_ACL != "" ]]; then
-      textFail "$BUCKET_LOCATION: $bucket bucket is Public!" "$BUCKET_LOCATION"
+      textFail "$BUCKET_LOCATION: $bucket bucket is Public!" "$BUCKET_LOCATION" "$bucket"
       continue
     fi
 
     AUTHENTICATEDUSERS_ACL=$(echo "$BUCKET_ACL" | jq '.Grants[]|select(.Grantee.URI != null)|select(.Grantee.URI | endswith("/AuthenticatedUsers"))')
     if [[ $AUTHENTICATEDUSERS_ACL != "" ]]; then
-      textFail "$BUCKET_LOCATION: $bucket bucket is Public!" "$BUCKET_LOCATION"
+      textFail "$BUCKET_LOCATION: $bucket bucket is Public!" "$BUCKET_LOCATION" "$bucket"
       continue
     fi
 
@@ -150,11 +150,11 @@ extra73(){
     fi
 
     if [[ $BUCKET_POLICY_STATUS != "" && $BUCKET_POLICY_STATUS != "False" ]]; then
-      textFail "$BUCKET_LOCATION: $bucket bucket is Public!" "$BUCKET_LOCATION"
+      textFail "$BUCKET_LOCATION: $bucket bucket is Public!" "$BUCKET_LOCATION" "$bucket"
       continue
     fi
 
-    textPass "$BUCKET_LOCATION: $bucket bucket is not Public" "$BUCKET_LOCATION"
+    textPass "$BUCKET_LOCATION: $bucket bucket is not Public" "$BUCKET_LOCATION" "$bucket"
 
   done
 }

--- a/checks/check_extra730
+++ b/checks/check_extra730
@@ -37,9 +37,9 @@ extra730(){
           EXPIRES_DATE=$(timestamp_to_date $NOTAFTER)
           COUNTER_DAYS=$(how_many_days_from_today $EXPIRES_DATE)
           if [[ $COUNTER_DAYS -le $DAYS_TO_EXPIRE_THRESHOLD ]]; then
-            textFail "$regx: Certificate for $FQDN is about to expire in $COUNTER_DAYS days!" "$regx"
+            textFail "$regx: Certificate for $FQDN is about to expire in $COUNTER_DAYS days!" "$regx" "$FQDN"
           else
-            textPass "$regx: Certificate for $FQDN expires in $COUNTER_DAYS days" "$regx"
+            textPass "$regx: Certificate for $FQDN expires in $COUNTER_DAYS days" "$regx" "$FQDN"
           fi
         done
       done

--- a/checks/check_extra731
+++ b/checks/check_extra731
@@ -39,9 +39,9 @@ extra731(){
           if [[ $SNS_POLICY_ALLOW_ALL_WITHOUT_CONDITION ]]; then
             SNS_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS=$(echo $SNS_POLICY_ALLOW_ALL_WITHOUT_CONDITION \
               | jq '"[Principal: " + (.Principal|tostring) + " Action: " + (.Action|tostring) + "]"' )
-            textFail "$regx: SNS topic $SHORT_TOPIC's policy with public access: $SNS_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS" "$regx"
+            textFail "$regx: SNS topic $SHORT_TOPIC's policy with public access: $SNS_POLICY_ALLOW_ALL_WITHOUT_CONDITION_DETAILS" "$regx" "$SHORT_TOPIC"
           else
-            textPass "$regx: SNS topic $SHORT_TOPIC's policy with public access but has a Condition" "$regx"
+            textPass "$regx: SNS topic $SHORT_TOPIC's policy with public access but has a Condition" "$regx" "$SHORT_TOPIC"
           fi
         else
           textPass "$regx: SNS topic without public access" "$regx"

--- a/checks/check_extra732
+++ b/checks/check_extra732
@@ -30,9 +30,9 @@ extra732(){
     for dist in $LIST_DISTRIBUTIONS; do
       GEO_ENABLED=$($AWSCLI cloudfront get-distribution-config $PROFILE_OPT --id $dist --query DistributionConfig.Restrictions.GeoRestriction.RestrictionType --output text)
       if [[ $GEO_ENABLED == "none" ]]; then
-        textFail "CloudFront distribution $dist has not Geo restrictions"
+        textFail "CloudFront distribution $dist has not Geo restrictions" "us-east-1" "$dist"
       else
-        textPass "CloudFront distribution $dist has Geo restrictions enabled"
+        textPass "CloudFront distribution $dist has Geo restrictions enabled" "us-east-1" "$dist"
       fi
     done
   else

--- a/checks/check_extra733
+++ b/checks/check_extra733
@@ -32,6 +32,6 @@ extra733(){
       textInfo "SAML Provider $PROVIDER_NAME has been found"
     done
   else
-    textInfo "No SAML Provider found. Add one and use STS"
+    textFail "No SAML Provider found. Add one and use STS"
   fi
 }

--- a/checks/check_extra734
+++ b/checks/check_extra734
@@ -52,7 +52,7 @@ extra734(){
 
       if [[ $RESULT == "AES256" || $RESULT == "aws:kms" ]];
       then
-        textPass "Bucket $bucket is enabled for default encryption with $RESULT"
+        textPass "Bucket $bucket is enabled for default encryption with $RESULT" "us-east-1" "$bucket"
         continue
       fi
 
@@ -66,7 +66,7 @@ extra734(){
         continue
       fi
       if [[ $(grep NoSuchBucketPolicy $TEMP_SSE_POLICY_FILE) ]]; then
-        textFail "No bucket policy for $bucket"
+        textFail "No bucket policy for $bucket" "us-east-1" "$bucket" "us-east-1" "$bucket"
         rm -f $TEMP_SSE_POLICY_FILE
         continue
       fi
@@ -74,7 +74,7 @@ extra734(){
       # check if the S3 policy forces SSE s3:x-amz-server-side-encryption:true
       CHECK_BUCKET_SSE_POLICY_PRESENT=$(cat $TEMP_SSE_POLICY_FILE | jq --arg arn "arn:${AWS_PARTITION}:s3:::${bucket}/*" '.Statement[]|select(.Effect=="Deny" and ((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*") and .Action=="s3:PutObject" and .Resource==$arn and .Condition.StringEquals."s3:x-amz-server-side-encryption" != null)')
       if [[ $CHECK_BUCKET_SSE_POLICY_PRESENT == "" ]]; then
-        textFail "Bucket $bucket does not enforce encryption!"
+        textFail "Bucket $bucket does not enforce encryption!" "us-east-1" "$bucket"
         rm -f $TEMP_SSE_POLICY_FILE
         continue
       fi

--- a/checks/check_extra736
+++ b/checks/check_extra736
@@ -32,9 +32,9 @@ extra736(){
       for key in $LIST_OF_CUSTOMER_KMS_KEYS; do
         CHECK_POLICY=$($AWSCLI kms get-key-policy --key-id $key --policy-name default $PROFILE_OPT --region $regx  --output text|awk '/Principal/{n=NR+1} n>=NR' |grep AWS\"\ :\ \"\\*\"$)
         if [[ $CHECK_POLICY ]]; then
-          textFail "$regx: KMS key $key may be publicly accessible!" "$regx"
+          textFail "$regx: KMS key $key may be publicly accessible!" "$regx" "$key"
         else
-          textPass "$regx: KMS key $key is not exposed to Public" "$regx"
+          textPass "$regx: KMS key $key is not exposed to Public" "$regx" "$key"
         fi
       done
     else

--- a/checks/check_extra737
+++ b/checks/check_extra737
@@ -35,9 +35,9 @@ extra737(){
         if [[ $CHECK_STATUS == "PendingDeletion" ]]; then
           textInfo "$regx: KMS key $key is pending deletion and cannot be rotated" "$regx"
         elif [[ $CHECK_ROTATION == "False" ]]; then
-          textFail "$regx: KMS key $key has rotation disabled!" "$regx"
+          textFail "$regx: KMS key $key has rotation disabled!" "$regx" "$key"
         else
-          textPass "$regx: KMS key $key has rotation enabled" "$regx"
+          textPass "$regx: KMS key $key has rotation enabled" "$regx" "$key"
         fi
       done
     else

--- a/checks/check_extra738
+++ b/checks/check_extra738
@@ -30,11 +30,11 @@ extra738(){
       for dist in $LIST_OF_DISTRIBUTIONS; do
         CHECK_HTTPS_STATUS=$($AWSCLI cloudfront get-distribution --id $dist --query Distribution.DistributionConfig.DefaultCacheBehavior.ViewerProtocolPolicy $PROFILE_OPT --output text)
         if [[ $CHECK_HTTPS_STATUS == "allow-all" ]]; then
-          textFail "CloudFront distribution $dist viewers can use HTTP or HTTPS!" "$regx"
+          textFail "CloudFront distribution $dist viewers can use HTTP or HTTPS!" "$regx" "$dist"
         elif [[ $CHECK_HTTPS_STATUS == "redirect-to-https" ]]; then
-          textPass "CloudFront distribution $dist has redirect to HTTPS" "$regx"
+          textPass "CloudFront distribution $dist has redirect to HTTPS" "$regx" "$dist"
         else
-          textPass "CloudFront distribution $dist has HTTPS only" "$regx"
+          textPass "CloudFront distribution $dist has HTTPS only" "$regx" "$dist"
         fi
       done
     else

--- a/checks/check_extra74
+++ b/checks/check_extra74
@@ -34,7 +34,7 @@ extra74(){
     for SG_ID in $LIST_OF_SECURITYGROUPS; do
       SG_NO_INGRESS_FILTER=$($AWSCLI ec2 describe-network-interfaces $PROFILE_OPT --region $regx --filters "Name=group-id,Values=$SG_ID" --query "length(NetworkInterfaces)" --output text)
       if [[ $SG_NO_INGRESS_FILTER -ne 0 ]];then
-        textFail "$regx: $SG_ID has no ingress filtering and it is being used!" "$regx"
+        textFail "$regx: $SG_ID has no ingress filtering and it is being used!" "$regx" "$SG_ID"
       else
         textInfo "$regx: $SG_ID has no ingress filtering but it is not being used" "$regx"
       fi

--- a/checks/check_extra741
+++ b/checks/check_extra741
@@ -51,12 +51,12 @@ extra741(){
             # delete file if nothing interesting is there
             rm -f "$EC2_USERDATA_FILE"
           else
-            textFail "$regx: Potential secret found in $instance User Data" "$regx"
+            textFail "$regx: Potential secret found in $instance User Data" "$regx" "$regx" "$instance"
             # delete file to not leave trace, user must look at the instance User Data
             rm -f "$EC2_USERDATA_FILE"
           fi
         else
-          textPass "$regx: No secrets found in $instance User Data or it is empty" "$regx"
+          textPass "$regx: No secrets found in $instance User Data or it is empty" "$regx" "$instance"
         fi
       done
     else

--- a/checks/check_extra742
+++ b/checks/check_extra742
@@ -45,11 +45,11 @@ extra742(){
           # New implementation using https://github.com/Yelp/detect-secrets
           FINDINGS=$(secretsDetector file $CFN_OUTPUTS_FILE)
             if [[ $FINDINGS -eq 0 ]]; then
-              textPass "$regx: No secrets found in stack $stack Outputs" "$regx"
+              textPass "$regx: No secrets found in stack $stack Outputs" "$regx" "$stack"
               # delete file if nothing interesting is there
               rm -f $CFN_OUTPUTS_FILE
             else
-              textFail "$regx: Potential secret found in stack $stack Outputs" "$regx"
+              textFail "$regx: Potential secret found in stack $stack Outputs" "$regx" "$stack"
               # delete file to not leave trace, user must look at the CFN Stack
               rm -f $CFN_OUTPUTS_FILE
             fi

--- a/checks/check_extra743
+++ b/checks/check_extra743
@@ -34,9 +34,9 @@ extra743(){
           for stage in $LIST_OF_STAGES; do
             CHECK_CERTIFICATE=$($AWSCLI $PROFILE_OPT --region $regx apigateway get-stages --rest-api-id $api --query "item[?stageName==\`$stage\`].clientCertificateId" --output text)
             if [[ $CHECK_CERTIFICATE ]]; then
-                textPass "$regx: API Gateway $API_GW_NAME ID $api in $stage has client certificate enabled" "$regx"
+                textPass "$regx: API Gateway $API_GW_NAME ID $api in $stage has client certificate enabled" "$regx" "$API_GW_NAME"
               else
-                textFail "$regx: API Gateway $API_GW_NAME ID $api in $stage has not client certificate enabled" "$regx"
+                textFail "$regx: API Gateway $API_GW_NAME ID $api in $stage has not client certificate enabled" "$regx" "$API_GW_NAME"
             fi
           done
         fi

--- a/checks/check_extra744
+++ b/checks/check_extra744
@@ -35,9 +35,9 @@ extra744(){
           for stage in $LIST_OF_STAGES; do
             CHECK_WAFACL=$($AWSCLI $PROFILE_OPT --region $regx apigateway get-stages --rest-api-id $api --query "item[?stageName==\`$stage\`].webAclArn" --output text)
             if [[ $CHECK_WAFACL ]]; then
-                textPass "$regx: API Gateway $API_GW_NAME ID $api in $stage has $CHECK_WAFACL WAF ACL attached" "$regx"
+                textPass "$regx: API Gateway $API_GW_NAME ID $api in $stage has $CHECK_WAFACL WAF ACL attached" "$regx" "$API_GW_NAME"
               else
-                textFail "$regx: API Gateway $API_GW_NAME ID $api in $stage has not WAF ACL attached" "$regx"
+                textFail "$regx: API Gateway $API_GW_NAME ID $api in $stage has not WAF ACL attached" "$regx" "$API_GW_NAME"
             fi
           done
         fi

--- a/checks/check_extra745
+++ b/checks/check_extra745
@@ -33,13 +33,13 @@ extra745(){
         if [[ $ENDPOINT_CONFIG_TYPE ]]; then
           case $ENDPOINT_CONFIG_TYPE in
             PRIVATE )
-              textPass "$regx: API Gateway $API_GW_NAME ID $api is set as $ENDPOINT_CONFIG_TYPE" "$regx"
+              textPass "$regx: API Gateway $API_GW_NAME ID $api is set as $ENDPOINT_CONFIG_TYPE" "$regx" "$API_GW_NAME"
             ;;
             REGIONAL )
-              textFail "$regx: API Gateway $API_GW_NAME ID $api is internet accesible as $ENDPOINT_CONFIG_TYPE" "$regx"
+              textFail "$regx: API Gateway $API_GW_NAME ID $api is internet accesible as $ENDPOINT_CONFIG_TYPE" "$regx" "$API_GW_NAME"
             ;;
             EDGE )
-              textFail "$regx: API Gateway $API_GW_NAME ID $api is internet accesible as $ENDPOINT_CONFIG_TYPE" "$regx"
+              textFail "$regx: API Gateway $API_GW_NAME ID $api is internet accesible as $ENDPOINT_CONFIG_TYPE" "$regx" "$API_GW_NAME"
           esac
         fi
       done

--- a/checks/check_extra746
+++ b/checks/check_extra746
@@ -31,9 +31,9 @@ extra746(){
         API_GW_NAME=$($AWSCLI apigateway get-rest-apis $PROFILE_OPT --region $regx --query "items[?id==\`$api\`].name" --output text)
         AUTHORIZER_CONFIGURED=$($AWSCLI $PROFILE_OPT --region $regx apigateway get-authorizers --rest-api-id $api --query items[*].type --output text)
         if [[ $AUTHORIZER_CONFIGURED ]]; then
-           textPass "$regx: API Gateway $API_GW_NAME ID $api has authorizer configured" "$regx"
+           textPass "$regx: API Gateway $API_GW_NAME ID $api has authorizer configured" "$regx" "$API_GW_NAME"
         else
-           textFail "$regx: API Gateway $API_GW_NAME ID $api has not authorizer configured" "$regx"
+           textFail "$regx: API Gateway $API_GW_NAME ID $api has not authorizer configured" "$regx" "$API_GW_NAME"
         fi
       done
     else

--- a/checks/check_extra748
+++ b/checks/check_extra748
@@ -28,7 +28,7 @@ extra748(){
     SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort==`0` && ToPort==`65535`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
     if [[ $SG_LIST ]];then
       for SG in $SG_LIST;do
-        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0" "$regx"
+        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0" "$regx" "$SG"
       done
     else
       textPass "$regx: No Security Groups found with any port open to 0.0.0.0/0" "$regx"

--- a/checks/check_extra749
+++ b/checks/check_extra749
@@ -29,7 +29,7 @@ extra749(){
     SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || ((FromPort<=`1521` && ToPort>=`1521`)||(FromPort<=`2483` && ToPort>=`2483`))) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
     if [[ $SG_LIST ]];then
       for SG in $SG_LIST;do
-        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Oracle ports" "$regx"
+        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Oracle ports" "$regx" "$SG"
       done
     else
       textPass "$regx: No Security Groups found with any port open to 0.0.0.0/0 for Oracle ports" "$regx"

--- a/checks/check_extra75
+++ b/checks/check_extra75
@@ -44,12 +44,12 @@ extra75(){
         GROUP_NAME=$(echo $SECURITYGROUPS | jq -r --arg id $SG_ID '.[$id]')
         if [[ $GROUP_NAME != "default" ]];
         then
-          textFail "$regx: $SG_ID is not being used!" "$regx"
+          textFail "$regx: $SG_ID is not being used!" "$regx" "$SG_ID"
         else
           textInfo "$regx: $SG_ID is not being used - default security group" "$regx"
         fi
       else
-        textPass "$regx: $SG_ID is being used" "$regx"
+        textPass "$regx: $SG_ID is being used" "$regx" "$SG_ID"
       fi
     done
   done

--- a/checks/check_extra750
+++ b/checks/check_extra750
@@ -29,7 +29,7 @@ extra750(){
     SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`3306` && ToPort>=`3306`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
     if [[ $SG_LIST ]];then
       for SG in $SG_LIST;do
-        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for MySQL port" "$regx"
+        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for MySQL port" "$regx" "$SG"
       done
     else
       textPass "$regx: No Security Groups found open to 0.0.0.0/0 for MySQL port" "$regx"

--- a/checks/check_extra751
+++ b/checks/check_extra751
@@ -29,7 +29,7 @@ extra751(){
     SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`5432` && ToPort>=`5432`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
     if [[ $SG_LIST ]];then
       for SG in $SG_LIST;do
-        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Postgres port" "$regx"
+        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Postgres port" "$regx" "$SG"
       done
     else
       textPass "$regx: No Security Groups found open to 0.0.0.0/0 for Postgres port" "$regx"

--- a/checks/check_extra752
+++ b/checks/check_extra752
@@ -29,7 +29,7 @@ extra752(){
     SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`6379` && ToPort>=`6379`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
     if [[ $SG_LIST ]];then
       for SG in $SG_LIST;do
-        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Redis port" "$regx"
+        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Redis port" "$regx" "$SG"
       done
     else
       textPass "$regx: No Security Groups found open to 0.0.0.0/0 for Redis port" "$regx"

--- a/checks/check_extra753
+++ b/checks/check_extra753
@@ -29,7 +29,7 @@ extra753(){
     SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || ((FromPort<=`27017` && ToPort>=`27017`) || (FromPort<=`27018` && ToPort>=`27018`))) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
     if [[ $SG_LIST ]];then
       for SG in $SG_LIST;do
-        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for MongoDB ports" "$regx"
+        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for MongoDB ports" "$regx" "$SG"
       done
     else
       textPass "$regx: No Security Groups found open to 0.0.0.0/0 for MongoDB ports" "$regx"

--- a/checks/check_extra754
+++ b/checks/check_extra754
@@ -29,7 +29,7 @@ extra754(){
     SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || ((FromPort<=`7199` && ToPort>=`7199`) || (FromPort<=`9160` && ToPort>=`9160`)|| (FromPort<=`8888` && ToPort>=`8888`))) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
     if [[ $SG_LIST ]];then
       for SG in $SG_LIST;do
-        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Cassandra ports" "$regx"
+        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Cassandra ports" "$regx" "$SG"
       done
     else
       textPass "$regx: No Security Groups found open to 0.0.0.0/0 for Cassandra ports" "$regx"

--- a/checks/check_extra755
+++ b/checks/check_extra755
@@ -29,7 +29,7 @@ extra755(){
     SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`11211` && ToPort>=`11211`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text)
     if [[ $SG_LIST ]];then
       for SG in $SG_LIST;do
-        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Memcached port" "$regx"
+        textFail "$regx: Found Security Group: $SG open to 0.0.0.0/0 for Memcached port" "$regx" "$SG"
       done
     else
       textPass "$regx: No Security Groups found open to 0.0.0.0/0 for Memcached port" "$regx"

--- a/checks/check_extra756
+++ b/checks/check_extra756
@@ -30,9 +30,9 @@ extra756(){
       for cluster in $LIST_OF_RS_CLUSTERS; do
         IS_PUBLICLY_ACCESSIBLE=$($AWSCLI $PROFILE_OPT redshift describe-clusters --region $regx --cluster-identifier $cluster --query Clusters[*].PubliclyAccessible --output text|grep True)
         if [[ $IS_PUBLICLY_ACCESSIBLE ]]; then
-          textFail "$regx: Redshift cluster $cluster is publicly accessible" "$regx"
+          textFail "$regx: Redshift cluster $cluster is publicly accessible" "$regx" "$cluster"
         else
-          textPass "$regx: Redshift cluster $cluster is not publicly accessible" "$regx"
+          textPass "$regx: Redshift cluster $cluster is not publicly accessible" "$regx" "$cluster"
         fi
       done
     else

--- a/checks/check_extra757
+++ b/checks/check_extra757
@@ -35,7 +35,7 @@ extra757(){
         do
           EC2_ID=$(echo "$ec2_instace" | awk '{print $1}')
           LAUNCH_DATE=$(echo "$ec2_instace" | awk '{print $2}')
-          textFail "$regx: EC2 Instance $EC2_ID running before than $OLDAGE" "$regx"
+          textFail "$regx: EC2 Instance $EC2_ID running before than $OLDAGE" "$regx" "$EC2_ID"
         done <<< "$INSTACES_OLD_THAN_AGE"
       else
         textPass "$regx: All Instances newer than 6 months" "$regx"

--- a/checks/check_extra758
+++ b/checks/check_extra758
@@ -35,7 +35,7 @@ extra758(){
         do
           EC2_ID=$(echo "$ec2_instace" | awk '{print $1}')
           LAUNCH_DATE=$(echo "$ec2_instace" | awk '{print $2}')
-          textFail "$regx: EC2 Instance $EC2_ID running before than $OLDAGE" "$regx"
+          textFail "$regx: EC2 Instance $EC2_ID running before than $OLDAGE" "$regx" "$EC2_ID"
         done <<< "$INSTACES_OLD_THAN_AGE"
       else
         textPass "$regx: All Instances newer than 12 months" "$regx"

--- a/checks/check_extra759
+++ b/checks/check_extra759
@@ -41,11 +41,11 @@ extra759(){
         # Implementation using https://github.com/Yelp/detect-secrets
         FINDINGS=$(secretsDetector file $LAMBDA_FUNCTION_VARIABLES_FILE)
           if [[ $FINDINGS -eq 0 ]]; then
-            textPass "$regx: No secrets found in Lambda function $lambdafunction variables" "$regx"
+            textPass "$regx: No secrets found in Lambda function $lambdafunction variables" "$regx" "$lambdafunction"
             # delete file if nothing interesting is there
             rm -f $LAMBDA_FUNCTION_VARIABLES_FILE
           else
-            textFail "$regx: Potential secret found in Lambda function $lambdafunction variables" "$regx"
+            textFail "$regx: Potential secret found in Lambda function $lambdafunction variables" "$regx" "$lambdafunction"
             # delete file to not leave trace, user must look at the function
             rm -f $LAMBDA_FUNCTION_VARIABLES_FILE
           fi

--- a/checks/check_extra76
+++ b/checks/check_extra76
@@ -31,10 +31,10 @@ extra76(){
     LIST_OF_PUBLIC_AMIS=$($AWSCLI ec2 describe-images --owners self $PROFILE_OPT --region $regx --filters "Name=is-public,Values=true" --query 'Images[*].{ID:ImageId}' --output text)
     if [[ $LIST_OF_PUBLIC_AMIS ]];then
       for ami in $LIST_OF_PUBLIC_AMIS; do
-        textFail "$regx: $ami is currently Public!" "$regx"
+        textFail "$regx: $ami is currently Public!" "$regx" "$ami"
       done
     else
-      textPass "$regx: No Public AMIs found" "$regx"
+      textPass "$regx: No Public AMIs found" "$regx" "$ami"
     fi
   done
 }

--- a/checks/check_extra760
+++ b/checks/check_extra760
@@ -45,11 +45,11 @@ extra760(){
         unzip -qq $LAMBDA_FUNCTION_FOLDER/$LAMBDA_FUNCTION_FILE -d $LAMBDA_FUNCTION_FOLDER
         FINDINGS=$(secretsDetector folder $LAMBDA_FUNCTION_FOLDER)
           if [[ $FINDINGS -eq 0 ]]; then
-            textPass "$regx: No secrets found in Lambda function $lambdafunction code" "$regx"
+            textPass "$regx: No secrets found in Lambda function $lambdafunction code" "$regx" "$lambdafunction"
             # delete files if nothing interesting is there
             rm -fr $LAMBDA_FUNCTION_FOLDER
           else
-            textFail "$regx: Potential secret found in Lambda function $lambdafunction code" "$regx"
+            textFail "$regx: Potential secret found in Lambda function $lambdafunction code" "$regx" "$lambdafunction"
             # delete files to not leave trace, user must look at the function
             rm -fr $LAMBDA_FUNCTION_FOLDER
           fi

--- a/checks/check_extra762
+++ b/checks/check_extra762
@@ -36,9 +36,9 @@ extra762(){
         fname=$(echo "$lambdafunction" | cut -d'%' -f1)
         runtime=$(echo "$lambdafunction" | cut -d'%' -f2)
         if echo "$lambdafunction" | grep -Eq $OBSOLETE  ; then
-          textFail "$regx: Obsolete runtime: ${runtime} used by: ${fname}" "$regx"
+          textFail "$regx: Obsolete runtime: ${runtime} used by: ${fname}" "$regx" "${fname}"
         else
-          textPass "$regx: Supported runtime: ${runtime} used by: ${fname}" "$regx"
+          textPass "$regx: Supported runtime: ${runtime} used by: ${fname}" "$regx" "${fname}"
         fi
       done
     else

--- a/checks/check_extra763
+++ b/checks/check_extra763
@@ -34,9 +34,9 @@ extra763(){
         continue
       fi
       if [[ $(echo "$BUCKET_VERSIONING_ENABLED" | grep "^Enabled$") ]]; then
-        textPass "Bucket $bucket has versioning enabled"
+        textPass "Bucket $bucket has versioning enabled" "us-east-1" "$bucket"
       else
-        textFail "Bucket $bucket has versioning disabled!"
+        textFail "Bucket $bucket has versioning disabled!" "us-east-1" "$bucket"
       fi
     done
   else

--- a/checks/check_extra764
+++ b/checks/check_extra764
@@ -49,7 +49,7 @@ extra764(){
         continue
       fi
       if [[ $(grep NoSuchBucketPolicy $TEMP_STP_POLICY_FILE) ]]; then
-        textFail "No bucket policy for $bucket"
+        textFail "No bucket policy for $bucket" "us-east-1" "$bucket"
         rm -f $TEMP_STP_POLICY_FILE
         continue
       fi
@@ -61,9 +61,9 @@ extra764(){
         CHECK_BUCKET_STP_POLICY_PRESENT=$(cat $TEMP_STP_POLICY_FILE | jq --arg arn "arn:${AWS_PARTITION}:s3:::${bucket}" \
           '.Statement[]|select((((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and .Effect=="Deny" and (.Action=="s3:*" or .Action=="*") and (.Resource|type == "array") and (.Resource|map({(.):0})[]|has($arn)) and (.Resource|map({(.):0})[]|has($arn+"/*")) and .Condition.Bool."aws:SecureTransport" == "false")')
         if [[ $CHECK_BUCKET_STP_POLICY_PRESENT ]]; then
-          textPass "Bucket $bucket has S3 bucket policy to deny requests over insecure transport"
+          textPass "Bucket $bucket has S3 bucket policy to deny requests over insecure transport" "us-east-1" "$bucket"
         else
-          textFail "Bucket $bucket allows requests over insecure transport"
+          textFail "Bucket $bucket allows requests over insecure transport" "us-east-1" "$bucket"
         fi
       else
           textInfo "Unknown Error occurred: $policy_str"

--- a/checks/check_extra765
+++ b/checks/check_extra765
@@ -44,16 +44,16 @@ extra765(){
         SCAN_ENABLED=$($AWSCLI ecr describe-repositories $PROFILE_OPT --region $region --query "repositories[?repositoryName==\`$repo\`].[imageScanningConfiguration.scanOnPush]" --output text 2>&1)
         case "$SCAN_ENABLED" in
           "True")
-            textPass "$region: ECR repository $repo has scan on push enabled" "$region"
+            textPass "$region: ECR repository $repo has scan on push enabled" "$region" "$repo"
             ;;
           "False")
-            textFail "$region: ECR repository $repo has scan on push disabled!" "$region"
+            textFail "$region: ECR repository $repo has scan on push disabled!" "$region" "$repo"
             ;;
           "None")
-            textInfo "$region: ECR repository $repo has no scanOnPush status, newer awscli needed" "$region"
+            textInfo "$region: ECR repository $repo has no scanOnPush status, newer awscli needed" "$region" "$repo"
             ;;
           "*")
-            textInfo "$region: ECR repository $repo has unknown scanOnPush status \"$SCAN_ENABLED\"" "$region"
+            textInfo "$region: ECR repository $repo has unknown scanOnPush status \"$SCAN_ENABLED\"" "$region" "$repo"
             ;;
         esac
       done

--- a/checks/check_extra767
+++ b/checks/check_extra767
@@ -29,9 +29,9 @@ extra767(){
       for dist in $LIST_OF_DISTRIBUTIONS; do
         CHECK_FLE=$($AWSCLI cloudfront get-distribution --id $dist --query Distribution.DistributionConfig.DefaultCacheBehavior.FieldLevelEncryptionId $PROFILE_OPT --output text)
         if [[ $CHECK_FLE ]]; then
-          textPass "CloudFront distribution $dist has Field Level Encryption enabled" "$regx"
+          textPass "CloudFront distribution $dist has Field Level Encryption enabled" "$regx" "$dist"
         else
-          textFail "CloudFront distribution $dist has Field Level Encryption disabled!" "$regx"
+          textFail "CloudFront distribution $dist has Field Level Encryption disabled!" "$regx" "$dist"
         fi
       done
     else

--- a/checks/check_extra768
+++ b/checks/check_extra768
@@ -46,11 +46,11 @@ extra768(){
           # Implementation using https://github.com/Yelp/detect-secrets
           FINDINGS=$(secretsDetector file $TASK_DEFINITION_ENV_VARIABLES_FILE)
           if [[ $FINDINGS -eq 0 ]]; then
-            textPass "$regx: No secrets found in ECS task definition $TASK_DEFINITION variables" "$regx"
+            textPass "$regx: No secrets found in ECS task definition $TASK_DEFINITION variables" "$regx" "$TASK_DEFINITION"
             # delete file if nothing interesting is there
             rm -f $TASK_DEFINITION_ENV_VARIABLES_FILE
           else
-            textFail "$regx: Potential secret found in ECS task definition $TASK_DEFINITION variables" "$regx"
+            textFail "$regx: Potential secret found in ECS task definition $TASK_DEFINITION variables" "$regx" "$TASK_DEFINITION"
           fi
         else
           textInfo "$regx: ECS task definition $TASK_DEFINITION has no variables" "$regx"

--- a/checks/check_extra769
+++ b/checks/check_extra769
@@ -38,9 +38,9 @@ extra769(){
       for accessAnalyzerArn in $LIST_OF_ACCESS_ANALYZERS;do
         ANALYZER_ACTIVE_FINDINGS_COUNT=$($AWSCLI accessanalyzer list-findings $PROFILE_OPT --region $regx --analyzer-arn $accessAnalyzerArn --query 'findings[?status == `ACTIVE`].[id,status]' --output text | wc -l | tr -d ' ')
         if [[ $ANALYZER_ACTIVE_FINDINGS_COUNT -eq 0 ]];then
-            textPass "$regx: IAM Access Analyzer $accessAnalyzerArn has no active findings" "$regx"
+            textPass "$regx: IAM Access Analyzer $accessAnalyzerArn has no active findings" "$regx" "$accessAnalyzerArn"
         else
-            textInfo "$regx: IAM Access Analyzer $accessAnalyzerArn has $ANALYZER_ACTIVE_FINDINGS_COUNT active findings" "$regx"
+            textInfo "$regx: IAM Access Analyzer $accessAnalyzerArn has $ANALYZER_ACTIVE_FINDINGS_COUNT active findings" "$regx" 
         fi
       done
     else

--- a/checks/check_extra77
+++ b/checks/check_extra77
@@ -48,7 +48,7 @@ extra77(){
         fi
         # https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policies.html - "By default, only the repository owner has access to a repository."
         if [[ $(grep RepositoryPolicyNotFoundException $TEMP_POLICY_FILE) ]]; then
-          textPass "$region: $repo is not open" "$region"
+          textPass "$region: $repo is not open" "$region" "$repo"
           rm -f $TEMP_POLICY_FILE
           continue
         fi
@@ -57,12 +57,12 @@ extra77(){
         if [[ $CHECK_ECR_REPO_ALLUSERS_POLICY ]]; then
           textFail "$region: $repo policy \"may\" allow Anonymous users to perform actions (Principal: \"*\")" "$region"
         else
-          textPass "$region: $repo is not open" "$region"
+          textPass "$region: $repo is not open" "$region" "$repo"
         fi
         rm -f $TEMP_POLICY_FILE
       done
     else
-      textInfo "$region: No ECR repositories found" "$region"
+      textInfo "$region: No ECR repositories found" "$region" "$repo"
     fi
   done
 }

--- a/checks/check_extra770
+++ b/checks/check_extra770
@@ -33,7 +33,7 @@ extra770(){
         INSTANCE_ID=$(echo $instance | awk '{ print $1; }')
         PUBLIC_IP=$(echo $instance | awk '{ print $2; }')
         INSTANCE_PROFILE=$(echo $instance | awk '{ print $3; }')
-        textFail "$regx: Instance: $INSTANCE_ID at IP: $PUBLIC_IP is internet-facing with Instance Profile $INSTANCE_PROFILE" "$regx"
+        textFail "$regx: Instance: $INSTANCE_ID at IP: $PUBLIC_IP is internet-facing with Instance Profile $INSTANCE_PROFILE" "$regx" "$INSTANCE_ID"
       done <<< "$LIST_OF_PUBLIC_INSTANCES_WITH_INSTANCE_PROFILES"
       else
         textPass "$regx: no Internet Facing EC2 Instances with Instance Profiles found" "$regx"

--- a/checks/check_extra771
+++ b/checks/check_extra771
@@ -33,9 +33,9 @@ extra771(){
       else
         BUCKET_POLICY_BAD_STATEMENTS=$(echo $BUCKET_POLICY_STATEMENTS | jq --arg arn "arn:${AWS_PARTITION}:s3:::$bucket" 'fromjson | .Statement[]|select(.Effect=="Allow" and (((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and (.Action|startswith("s3:Put") or startswith("s3:*")) and .Condition == null)')
         if [[ $BUCKET_POLICY_BAD_STATEMENTS != "" ]]; then
-          textFail "Bucket $bucket allows public write: $BUCKET_POLICY_BAD_STATEMENTS"
+          textFail "Bucket $bucket allows public write: $BUCKET_POLICY_BAD_STATEMENTS" "us-east-1" "$bucket"
         else
-          textPass "Bucket $bucket has S3 bucket policy which does not allow public write access"
+          textPass "Bucket $bucket has S3 bucket policy which does not allow public write access" "us-east-1" "$bucket"
         fi
       fi
     done

--- a/checks/check_extra772
+++ b/checks/check_extra772
@@ -31,9 +31,9 @@ extra772(){
       for eip in $EIP_LIST; do
         ASSOCIATION_ID=$(echo $EIP_DUMP | jq -r --arg i "$eip" '.Addresses[]|select(.AllocationId==$i)|.AssociationId')
         if [[ "$ASSOCIATION_ID" == "null" ]]; then
-          textFail "$region: EIP $eip is unused" $region
+          textFail "$region: EIP $eip is unused" "$region" "$eip"
         else
-          textPass "$region: EIP $eip is used" $region
+          textPass "$region: EIP $eip is used" "$region" "$eip"
         fi
       done
     else

--- a/checks/check_extra773
+++ b/checks/check_extra773
@@ -31,9 +31,9 @@ extra773(){
     for dist in $LIST_OF_DISTRIBUTIONS; do
       WEB_ACL_ID=$($AWSCLI cloudfront get-distribution $PROFILE_OPT --id "$dist" --query 'Distribution.DistributionConfig.WebACLId' --output text)
       if [[ $WEB_ACL_ID ]]; then
-        textPass "CloudFront distribution $dist is using AWS WAF web ACL $WEB_ACL_ID"
+        textPass "CloudFront distribution $dist is using AWS WAF web ACL $WEB_ACL_ID" "us-east-1" "$dist"
       else
-        textFail "CloudFront distribution $dist is not using AWS WAF web ACL"
+        textFail "CloudFront distribution $dist is not using AWS WAF web ACL" "us-east-1" "$dist"
       fi
     done
   else

--- a/checks/check_extra775
+++ b/checks/check_extra775
@@ -44,11 +44,11 @@ extra775(){
           if [[ $FILE_FORMAT_ASCII ]]; then
           FINDINGS=$(secretsDetector file $EC2_AUTOSCALING_USERDATA_FILE)
             if [[ $FINDINGS -eq 0 ]]; then
-              textPass "$regx: No secrets found in $autoscaling_configuration" "$regx"
+              textPass "$regx: No secrets found in $autoscaling_configuration" "$regx" "$autoscaling_configuration"
               # delete file if nothing interesting is there
               rm -f $EC2_AUTOSCALING_USERDATA_FILE
             else
-              textFail "$regx: Potential secret found in $autoscaling_configuration" "$regx"
+              textFail "$regx: Potential secret found in $autoscaling_configuration" "$regx" "$autoscaling_configuration"
               # delete file to not leave trace, user must look at the autoscaling_configuration User Data
               rm -f $EC2_AUTOSCALING_USERDATA_FILE
             fi
@@ -56,14 +56,14 @@ extra775(){
             mv $EC2_AUTOSCALING_USERDATA_FILE $EC2_AUTOSCALING_USERDATA_FILE.gz ; gunzip $EC2_AUTOSCALING_USERDATA_FILE.gz
             FINDINGS=$(secretsDetector file $EC2_AUTOSCALING_USERDATA_FILE)
             if [[ $FINDINGS -eq 0 ]]; then
-              textPass "$regx: No secrets found in $autoscaling_configuration User Data" "$regx"
+              textPass "$regx: No secrets found in $autoscaling_configuration User Data" "$regx" "$autoscaling_configuration"
               rm -f $EC2_AUTOSCALING_USERDATA_FILE
             else
-              textFail "$regx: Potential secret found in $autoscaling_configuration" "$regx"
+              textFail "$regx: Potential secret found in $autoscaling_configuration" "$regx" "$autoscaling_configuration"
             fi
           fi
         else 
-          textPass "$regx: No secrets found in $autoscaling_configuration User Data or it is empty" "$regx"
+          textPass "$regx: No secrets found in $autoscaling_configuration User Data or it is empty" "$regx" "$autoscaling_configuration"
         fi
       done
     else

--- a/checks/check_extra776
+++ b/checks/check_extra776
@@ -54,28 +54,28 @@ extra776(){
             if [[ ! -z "$LIST_ECR_REPOS" ]]; then
               IMAGE_SCAN_STATUS=$($AWSCLI ecr describe-image-scan-findings $PROFILE_OPT --region $region --repository-name "$repo" --image-id imageDigest="$IMAGE_DIGEST" --query "imageScanStatus.status" 2>&1)
               if [[ $IMAGE_SCAN_STATUS == *"ScanNotFoundException"* ]]; then
-                textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG without a scan" "$region"
+                textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG without a scan" "$region" "$repo"
               else
                 if [[ $IMAGE_SCAN_STATUS == *"FAILED"* ]]; then
-                  textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with scan status $IMAGE_SCAN_STATUS" "$region"
+                  textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with scan status $IMAGE_SCAN_STATUS" "$region" "$repo"
                 else
                   FINDINGS_COUNT=$($AWSCLI ecr describe-image-scan-findings $PROFILE_OPT --region $region --repository-name "$repo" --image-id imageDigest="$IMAGE_DIGEST" --query "imageScanFindings.findingSeverityCounts" 2>&1)
                   if [[ ! -z "$FINDINGS_COUNT" ]]; then
                       SEVERITY_CRITICAL=$(echo "$FINDINGS_COUNT" | jq -r '.CRITICAL' )
                       if [[ "$SEVERITY_CRITICAL" != "null" ]]; then
-                        textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with CRITICAL ($SEVERITY_CRITICAL) findings" "$region"
+                        textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with CRITICAL ($SEVERITY_CRITICAL) findings" "$region" "$repo"
                       fi
                       SEVERITY_HIGH=$(echo "$FINDINGS_COUNT" | jq -r '.HIGH' )
                       if [[ "$SEVERITY_HIGH" != "null" ]]; then
-                        textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with HIGH ($SEVERITY_HIGH) findings" "$region"
+                        textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with HIGH ($SEVERITY_HIGH) findings" "$region" "$repo"
                       fi
                       SEVERITY_MEDIUM=$(echo "$FINDINGS_COUNT" | jq -r '.MEDIUM' )
                       if [[ "$SEVERITY_MEDIUM" != "null" ]]; then
-                        textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with MEDIUM ($SEVERITY_MEDIUM) findings" "$region"
+                        textFail "$region: ECR repository $repo has imageTag $IMAGE_TAG with MEDIUM ($SEVERITY_MEDIUM) findings" "$region" "$repo"
                       fi
                       SEVERITY_LOW=$(echo "$FINDINGS_COUNT" | jq -r '.LOW' )
                       if [[ "$SEVERITY_LOW" != "null" ]]; then
-                        textInfo "$region: ECR repository $repo has imageTag $IMAGE_TAG with LOW ($SEVERITY_LOW) findings" "$region"
+                        textInfo "$region: ECR repository $repo has imageTag $IMAGE_TAG with LOW ($SEVERITY_LOW) findings" "$region" 
                       fi
                       SEVERITY_INFORMATIONAL=$(echo "$FINDINGS_COUNT" | jq -r '.INFORMATIONAL' )
                       if [[ "$SEVERITY_INFORMATIONAL" != "null" ]]; then

--- a/checks/check_extra777
+++ b/checks/check_extra777
@@ -58,7 +58,7 @@ extra777(){
                             )
 
             if [[ (${INGRESS_TOTAL} -ge ${THRESHOLD}) || (${EGRESS_TOTAL} -ge ${THRESHOLD}) ]]; then
-                textFail "${regx}: ${SECURITY_GROUP} has ${INGRESS_TOTAL} inbound rules and ${EGRESS_TOTAL} outbound rules" "${regx}"
+                textFail "${regx}: ${SECURITY_GROUP} has ${INGRESS_TOTAL} inbound rules and ${EGRESS_TOTAL} outbound rules" "${regx}" "${SECURITY_GROUP}"
             fi
         done
     done

--- a/checks/check_extra778
+++ b/checks/check_extra778
@@ -58,7 +58,7 @@ extra778(){
 
                 # Edge case "0.0.0.0/0" for RDP and SSH are checked already by check41 and check42
                 if [[ ${CIDR} < ${CIDR_THRESHOLD} && 0 < ${CIDR} ]]; then
-                    textFail "${REGION}: ${SECURITY_GROUP} has potential wide-open non-RFC1918 address ${CIDR_IP} in ${DIRECTION} rule" "${REGION}"
+                    textFail "${REGION}: ${SECURITY_GROUP} has potential wide-open non-RFC1918 address ${CIDR_IP} in ${DIRECTION} rule" "${REGION}" "${SECURITY_GROUP}"
                 fi
             fi
         done

--- a/checks/check_extra779
+++ b/checks/check_extra779
@@ -45,7 +45,7 @@ extra779(){
             if [[ "$eip" == "None" ]];then
               textInfo "$regx: Found instance $instance with private IP on Security Group: $sg" "$regx"
             else
-              textFail "$regx: Found instance $instance with public IP $eip on Security Group: $sg open to 0.0.0.0/0 on for Elasticsearch/Kibana ports - use extra787 to test AUTH" "$regx"
+              textFail "$regx: Found instance $instance with public IP $eip on Security Group: $sg open to 0.0.0.0/0 on for Elasticsearch/Kibana ports - use extra787 to test AUTH" "$regx" "$sg" 
             fi
           done < <(cat $TEMP_EXTRA779_FILE)
         fi

--- a/checks/check_extra780
+++ b/checks/check_extra780
@@ -30,9 +30,9 @@ extra780(){
       for domain in $LIST_OF_DOMAINS;do
         CHECK_IF_COGNITO_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.CognitoOptions.Enabled' --output text|grep -i true)
         if [[ $CHECK_IF_COGNITO_ENABLED ]];then
-          textPass "$regx: Amazon ES domain $domain has Amazon Cognito authentication for Kibana enabled" "$regx"
+          textPass "$regx: Amazon ES domain $domain has Amazon Cognito authentication for Kibana enabled" "$regx" "$domain"
         else
-          textFail "$regx: Amazon ES domain $domain does not have Amazon Cognito authentication for Kibana enabled" "$regx"
+          textFail "$regx: Amazon ES domain $domain does not have Amazon Cognito authentication for Kibana enabled" "$regx" "$domain"
         fi
       done
     else

--- a/checks/check_extra781
+++ b/checks/check_extra781
@@ -31,9 +31,9 @@ extra781(){
       for domain in $LIST_OF_DOMAINS;do
         CHECK_IF_ENCREST_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.EncryptionAtRestOptions.Enabled' --output text|grep -i true)
         if [[ $CHECK_IF_ENCREST_ENABLED ]];then
-          textPass "$regx: Amazon ES domain $domain has encryption at-rest enabled" "$regx"
+          textPass "$regx: Amazon ES domain $domain has encryption at-rest enabled" "$regx" "$domain"
         else
-          textFail "$regx: Amazon ES domain $domain does not have encryption at-rest enabled" "$regx"
+          textFail "$regx: Amazon ES domain $domain does not have encryption at-rest enabled" "$regx" "$domain"
         fi
       done
     else

--- a/checks/check_extra782
+++ b/checks/check_extra782
@@ -30,9 +30,9 @@ extra782(){
       for domain in $LIST_OF_DOMAINS;do
         CHECK_IF_NODETOENCR_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.NodeToNodeEncryptionOptions.Enabled' --output text|grep -i true)
         if [[ $CHECK_IF_NODETOENCR_ENABLED ]];then
-          textPass "$regx: Amazon ES domain $domain has node-to-node encryption enabled" "$regx"
+          textPass "$regx: Amazon ES domain $domain has node-to-node encryption enabled" "$regx" "$domain"
         else
-          textFail "$regx: Amazon ES domain $domain does not have node-to-node encryption enabled" "$regx"
+          textFail "$regx: Amazon ES domain $domain does not have node-to-node encryption enabled" "$regx" "$domain"
         fi
       done
     else

--- a/checks/check_extra783
+++ b/checks/check_extra783
@@ -30,9 +30,9 @@ extra783(){
       for domain in $LIST_OF_DOMAINS;do
         CHECK_IF_ENFORCEHTTPS_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.DomainEndpointOptions.EnforceHTTPS' --output text|grep -i true)
         if [[ $CHECK_IF_ENFORCEHTTPS_ENABLED ]];then
-          textPass "$regx: Amazon ES domain $domain has enforce HTTPS enabled" "$regx"
+          textPass "$regx: Amazon ES domain $domain has enforce HTTPS enabled" "$regx" "$domain"
         else
-          textFail "$regx: Amazon ES domain $domain does not have enforce HTTPS enabled" "$regx"
+          textFail "$regx: Amazon ES domain $domain does not have enforce HTTPS enabled" "$regx" "$domain"
         fi
       done
     else

--- a/checks/check_extra784
+++ b/checks/check_extra784
@@ -30,9 +30,9 @@ extra784(){
       for domain in $LIST_OF_DOMAINS;do
         CHECK_IF_INTERNALDB_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.AdvancedSecurityOptions.InternalUserDatabaseEnabled' --output text|grep -i true)
         if [[ $CHECK_IF_INTERNALDB_ENABLED ]];then
-          textPass "$regx: Amazon ES domain $domain has internal user database enabled" "$regx"
+          textPass "$regx: Amazon ES domain $domain has internal user database enabled" "$regx" "$domain"
         else
-          textFail "$regx: Amazon ES domain $domain does not have internal user database enabled" "$regx"
+          textFail "$regx: Amazon ES domain $domain does not have internal user database enabled" "$regx" "$domain"
         fi
       done
     else

--- a/checks/check_extra785
+++ b/checks/check_extra785
@@ -36,9 +36,9 @@ extra785(){
         CHECK_IF_UPDATE_AVAILABLE_AND_VERSION=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.[ServiceSoftwareOptions.UpdateAvailable,ElasticsearchVersion]' --output text)
         while read update_status es_version;do
           if [[ $update_status != "False" ]];then
-            textInfo "$regx: Amazon ES domain $domain v$es_version has updates available" "$regx"
+            textInfo "$regx: Amazon ES domain $domain v$es_version has updates available" "$regx" "$domain"
           else
-            textPass "$regx: Amazon ES domain $domain v$es_version does not have have updates available" "$regx"
+            textPass "$regx: Amazon ES domain $domain v$es_version does not have have updates available" "$regx" "$domain"
           fi
         done < <(echo $CHECK_IF_UPDATE_AVAILABLE_AND_VERSION)
       done

--- a/checks/check_extra786
+++ b/checks/check_extra786
@@ -35,11 +35,11 @@ extra786(){
       while read httpendpoint httptokens_status instanceid  ; do
         #echo i:$instanceid tok:$httptokens_status end:$httpendpoint
         if [[ "$httpendpoint" == "enabled" &&  "$httptokens_status" == "required" ]];then
-          textPass "$regx: EC2 Instance $instanceid has IMDSv2 enabled and required" "$regx"
+          textPass "$regx: EC2 Instance $instanceid has IMDSv2 enabled and required" "$regx" "$instanceid"
         elif [[ "$httpendpoint" == "disabled" ]];then
           textInfo "$regx: EC2 Instance $instanceid has HTTP endpoint access to metadata service disabled" "$regx"
         else
-          textFail "$regx: EC2 Instance $instanceid has IMDSv2 disabled or not required" "$regx"
+          textFail "$regx: EC2 Instance $instanceid has IMDSv2 disabled or not required" "$regx" "$instanceid"
         fi
       done < <(cat $TEMP_EXTRA786_FILE)
     else

--- a/checks/check_extra787
+++ b/checks/check_extra787
@@ -50,9 +50,9 @@ extra787(){
               CHECH_HTTP_ES_API=$(curl -m 2 -s -w "%{http_code}" -o /dev/null -X GET "http://$eip:$ES_API_PORT/_cat/indices")
               httpStatus $CHECH_HTTP_ES_API
               if [[ $CHECH_HTTP_ES_API -eq "200" ]];then
-                textFail "$regx: Found instance $instance with public IP $eip on Security Group: $sg with Elasticsearch port $ES_API_PORT response $SERVER_RESPONSE" "$regx"
+                textFail "$regx: Found instance $instance with public IP $eip on Security Group: $sg with Elasticsearch port $ES_API_PORT response $SERVER_RESPONSE" "$regx" "$instance"
               else
-                textInfo "$regx: Found instance $instance with public IP $eip on Security Group: $sg with Elasticsearch port $ES_API_PORT response $SERVER_RESPONSE" "$regx"
+                textInfo "$regx: Found instance $instance with public IP $eip on Security Group: $sg with Elasticsearch port $ES_API_PORT response $SERVER_RESPONSE" "$regx" "$instance"
               fi
               # check for port $ES_DATA_PORT TCP, this is the communication port, not:
               # test_tcp_connectivity is in include/os_detector
@@ -62,17 +62,17 @@ extra787(){
               # codes for better handling, so 200 is open and 000 is not responding
               httpStatus $CHECH_HTTP_ES_DATA
               if [[ $CHECH_HTTP_ES_DATA -eq "200" ]];then
-                textFail "$regx: Found instance $instance with public IP $eip on Security Group: $sg with Elasticsearch port $ES_DATA_PORT response $SERVER_RESPONSE" "$regx"
+                textFail "$regx: Found instance $instance with public IP $eip on Security Group: $sg with Elasticsearch port $ES_DATA_PORT response $SERVER_RESPONSE" "$regx" "$instance"
               else
-                textInfo "$regx: Found instance $instance with public IP $eip on Security Group: $sg with Elasticsearch port $ES_DATA_PORT response $SERVER_RESPONSE" "$regx"
+                textInfo "$regx: Found instance $instance with public IP $eip on Security Group: $sg with Elasticsearch port $ES_DATA_PORT response $SERVER_RESPONSE" "$regx" "$instance"
               fi
               # check for Kibana on port $ES_KIBANA_PORT
               CHECH_HTTP_ES_KIBANA=$(curl -m 2 -s -w "%{http_code}" -o /dev/null -X GET "http://$eip:$ES_KIBANA_PORT/api/status")
               httpStatus $CHECH_HTTP_ES_KIBANA
               if [[ $CHECH_AUTH_5601 -eq "200" ]];then
-                textFail "$regx: Found instance $instance with public IP $eip on Security Group: $sg with Kibana on port $ES_KIBANA_PORT response $SERVER_RESPONSE" "$regx"
+                textFail "$regx: Found instance $instance with public IP $eip on Security Group: $sg with Kibana on port $ES_KIBANA_PORT response $SERVER_RESPONSE" "$regx" "$instance"
               else
-                textInfo "$regx: Found instance $instance with public IP $eip on Security Group: $sg with Kibana on port $ES_KIBANA_PORT response $SERVER_RESPONSE" "$regx"
+                textInfo "$regx: Found instance $instance with public IP $eip on Security Group: $sg with Kibana on port $ES_KIBANA_PORT response $SERVER_RESPONSE" "$regx" "$instance"
               fi
             else
               textInfo "$regx: Found instance $instance with private IP on Security Group: $sg" "$regx"

--- a/checks/check_extra788
+++ b/checks/check_extra788
@@ -78,15 +78,15 @@ extra788(){
             CHECH_KIBANA_HTTPS=$(curl -m 2 -s -w "%{http_code}" -o /dev/null -X GET "https://$ES_DOMAIN_ENDPOINT/_plugin/kibana")
             httpStatus $CHECH_KIBANA_HTTPS
             if [[ $CHECH_KIBANA_HTTPS -eq "200" || $CHECH_KIBANA_HTTPS -eq "301" || $CHECH_KIBANA_HTTPS -eq "302" ]];then
-              textFail "$regx: Amazon ES domain $domain policy allows Anonymous access and Kibana service endpoint $ES_DOMAIN_ENDPOINT responded $SERVER_RESPONSE" "$regx"
+              textFail "$regx: Amazon ES domain $domain policy allows Anonymous access and Kibana service endpoint $ES_DOMAIN_ENDPOINT responded $SERVER_RESPONSE" "$regx" "$domain"
             else
-              textInfo "$regx: Amazon ES domain $domain policy allows Anonymous access but Kibana service endpoint $ES_DOMAIN_ENDPOINT responded $SERVER_RESPONSE" "$regx"
+              textInfo "$regx: Amazon ES domain $domain policy allows Anonymous access but Kibana service endpoint $ES_DOMAIN_ENDPOINT responded $SERVER_RESPONSE" "$regx" "$domain"
             fi
           else
             if [[ $CHECK_ES_DOMAIN_POLICY_HAS_CONDITION && ${CHECK_ES_DOMAIN_POLICY_CONDITION_PRIVATE_IP[@]} ]];then
               textInfo "$regx: Amazon ES domain $domain policy allows access from a Private IP or CIDR RFC1918 $(echo ${CONDITION_HAS_PRIVATE_IP_ARRAY[@]})" "$regx"
             else
-              textPass "$regx: Amazon ES domain $domain does not allow Anonymous cross account access" "$regx"
+              textPass "$regx: Amazon ES domain $domain does not allow Anonymous cross account access" "$regx" "$domain"
             fi
           fi
           rm -f $TEMP_POLICY_FILE

--- a/checks/check_extra789
+++ b/checks/check_extra789
@@ -47,7 +47,7 @@ extra789(){
             for ENDPOINT_CONNECTION in ${ENDPOINT_CONNECTION_LIST}; do
                 for ACCOUNT_ID in ${TRUSTED_ACCOUNT_IDS}; do
                     if [[ "${ACCOUNT_ID}" == "${ENDPOINT_CONNECTION}" ]]; then
-                        textPass "${regx}: Found trusted account in VPC endpoint service connection ${ENDPOINT_CONNECTION}" "${regx}"
+                        textPass "${regx}: Found trusted account in VPC endpoint service connection ${ENDPOINT_CONNECTION}" "${regx}" "${ENDPOINT_CONNECTION}"
                         # Algorithm:
                         # Remove all trusted ACCOUNT_IDs from ENDPOINT_CONNECTION_LIST.
                         # As a result, the ENDPOINT_CONNECTION_LIST finally contains only unknown/untrusted account ids.
@@ -57,7 +57,7 @@ extra789(){
             done
 
             for UNTRUSTED_CONNECTION in ${ENDPOINT_CONNECTION_LIST}; do
-                textFail "${regx}: Found untrusted account in VPC endpoint service connection ${UNTRUSTED_CONNECTION}" "${regx}"
+                textFail "${regx}: Found untrusted account in VPC endpoint service connection ${UNTRUSTED_CONNECTION}" "${regx}" "${ENDPOINT_CONNECTION}"
             done
         done
     done

--- a/checks/check_extra79
+++ b/checks/check_extra79
@@ -37,7 +37,7 @@ extra79(){
       while read -r elb;do
         ELB_NAME=$(echo $elb | awk '{ print $1; }')
         ELB_DNSNAME=$(echo $elb | awk '{ print $2; }')
-        textFail "$regx: ELB: $ELB_NAME at DNS: $ELB_DNSNAME is internet-facing!" "$regx"
+        textFail "$regx: ELB: $ELB_NAME at DNS: $ELB_DNSNAME is internet-facing!" "$regx" "$ELB_NAME"
       done <<< "$LIST_OF_ALL_ELBS_PER_LINE"
       else
         textPass "$regx: no Internet Facing ELBs found" "$regx"

--- a/checks/check_extra790
+++ b/checks/check_extra790
@@ -60,7 +60,7 @@ extra790(){
             done
 
             for UNTRUSTED_PERMISSION in ${ENDPOINT_PERMISSIONS_LIST}; do
-                textFail "${regx}: Found untrusted account in VPC endpoint service permission ${UNTRUSTED_PERMISSION}" "${regx}"
+                textFail "${regx}: Found untrusted account in VPC endpoint service permission ${UNTRUSTED_PERMISSION}" "${regx}" "${UNTRUSTED_PERMISSION}"
             done
         done
     done

--- a/checks/check_extra791
+++ b/checks/check_extra791
@@ -29,9 +29,9 @@ extra791(){
       for dist in $LIST_OF_DISTRIBUTIONS; do
         CHECK_ORIGINSSLPROTOCOL_STATUS=$($AWSCLI cloudfront get-distribution --id $dist --query Distribution.DistributionConfig.Origins.Items[].CustomOriginConfig.OriginSslProtocols.Items $PROFILE_OPT --output text)
         if [[ $CHECK_ORIGINSSLPROTOCOL_STATUS == *"SSLv2"* ]] || [[ $CHECK_ORIGINSSLPROTOCOL_STATUS == *"SSLv3"* ]]; then
-          textFail "CloudFront distribution $dist is using a deprecated SSL protocol!" "$regx"
+          textFail "CloudFront distribution $dist is using a deprecated SSL protocol!" "$regx" "$dist"
         else
-          textPass "CloudFront distribution $dist is not using a deprecated SSL protocol" "$regx"
+          textPass "CloudFront distribution $dist is not using a deprecated SSL protocol" "$regx" "$dist"
         fi
       done
     else

--- a/checks/check_extra792
+++ b/checks/check_extra792
@@ -66,9 +66,9 @@ extra792(){
              done
           
              if $passed; then
-               textPass "$regx: $elb has no insecure SSL ciphers" "$regx"
+               textPass "$regx: $elb has no insecure SSL ciphers" "$regx" "$elb"
              else
-               textFail "$regx: $elb has insecure SSL ciphers" "$regx" 
+               textFail "$regx: $elb has insecure SSL ciphers" "$regx" "$elb"
              fi
           else
              textInfo "$regx: $elb does not have an HTTPS or SSL listener" "$regx"
@@ -106,9 +106,9 @@ extra792(){
              done
    
              if $passed; then
-               textPass "$regx: $elbname has no insecure SSL ciphers" "$regx"
+               textPass "$regx: $elbname has no insecure SSL ciphers" "$regx" "$elbname"
              else
-               textFail "$regx: $elbname has insecure SSL ciphers" "$regx"
+               textFail "$regx: $elbname has insecure SSL ciphers" "$regx" "$elbname"
              fi
           else
              textInfo "$regx: $elbname does not have an HTTPS or TLS listener" "$regx"

--- a/checks/check_extra793
+++ b/checks/check_extra793
@@ -54,7 +54,7 @@ extra793(){
             if $potential_redirect; then
               textInfo "$regx: $elb has both encrypted and non-encrypted listeners" "$regx"
             else
-              textFail "$regx: $elb has non-encrypted listeners" "$regx" 
+              textFail "$regx: $elb has non-encrypted listeners" "$regx" "$elb"
             fi 
           fi
         done
@@ -88,11 +88,11 @@ extra793(){
                if $redirect_rule; then
                  textInfo "$regx: $elbname has HTTP listener that redirects to HTTPS" "$regx"
                else
-                 textFail "$regx: $elbname has non-encrypted listeners" "$regx"
+                 textFail "$regx: $elbname has non-encrypted listeners" "$regx" "$elbname"
                fi
              fi
           else
-            textFail "$regx: $elbname has non-encrypted listeners" "$regx"
+            textFail "$regx: $elbname has non-encrypted listeners" "$regx" "$elbname"
           fi
         done
       fi

--- a/checks/check_extra794
+++ b/checks/check_extra794
@@ -34,12 +34,12 @@ extra794(){
         TYPES=$(echo $CLUSTERDEF | jq -r '.types[]')
         if [[ $LOGGING_ENABLED == "true" ]]; then
            if [[ $(echo $TYPES | egrep "api.*audit.*authenticator.*controllerManager.*scheduler") ]]; then
-              textPass "$regx: Control plane logging enabled and correctly configured for EKS cluster $CLUSTER" "$regx"
+              textPass "$regx: Control plane logging enabled and correctly configured for EKS cluster $CLUSTER" "$regx" "$CLUSTER"
            else
-              textFail "$regx: Control plane logging enabled, but not all log types collected for EKS cluster $CLUSTER" "$regx"
+              textFail "$regx: Control plane logging enabled, but not all log types collected for EKS cluster $CLUSTER" "$regx" "$CLUSTER"
            fi
         else
-              textFail "$regx: Control plane logging is not enabled for EKS cluster $CLUSTER" "$regx"
+              textFail "$regx: Control plane logging is not enabled for EKS cluster $CLUSTER" "$regx" "$CLUSTER"
         fi
       done
     else

--- a/checks/check_extra795
+++ b/checks/check_extra795
@@ -34,9 +34,9 @@ extra795(){
         PRIV_ENABLED=$(echo $CLUSTERDEF | jq -r '.endpointPrivateAccess')
 
         if [[ $PUB_ENABLED == "false" ]] && [[ $PRIV_ENABLED == "true" ]] ; then
-          textPass "$regx: Cluster endpoint access is private for EKS cluster $CLUSTER" "$regx"
+          textPass "$regx: Cluster endpoint access is private for EKS cluster $CLUSTER" "$regx" "$CLUSTER"
         else
-              textFail "$regx: Cluster endpoint access is public for EKS cluster $CLUSTER" "$regx"
+              textFail "$regx: Cluster endpoint access is public for EKS cluster $CLUSTER" "$regx" "$CLUSTER"
         fi
       done
     else

--- a/checks/check_extra796
+++ b/checks/check_extra796
@@ -38,9 +38,9 @@ extra796(){
           textPass "$regx: Cluster endpoint access is private for EKS cluster $CLUSTER" "$regx"
         else
           if [[ $(echo $PUB_ACCESS_CIDRS | grep "0.0.0.0/0") ]] ; then
-            textFail "$regx: Cluster control plane access is not restricted for EKS cluster $CLUSTER" "$regx"
+            textFail "$regx: Cluster control plane access is not restricted for EKS cluster $CLUSTER" "$regx" "$CLUSTER"
           else
-            textPass "$regx: Cluster control plane access is restricted for EKS cluster $CLUSTER" "$regx"
+            textPass "$regx: Cluster control plane access is restricted for EKS cluster $CLUSTER" "$regx" "$CLUSTER"
           fi
         fi
       done

--- a/checks/check_extra797
+++ b/checks/check_extra797
@@ -32,9 +32,9 @@ extra797(){
         ENC_CONFIG=$($AWSCLI eks describe-cluster $PROFILE_OPT --region $regx --name $CLUSTER --query 'cluster.encryptionConfig')
 
         if [[ $ENC_CONFIG == "null" ]]; then
-           textFail "$regx: Encryption for Kubernetes secrets is not configured for EKS cluster $CLUSTER" "$regx"
+           textFail "$regx: Encryption for Kubernetes secrets is not configured for EKS cluster $CLUSTER" "$regx" "$CLUSTER"
         else
-           textPass "$regx: Encryption for Kubernetes secrets is configured for EKS cluster $CLUSTER" "$regx"
+           textPass "$regx: Encryption for Kubernetes secrets is configured for EKS cluster $CLUSTER" "$regx" "$CLUSTER"
         fi
       done
     else

--- a/checks/check_extra798
+++ b/checks/check_extra798
@@ -35,12 +35,12 @@ extra798(){
           FUNCTION_POLICY_ALLOW_ALL=$(echo $FUNCTION_POLICY \
             | jq '.Statement[] | select(.Effect=="Allow") | select(.Principal=="*" or .Principal.AWS=="*" or .Principal.CanonicalUser=="*")')
           if [[ $FUNCTION_POLICY_ALLOW_ALL ]]; then
-            textFail "$regx: Lambda function $lambdafunction has a policy with public access" "$regx"
+            textFail "$regx: Lambda function $lambdafunction has a policy with public access" "$regx" "$lambdafunction"
           else
-            textPass "$regx: Lambda function $lambdafunction has a policy resource-based policy and is not public" "$regx"
+            textPass "$regx: Lambda function $lambdafunction has a policy resource-based policy and is not public" "$regx" "$lambdafunction"
           fi
         else
-          textPass "$regx: Lambda function $lambdafunction does not have resource-based policy" "$regx"
+          textPass "$regx: Lambda function $lambdafunction does not have resource-based policy" "$regx" "$lambdafunction"
         fi
       done
     else

--- a/include/outputs
+++ b/include/outputs
@@ -319,17 +319,25 @@ generateJsonAsffOutput(){
   # Replace any successive non-conforming characters with a single underscore
   local message=$1
   local status=$2
-
+  
+  #Checks to determine if the rule passes in a resource name that prowler uses to track the AWS Resource for whitelisting purposes
+  if [ -z $3 ]
+  then
+    local resource_id="NONE_PROVIDED"
+   else
+    local resource_id=$3
+  fi
+  
   if [[ "$status" == "FAIL" ]]; then
     status="FAILED"
   fi
   jq -M -c \
   --arg ACCOUNT_NUM "$ACCOUNT_NUM" \
   --arg TITLE_TEXT "$TITLE_TEXT" \
-  --arg MESSAGE "$(echo -e "${message}" | sed -e 's/^[[:space:]]*//')" \
+  --arg MESSAGE "$(echo -e "${message}")" \
   --arg UNIQUE_ID "$(LC_ALL=C echo -e -n "${message}" | tr -cs '[:alnum:]._~-' '_')" \
   --arg STATUS "$status" \
-  --arg SEVERITY "$(echo $CHECK_SEVERITY| awk '{ print toupper($0) }')" \
+  --arg SEVERITY "$(echo $CHECK_SEVERITY| awk '{ print toupper($0) }' |  sed 's/[][]//g')" \
   --arg TITLE_ID "$TITLE_ID" \
   --arg CHECK_ID "$CHECK_ID" \
   --arg TYPE "$CHECK_ASFF_COMPLIANCE_TYPE" \
@@ -339,6 +347,7 @@ generateJsonAsffOutput(){
   --arg TIMESTAMP "$(get_iso8601_timestamp)" \
   --arg PROWLER_VERSION "$PROWLER_VERSION" \
   --arg AWS_PARTITION "$AWS_PARTITION" \
+  --arg CHECK_RESOURCE_ID "$resource_id" \
   -n '{
       "SchemaVersion": "2018-10-08",
       "Id": "prowler-\($TITLE_ID)-\($ACCOUNT_NUM)-\($REPREGION)-\($UNIQUE_ID)",
@@ -346,7 +355,8 @@ generateJsonAsffOutput(){
       "RecordState": "ACTIVE",
       "ProductFields": {
           "ProviderName": "Prowler",
-          "ProviderVersion": $PROWLER_VERSION
+          "ProviderVersion": $PROWLER_VERSION,
+          "ProwlerResourceName": $CHECK_RESOURCE_ID
       },
       "GeneratorId": "prowler-\($CHECK_ID)",
       "AwsAccountId": $ACCOUNT_NUM,
@@ -373,6 +383,7 @@ generateJsonAsffOutput(){
           "Status": $STATUS,
           "RelatedRequirements": [ $COMPLIANCE_RELATED_REQUIREMENTS ]
       }
+      
   }'
 }
 


### PR DESCRIPTION
Here are updates to prowler checks that support passing the resource name in with the third parameter.   For some resources that dont have regions hardcoded us-east-1 as the second parameter.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
