### PR TITLE
Revert "fix: extra7167 Advanced Shield and CloudFront bug parsing None output without distributions"

### DIFF
--- a/checks/check_extra7167
+++ b/checks/check_extra7167
@@ -26,8 +26,8 @@ CHECK_CAF_EPIC_extra7167='Infrastructure security'
 
 extra7167() {
   if [[ "$($AWSCLI $PROFILE_OPT shield get-subscription-state --output text)" == "ACTIVE" ]]; then
-    LIST_OF_CLOUDFRONT_DISTRIBUTIONS=$($AWSCLI cloudfront list-distributions $PROFILE_OPT --query 'DistributionList.Items[*].[Id,ARN]' --output text  | grep -v None)
-    if [[ $LIST_OF_CLOUDFRONT_DISTRIBUTIONS]]; then
+    LIST_OF_CLOUDFRONT_DISTRIBUTIONS=$($AWSCLI cloudfront list-distributions $PROFILE_OPT --query 'DistributionList.Items[*].[Id,ARN]' --output text)
+    if [[ $LIST_OF_CLOUDFRONT_DISTRIBUTIONS ]]; then
       while read -r distribution; do
         DISTRIBUTION_ID=$(echo $distribution | awk '{ print $1; }')
         DISTRIBUTION_ARN=$(echo $distribution | awk '{ print $2; }')


### PR DESCRIPTION
Reverts prowler-cloud/prowler#1053

There is an error in line 30
```
./checks/check_extra7167: line 30: `    if [[ $LIST_OF_CLOUDFRONT_DISTRIBUTIONS]]; then'
```
a missed space after the variable, the correct one must be like:
```
./checks/check_extra7167: line 30: `    if [[ $LIST_OF_CLOUDFRONT_DISTRIBUTIONS ]]; then'
```