### PR TITLE
Fix: Credential chaining from environment variables @lazize

### DIFF
--- a/include/assume_role
+++ b/include/assume_role
@@ -14,7 +14,11 @@
 assume_role(){
 
     PROFILE_OPT=$PROFILE_OPT_BAK
-
+    if [[ "${PROFILE_OPT}" = "" ]]; then
+        # If profile is not defined, restore original credentials from environment variables, if they exists!
+        restoreInitialAWSCredentials
+    fi
+    
     # Both variables are mandatory to be set together
     if [[ -z $ROLE_TO_ASSUME || -z $ACCOUNT_TO_ASSUME ]]; then
         echo "$OPTRED ERROR!$OPTNORMAL - Both Account ID (-A) and IAM Role to assume (-R) must be set"


### PR DESCRIPTION
If profile is not defined, restore original credentials from environment variables, if they exists, before assume-role

Fix #993 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
