### PR TITLE
fix: CFN codebuild example

### DIFF
--- a/util/codebuild/codebuild-prowler-audit-account-cfn.yaml
+++ b/util/codebuild/codebuild-prowler-audit-account-cfn.yaml
@@ -197,7 +197,7 @@ Resources:
                   - shield:GetSubscriptionState
                   - shield:DescribeProtection
                 Effect: Allow
-                Resource: !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog'
+                Resource: '*'
         - PolicyName: CodeBuild
           PolicyDocument:
             Version: '2012-10-17'


### PR DESCRIPTION
Since 2.7.0 this template failed:

```
An error occurred (AccessDeniedException) when calling the GetSubscriptionState operation: User: arn:aws:sts::863046042023:assumed-role/prowler-codebuild-role/AWSCodeBuild-2c3151c9-7c5d-4618-94e5-0234bddce775 is not authorized to perform: shield:GetSubscriptionState on resource: arn:aws:shield::863046042023:subscription/* because no identity-based policy allows the shield:GetSubscriptionState action
       INFO! No AWS Shield Advanced subscription found. Skipping check. 
7.167 [extra7167] Check if Cloudfront distributions are protected by AWS Shield Advanced - shield [Medium]
```

I aligned it with https://github.com/prowler-cloud/prowler/blob/master/iam/prowler-additions-policy.json#L19 .

### Context 

Please include relevant motivation and context for this PR.


### Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
