### PR TITLE
Add start after flag (-a) for restarting a failed run

### DIFF
--- a/prowler
+++ b/prowler
@@ -84,6 +84,7 @@ USAGE:
       -l                  list all available checks only (does not perform any check). Add -g <group_id> to only list checks within the specified group
       -L                  list all groups (does not perform any check)
       -e                  exclude group extras
+      -a <check>          start after the given check. Useful for restarting a failed run, in which case this would be set to the last succesfully ran check
       -E                  execute all tests except a list of specified checks separated by comma (i.e. check21,check31)
       -b                  do not print Prowler banner
       -s                  show scoring report
@@ -111,7 +112,7 @@ USAGE:
   exit
 }
 
-while getopts ":hlLkqp:r:c:g:f:m:M:E:x:enbVsSI:A:R:T:w:N:o:B:F:" OPTION; do
+while getopts ":hlLkqp:r:c:g:f:m:M:E:x:ea:nbVsSI:A:R:T:w:N:o:B:F:" OPTION; do
    case $OPTION in
      h )
         usage
@@ -156,6 +157,9 @@ while getopts ":hlLkqp:r:c:g:f:m:M:E:x:enbVsSI:A:R:T:w:N:o:B:F:" OPTION; do
         ;;
      e )
         EXTRAS=1
+        ;;
+     a )
+        START_AFTER=$OPTARG
         ;;
      E )
         EXCLUDE_CHECK_ID=$OPTARG
@@ -494,6 +498,13 @@ execute_group() {
         unset EXCLUDED_CHECKS
     fi
     for i in ${CHECKS[@]}; do
+        if [[ -n $START_AFTER && $START_AFTER == $i ]]; then
+            unset START_AFTER
+            continue
+        elif [[ -n $START_AFTER ]]; then
+            continue
+        fi
+
         execute_check ${i}
     done
 }


### PR DESCRIPTION
I tend to run into issues fairly often where a run fails have way through, many times this is just because the temporary tokens expired or something along those lines. In any case figuring out how to resume the run is fairly challenging and usually means listing out all the checks on the command line with the -c option. This PR adds the -a flag which will instead allow you to continue a failed run, skipping all checks up to and including the check passed to the -a flag.

TODO:
* Verify this works with all run modes
  * [x] All checks
  * [ ] -g ...
  * [ ] -c ...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
