### PR TITLE
Fix group25 FTR @lopmoris

### DIFF
--- a/groups/group25_FTR
+++ b/groups/group25_FTR
@@ -14,8 +14,8 @@
 GROUP_ID[25]='ftr'
 GROUP_NUMBER[25]='25.0'
 GROUP_TITLE[25]='Amazon FTR related security checks - [ftr] ******************'
-GROUP_RUN_BY_DEFAULT[9]='N' # run it when execute_all is called
-GROUP_CHECKS[9]='check11,check12,check13,check14,check15,check16,check17,check18,check19,check110,check111,check111,check112,check113,check117,check118,check122,check21,check22,extra759,extra760,extra768,extra775,extra797,extra7141,extra73'
+GROUP_RUN_BY_DEFAULT[25]='N' # run it when execute_all is called
+GROUP_CHECKS[25]='check11,check12,check13,check14,check15,check16,check17,check18,check19,check110,check111,check111,check112,check113,check117,check118,check122,check21,check22,extra759,extra760,extra768,extra775,extra797,extra7141,extra73'
 
 # Checks from AWS FTR https://apn-checklists.s3.amazonaws.com/foundational/partner-hosted/partner-hosted/CVLHEC5X7.html
 # 1.1 [check11] Avoid the use of the root account - iam [High]


### PR DESCRIPTION
When trying to run the group 25 (Amazon FTR related security checks) nothing happens, after looking at the code there is a misconfiguration in 2 params: GROUP_RUN_BY_DEFAULT[9] and GROUP_CHECKS[9]. Updating values to 25 fixed the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
