### PR TITLE
fix(extra736): Recover only Customer Managed KMS keys

### DIFF
--- a/checks/check_extra736
+++ b/checks/check_extra736
@@ -26,18 +26,39 @@ CHECK_CAF_EPIC_extra736='Data Protection'
 
 extra736(){
   for regx in $REGIONS; do
-    LIST_OF_CUSTOMER_KMS_KEYS=$($AWSCLI kms list-aliases $PROFILE_OPT --region $regx --query "Aliases[].[AliasName,TargetKeyId]" --output text |grep -v ^alias/aws/ |awk '{ print $2 }')
-    if [[ $LIST_OF_CUSTOMER_KMS_KEYS ]];then
-      for key in $LIST_OF_CUSTOMER_KMS_KEYS; do
-        CHECK_POLICY=$($AWSCLI kms get-key-policy --key-id $key --policy-name default $PROFILE_OPT --region $regx  --output text| jq '.Statement[]|select(.Effect=="Allow" and (((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and .Condition == null)')
-        if [[ $CHECK_POLICY ]]; then
-          textFail "$regx: KMS key $key may be publicly accessible!" "$regx" "$key"
-        else
-          textPass "$regx: KMS key $key is not exposed to Public" "$regx" "$key"
+    local CUSTOMER_MANAGED_KMS_KEYS=()
+    # First, we need to recover every KMS key
+    LIST_OF_KMS_KEYS=$($AWSCLI kms list-keys $PROFILE_OPT --region "${regx}" --query "Keys[].[KeyArn]" --output text)
+    if [[ $LIST_OF_KMS_KEYS ]]
+    then
+      # Second, we need to check for Customer Managed KMS keys, with or without a configured alias
+      for keyID in ${LIST_OF_KMS_KEYS}
+      do
+        KMS_KEY_MANAGER=$($AWSCLI kms describe-key --region "${regx}" --key-id "${keyID}" --query "KeyMetadata.KeyManager" --output text)
+        if [[ "${KMS_KEY_MANAGER}" == "CUSTOMER" ]]
+        then 
+          CUSTOMER_MANAGED_KMS_KEYS+=( "${keyID}" )
         fi
       done
     else
-      textInfo "$regx: No KMS keys found" "$regx"
+      textInfo "${regx}: No KMS keys found" "${regx}"
+      continue
+    fi
+
+    # Third, we need to check the policy included in every Customer Managed KMS key
+    if [[ "${CUSTOMER_MANAGED_KMS_KEYS[*]}" ]]
+    then
+      for keyID in "${CUSTOMER_MANAGED_KMS_KEYS[@]}"
+      do
+        CHECK_POLICY=$($AWSCLI kms get-key-policy --key-id "${keyID}" --policy-name default $PROFILE_OPT --region "${regx}" --output text | jq '.Statement[]|select(.Effect=="Allow" and (((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and .Condition == null)')
+        if [[ $CHECK_POLICY ]]; then
+          textFail "${regx}: KMS key ${keyID} may be publicly accessible!" "${regx}" "${keyID}"
+        else
+          textPass "${regx}: KMS key ${keyID} is not exposed to Public" "${regx}" "${keyID}"
+        fi
+      done
+    else
+      textInfo "${regx}: No Customer Managed KMS keys found" "${regx}"
     fi
   done
 }


### PR DESCRIPTION
### Context 

Previously, check `extra736` only checked if KMS Keys **with an alias configured** were publicly exposed.

### Description

Right now, this control recovers every KMS Key at the account and checks the `KeyManager` property to extract only the policy for the ones not managed by AWS. So, with that KMS Keys without an alias configured are also audited.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
