### PR TITLE
Add whitelist examples for Control Tower resources

### DIFF
--- a/whitelist_sample.txt
+++ b/whitelist_sample.txt
@@ -19,3 +19,11 @@ check26:myignoredbucket
 # This whitelist works with regexes (ERE, the same style of regex as grep -E and bash's =~ use)
 # therefore:
 # extra718:[[:alnum:]]+-logs # will ignore all buckets containing the terms ci-logs, qa-logs, etc.
+
+# EXAMPLE: CONTROL TOWER
+# When using Control Tower, guardrails prevent access to certain protected resources. The whitelist
+# below ensures that warnings instead of errors are reported for the affected resources.
+#extra734:aws-controltower-logs-[[:digit:]]+-[[:alpha:]\-]+
+#extra734:aws-controltower-s3-access-logs-[[:digit:]]+-[[:alpha:]\-]+
+#extra764:aws-controltower-logs-[[:digit:]]+-[[:alpha:]\-]+
+#extra764:aws-controltower-s3-access-logs-[[:digit:]]+-[[:alpha:]\-]+


### PR DESCRIPTION
### Context 

When using Control Tower, guardrails prevent access to certain protected resources. The whitelist examples included ensures that warnings instead of errors are reported for the affected resources.

### Description

With whitelist:

```
7.34 [extra734] Check if S3 buckets have default encryption (SSE) enabled or use a bucket policy to enforce it - s3 [Medium]
INFO! An error occurred (AccessDenied) when calling the GetBucketLocation operation: Access Denied: Access Denied Trying to Get Bucket Location for aws-controltower-logs-1234567890-eu-central-1 
INFO! An error occurred (AccessDenied) when calling the GetBucketLocation operation: Access Denied: Access Denied Trying to Get Bucket Location for aws-controltower-s3-access-logs-1234567890-eu-central-1 
```

Without whitelist entries, these would be `FAIL!` entries.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
