### PR TITLE
Fix(extra760): Error handling

### DIFF
--- a/checks/check_extra760
+++ b/checks/check_extra760
@@ -40,7 +40,11 @@ extra760(){
       for lambdafunction in $LIST_OF_FUNCTIONS;do
         LAMBDA_FUNCTION_FOLDER="$SECRETS_TEMP_FOLDER/extra760-$lambdafunction-$regx"
         LAMBDA_FUNCTION_FILE="$lambdafunction-code.zip"
-        LAMBDA_CODE_LOCATION=$($AWSCLI lambda get-function $PROFILE_OPT --region $regx --function-name $lambdafunction --query Code.Location --output text)
+        LAMBDA_CODE_LOCATION=$($AWSCLI lambda get-function $PROFILE_OPT --region $regx --function-name $lambdafunction --query Code.Location --output text 2>&1)
+        if [[ $(echo "$LAMBDA_CODE_LOCATION" | grep AccessDenied) ]]; then
+          textInfo "$regx: Access Denied trying to get Lambda functions" "$regx" "$lambdafunction"
+          continue
+        fi
         mkdir $LAMBDA_FUNCTION_FOLDER
         # DOWNLOAD the code in a zip file
         curl -s $LAMBDA_CODE_LOCATION -o $LAMBDA_FUNCTION_FOLDER/$LAMBDA_FUNCTION_FILE


### PR DESCRIPTION
### Context 

Missing permission was exposing AccessDenied error message.
Also missing check was generating false positive.

### Description

Add check to validate access denied when get function from Lambda.

Issue #1014

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
