### PR TITLE
fix(include/outputs):Rolling back whitelist checking to RE check

### DIFF
--- a/include/outputs
+++ b/include/outputs
@@ -171,7 +171,7 @@ textFail(){
     ignore_check_name="${excluded_item%%:*}" # Check name is everything up to the first :
     # Resource value is the second field of line included in whitelist divided by :
     resource_value=$(awk -F ":" '{print $2}' <<< $excluded_item)
-    # Checked value is the second field of log message divided by spaces
+    # Checked value is the whole log message that comes as argument
     checked_value=$1
     if [[ "${ignore_check_name}" != "${CHECK_NAME}" ]]; then
       # not for this check

--- a/include/outputs
+++ b/include/outputs
@@ -172,13 +172,13 @@ textFail(){
     # Resource value is the second field of line included in whitelist divided by :
     resource_value=$(awk -F ":" '{print $2}' <<< $excluded_item)
     # Checked value is the second field of log message divided by spaces
-    checked_value=$(awk '{print $2}' <<< $1)
+    checked_value=$1
     if [[ "${ignore_check_name}" != "${CHECK_NAME}" ]]; then
       # not for this check
       continue
     fi
     # To set WARNING flag both values must be exactly the same
-    if [[ "${checked_value}" == "${resource_value}" ]]; then
+    if [[ "${checked_value}" == *"${resource_value}"* ]]; then
       level="WARNING"
       colorcode="${WARNING}"
       break


### PR DESCRIPTION
### Context 

With last change to exactly match elements included in the whitelist and log info returned whitelist feature was broken not whitelisting multitude of items


### Description

Fix the feature, rolling back to regular expression checking to find if whitelisted element is included into log message


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
