### PR TITLE
fix(extra765/776): Add right region to CSV if access is denied

### DIFF
--- a/checks/check_extra765
+++ b/checks/check_extra765
@@ -36,7 +36,7 @@ extra765(){
   for region in $REGIONS; do
     LIST_ECR_REPOS=$($AWSCLI ecr describe-repositories $PROFILE_OPT --region $region --query "repositories[*].[repositoryName]" --output text 2>&1)
     if [[ $(echo "$LIST_ECR_REPOS" | grep AccessDenied) ]]; then
-      textInfo "$region: Access Denied Trying to describe ECR repositories"
+      textInfo "$region: Access Denied Trying to describe ECR repositories" "$region"
       continue
     fi
     if [[ ! -z "$LIST_ECR_REPOS" ]]; then

--- a/checks/check_extra776
+++ b/checks/check_extra776
@@ -42,7 +42,7 @@ extra776(){
   for region in $REGIONS; do
     LIST_ECR_REPOS=$($AWSCLI ecr describe-repositories $PROFILE_OPT --region $region --query "repositories[*].[repositoryName]" --output text 2>&1)
     if [[ $(echo "$LIST_ECR_REPOS" | grep AccessDenied) ]]; then
-      textInfo "$region: Access Denied trying to describe ECR repositories"
+      textInfo "$region: Access Denied trying to describe ECR repositories" "$region"
       continue
     fi
     if [[ ! -z "$LIST_ECR_REPOS" ]]; then


### PR DESCRIPTION
### Context 

If access is denied on checks extra765 or extra776 currently no region is specified.
In the CSV output those checks then default to a different/wrong region. 

### Description

Add region parameter to `textInfo` call. 

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
