### PR TITLE
Fix assume-role: check if `-T` and `-A` options are set together @jfagoagas

### DIFF
--- a/include/assume_role
+++ b/include/assume_role
@@ -11,9 +11,9 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-# both variables are mandatory to be set together
 assume_role(){
-    if [[ -z $ROLE_TO_ASSUME ]]; then
+    # Both variables are mandatory to be set togethe
+    if [[ -z $ROLE_TO_ASSUME || -z $ACCOUNT_TO_ASSUME ]]; then
         echo "$OPTRED ERROR!$OPTNORMAL - Both Account ID (-A) and IAM Role to assume (-R) must be set"
         exit 1
     fi

--- a/prowler
+++ b/prowler
@@ -392,7 +392,7 @@ show_group_title() {
 # Function to execute the check
 execute_check() {
 
-  if [[ $ACCOUNT_TO_ASSUME ]]; then
+  if [[ -n "${ACCOUNT_TO_ASSUME}" || -n "${ROLE_TO_ASSUME}" ]]; then
     # Following logic looks for time remaining in the session and review it
     # if it is less than 600 seconds, 10 minutes.
     CURRENT_TIMESTAMP=$(date -u "+%s")
@@ -639,7 +639,7 @@ fi
 
 # Gather account data / test aws cli connectivity
 getWhoami
-if [[ $ACCOUNT_TO_ASSUME ]]; then
+if [[ -n "${ACCOUNT_TO_ASSUME}" || -n "${ROLE_TO_ASSUME}" ]]; then
   assume_role
 fi
 


### PR DESCRIPTION
Check if `-T` and `-A` options are set together. 

If not Prowler is executed with the default profile if present and I think this is not the expected behaviour.

e.g.:
`./prowler -R test-role -T 1800 -g group1` --> it is executed with the default profile because `-A` is not set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
