### PR TITLE
Fix: when prowler exits with a non-zero status, the remainder of the block is not executed

### DIFF
--- a/util/org-multi-account/serverless_codebuild/src/run-prowler-reports.sh
+++ b/util/org-multi-account/serverless_codebuild/src/run-prowler-reports.sh
@@ -93,7 +93,7 @@ for accountId in $ACCOUNTS_IN_ORGS; do
         # Run Prowler
         echo -e "Assessing AWS Account: $accountId, using Role: $ROLE on $(date)"
         # remove -g cislevel for a full report and add other formats if needed
-        ./prowler/prowler -R "$ROLE" -A "$accountId" -g cislevel1 -M $FORMAT || true
+        ./prowler/prowler -R "$ROLE" -A "$accountId" -g cislevel1 -M $FORMAT -z
         echo "Report stored locally at: prowler/output/ directory"
         TOTAL_SEC=$((SECONDS - START_TIME))
         echo -e "Completed AWS Account: $accountId, using Role: $ROLE on $(date)"

--- a/util/org-multi-account/serverless_codebuild/src/run-prowler-reports.sh
+++ b/util/org-multi-account/serverless_codebuild/src/run-prowler-reports.sh
@@ -93,7 +93,7 @@ for accountId in $ACCOUNTS_IN_ORGS; do
         # Run Prowler
         echo -e "Assessing AWS Account: $accountId, using Role: $ROLE on $(date)"
         # remove -g cislevel for a full report and add other formats if needed
-        ./prowler/prowler -R "$ROLE" -A "$accountId" -g cislevel1 -M $FORMAT
+        ./prowler/prowler -R "$ROLE" -A "$accountId" -g cislevel1 -M $FORMAT || true
         echo "Report stored locally at: prowler/output/ directory"
         TOTAL_SEC=$((SECONDS - START_TIME))
         echo -e "Completed AWS Account: $accountId, using Role: $ROLE on $(date)"

--- a/util/org-multi-account/src/run-prowler-reports.sh
+++ b/util/org-multi-account/src/run-prowler-reports.sh
@@ -89,7 +89,7 @@ for accountId in $ACCOUNTS_IN_ORGS; do
         # Run Prowler
         echo -e "Assessing AWS Account: $accountId, using Role: $ROLE on $(date)"
         # remove -g cislevel for a full report and add other formats if needed
-        ./prowler/prowler -R "$ROLE" -A "$accountId" -g cislevel1 -M html
+        ./prowler/prowler -R "$ROLE" -A "$accountId" -g cislevel1 -M html || true
         echo "Report stored locally at: prowler/output/ directory"
         TOTAL_SEC=$((SECONDS - START_TIME))
         echo -e "Completed AWS Account: $accountId, using Role: $ROLE on $(date)"

--- a/util/org-multi-account/src/run-prowler-reports.sh
+++ b/util/org-multi-account/src/run-prowler-reports.sh
@@ -89,7 +89,7 @@ for accountId in $ACCOUNTS_IN_ORGS; do
         # Run Prowler
         echo -e "Assessing AWS Account: $accountId, using Role: $ROLE on $(date)"
         # remove -g cislevel for a full report and add other formats if needed
-        ./prowler/prowler -R "$ROLE" -A "$accountId" -g cislevel1 -M html || true
+        ./prowler/prowler -R "$ROLE" -A "$accountId" -g cislevel1 -M html -z
         echo "Report stored locally at: prowler/output/ directory"
         TOTAL_SEC=$((SECONDS - START_TIME))
         echo -e "Completed AWS Account: $accountId, using Role: $ROLE on $(date)"


### PR DESCRIPTION
### Context 

When `prowler` exits with a non-zero status code, the remainder of the block is not executed.

### Description

`|| true` ensures the remainder of the block is executed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
