### PR TITLE
updated alpine, used aws cli v2 instead of v1, and added directory cl…

### DIFF
--- a/util/Dockerfile
+++ b/util/Dockerfile
@@ -1,13 +1,18 @@
-FROM alpine:3.13
+FROM alpine:3.15
 
 ARG USERNAME=prowler
 ARG USERID=34000
 
 RUN addgroup -g ${USERID} ${USERNAME} && \
     adduser -s /bin/sh -G ${USERNAME} -D -u ${USERID} ${USERNAME} && \
-    apk --update --no-cache add python3 bash curl jq file coreutils py3-pip git && \
+    apk --update --no-cache add unzip python3 bash curl jq file coreutils py3-pip git && \
     pip3 install --upgrade pip && \
-    pip3 install awscli boto3 detect-secrets==1.0.3
+    pip3 install awscli boto3 detect-secrets==1.0.3 && \
+    curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && \
+    unzip awscliv2.zip &&\
+    aws/install && \
+    rm -rf aws && \
+    rm -rf /var/cache/apk/*
 
 WORKDIR /prowler
 


### PR DESCRIPTION
Updated alpine, use aws cli v2 instead of v1, and added directory cleanup to reduce image size

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
