### PR TITLE
Fix docker references

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,12 +168,12 @@ Prowler has been written in bash using AWS-CLI underneath and it works in Linux,
     If you want to avoid installing dependencies run it using Docker:
 
     ```sh
-    docker run -ti --rm --name prowler --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN prowler-cloud/prowler:latest
+    docker run -ti --rm --name prowler --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN toniblyx/prowler:latest
     ```
 
     In case you want to get reports created by Prowler use docker volume option like in the example below:
     ```sh
-    docker run -ti --rm -v /your/local/output:/prowler/output --name prowler --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN prowler-cloud/prowler:latest -g hipaa -M csv,json,html
+    docker run -ti --rm -v /your/local/output:/prowler/output --name prowler --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN toniblyx/prowler:latest -g hipaa -M csv,json,html
     ```
 
 1. For custom AWS-CLI profile and region, use the following: (it will use your custom profile and run checks over all regions when needed):
@@ -191,7 +191,7 @@ Prowler has been written in bash using AWS-CLI underneath and it works in Linux,
     With Docker:
 
     ```sh
-    docker run -ti --rm --name prowler --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN prowler-cloud/prowler:latest "-c check310"
+    docker run -ti --rm --name prowler --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN toniblyx/prowler:latest "-c check310"
     ```
 
     or multiple checks separated by comma:
@@ -301,7 +301,7 @@ Prowler has two parameters related to regions: `-r` that is used query AWS servi
     When generating multiple formats and running using Docker, to retrieve the reports, bind a local directory to the container, e.g.:
 
     ```sh
-    docker run -ti --rm --name prowler --volume "$(pwd)":/prowler/output --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN prowler-cloud/prowler:latest -M csv,json
+    docker run -ti --rm --name prowler --volume "$(pwd)":/prowler/output --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN toniblyx/prowler:latest -M csv,json
     ```
 
 1. To perform an assessment based on CIS Profile Definitions you can use cislevel1 or cislevel2 with `-g` flag, more information about this [here, page 8](https://d0.awsstatic.com/whitepapers/compliance/AWS_CIS_Foundations_Benchmark.pdf):


### PR DESCRIPTION
### Context 

Looks like prowler-cloud/prowler#1003 may have erroneously changed the example docker commands. 

### Description

Updated docker example commands.

This registry exists: https://hub.docker.com/r/toniblyx/prowler
This one does not: https://hub.docker.com/r/prowler-cloud/prowler

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
