### PR TITLE
Docs Readme: fix link for group25 FTR @lopmoris

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ The `gdpr` group of checks uses existing and extra checks. To get a GDPR report,
 
 With this group of checks, Prowler shows result of checks related to the AWS Foundational Technical Review, more information [here](https://apn-checklists.s3.amazonaws.com/foundational/partner-hosted/partner-hosted/CVLHEC5X7.html). The list of checks can be seen in the group file at:
 
-[groups/group25_ftr](groups/group25_ftr)
+[groups/group25_ftr](groups/group25_FTR)
 
 The `ftr` group of checks uses existing and extra checks. To get a AWS FTR report, run this command:
 


### PR DESCRIPTION
Broken link for capital letters in group file (group25_FTR)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
