### PR TITLE
fix(extra761): Match insensitive values

### DIFF
--- a/checks/check_extra761
+++ b/checks/check_extra761
@@ -34,10 +34,12 @@ extra761(){
       textFail "$regx: Prowler needs ec2:GetEbsEncryptionByDefault permission for this check" "$regx"
       continue
     fi
+    shopt -s nocasematch
     if [[ $EBS_DEFAULT_ENCRYPTION == "true" ]];then
       textPass "$regx: EBS Default Encryption is activated" "$regx"
     else
       textFail "$regx: EBS Default Encryption is not activated" "$regx"
     fi
+    shopt -u nocasematch
     done
 }


### PR DESCRIPTION
### Motivation

A new bug was discovered at https://github.com/toniblyx/prowler/issues/986 because this check performs a case sensitive comparison.

### Description

Match insensitive values using `shopt -s nocasematch`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.