### PR TITLE
Added timestamp to temp folders for secrets related checks

### DIFF
--- a/checks/check_extra7141
+++ b/checks/check_extra7141
@@ -24,7 +24,7 @@ CHECK_DOC_extra7141='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGu
 CHECK_CAF_EPIC_extra7141='IAM'
 
 extra7141(){
-  SECRETS_TEMP_FOLDER="${PROWLER_DIR}/secrets-${ACCOUNT_NUM}"
+  SECRETS_TEMP_FOLDER="$PROWLER_DIR/secrets-$ACCOUNT_NUM-$PROWLER_START_TIME"
   if [[ ! -d "${SECRETS_TEMP_FOLDER}" ]]; then
     # this folder is deleted once this check is finished
     mkdir "${SECRETS_TEMP_FOLDER}"

--- a/checks/check_extra759
+++ b/checks/check_extra759
@@ -24,7 +24,7 @@ CHECK_DOC_extra759='https://docs.aws.amazon.com/secretsmanager/latest/userguide/
 CHECK_CAF_EPIC_extra759='IAM'
 
 extra759(){
-  SECRETS_TEMP_FOLDER="$PROWLER_DIR/secrets-$ACCOUNT_NUM"
+  SECRETS_TEMP_FOLDER="$PROWLER_DIR/secrets-$ACCOUNT_NUM-$PROWLER_START_TIME"
   if [[ ! -d $SECRETS_TEMP_FOLDER ]]; then
     # this folder is deleted once this check is finished
     mkdir $SECRETS_TEMP_FOLDER

--- a/checks/check_extra760
+++ b/checks/check_extra760
@@ -24,7 +24,7 @@ CHECK_DOC_extra760='https://docs.aws.amazon.com/secretsmanager/latest/userguide/
 CHECK_CAF_EPIC_extra760='IAM'
 
 extra760(){
-  SECRETS_TEMP_FOLDER="$PROWLER_DIR/secrets-$ACCOUNT_NUM"
+  SECRETS_TEMP_FOLDER="$PROWLER_DIR/secrets-$ACCOUNT_NUM-$PROWLER_START_TIME"
   if [[ ! -d $SECRETS_TEMP_FOLDER ]]; then
     # this folder is deleted once this check is finished
     mkdir $SECRETS_TEMP_FOLDER

--- a/checks/check_extra768
+++ b/checks/check_extra768
@@ -24,7 +24,7 @@ CHECK_DOC_extra768='https://docs.aws.amazon.com/AmazonECS/latest/developerguide/
 CHECK_CAF_EPIC_extra768='Logging and Monitoring'
 
 extra768(){
-  SECRETS_TEMP_FOLDER="$PROWLER_DIR/secrets-$ACCOUNT_NUM"
+  SECRETS_TEMP_FOLDER="$PROWLER_DIR/secrets-$ACCOUNT_NUM-$PROWLER_START_TIME"
   if [[ ! -d $SECRETS_TEMP_FOLDER ]]; then
     mkdir $SECRETS_TEMP_FOLDER
   fi

--- a/checks/check_extra775
+++ b/checks/check_extra775
@@ -23,7 +23,7 @@ CHECK_DOC_extra775='https://docs.aws.amazon.com/secretsmanager/latest/userguide/
 CHECK_CAF_EPIC_extra775='IAM'
 
 extra775(){
-  SECRETS_TEMP_FOLDER="$PROWLER_DIR/secrets-$ACCOUNT_NUM"
+  SECRETS_TEMP_FOLDER="$PROWLER_DIR/secrets-$ACCOUNT_NUM-$PROWLER_START_TIME"
   if [[ ! -d $SECRETS_TEMP_FOLDER ]]; then 
     # this folder is deleted once this check is finished
     mkdir $SECRETS_TEMP_FOLDER


### PR DESCRIPTION
### Context 

Added a timestamp to the checks. When running prowler in parallel for multiple zones, the SECRETS_TEMP_FOLDER file is overwritten"


### Description

The five checks have been changed to include a timestamp in the file name to avoid race conditions:
- **Before:** SECRETS_TEMP_FOLDER="$PROWLER_DIR/secrets-$ACCOUNT_NUM"
- **After:** SECRETS_TEMP_FOLDER="$PROWLER_DIR/secrets-$ACCOUNT_NUM-$PROWLER_START_TIME"


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
