### PR TITLE
Ignore secrets folder in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Sessionx.vim
 *~
 # Auto-generated tag files
 tags
+
 # Persistent undo
 [._]*.un~
 
@@ -22,6 +23,9 @@ tags
 
 # Prowler output
 output/
+
+# Prowler found secrets
+secrets-*/
 
 # JUnit Reports
 junit-reports/


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


Ignoring `secrets-*` folder (where `*` belongs to the account you are scanning).