### PR TITLE
docs(Readme): `-T` option is not mandatory

### DIFF
--- a/prowler
+++ b/prowler
@@ -97,7 +97,7 @@ USAGE:
                             (i.e.: 123456789012)
       -R                  role name or role arn to assume in the account, requires -A and -T
                             (i.e.: ProwlerRole)
-      -T                  session duration given to that role credentials in seconds, default 1h (3600) recommended 12h, requires -R and -T
+      -T                  session duration given to that role credentials in seconds, default 1h (3600) recommended 12h, optional with -R and -A (default 3600 seconds)
                             (i.e.: 43200)
       -I                  External ID to be used when assuming roles (not mandatory), requires -A and -R
       -w                  whitelist file. See whitelist_sample.txt for reference and format


### PR DESCRIPTION
`-T` option to set assumed role maximum session duration is not mandatory.

It has a default value if not present https://github.com/toniblyx/prowler/blob/master/include/assume_role#L23

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
