### PR TITLE
New feature: adding the ability to provide a file for checks to be ran @Kirizan

### DIFF
--- a/checklist.txt
+++ b/checklist.txt
@@ -1,0 +1,6 @@
+# You can add a comma seperated list of checks like this:
+check11, check12
+extra72 # You can also use newlines for each check
+check13 # This way allows you to add inline comments
+# Both of these can be combined if you have a standard list and want to add
+# inline comments for other checks.

--- a/checklist.txt
+++ b/checklist.txt
@@ -1,5 +1,5 @@
 # You can add a comma seperated list of checks like this:
-check11, check12
+check11,check12
 extra72 # You can also use newlines for each check
 check13 # This way allows you to add inline comments
 # Both of these can be combined if you have a standard list and want to add

--- a/prowler
+++ b/prowler
@@ -72,6 +72,8 @@ USAGE:
                             (i.e.: us-east-1), all regions are checked anyway if the check requires it
       -c <check_id>       specify one or multiple check ids separated by commas, to see all available checks use "-l" option
                             (i.e.: "check11" for check 1.1 or "extra71,extra72" for extra check 71 and extra check 72)
+      -C                  Checklist file. See checklist.txt for reference and format.
+                            (i.e.: checklist.txt)
       -g <group_id>       specify a group of checks by id, to see all available group of checks use "-L"
                             (i.e.: "group3" for entire section 3, "cislevel1" for CIS Level 1 Profile Definitions or "forensics-ready")
       -f <filterregion>   specify an AWS region to run checks against
@@ -115,7 +117,7 @@ USAGE:
   exit
 }
 
-while getopts ":hlLkqp:r:c:g:f:m:M:E:x:enbVsSI:A:R:T:w:N:o:B:F:zZ:" OPTION; do
+while getopts ":hlLkqp:r:c:C:g:f:m:M:E:x:enbVsSI:A:R:T:w:N:o:B:F:zZ:" OPTION; do
    case $OPTION in
      h )
         usage
@@ -139,6 +141,9 @@ while getopts ":hlLkqp:r:c:g:f:m:M:E:x:enbVsSI:A:R:T:w:N:o:B:F:zZ:" OPTION; do
         ;;
      c )
         CHECK_ID=$OPTARG
+        ;;
+     C )
+        CHECK_FILE=$OPTARG
         ;;
      g )
         GROUP_ID_READ=$OPTARG
@@ -278,6 +283,19 @@ unset AWS_DEFAULT_OUTPUT
 . $PROWLER_DIR/include/connection_tests
 . $PROWLER_DIR/include/securityhub_integration
 . $PROWLER_DIR/include/junit_integration
+
+# Parses the check file into CHECK_ID's.
+if [[ -n "$CHECK_FILE" ]]; then
+  if [[ -f $CHECK_FILE ]]; then
+    # Parses the file, converting it to a comma seperated list. Ignores all # comments and removes extra blank spaces
+    CHECK_ID="$(awk '!/^[[:space:]]*#/{print }' <(cat $CHECK_FILE | sed 's/[[:space:]]*#.*$//g;/^$/d' | sed 'H;1h;$!d;x;y/\n/,/' | tr -d ' '))"
+  else
+    # If the file doesn't exist, exits Prowler
+    echo "$CHECK_FILE does not exist"
+    EXITCODE=1
+    exit $EXITCODE
+  fi
+fi
 
 # Pre-process whitelist file if supplied
 if [[ -n "$WHITELIST_FILE" ]]; then


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I've added the flag `-C` that accepts a file name as input. This file is then parsed and treated like the existing `-c` flag.