### PR TITLE
Fix(ES): Improve AWS CLI query and add error handling for ElasticSearch/OpenSearch checks

### DIFF
--- a/checks/check_extra7101
+++ b/checks/check_extra7101
@@ -26,15 +26,19 @@ CHECK_CAF_EPIC_extra7101='Logging and Monitoring'
 
 extra7101(){
   for regx in $REGIONS; do
-    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query DomainNames --output text 2>&1)
+    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query 'DomainNames[].DomainName' --output text 2>&1)
     if [[ $(echo "$LIST_OF_DOMAINS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
         textInfo "$regx: Access Denied trying to list domain names" "$regx"
         continue
     fi
     if [[ $LIST_OF_DOMAINS ]]; then
       for domain in $LIST_OF_DOMAINS;do
-        AUDIT_LOGS_ENABLED=$($AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query DomainConfig.LogPublishingOptions.Options.AUDIT_LOGS.Enabled --output text |grep -v ^None|grep -v ^False)
-        if [[ $AUDIT_LOGS_ENABLED ]];then
+        AUDIT_LOGS_ENABLED=$($AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainConfig.LogPublishingOptions.Options.AUDIT_LOGS.Enabled' --output text 2>&1)
+        if [[ $(echo "$AUDIT_LOGS_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+            textInfo "$regx: Access Denied trying to get ES domain config for $domain" "$regx"
+            continue
+        fi
+        if [[ "${AUDIT_LOGS_ENABLED,,}" == "true" ]];then
           textPass "$regx: Amazon ES domain $domain AUDIT_LOGS enabled" "$regx" "$domain"
         else
           textFail "$regx: Amazon ES domain $domain AUDIT_LOGS disabled!" "$regx" "$domain"

--- a/checks/check_extra715
+++ b/checks/check_extra715
@@ -32,7 +32,7 @@ extra715(){
     fi
     if [[ $LIST_OF_DOMAINS ]]; then
       for domain in $LIST_OF_DOMAINS;do
-        SLOWLOG_ENABLED=$($AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query "DomainConfig.LogPublishingOptions.Options.[SEARCH_SLOW_LOGS.Enabled, INDEX_SLOW_LOGS.Enabled]" --output text 2>&1)
+        SLOWLOG_ENABLED=$($AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainConfig.LogPublishingOptions.Options.[SEARCH_SLOW_LOGS.Enabled, INDEX_SLOW_LOGS.Enabled]' --output text 2>&1)
         if [[ $(echo "$SLOWLOG_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
             textInfo "$regx: Access Denied trying to get ES domain config for $domain" "$regx"
             continue

--- a/checks/check_extra715
+++ b/checks/check_extra715
@@ -25,25 +25,30 @@ CHECK_CAF_EPIC_extra715='Logging and Monitoring'
 
 extra715(){
   for regx in $REGIONS; do
-    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query DomainNames --output text 2>&1)
+    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query 'DomainNames[].DomainName' --output text 2>&1)
     if [[ $(echo "$LIST_OF_DOMAINS" | grep -E 'AccessDenied|UnauthorizedOperation') ]]; then
         textInfo "$regx: Access Denied trying to list domain names" "$regx"
         continue
     fi
     if [[ $LIST_OF_DOMAINS ]]; then
       for domain in $LIST_OF_DOMAINS;do
-        SEARCH_SLOWLOG_ENABLED=$($AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query DomainConfig.LogPublishingOptions.Options.SEARCH_SLOW_LOGS.Enabled --output text |grep -v ^None|grep -v ^False)
-        if [[ $SEARCH_SLOWLOG_ENABLED ]];then
-          textPass "$regx: Amazon ES domain $domain SEARCH_SLOW_LOGS enabled" "$regx" "$domain"
-        else
-          textFail "$regx: Amazon ES domain $domain SEARCH_SLOW_LOGS disabled!" "$regx" "$domain"
+        SLOWLOG_ENABLED=$($AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query "DomainConfig.LogPublishingOptions.Options.[SEARCH_SLOW_LOGS.Enabled, INDEX_SLOW_LOGS.Enabled]" --output text 2>&1)
+        if [[ $(echo "$SLOWLOG_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+            textInfo "$regx: Access Denied trying to get ES domain config for $domain" "$regx"
+            continue
         fi
-        INDEX_SLOWLOG_ENABLED=$($AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query DomainConfig.LogPublishingOptions.Options.INDEX_SLOW_LOGS.Enabled --output text |grep -v ^None|grep -v ^False)
-        if [[ $INDEX_SLOWLOG_ENABLED ]];then
-          textPass "$regx: Amazon ES domain $domain INDEX_SLOW_LOGS enabled" "$regx" "$domain"
-        else
-          textFail "$regx: Amazon ES domain $domain INDEX_SLOW_LOGS disabled!" "$regx" "$domain"
-        fi
+        read SEARCH_SLOWLOG_ENABLED INDEX_SLOWLOG_ENABLED <<< "$SLOWLOG_ENABLED" && {
+          if [[ "${SEARCH_SLOWLOG_ENABLED,,}" == "true" ]];then
+            textPass "$regx: Amazon ES domain $domain SEARCH_SLOW_LOGS enabled" "$regx" "$domain"
+          else
+            textFail "$regx: Amazon ES domain $domain SEARCH_SLOW_LOGS disabled!" "$regx" "$domain"
+          fi
+          if [[ "${INDEX_SLOWLOG_ENABLED,,}" == "true" ]];then
+            textPass "$regx: Amazon ES domain $domain INDEX_SLOW_LOGS enabled" "$regx" "$domain"
+          else
+            textFail "$regx: Amazon ES domain $domain INDEX_SLOW_LOGS disabled!" "$regx" "$domain"
+          fi
+        }
       done
     else
       textInfo "$regx: No Amazon ES domain found" "$regx"

--- a/checks/check_extra716
+++ b/checks/check_extra716
@@ -31,16 +31,24 @@ extra716(){
         continue
     fi    
     if [[ $LIST_OF_DOMAINS ]]; then
+      TEMP_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-es-domain.policy.XXXXXXXXXX)
       for domain in $LIST_OF_DOMAINS;do
-        TEMP_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-es-domain.policy.XXXXXXXXXX)
         # get endpoint or vpc endpoints
-        ES_DOMAIN_ENDPOINT=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.[Endpoint || Endpoints]' --output text)
+        ES_DOMAIN_INFO=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.[Endpoints.vpc, VPCOptions.VPCId]' --output text 2>&1)
+        if [[ $(echo "$ES_DOMAIN_INFO" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+          textInfo "$regx: Access Denied trying to get domain $domain" "$regx"
+          continue
+        fi
+        read ES_DOMAIN_ENDPOINT_VPC ES_DOMAIN_VPC <<< "$ES_DOMAIN_INFO" &&
         # If the endpoint starts with "vpc-" it is in a VPC then it is fine.
-        if [[ "$ES_DOMAIN_ENDPOINT" =~ ^vpc-* ]];then
-          ES_DOMAIN_VPC=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.VPCOptions.VPCId' --output text)
+        if [[ "${ES_DOMAIN_ENDPOINT_VPC:0:3}" == "vpc" ]]; then
           textInfo "$regx: Amazon ES domain $domain is in VPC $ES_DOMAIN_VPC run extra779 to make sure it is not exposed using custom proxy" "$regx" "$domain"
         else
-          $AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query DomainConfig.AccessPolicies.Options --output text > $TEMP_POLICY_FILE 2> /dev/null
+          $AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainConfig.AccessPolicies.Options' --output text > $TEMP_POLICY_FILE 2>&1
+          if [[ $(grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' $TEMP_POLICY_FILE) ]]; then
+            textInfo "$regx: Access Denied trying to get domain config for $domain" "$regx"
+            continue
+          fi
           # check if the policy has a principal set up
           CHECK_ES_POLICY_PRINCIPAL=$(cat $TEMP_POLICY_FILE | jq -r '. | .Statement[] | select(.Effect == "Allow" and (((.Principal|type == "object") and .Principal.AWS != "*") or ((.Principal|type == "string") and .Principal != "*")) and select(has("Condition") | not))')
           if [[ $CHECK_ES_POLICY_PRINCIPAL ]]; then 
@@ -89,9 +97,9 @@ extra716(){
               textPass "$regx: Amazon ES domain $domain does not allow anonymous access" "$regx" "$domain"
             fi
           fi
-          rm -f $TEMP_POLICY_FILE
         fi
       done
+      [[ -f "${TEMP_POLICY_FILE}" ]] && rm -f $TEMP_POLICY_FILE
     else
       textInfo "$regx: No Amazon ES domain found" "$regx"
     fi

--- a/checks/check_extra716
+++ b/checks/check_extra716
@@ -25,7 +25,7 @@ CHECK_CAF_EPIC_extra716='Infrastructure Security'
 
 extra716(){
   for regx in $REGIONS; do
-    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query DomainNames --output text 2>&1)
+    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query 'DomainNames[].DomainName' --output text 2>&1)
     if [[ $(echo "$LIST_OF_DOMAINS" | grep -E 'AccessDenied|UnauthorizedOperation') ]]; then
         textInfo "$regx: Access Denied trying to list domain names" "$regx"
         continue

--- a/checks/check_extra780
+++ b/checks/check_extra780
@@ -34,7 +34,7 @@ extra780(){
       for domain in $LIST_OF_DOMAINS;do
         CHECK_IF_COGNITO_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.CognitoOptions.Enabled' --output text 2>&1)
         if [[ $(echo "$CHECK_IF_COGNITO_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-            textInfo "$regx: Access Denied trying to get ES domain" "$regx"
+            textInfo "$regx: Access Denied trying to get ES domain $domain" "$regx"
             continue
         fi
         if [[ "${CHECK_IF_COGNITO_ENABLED,,}" == "true" ]];then

--- a/checks/check_extra780
+++ b/checks/check_extra780
@@ -25,15 +25,19 @@ CHECK_CAF_EPIC_extra780='IAM'
 
 extra780(){
   for regx in $REGIONS; do
-    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query DomainNames --output text 2>&1)
+    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query 'DomainNames[].DomainName' --output text 2>&1)
     if [[ $(echo "$LIST_OF_DOMAINS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
         textInfo "$regx: Access Denied trying to list domain names" "$regx"
         continue
     fi
     if [[ $LIST_OF_DOMAINS ]]; then
       for domain in $LIST_OF_DOMAINS;do
-        CHECK_IF_COGNITO_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.CognitoOptions.Enabled' --output text|grep -i true)
-        if [[ $CHECK_IF_COGNITO_ENABLED ]];then
+        CHECK_IF_COGNITO_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.CognitoOptions.Enabled' --output text 2>&1)
+        if [[ $(echo "$CHECK_IF_COGNITO_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+            textInfo "$regx: Access Denied trying to get ES domain" "$regx"
+            continue
+        fi
+        if [[ "${CHECK_IF_COGNITO_ENABLED,,}" == "true" ]];then
           textPass "$regx: Amazon ES domain $domain has Amazon Cognito authentication for Kibana enabled" "$regx" "$domain"
         else
           textFail "$regx: Amazon ES domain $domain does not have Amazon Cognito authentication for Kibana enabled" "$regx" "$domain"

--- a/checks/check_extra781
+++ b/checks/check_extra781
@@ -26,15 +26,19 @@ CHECK_CAF_EPIC_extra781='Data Protection'
 
 extra781(){
   for regx in $REGIONS; do
-    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query DomainNames --output text 2>&1)
+    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query 'DomainNames[].DomainName' --output text 2>&1)
     if [[ $(echo "$LIST_OF_DOMAINS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
         textInfo "$regx: Access Denied trying to list domain names" "$regx"
         continue
     fi
     if [[ $LIST_OF_DOMAINS ]]; then
       for domain in $LIST_OF_DOMAINS;do
-        CHECK_IF_ENCREST_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.EncryptionAtRestOptions.Enabled' --output text|grep -i true)
-        if [[ $CHECK_IF_ENCREST_ENABLED ]];then
+        CHECK_IF_ENCREST_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.EncryptionAtRestOptions.Enabled' --output text 2>&1)
+        if [[ $(echo "$CHECK_IF_ENCREST_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+            textInfo "$regx: Access Denied trying to get ES domain" "$regx"
+            continue
+        fi
+        if [[ $(echo "$CHECK_IF_ENCREST_ENABLED" | grep -i true) ]];then
           textPass "$regx: Amazon ES domain $domain has encryption at-rest enabled" "$regx" "$domain"
         else
           textFail "$regx: Amazon ES domain $domain does not have encryption at-rest enabled" "$regx" "$domain"

--- a/checks/check_extra781
+++ b/checks/check_extra781
@@ -35,7 +35,7 @@ extra781(){
       for domain in $LIST_OF_DOMAINS;do
         CHECK_IF_ENCREST_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.EncryptionAtRestOptions.Enabled' --output text 2>&1)
         if [[ $(echo "$CHECK_IF_ENCREST_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-            textInfo "$regx: Access Denied trying to get ES domain" "$regx"
+            textInfo "$regx: Access Denied trying to get ES domain $domain" "$regx"
             continue
         fi
         if [[ $(echo "$CHECK_IF_ENCREST_ENABLED" | grep -i true) ]];then

--- a/checks/check_extra782
+++ b/checks/check_extra782
@@ -34,7 +34,7 @@ extra782(){
       for domain in $LIST_OF_DOMAINS;do
         CHECK_IF_NODETOENCR_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.NodeToNodeEncryptionOptions.Enabled' --output text 2>&1)
         if [[ $(echo "$CHECK_IF_NODETOENCR_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-            textInfo "$regx: Access Denied trying to get ES domain" "$regx"
+            textInfo "$regx: Access Denied trying to get ES domain $domain" "$regx"
             continue
         fi
         if [[ $(echo "$CHECK_IF_NODETOENCR_ENABLED" | grep -i true) ]];then

--- a/checks/check_extra782
+++ b/checks/check_extra782
@@ -25,15 +25,19 @@ CHECK_CAF_EPIC_extra782='Data Protection'
 
 extra782(){
   for regx in $REGIONS; do
-    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query DomainNames --output text 2>&1)
+    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query 'DomainNames[].DomainName' --output text 2>&1)
     if [[ $(echo "$LIST_OF_DOMAINS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
         textInfo "$regx: Access Denied trying to list domain names" "$regx"
         continue
     fi
     if [[ $LIST_OF_DOMAINS ]]; then
       for domain in $LIST_OF_DOMAINS;do
-        CHECK_IF_NODETOENCR_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.NodeToNodeEncryptionOptions.Enabled' --output text|grep -i true)
-        if [[ $CHECK_IF_NODETOENCR_ENABLED ]];then
+        CHECK_IF_NODETOENCR_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.NodeToNodeEncryptionOptions.Enabled' --output text 2>&1)
+        if [[ $(echo "$CHECK_IF_NODETOENCR_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+            textInfo "$regx: Access Denied trying to get ES domain" "$regx"
+            continue
+        fi
+        if [[ $(echo "$CHECK_IF_NODETOENCR_ENABLED" | grep -i true) ]];then
           textPass "$regx: Amazon ES domain $domain has node-to-node encryption enabled" "$regx" "$domain"
         else
           textFail "$regx: Amazon ES domain $domain does not have node-to-node encryption enabled" "$regx" "$domain"

--- a/checks/check_extra783
+++ b/checks/check_extra783
@@ -25,15 +25,19 @@ CHECK_CAF_EPIC_extra783='Data Protection'
 
 extra783(){
   for regx in $REGIONS; do
-    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query DomainNames --output text 2>&1)
+    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query 'DomainNames[].DomainName' --output text 2>&1)
     if [[ $(echo "$LIST_OF_DOMAINS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
         textInfo "$regx: Access Denied trying to list domain names" "$regx"
         continue
     fi
     if [[ $LIST_OF_DOMAINS ]]; then
       for domain in $LIST_OF_DOMAINS;do
-        CHECK_IF_ENFORCEHTTPS_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.DomainEndpointOptions.EnforceHTTPS' --output text|grep -i true)
-        if [[ $CHECK_IF_ENFORCEHTTPS_ENABLED ]];then
+        CHECK_IF_ENFORCEHTTPS_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.DomainEndpointOptions.EnforceHTTPS' --output text 2>&1)
+        if [[ $(echo "$CHECK_IF_ENFORCEHTTPS_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+            textInfo "$regx: Access Denied trying to get ES domain" "$regx"
+            continue
+        fi
+        if [[ $(echo "$CHECK_IF_ENFORCEHTTPS_ENABLED" | grep -i true) ]];then
           textPass "$regx: Amazon ES domain $domain has enforce HTTPS enabled" "$regx" "$domain"
         else
           textFail "$regx: Amazon ES domain $domain does not have enforce HTTPS enabled" "$regx" "$domain"

--- a/checks/check_extra783
+++ b/checks/check_extra783
@@ -34,7 +34,7 @@ extra783(){
       for domain in $LIST_OF_DOMAINS;do
         CHECK_IF_ENFORCEHTTPS_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.DomainEndpointOptions.EnforceHTTPS' --output text 2>&1)
         if [[ $(echo "$CHECK_IF_ENFORCEHTTPS_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-            textInfo "$regx: Access Denied trying to get ES domain" "$regx"
+            textInfo "$regx: Access Denied trying to get ES domain $domain" "$regx"
             continue
         fi
         if [[ $(echo "$CHECK_IF_ENFORCEHTTPS_ENABLED" | grep -i true) ]];then

--- a/checks/check_extra784
+++ b/checks/check_extra784
@@ -34,7 +34,7 @@ extra784(){
       for domain in $LIST_OF_DOMAINS;do
         CHECK_IF_INTERNALDB_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.AdvancedSecurityOptions.InternalUserDatabaseEnabled' --output text 2>&1)
         if [[ $(echo "$CHECK_IF_INTERNALDB_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-            textInfo "$regx: Access Denied trying to get ES domain" "$regx"
+            textInfo "$regx: Access Denied trying to get ES domain $domain" "$regx"
             continue
         fi
         if [[ $(echo "$CHECK_IF_INTERNALDB_ENABLED" | grep -i true) ]];then

--- a/checks/check_extra784
+++ b/checks/check_extra784
@@ -25,15 +25,19 @@ CHECK_CAF_EPIC_extra784='IAM'
 
 extra784(){
   for regx in $REGIONS; do
-    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query DomainNames --output text 2>&1)
+    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query 'DomainNames[].DomainName' --output text 2>&1)
     if [[ $(echo "$LIST_OF_DOMAINS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
         textInfo "$regx: Access Denied trying to list domain names" "$regx"
         continue
     fi
     if [[ $LIST_OF_DOMAINS ]]; then
       for domain in $LIST_OF_DOMAINS;do
-        CHECK_IF_INTERNALDB_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.AdvancedSecurityOptions.InternalUserDatabaseEnabled' --output text|grep -i true)
-        if [[ $CHECK_IF_INTERNALDB_ENABLED ]];then
+        CHECK_IF_INTERNALDB_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.AdvancedSecurityOptions.InternalUserDatabaseEnabled' --output text 2>&1)
+        if [[ $(echo "$CHECK_IF_INTERNALDB_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+            textInfo "$regx: Access Denied trying to get ES domain" "$regx"
+            continue
+        fi
+        if [[ $(echo "$CHECK_IF_INTERNALDB_ENABLED" | grep -i true) ]];then
           textFail "$regx: Amazon ES domain $domain has internal user database enabled" "$regx" "$domain"
         else
           textPass "$regx: Amazon ES domain $domain does not have internal user database enabled" "$regx" "$domain"

--- a/checks/check_extra785
+++ b/checks/check_extra785
@@ -30,14 +30,18 @@ CHECK_CAF_EPIC_extra785='Infrastructure Security'
 
 extra785(){
   for regx in $REGIONS; do
-    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query DomainNames --output text 2>&1)
+    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query 'DomainNames[].DomainName' --output text 2>&1)
     if [[ $(echo "$LIST_OF_DOMAINS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
         textInfo "$regx: Access Denied trying to list domain names" "$regx"
         continue
     fi
     if [[ $LIST_OF_DOMAINS ]]; then
       for domain in $LIST_OF_DOMAINS;do
-        CHECK_IF_UPDATE_AVAILABLE_AND_VERSION=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.[ServiceSoftwareOptions.UpdateAvailable,ElasticsearchVersion]' --output text)
+        CHECK_IF_UPDATE_AVAILABLE_AND_VERSION=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.[ServiceSoftwareOptions.UpdateAvailable,ElasticsearchVersion]' --output text 2>&1)
+        if [[ $(echo "$CHECK_IF_UPDATE_AVAILABLE_AND_VERSION" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+            textInfo "$regx: Access Denied trying to get ES domain" "$regx"
+            continue
+        fi
         while read update_status es_version;do
           if [[ $update_status != "False" ]];then
             textInfo "$regx: Amazon ES domain $domain v$es_version has updates available" "$regx" "$domain"

--- a/checks/check_extra785
+++ b/checks/check_extra785
@@ -42,13 +42,12 @@ extra785(){
             textInfo "$regx: Access Denied trying to get ES domain" "$regx"
             continue
         fi
-        while read update_status es_version;do
-          if [[ $update_status != "False" ]];then
-            textInfo "$regx: Amazon ES domain $domain v$es_version has updates available" "$regx" "$domain"
-          else
-            textPass "$regx: Amazon ES domain $domain v$es_version does not have have updates available" "$regx" "$domain"
-          fi
-        done < <(echo $CHECK_IF_UPDATE_AVAILABLE_AND_VERSION)
+        read update_status es_version <<< "$CHECK_IF_UPDATE_AVAILABLE_AND_VERSION" &&
+        if [[ ${update_status,,} != "false" ]];then
+          textInfo "$regx: Amazon ES domain $domain v$es_version has updates available" "$regx" "$domain"
+        else
+          textPass "$regx: Amazon ES domain $domain v$es_version does not have have updates available" "$regx" "$domain"
+        fi
       done
     else
       textInfo "$regx: No Amazon ES domain found" "$regx"

--- a/checks/check_extra785
+++ b/checks/check_extra785
@@ -39,7 +39,7 @@ extra785(){
       for domain in $LIST_OF_DOMAINS;do
         CHECK_IF_UPDATE_AVAILABLE_AND_VERSION=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.[ServiceSoftwareOptions.UpdateAvailable,ElasticsearchVersion]' --output text 2>&1)
         if [[ $(echo "$CHECK_IF_UPDATE_AVAILABLE_AND_VERSION" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-            textInfo "$regx: Access Denied trying to get ES domain" "$regx"
+            textInfo "$regx: Access Denied trying to get ES domain $domain" "$regx"
             continue
         fi
         read update_status es_version <<< "$CHECK_IF_UPDATE_AVAILABLE_AND_VERSION" &&

--- a/checks/check_extra788
+++ b/checks/check_extra788
@@ -29,22 +29,32 @@ extra788(){
 
   # "Check if Elasticsearch Service domains allow open access "
   for regx in $REGIONS; do
-    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query DomainNames --output text 2>&1)
+    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query 'DomainNames[].DomainName' --output text 2>&1)
     if [[ $(echo "$LIST_OF_DOMAINS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-        textInfo "$regx: Access Denied trying to list domain names" "$regx"
-        continue
+      textInfo "$regx: Access Denied trying to list domain names" "$regx"
+      continue
     fi
     if [[ $LIST_OF_DOMAINS ]]; then
+      TEMP_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-es-domain.policy.XXXXXXXXXX)
       for domain in $LIST_OF_DOMAINS;do
-        TEMP_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-es-domain.policy.XXXXXXXXXX)
         # get endpoint or vpc endpoints
-        ES_DOMAIN_ENDPOINT=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.[Endpoint || Endpoints]' --output text)
+        ES_DOMAIN_INFO=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.[Endpoint, Endpoints.vpc, VPCOptions.VPCId]' --output text 2>&1)
+        if [[ $(echo "$ES_DOMAIN_INFO" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+          textInfo "$regx: Access Denied trying to get domain $domain" "$regx"
+          continue
+        fi
+        read ES_DOMAIN_ENDPOINT ES_DOMAIN_ENDPOINTS ES_DOMAIN_VPC <<< "$ES_DOMAIN_INFO" && {
+          [[ "${ES_DOMAIN_ENDPOINT}" == "None" ]] && ES_DOMAIN_ENDPOINT="${ES_DOMAIN_ENDPOINTS}"
+        }
         # If the endpoint starts with "vpc-" it is in a VPC then it is fine.
-        if [[ "$ES_DOMAIN_ENDPOINT" =~ ^vpc-* ]];then
-          ES_DOMAIN_VPC=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.VPCOptions.VPCId' --output text)
+        if [[ "${ES_DOMAIN_ENDPOINT:0:3}" == "vpc" ]]; then
           textInfo "$regx: Amazon ES domain $domain is in VPC $ES_DOMAIN_VPC run extra779 to make sure it is not exposed using custom proxy" "$regx"
         else
-          $AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query DomainConfig.AccessPolicies.Options --output text > $TEMP_POLICY_FILE 2> /dev/null
+          $AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainConfig.AccessPolicies.Options' --output text > $TEMP_POLICY_FILE 2>&1
+          if [[ $(grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' $TEMP_POLICY_FILE) ]]; then
+            textInfo "$regx: Access Denied trying to get domain config for $domain" "$regx"
+            continue
+          fi
           CHECK_ES_DOMAIN_POLICY_OPEN=$(cat $TEMP_POLICY_FILE | jq -r '. | .Statement[] | select(.Effect == "Allow" and (((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and select(has("Condition") | not))')
           CHECK_ES_DOMAIN_POLICY_HAS_CONDITION=$(cat $TEMP_POLICY_FILE | jq -r '. | .Statement[] | select(.Effect == "Allow" and (((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and select(has("Condition")))' )
           if [[ $CHECK_ES_DOMAIN_POLICY_HAS_CONDITION ]]; then
@@ -93,9 +103,9 @@ extra788(){
               textPass "$regx: Amazon ES domain $domain does not allow Anonymous cross account access" "$regx" "$domain"
             fi
           fi
-          rm -f $TEMP_POLICY_FILE
         fi
       done
+      [[ -f "${TEMP_POLICY_FILE}" ]] && rm -f $TEMP_POLICY_FILE
     else
       textInfo "$regx: No Amazon ES domain found" "$regx"
     fi

--- a/checks/check_extra788
+++ b/checks/check_extra788
@@ -43,11 +43,9 @@ extra788(){
           textInfo "$regx: Access Denied trying to get domain $domain" "$regx"
           continue
         fi
-        read ES_DOMAIN_ENDPOINT ES_DOMAIN_ENDPOINTS ES_DOMAIN_VPC <<< "$ES_DOMAIN_INFO" && {
-          [[ "${ES_DOMAIN_ENDPOINT}" == "None" ]] && ES_DOMAIN_ENDPOINT="${ES_DOMAIN_ENDPOINTS}"
-        }
+        read ES_DOMAIN_ENDPOINT ES_DOMAIN_ENDPOINT_VPC ES_DOMAIN_VPC <<< "$ES_DOMAIN_INFO" &&
         # If the endpoint starts with "vpc-" it is in a VPC then it is fine.
-        if [[ "${ES_DOMAIN_ENDPOINT:0:3}" == "vpc" ]]; then
+        if [[ "${ES_DOMAIN_ENDPOINT_VPC:0:3}" == "vpc" ]]; then
           textInfo "$regx: Amazon ES domain $domain is in VPC $ES_DOMAIN_VPC run extra779 to make sure it is not exposed using custom proxy" "$regx"
         else
           $AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainConfig.AccessPolicies.Options' --output text > $TEMP_POLICY_FILE 2>&1


### PR DESCRIPTION
### Context 

AWS CLI query was return wrong information.

Missing error handling.


### Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.
Fix CLI query and add error handling.

Checks:
* extra715
* extra716
* extra780
* extra781
* extra782
* extra783
* extra784
* extra785
* extra788
* extra7101

Fix issue #989 

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
