### PR TITLE
Fix(extra7148): Error handling and include missing policy

### DIFF
--- a/checks/check_extra7148
+++ b/checks/check_extra7148
@@ -33,7 +33,11 @@ extra7148() {
     if [[ $LIST_OF_EFS_SYSTEMS ]]; then
       for filesystem in $LIST_OF_EFS_SYSTEMS; do
         # if retention is 0 then is disabled
-        BACKUP_POLICY=$($AWSCLI efs describe-backup-policy $PROFILE_OPT --region $regx --file-system-id $filesystem --query BackupPolicy --output text)
+        BACKUP_POLICY=$($AWSCLI efs describe-backup-policy $PROFILE_OPT --region $regx --file-system-id $filesystem --query BackupPolicy --output text 2>&1)
+        if [[ $(echo "$BACKUP_POLICY" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+          textInfo "$regx: Access Denied trying to describe backup policy" "$regx"
+          continue
+        fi
         if [[ $BACKUP_POLICY == "DISABLED" ]]; then
           textFail "$regx: File system $filesystem does not have backup enabled!" "$regx" "$filesystem"
         else

--- a/iam/create_role_to_assume_cfn.yaml
+++ b/iam/create_role_to_assume_cfn.yaml
@@ -67,4 +67,5 @@ Resources:
                 - 's3:GetAccountPublicAccessBlock'
                 - 'shield:GetSubscriptionState'
                 - 'shield:DescribeProtection'
+                - 'elasticfilesystem:DescribeBackupPolicy'
               Resource: '*'

--- a/iam/prowler-additions-policy.json
+++ b/iam/prowler-additions-policy.json
@@ -14,7 +14,8 @@
                 "glue:SearchTables",
                 "s3:GetAccountPublicAccessBlock",
                 "shield:GetSubscriptionState",
-                "shield:DescribeProtection"
+                "shield:DescribeProtection",
+                "elasticfilesystem:DescribeBackupPolicy"
             ],
             "Resource": "*",
             "Effect": "Allow",

--- a/util/codebuild/codebuild-prowler-audit-account-cfn.yaml
+++ b/util/codebuild/codebuild-prowler-audit-account-cfn.yaml
@@ -196,6 +196,7 @@ Resources:
                   - s3:GetAccountPublicAccessBlock
                   - shield:GetSubscriptionState
                   - shield:DescribeProtection
+                  - elasticfilesystem:DescribeBackupPolicy
                 Effect: Allow
                 Resource: !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog'
         - PolicyName: CodeBuild

--- a/util/org-multi-account/ProwlerRole.yaml
+++ b/util/org-multi-account/ProwlerRole.yaml
@@ -98,6 +98,7 @@ Resources:
                   - tag:GetTagKeys
                   - shield:GetSubscriptionState
                   - shield:DescribeProtection
+                  - elasticfilesystem:DescribeBackupPolicy
         - PolicyName: Prowler-S3-Reports
           PolicyDocument:
             Version: 2012-10-17

--- a/util/org-multi-account/serverless_codebuild/templates/ProwlerRole.yaml
+++ b/util/org-multi-account/serverless_codebuild/templates/ProwlerRole.yaml
@@ -99,6 +99,7 @@ Resources:
                   - tag:GetTagKeys
                   - shield:GetSubscriptionState
                   - shield:DescribeProtection
+                  - elasticfilesystem:DescribeBackupPolicy
         - PolicyName: Prowler-S3-Reports
           PolicyDocument:
             Version: 2012-10-17

--- a/util/terraform-kickstarter/main.tf
+++ b/util/terraform-kickstarter/main.tf
@@ -322,7 +322,8 @@ resource "aws_iam_policy" "prowler_kickstarter_iam_policy" {
                   "glue:SearchTables",
                   "s3:GetAccountPublicAccessBlock",
                   "shield:GetSubscriptionState",
-                  "shield:DescribeProtection"
+                  "shield:DescribeProtection",
+                  "elasticfilesystem:DescribeBackupPolicy"
                   ]
         Effect   = "Allow"
         Resource = "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog"


### PR DESCRIPTION
### Context 

Fix issue #1017


### Description

Include error handling for check `extra7148` and a missing policy permission `elasticfilesystem:DescribeBackupPolicy`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
