### PR TITLE
Make python3 default in Dockerfile

### DIFF
--- a/util/Dockerfile
+++ b/util/Dockerfile
@@ -19,7 +19,9 @@ RUN yum install -y shadow-utils && \
   curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && \
   unzip awscliv2.zip && \
   aws/install && \
-  rm -rf aws awscliv2.zip /var/cache/yum
+  rm -rf aws awscliv2.zip /var/cache/yum && \
+  rm /usr/bin/python && \
+  ln -s /usr/bin/python3 /usr/bin/python
 
 WORKDIR /prowler
 


### PR DESCRIPTION
### Context 

Although python3 was installed. the /usr/bin directory still had a symlink to python2. Fixed by removing the symlink and creating a new one that points to python3. Verified with 

[host] Prowler % docker run --rm -it --entrypoint /bin/bash prowler:latest                             
[prowler@302c9cbd6e18 prowler]$ ls -al /usr/bin/pytho*
lrwxrwxrwx 1 root root   16 Feb 14 19:19 /usr/bin/python -> /usr/bin/python3
lrwxrwxrwx 1 root root    9 Feb  7 22:13 /usr/bin/python2 -> python2.7
-rwxr-xr-x 1 root root 7048 Jun 10  2021 /usr/bin/python2.7
lrwxrwxrwx 1 root root    9 Feb 14 19:19 /usr/bin/python3 -> python3.7
-rwxr-xr-x 2 root root 7048 Jun  3  2021 /usr/bin/python3.7
-rwxr-xr-x 2 root root 7048 Jun  3  2021 /usr/bin/python3.7m
[prowler@302c9cbd6e18 prowler]$ 



### Description

Removed symlink  /usr/bin/python -> /usr/bin/python2 and created stymlink /usr/bin/python -> /usr/bin/python3

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
