### PR TITLE
fix: extra7167 Advanced Shield and CloudFront bug parsing None output without distributions

### DIFF
--- a/checks/check_extra7167
+++ b/checks/check_extra7167
@@ -27,7 +27,7 @@ CHECK_CAF_EPIC_extra7167='Infrastructure security'
 extra7167() {
   if [[ "$($AWSCLI $PROFILE_OPT shield get-subscription-state --output text)" == "ACTIVE" ]]; then
     LIST_OF_CLOUDFRONT_DISTRIBUTIONS=$($AWSCLI cloudfront list-distributions $PROFILE_OPT --query 'DistributionList.Items[*].[Id,ARN]' --output text)
-    if [[ $LIST_OF_CLOUDFRONT_DISTRIBUTIONS ]]; then
+    if [[ $LIST_OF_CLOUDFRONT_DISTRIBUTIONS != "None"]]; then
       while read -r distribution; do
         DISTRIBUTION_ID=$(echo $distribution | awk '{ print $1; }')
         DISTRIBUTION_ARN=$(echo $distribution | awk '{ print $2; }')

--- a/checks/check_extra7167
+++ b/checks/check_extra7167
@@ -27,7 +27,7 @@ CHECK_CAF_EPIC_extra7167='Infrastructure security'
 extra7167() {
   if [[ "$($AWSCLI $PROFILE_OPT shield get-subscription-state --output text)" == "ACTIVE" ]]; then
     LIST_OF_CLOUDFRONT_DISTRIBUTIONS=$($AWSCLI cloudfront list-distributions $PROFILE_OPT --query 'DistributionList.Items[*].[Id,ARN]' --output text  | grep -v None)
-    if [[ $LIST_OF_CLOUDFRONT_DISTRIBUTIONS]]; then
+    if [[ $LIST_OF_CLOUDFRONT_DISTRIBUTIONS ]]; then
       while read -r distribution; do
         DISTRIBUTION_ID=$(echo $distribution | awk '{ print $1; }')
         DISTRIBUTION_ARN=$(echo $distribution | awk '{ print $2; }')

--- a/checks/check_extra7167
+++ b/checks/check_extra7167
@@ -26,8 +26,8 @@ CHECK_CAF_EPIC_extra7167='Infrastructure security'
 
 extra7167() {
   if [[ "$($AWSCLI $PROFILE_OPT shield get-subscription-state --output text)" == "ACTIVE" ]]; then
-    LIST_OF_CLOUDFRONT_DISTRIBUTIONS=$($AWSCLI cloudfront list-distributions $PROFILE_OPT --query 'DistributionList.Items[*].[Id,ARN]' --output text)
-    if [[ $LIST_OF_CLOUDFRONT_DISTRIBUTIONS != "None"]]; then
+    LIST_OF_CLOUDFRONT_DISTRIBUTIONS=$($AWSCLI cloudfront list-distributions $PROFILE_OPT --query 'DistributionList.Items[*].[Id,ARN]' --output text  | grep -v None)
+    if [[ $LIST_OF_CLOUDFRONT_DISTRIBUTIONS]]; then
       while read -r distribution; do
         DISTRIBUTION_ID=$(echo $distribution | awk '{ print $1; }')
         DISTRIBUTION_ARN=$(echo $distribution | awk '{ print $2; }')


### PR DESCRIPTION
### Context 

* fix: not to flag as finding for account without cloudfront distributions

* fix: output empty for None from cloudfront list-distributions


### Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
