### PR TITLE
Quotes to output file

### DIFF
--- a/prowler
+++ b/prowler
@@ -244,7 +244,7 @@ clean_up() {
   rm -f /tmp/prowler*.policy.*
   # in case html output is used, make sure it closes html file properly
   if [[ "${MODES[@]}" =~ "html" ]]; then
-    addHtmlFooter >> ${OUTPUT_FILE_NAME}.$EXTENSION_HTML
+    addHtmlFooter >> '${OUTPUT_FILE_NAME}.$EXTENSION_HTML'
   fi
   # puts the AWS_DEFAULT_OUTPUT back to what it was at the start
   if [ -z "$ORIGINAL_OUTPUT"]; then
@@ -660,7 +660,7 @@ if [[ $GROUP_ID_READ ]];then
 
     execute_group_by_id ${GROUP_ID_READ} ${EXCLUDE_CHECK_ID}
     if [[ "${MODES[@]}" =~ "html" ]]; then
-      addHtmlFooter >> ${OUTPUT_FILE_NAME}.$EXTENSION_HTML
+      addHtmlFooter >> '${OUTPUT_FILE_NAME}.$EXTENSION_HTML'
     fi
     cleanTemp
     scoring
@@ -693,7 +693,7 @@ if [[ $CHECK_ID ]];then
     execute_check $CHECK
   done
   if [[ "${MODES[@]}" =~ "html" ]]; then
-    addHtmlFooter >> ${OUTPUT_FILE_NAME}.$EXTENSION_HTML
+    addHtmlFooter >> '${OUTPUT_FILE_NAME}.$EXTENSION_HTML'
   fi
   if [[ $OUTPUT_BUCKET_NOASSUME ]]; then
     restoreInitialAWSCredentials
@@ -707,7 +707,7 @@ fi
 execute_all
 
 if [[ "${MODES[@]}" =~ "html" ]]; then
-  addHtmlFooter >> ${OUTPUT_FILE_NAME}.$EXTENSION_HTML
+  addHtmlFooter >> '${OUTPUT_FILE_NAME}.$EXTENSION_HTML'
 fi
 
 scoring


### PR DESCRIPTION
Necessary quotes to process the special characters of the output file and avoid errors when writing the results of the scan.

### Context 

When trying to run prowler in macOS I've had some problems related with writing the results of the scan. The error is:

**./prowler: line 247: ${OUTPUT_FILE_NAME}.$EXTENSION_HTML: ambiguous redirect**

### Description

Quotes have been added in the prowler file and also in the output file. It seems this has solved the situation and now prowler is running nice.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
