### PR TITLE
Enhancement IAM assumed role session duration error handling by @jfagoagas

### DIFF
--- a/include/assume_role
+++ b/include/assume_role
@@ -52,12 +52,10 @@ assume_role(){
     fi
     if [[ $(grep AccessDenied $TEMP_STS_ASSUMED_FILE) ]]; then
       textFail "Access Denied assuming role $PROWLER_ROLE"
-      rm -f $TEMP_STS_ASSUMED_FILE
       EXITCODE=1
       exit $EXITCODE
     elif [[ "$(grep MaxSessionDuration $TEMP_STS_ASSUMED_FILE)" ]]; then
       textFail "The requested DurationSeconds exceeds the MaxSessionDuration set for the role ${PROWLER_ROLE}"
-      rm -f $TEMP_STS_ASSUMED_FILE
       EXITCODE=1
       exit $EXITCODE
     fi
@@ -86,5 +84,9 @@ assume_role(){
     export AWS_SECRET_ACCESS_KEY=$(cat $TEMP_STS_ASSUMED_FILE | jq -r '.Credentials.SecretAccessKey')
     export AWS_SESSION_TOKEN=$(cat $TEMP_STS_ASSUMED_FILE | jq -r '.Credentials.SessionToken')
     export AWS_SESSION_EXPIRATION=$(cat $TEMP_STS_ASSUMED_FILE | jq -r '.Credentials.Expiration | sub("\\+00:00";"Z") | fromdateiso8601')
-    rm -fr $TEMP_STS_ASSUMED_FILE
+    cleanSTSAssumeFile
+}
+
+cleanSTSAssumeFile() {
+    rm -fr "${TEMP_STS_ASSUMED_FILE}"
 }

--- a/include/assume_role
+++ b/include/assume_role
@@ -21,6 +21,9 @@ assume_role(){
     # In some cases you will need more than 1h.
     if [[ -z $SESSION_DURATION_TO_ASSUME ]]; then
         SESSION_DURATION_TO_ASSUME="3600"
+    elif [[ "${SESSION_DURATION_TO_ASSUME}" -gt "43200" ]] || [[ "${SESSION_DURATION_TO_ASSUME}" -lt "900" ]]; then
+        echo "$OPTRED ERROR!$OPTNORMAL - Role session duration must be more than 900 seconds and less than 4300 seconds"
+        exit 1
     fi
 
     # temporary file where to store credentials
@@ -52,6 +55,11 @@ assume_role(){
       rm -f $TEMP_STS_ASSUMED_FILE
       EXITCODE=1
       exit $EXITCODE
+    elif [[ "$(grep MaxSessionDuration $TEMP_STS_ASSUMED_FILE)" ]]; then
+      textFail "The requested DurationSeconds exceeds the MaxSessionDuration set for the role ${PROWLER_ROLE}"
+      rm -f $TEMP_STS_ASSUMED_FILE
+      EXITCODE=1
+      exit $EXITCODE
     fi
 
     # assume role command
@@ -80,4 +88,3 @@ assume_role(){
     export AWS_SESSION_EXPIRATION=$(cat $TEMP_STS_ASSUMED_FILE | jq -r '.Credentials.Expiration | sub("\\+00:00";"Z") | fromdateiso8601')
     rm -fr $TEMP_STS_ASSUMED_FILE
 }
-

--- a/include/credentials_report
+++ b/include/credentials_report
@@ -43,6 +43,7 @@ cleanTemp(){
   if [[ $KEEPCREDREPORT -ne 1 ]]; then
     rm -fr $TEMP_REPORT_FILE
   fi
+  cleanSTSAssumeFile
 }
 
 # Delete the temporary report file if we get interrupted/terminated


### PR DESCRIPTION
### Description

We need to check the following behaviours:

- `$SESSION_DURATION_TO_ASSUME` must be more than 900 and less than 43200 seconds
- `$SESSION_DURATION_TO_ASSUME` must be less than the MaxSessionDuration specified for this role. In this case the AWS CLI throws the following error `An error occurred (ValidationError) when calling the AssumeRole operation: The requested DurationSeconds exceeds the MaxSessionDuration set for this role.`

Also I have included a new function called `cleanSTSAssumeFile` to handle the deletion of this file `TEMP_STS_ASSUMED_FILE`.

I think that it is necessary to group every cleanup function because it is not possible to set multiple traps for the same signal. Due to that I have to include `cleanSTSAssumeFile` at `/utils/credentials_report` `cleanTemp` function.

----------------------------------
During this work I have noticed that Prowler's clean_up function (https://github.com/toniblyx/prowler/blob/master/prowler#L239) is not running because `/utils/credentials_report` `trap cleanTemp EXIT` overrides `trap clean_up EXIT`.

You can test it with the following code:
```bash
trap "echo first trap" exit
trap "echo second trap" exit
exit 1
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
