### PR TITLE
Fix extra737 remove false positives due to policies with condition @rinaudjaws

### DIFF
--- a/checks/check_extra736
+++ b/checks/check_extra736
@@ -29,7 +29,7 @@ extra736(){
     LIST_OF_CUSTOMER_KMS_KEYS=$($AWSCLI kms list-aliases $PROFILE_OPT --region $regx --query "Aliases[].[AliasName,TargetKeyId]" --output text |grep -v ^alias/aws/ |awk '{ print $2 }')
     if [[ $LIST_OF_CUSTOMER_KMS_KEYS ]];then
       for key in $LIST_OF_CUSTOMER_KMS_KEYS; do
-        CHECK_POLICY=$($AWSCLI kms get-key-policy --key-id $key --policy-name default $PROFILE_OPT --region $regx  --output text|awk '/Principal/{n=NR+1} n>=NR' |grep AWS\"\ :\ \"\\*\"$)
+        CHECK_POLICY=$($AWSCLI kms get-key-policy --key-id $key --policy-name default $PROFILE_OPT --region $regx  --output text| jq '.Statement[]|select(.Effect=="Allow" and (((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and .Condition == null)')
         if [[ $CHECK_POLICY ]]; then
           textFail "$regx: KMS key $key may be publicly accessible!" "$regx" "$key"
         else


### PR DESCRIPTION
CDK for example implements callerAccount as a condition for the KMS policy resulting in too many false positives.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
