### PR TITLE
docs(templates): Include triage label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[Bug]: "
-labels: ["bug", "triage"]
+labels: bug, status/needs-triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: enhancement
+labels: enhancement, status/needs-triage
 assignees: ''
 
 ---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,6 @@
+---
+labels: status/needs-triage
+---
 ### Context 
 
 Please include relevant motivation and context for this PR.


### PR DESCRIPTION
### Description

Include triage label in every template.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
