### PR TITLE
Updated prowler-codebuild-role name for CFN StackSets name length limit @varunirv

### DIFF
--- a/util/codebuild/codebuild-prowler-audit-account-cfn.yaml
+++ b/util/codebuild/codebuild-prowler-audit-account-cfn.yaml
@@ -141,7 +141,7 @@ Resources:
           - id: W28
             reason: "Explicit name is required for this resource to avoid circular dependencies."
     Properties:
-      RoleName: !Sub 'prowler-codebuild-role-${ServiceName}-${AWS::StackName}'
+      RoleName: !Sub 'prowler-codebuild-role'
       Path: '/service-role/'
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/job-function/SupportUser'


### PR DESCRIPTION
This change is to fix the issue as reported at
https://github.com/toniblyx/prowler/issues/845

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
