### PR TITLE
Fix Security Hub conflict with duplicated findings in the management account #711 @xeroxnir

### DIFF
--- a/include/securityhub_integration
+++ b/include/securityhub_integration
@@ -47,7 +47,7 @@ resolveSecurityHubPreviousFails(){
     local check="$1"
     NEW_TIMESTAMP=$(get_iso8601_timestamp)
 
-    FILTER="{\"GeneratorId\":[{\"Value\": \"prowler-$check\",\"Comparison\":\"EQUALS\"}],\"RecordState\":[{\"Value\": \"ACTIVE\",\"Comparison\":\"EQUALS\"}]}"
+    FILTER="{\"GeneratorId\":[{\"Value\": \"prowler-$check\",\"Comparison\":\"EQUALS\"}],\"RecordState\":[{\"Value\": \"ACTIVE\",\"Comparison\":\"EQUALS\"}],\"AwsAccountId\":[{\"Value\": \"$ACCOUNT_NUM\",\"Comparison\":\"EQUALS\"}]}"
 
     NEW_FINDING_IDS=$(echo -n "${SECURITYHUB_NEW_FINDINGS_IDS[@]}" | jq -cRs 'split(" ")')
     SECURITY_HUB_PREVIOUS_FINDINGS=$($AWSCLI securityhub --region "$regx" $PROFILE_OPT get-findings --filters "${FILTER}" | jq -c --argjson ids "$NEW_FINDING_IDS" --arg updated_at $NEW_TIMESTAMP  '[ .Findings[] | select( .Id| first(select($ids[] == .)) // false | not) | .RecordState = "ARCHIVED" | .UpdatedAt = $updated_at ]')


### PR DESCRIPTION
* Filter by AWS account Id to avoid importing findings from other accounts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
