### PR TITLE
Skip packages with broken dependencies when upgrading system

### DIFF
--- a/util/org-multi-account/serverless_codebuild/templates/ProwlerCodeBuildStack.yaml
+++ b/util/org-multi-account/serverless_codebuild/templates/ProwlerCodeBuildStack.yaml
@@ -124,7 +124,7 @@ Resources:
                 python: 3.8
               commands:
                 - echo "Updating yum ..."
-                - yum -y update
+                - yum -y update --skip-broken
                 - echo "Updating pip ..."
                 - python -m pip install --upgrade pip
                 - echo "Installing requirements ..."


### PR DESCRIPTION
### Context 

Instead of breaking the build and stopping the CodeBuild job, the flag `--skip-broken` will skip packages with broken dependencies. This can occur when a package suddenly introduces a new dependency that cannot be resolved by the system, causing the CodeBuild job to suddenly fail.

### Description

Example of a broken build, due to a new version of NodeJS introducing a dependency to a libuv version that cannot be resolved. Instead of stopping the build, the flag `--skip-broken` will skip upgrading NodeJS and ensure prowler can still run with the older version of NodeJS.

```
--> Finished Dependency Resolution
Error: Package: 1:nodejs-16.13.2-3.el7.x86_64 (epel)
           Requires: libuv >= 1:1.42.0
           Installed: 1:libuv-1.39.0-1.amzn2.x86_64 (@amzn2-core)
               libuv = 1:1.39.0-1.amzn2
           Available: 1:libuv-1.23.2-1.amzn2.0.2.i686 (amzn2-core)
               libuv = 1:1.23.2-1.amzn2.0.2
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
[Container] 2022/01/31 09:03:20 Command did not exit successfully yum install -y nodejs exit status 1
[Container] 2022/01/31 09:03:20 Phase complete: INSTALL State: FAILED
[Container] 2022/01/31 09:03:20 Phase context status code: COMMAND_EXECUTION_ERROR Message: Error while executing command: yum install -y nodejs. Reason: exit status 1
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
