### PR TITLE
Add glue permissions

### DIFF
--- a/iam/create_role_to_assume_cfn.yaml
+++ b/iam/create_role_to_assume_cfn.yaml
@@ -63,4 +63,6 @@ Resources:
                 - 'support:Describe*'
                 - 'tag:GetTagKeys'
                 - 'lambda:GetFunction'
+                - 'glue:GetConnections'
+                - 'glue:SearchTables'
               Resource: '*'

--- a/iam/prowler-additions-policy.json
+++ b/iam/prowler-additions-policy.json
@@ -10,7 +10,9 @@
                 "ecr:Describe*",
                 "support:Describe*",
                 "tag:GetTagKeys",
-		"lambda:GetFunction"
+		        "lambda:GetFunction",
+                "glue:GetConnections",
+                "glue:SearchTables"
             ],
             "Resource": "*",
             "Effect": "Allow",

--- a/util/codebuild/codebuild-prowler-audit-account-cfn.yaml
+++ b/util/codebuild/codebuild-prowler-audit-account-cfn.yaml
@@ -207,6 +207,17 @@ Resources:
                   - sts:AssumeRole
                 Effect: Allow
                 Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/service-role/prowler-codebuild-role'
+        - PolicyName: Glue
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Action:
+                  - glue:GetConnections
+                  - glue:SearchTables
+                Effect: Allow
+                Resource: 
+                  - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog'
+                  - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:connection/*'
 
   ProwlerCodeBuild:
     Type: AWS::CodeBuild::Project


### PR DESCRIPTION
Adding necessary IAM permissions to run OOTB WRT glue checks

```
glue:GetConnections
glue:SearchTables
```

Without these an OOTB run of `prowler` does not succeed due to `AccessDeniedException` due to these permissions.