### PR TITLE
fix(check32): filterName base64encoded to avoid space problems in filter names

### DIFF
--- a/include/check3x
+++ b/include/check3x
@@ -39,12 +39,12 @@ check3x(){
       if [ "$CLOUDWATCH_LOGGROUP_ACCOUNT" == "$CURRENT_ACCOUNT_ID" ];then
         # Filter control and whitespace from .metricFilters[*].filterPattern for easier matching later
         METRICFILTER_CACHE=$($AWSCLI logs describe-metric-filters --log-group-name "$CLOUDWATCH_LOGGROUP_NAME" $PROFILE_OPT --region "$CLOUDWATCH_LOGGROUP_REGION"|jq '.metricFilters|=map(.filterPattern|=gsub("[[:space:]]+"; " "))')
-        METRICFILTER_SET=$(echo $METRICFILTER_CACHE | jq -r --arg re "$grep_filter" '.metricFilters[]|select(.filterPattern|test($re))|.filterName|@base64')
+        METRICFILTER_SET=$(echo "${METRICFILTER_CACHE}" | jq -r --arg re "${grep_filter}" '.metricFilters[]|select(.filterPattern|test($re))|.filterName|@base64')
       fi
       if [[ $METRICFILTER_SET ]];then
         for metric in $METRICFILTER_SET; do
           metric_decode=$(base64 -d <<< "${metric}")
-          metric_name=$(echo $METRICFILTER_CACHE | jq -r --arg name "${metric_decode}" '.metricFilters[]|select(.filterName==$name)|.metricTransformations[0].metricName')
+          metric_name=$(echo "${METRICFILTER_CACHE}" | jq -r --arg name "${metric_decode}" '.metricFilters[]|select(.filterName==$name)|.metricTransformations[0].metricName')
           HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region "$CLOUDWATCH_LOGGROUP_REGION" --query 'MetricAlarms[?MetricName==`'"$metric_name"'`]' --output text)
           if [[ $HAS_ALARM_ASSOCIATED ]];then
             CHECK_OK="$CHECK_OK $CLOUDWATCH_LOGGROUP_NAME:$metric"

--- a/include/check3x
+++ b/include/check3x
@@ -39,11 +39,12 @@ check3x(){
       if [ "$CLOUDWATCH_LOGGROUP_ACCOUNT" == "$CURRENT_ACCOUNT_ID" ];then
         # Filter control and whitespace from .metricFilters[*].filterPattern for easier matching later
         METRICFILTER_CACHE=$($AWSCLI logs describe-metric-filters --log-group-name "$CLOUDWATCH_LOGGROUP_NAME" $PROFILE_OPT --region "$CLOUDWATCH_LOGGROUP_REGION"|jq '.metricFilters|=map(.filterPattern|=gsub("[[:space:]]+"; " "))')
-        METRICFILTER_SET=$(echo $METRICFILTER_CACHE | jq -r --arg re "$grep_filter" '.metricFilters[]|select(.filterPattern|test($re))|.filterName')
+        METRICFILTER_SET=$(echo $METRICFILTER_CACHE | jq -r --arg re "$grep_filter" '.metricFilters[]|select(.filterPattern|test($re))|.filterName|@base64')
       fi
       if [[ $METRICFILTER_SET ]];then
         for metric in $METRICFILTER_SET; do
-          metric_name=$(echo $METRICFILTER_CACHE | jq -r --arg name $metric '.metricFilters[]|select(.filterName==$name)|.metricTransformations[0].metricName')
+          metric_decode=$(echo $metric | base64 -d)
+          metric_name=$(echo $METRICFILTER_CACHE | jq -r --arg name "${metric_decode}" '.metricFilters[]|select(.filterName==$name)|.metricTransformations[0].metricName')
           HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region "$CLOUDWATCH_LOGGROUP_REGION" --query 'MetricAlarms[?MetricName==`'"$metric_name"'`]' --output text)
           if [[ $HAS_ALARM_ASSOCIATED ]];then
             CHECK_OK="$CHECK_OK $CLOUDWATCH_LOGGROUP_NAME:$metric"
@@ -61,7 +62,7 @@ check3x(){
 
     if [[ $CHECK_OK ]]; then
       for group in $CHECK_OK; do
-        metric=${group#*:}
+        metric=$(echo ${group#*:} | base64 -d)
         group=${group%:*}
         textPass "$REGION: CloudWatch group $group found with metric filter $metric and alarms set" "$REGION" "$group"
       done
@@ -69,7 +70,7 @@ check3x(){
     if [[ $CHECK_WARN ]]; then
       for group in $CHECK_WARN; do
         case $group in
-           *:*) metric=${group#*:}
+           *:*) metric=$(echo ${group#*:} | base64 -d)
                 group=${group%:*}
                 if [[ $pass_count == 0 ]]; then
                   textFail "$REGION: CloudWatch group $group found with metric filter $metric but no alarms associated" "$REGION" "$group"

--- a/include/check3x
+++ b/include/check3x
@@ -43,7 +43,7 @@ check3x(){
       fi
       if [[ $METRICFILTER_SET ]];then
         for metric in $METRICFILTER_SET; do
-          metric_decode=$(echo $metric | base64 -d)
+          metric_decode=$(base64 -d <<< "${metric}")
           metric_name=$(echo $METRICFILTER_CACHE | jq -r --arg name "${metric_decode}" '.metricFilters[]|select(.filterName==$name)|.metricTransformations[0].metricName')
           HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region "$CLOUDWATCH_LOGGROUP_REGION" --query 'MetricAlarms[?MetricName==`'"$metric_name"'`]' --output text)
           if [[ $HAS_ALARM_ASSOCIATED ]];then
@@ -62,7 +62,7 @@ check3x(){
 
     if [[ $CHECK_OK ]]; then
       for group in $CHECK_OK; do
-        metric=$(echo ${group#*:} | base64 -d)
+        metric=$(base64 -d <<< "${group#*:}")
         group=${group%:*}
         textPass "$REGION: CloudWatch group $group found with metric filter $metric and alarms set" "$REGION" "$group"
       done
@@ -70,7 +70,7 @@ check3x(){
     if [[ $CHECK_WARN ]]; then
       for group in $CHECK_WARN; do
         case $group in
-           *:*) metric=$(echo ${group#*:} | base64 -d)
+           *:*) metric=$(base64 -d <<< "${group#*:}")
                 group=${group%:*}
                 if [[ $pass_count == 0 ]]; then
                   textFail "$REGION: CloudWatch group $group found with metric filter $metric but no alarms associated" "$REGION" "$group"


### PR DESCRIPTION

### Context 

Prowler fails in check32 when metric filter names include spaces, interpreting each single word of the name as a different metric filter name. This generates false positives from non existing metric filter names -  prowler-cloud/prowler#745


### Description

To avoid this metric filter name is base64 encoded in check3x file, decoding it when its needed ( aws api calls and display messages)


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
