### PR TITLE
fix(check41/42): Added tcp protocol filter to query

### DIFF
--- a/checks/check41
+++ b/checks/check41
@@ -29,7 +29,7 @@ CHECK_CAF_EPIC_check41='Infrastructure Security'
 check41(){
   # "Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to port 22 (Scored)"
   for regx in $REGIONS; do
-    SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`22` && ToPort>=`22`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text 2>&1)
+    SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`22` && ToPort>=`22`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`)) && (IpProtocol==`tcp`)]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text 2>&1)
     if [[ $(echo "$SG_LIST" | grep -E 'AccessDenied|UnauthorizedOperation') ]]; then
         textInfo "$regx: Access Denied trying to describe security groups" "$regx"
         continue

--- a/checks/check41
+++ b/checks/check41
@@ -29,7 +29,7 @@ CHECK_CAF_EPIC_check41='Infrastructure Security'
 check41(){
   # "Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to port 22 (Scored)"
   for regx in $REGIONS; do
-    SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`22` && ToPort>=`22`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`)) && (IpProtocol==`tcp`)]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text 2>&1)
+    SG_LIST=$("${AWSCLI}" ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`22` && ToPort>=`22`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`)) && (IpProtocol==`tcp`)]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region "${regx}" --output text 2>&1)
     if [[ $(echo "$SG_LIST" | grep -E 'AccessDenied|UnauthorizedOperation') ]]; then
         textInfo "$regx: Access Denied trying to describe security groups" "$regx"
         continue

--- a/checks/check42
+++ b/checks/check42
@@ -29,7 +29,7 @@ CHECK_CAF_EPIC_check42='Infrastructure Security'
 check42(){
   # "Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to port 3389 (Scored)"
   for regx in $REGIONS; do
-    SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`3389` && ToPort>=`3389`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`)) && (IpProtocol==`tcp`) ]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text 2>&1)
+    SG_LIST=$("${AWSCLI}" ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`3389` && ToPort>=`3389`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`)) && (IpProtocol==`tcp`) ]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region "${regx}" --output text 2>&1)
     if [[ $(echo "$SG_LIST" | grep -E 'AccessDenied|UnauthorizedOperation') ]]; then
         textInfo "$regx: Access Denied trying to describe security groups" "$regx"
         continue

--- a/checks/check42
+++ b/checks/check42
@@ -29,7 +29,7 @@ CHECK_CAF_EPIC_check42='Infrastructure Security'
 check42(){
   # "Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to port 3389 (Scored)"
   for regx in $REGIONS; do
-    SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`3389` && ToPort>=`3389`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`))]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text 2>&1)
+    SG_LIST=$($AWSCLI ec2 describe-security-groups --query 'SecurityGroups[?length(IpPermissions[?((FromPort==null && ToPort==null) || (FromPort<=`3389` && ToPort>=`3389`)) && (contains(IpRanges[].CidrIp, `0.0.0.0/0`) || contains(Ipv6Ranges[].CidrIpv6, `::/0`)) && (IpProtocol==`tcp`) ]) > `0`].{GroupId:GroupId}' $PROFILE_OPT --region $regx --output text 2>&1)
     if [[ $(echo "$SG_LIST" | grep -E 'AccessDenied|UnauthorizedOperation') ]]; then
         textInfo "$regx: Access Denied trying to describe security groups" "$regx"
         continue


### PR DESCRIPTION
### Context 

Check41 and Check42 returns false positives when gre protocol rule is included in sg 


### Description

When working with check41 and check42 some false positives rose up due to not including protocol filtering


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
