### PR TITLE
Fix support policy arn in check120 @hersh86

### DIFF
--- a/checks/check120
+++ b/checks/check120
@@ -31,7 +31,7 @@ check120(){
   SUPPORTPOLICYARN=$($AWSCLI iam list-policies --query "Policies[?PolicyName == 'AWSSupportAccess'].Arn" $PROFILE_OPT --region $REGION --output text)
   if [[ $SUPPORTPOLICYARN ]];then
     for policyarn in $SUPPORTPOLICYARN;do
-      POLICYROLES=$($AWSCLI iam list-entities-for-policy --policy-arn $SUPPORTPOLICYARN $PROFILE_OPT --region $REGION --output text | awk -F$'\t' '{ print $3 }')
+      POLICYROLES=$($AWSCLI iam list-entities-for-policy --policy-arn $policyarn $PROFILE_OPT --region $REGION --output text | awk -F$'\t' '{ print $3 }')
       if [[ $POLICYROLES ]];then
         for name in $POLICYROLES; do
           textPass "$REGION: Support Policy attached to $name" "$REGION" "$name"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For situations when the account has copied the default AWS policy but kept the name this would fail as the for loop variable wasn't in the right place. Working as expected on ubuntu 20.04.