### PR TITLE
fix: extra7167 Advanced Shield and CloudFront bug parsing None output without distributions

### DIFF
--- a/checks/check_extra7167
+++ b/checks/check_extra7167
@@ -27,7 +27,7 @@ CHECK_CAF_EPIC_extra7167='Infrastructure security'
 extra7167() {
   if [[ "$($AWSCLI $PROFILE_OPT shield get-subscription-state --output text)" == "ACTIVE" ]]; then
     LIST_OF_CLOUDFRONT_DISTRIBUTIONS=$($AWSCLI cloudfront list-distributions $PROFILE_OPT --query 'DistributionList.Items[*].[Id,ARN]' --output text)
-    if [[ $LIST_OF_CLOUDFRONT_DISTRIBUTIONS ]]; then
+    if [[ $LIST_OF_CLOUDFRONT_DISTRIBUTIONS != "None"]]; then
       while read -r distribution; do
         DISTRIBUTION_ID=$(echo $distribution | awk '{ print $1; }')
         DISTRIBUTION_ARN=$(echo $distribution | awk '{ print $2; }')

--- a/checks/check_extra7167
+++ b/checks/check_extra7167
@@ -26,8 +26,8 @@ CHECK_CAF_EPIC_extra7167='Infrastructure security'
 
 extra7167() {
   if [[ "$($AWSCLI $PROFILE_OPT shield get-subscription-state --output text)" == "ACTIVE" ]]; then
-    LIST_OF_CLOUDFRONT_DISTRIBUTIONS=$($AWSCLI cloudfront list-distributions $PROFILE_OPT --query 'DistributionList.Items[*].[Id,ARN]' --output text)
-    if [[ $LIST_OF_CLOUDFRONT_DISTRIBUTIONS != "None"]]; then
+    LIST_OF_CLOUDFRONT_DISTRIBUTIONS=$($AWSCLI cloudfront list-distributions $PROFILE_OPT --query 'DistributionList.Items[*].[Id,ARN]' --output text  | grep -v None)
+    if [[ $LIST_OF_CLOUDFRONT_DISTRIBUTIONS]]; then
       while read -r distribution; do
         DISTRIBUTION_ID=$(echo $distribution | awk '{ print $1; }')
         DISTRIBUTION_ARN=$(echo $distribution | awk '{ print $2; }')


### PR DESCRIPTION
### Context 

My AWS account is encountering false positive with extra7167
We do not have any cloudfront distribution, yet they are being flagged as 
"Cloudfront distribution None is not protected by AWS Shield Advanced"
due to `aws cloudfront list-distributions --profile $profile --query 'DistributionList.Items[*].[Id,ARN]' --output text` is outputting as 'None' even thought there is no cloudfront distribution.


### Description

In the if statement, Instead of detecting if there is any value in the variable $LIST_OF_CLOUDFRONT_DISTRIBUTIONS, I updated the code with `$LIST_OF_CLOUDFRONT_DISTRIBUTIONS != 'None'`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
