### PR TITLE
Update extra71 

### DIFF
--- a/checks/check_extra71
+++ b/checks/check_extra71
@@ -43,10 +43,13 @@ extra71(){
         # users
         # check for user MFA device in credential report
         USER_MFA_ENABLED=$( cat $TEMP_REPORT_FILE | grep "^$auser," | cut -d',' -f8)
-        if [[ "true" == $USER_MFA_ENABLED ]]; then
-          textPass "$REGION: $auser / MFA Enabled / admin via group $grp" "$REGION" "$grp"
-        else
-          textFail "$REGION: $auser / MFA DISABLED / admin via group $grp" "$REGION" "$grp"
+        USER_PASSWORD_ENABLED=$( cat $TEMP_REPORT_FILE | grep "^$auser," | cut -d',' -f4) 
+        if [ "true" == $USER_PASSWORD_ENABLED ] ; then
+              if [[ "true" == $USER_MFA_ENABLED ]] ; then
+                textPass "$auser / MFA Enabled / admin via group $grp"
+              else
+                textFail "$auser / MFA DISABLED / admin via group $grp"
+              fi
         fi
       done
     else


### PR DESCRIPTION
El extra71 revisa los usuarios en grupos con politicas administativas y analiza si tiene el MFA Habilitado, sin embargo no toma en cuenta si el usuario es de acceso programatico, si es asi, no tiene caso habilitar el MFA, acabo de agregar una condicional a este punto.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
