### PR TITLE
fix: Change lower case from bash variable expansion to tr

### DIFF
--- a/checks/check_extra7101
+++ b/checks/check_extra7101
@@ -25,27 +25,27 @@ CHECK_DOC_extra7101='https://docs.aws.amazon.com/elasticsearch-service/latest/de
 CHECK_CAF_EPIC_extra7101='Logging and Monitoring'
 
 extra7101(){
-  for regx in $REGIONS; do
-    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query 'DomainNames[].DomainName' --output text 2>&1)
-    if [[ $(echo "$LIST_OF_DOMAINS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-        textInfo "$regx: Access Denied trying to list domain names" "$regx"
+  for regx in ${REGIONS}; do
+    LIST_OF_DOMAINS=$("${AWSCLI}" es list-domain-names ${PROFILE_OPT} --region "${regx}" --query 'DomainNames[].DomainName' --output text 2>&1)
+    if [[ $(echo "${LIST_OF_DOMAINS}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+        textInfo "${regx}: Access Denied trying to list domain names" "${regx}"
         continue
     fi
-    if [[ $LIST_OF_DOMAINS ]]; then
-      for domain in $LIST_OF_DOMAINS;do
-        AUDIT_LOGS_ENABLED=$($AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainConfig.LogPublishingOptions.Options.AUDIT_LOGS.Enabled' --output text 2>&1)
-        if [[ $(echo "$AUDIT_LOGS_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-            textInfo "$regx: Access Denied trying to get ES domain config for $domain" "$regx"
+    if [[ "${LIST_OF_DOMAINS}" ]]; then
+      for domain in ${LIST_OF_DOMAINS}; do
+        AUDIT_LOGS_ENABLED=$("${AWSCLI}" es describe-elasticsearch-domain-config --domain-name "${domain}" ${PROFILE_OPT} --region "${regx}" --query 'DomainConfig.LogPublishingOptions.Options.AUDIT_LOGS.Enabled' --output text 2>&1)
+        if [[ $(echo "${AUDIT_LOGS_ENABLED}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+            textInfo "${regx}: Access Denied trying to get ES domain config for ${domain}" "${regx}"
             continue
         fi
-        if [[ "${AUDIT_LOGS_ENABLED,,}" == "true" ]];then
-          textPass "$regx: Amazon ES domain $domain AUDIT_LOGS enabled" "$regx" "$domain"
+        if [[ $(echo "${AUDIT_LOGS_ENABLED}" | tr '[:upper:]' '[:lower:]') == "true" ]]; then
+          textPass "${regx}: Amazon ES domain ${domain} AUDIT_LOGS enabled" "${regx}" "${domain}"
         else
-          textFail "$regx: Amazon ES domain $domain AUDIT_LOGS disabled!" "$regx" "$domain"
+          textFail "${regx}: Amazon ES domain ${domain} AUDIT_LOGS disabled!" "${regx}" "${domain}"
         fi
       done
     else
-      textInfo "$regx: No Amazon ES domain found" "$regx"
+      textInfo "${regx}: No Amazon ES domain found" "${regx}"
     fi
   done
 }

--- a/checks/check_extra7101
+++ b/checks/check_extra7101
@@ -38,7 +38,7 @@ extra7101(){
             textInfo "${regx}: Access Denied trying to get ES domain config for ${domain}" "${regx}"
             continue
         fi
-        if [[ $(echo "${AUDIT_LOGS_ENABLED}" | tr '[:upper:]' '[:lower:]') == "true" ]]; then
+        if [[ $(tr '[:upper:]' '[:lower:]' <<< "${AUDIT_LOGS_ENABLED}") == "true" ]]; then
           textPass "${regx}: Amazon ES domain ${domain} AUDIT_LOGS enabled" "${regx}" "${domain}"
         else
           textFail "${regx}: Amazon ES domain ${domain} AUDIT_LOGS disabled!" "${regx}" "${domain}"

--- a/checks/check_extra715
+++ b/checks/check_extra715
@@ -24,34 +24,35 @@ CHECK_DOC_extra715='https://docs.aws.amazon.com/elasticsearch-service/latest/dev
 CHECK_CAF_EPIC_extra715='Logging and Monitoring'
 
 extra715(){
-  for regx in $REGIONS; do
-    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query 'DomainNames[].DomainName' --output text 2>&1)
-    if [[ $(echo "$LIST_OF_DOMAINS" | grep -E 'AccessDenied|UnauthorizedOperation') ]]; then
-        textInfo "$regx: Access Denied trying to list domain names" "$regx"
+  for regx in ${REGIONS}; do
+    LIST_OF_DOMAINS=$("${AWSCLI}" es list-domain-names ${PROFILE_OPT} --region "${regx}" --query 'DomainNames[].DomainName' --output text 2>&1)
+    if [[ $(echo "${LIST_OF_DOMAINS}" | grep -E 'AccessDenied|UnauthorizedOperation') ]]; then
+        textInfo "${regx}: Access Denied trying to list domain names" "${regx}"
         continue
     fi
-    if [[ $LIST_OF_DOMAINS ]]; then
-      for domain in $LIST_OF_DOMAINS;do
-        SLOWLOG_ENABLED=$($AWSCLI es describe-elasticsearch-domain-config --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainConfig.LogPublishingOptions.Options.[SEARCH_SLOW_LOGS.Enabled, INDEX_SLOW_LOGS.Enabled]' --output text 2>&1)
-        if [[ $(echo "$SLOWLOG_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-            textInfo "$regx: Access Denied trying to get ES domain config for $domain" "$regx"
+    if [[ "${LIST_OF_DOMAINS}" ]]; then
+      for domain in ${LIST_OF_DOMAINS}; do
+        SLOWLOG_ENABLED=$("${AWSCLI}" es describe-elasticsearch-domain-config --domain-name "${domain}" ${PROFILE_OPT} --region "${regx}" --query 'DomainConfig.LogPublishingOptions.Options.[SEARCH_SLOW_LOGS.Enabled, INDEX_SLOW_LOGS.Enabled]' --output text 2>&1)
+        if [[ $(echo "${SLOWLOG_ENABLED}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+            textInfo "${regx}: Access Denied trying to get ES domain config for ${domain}" "${regx}"
             continue
         fi
-        read SEARCH_SLOWLOG_ENABLED INDEX_SLOWLOG_ENABLED <<< "$SLOWLOG_ENABLED" && {
-          if [[ "${SEARCH_SLOWLOG_ENABLED,,}" == "true" ]];then
-            textPass "$regx: Amazon ES domain $domain SEARCH_SLOW_LOGS enabled" "$regx" "$domain"
+        read -r SEARCH_SLOWLOG_ENABLED INDEX_SLOWLOG_ENABLED <<< "$SLOWLOG_ENABLED" && {
+          if [[ $(echo "${SEARCH_SLOWLOG_ENABLED}" | tr '[:upper:]' '[:lower:]') == "true" ]]; then
+            textPass "${regx}: Amazon ES domain ${domain} SEARCH_SLOW_LOGS enabled" "${regx}" "${domain}"
           else
-            textFail "$regx: Amazon ES domain $domain SEARCH_SLOW_LOGS disabled!" "$regx" "$domain"
+            textFail "${regx}: Amazon ES domain ${domain} SEARCH_SLOW_LOGS disabled!" "${regx}" "${domain}"
           fi
-          if [[ "${INDEX_SLOWLOG_ENABLED,,}" == "true" ]];then
-            textPass "$regx: Amazon ES domain $domain INDEX_SLOW_LOGS enabled" "$regx" "$domain"
+
+          if [[ $(echo "${INDEX_SLOWLOG_ENABLED}" | tr '[:upper:]' '[:lower:]') == "true" ]]; then
+            textPass "${regx}: Amazon ES domain ${domain} INDEX_SLOW_LOGS enabled" "${regx}" "${domain}"
           else
-            textFail "$regx: Amazon ES domain $domain INDEX_SLOW_LOGS disabled!" "$regx" "$domain"
+            textFail "${regx}: Amazon ES domain ${domain} INDEX_SLOW_LOGS disabled!" "${regx}" "${domain}"
           fi
         }
       done
     else
-      textInfo "$regx: No Amazon ES domain found" "$regx"
+      textInfo "${regx}: No Amazon ES domain found" "${regx}"
     fi
   done
 }

--- a/checks/check_extra715
+++ b/checks/check_extra715
@@ -37,14 +37,14 @@ extra715(){
             textInfo "${regx}: Access Denied trying to get ES domain config for ${domain}" "${regx}"
             continue
         fi
-        read -r SEARCH_SLOWLOG_ENABLED INDEX_SLOWLOG_ENABLED <<< "$SLOWLOG_ENABLED" && {
-          if [[ $(echo "${SEARCH_SLOWLOG_ENABLED}" | tr '[:upper:]' '[:lower:]') == "true" ]]; then
+        read -r SEARCH_SLOWLOG_ENABLED INDEX_SLOWLOG_ENABLED <<< "${SLOWLOG_ENABLED}" && {
+          if [[ $(tr '[:upper:]' '[:lower:]' <<< "${SEARCH_SLOWLOG_ENABLED}") == "true" ]]; then
             textPass "${regx}: Amazon ES domain ${domain} SEARCH_SLOW_LOGS enabled" "${regx}" "${domain}"
           else
             textFail "${regx}: Amazon ES domain ${domain} SEARCH_SLOW_LOGS disabled!" "${regx}" "${domain}"
           fi
 
-          if [[ $(echo "${INDEX_SLOWLOG_ENABLED}" | tr '[:upper:]' '[:lower:]') == "true" ]]; then
+          if [[ $(tr '[:upper:]' '[:lower:]' <<< "${INDEX_SLOWLOG_ENABLED}") == "true" ]]; then
             textPass "${regx}: Amazon ES domain ${domain} INDEX_SLOW_LOGS enabled" "${regx}" "${domain}"
           else
             textFail "${regx}: Amazon ES domain ${domain} INDEX_SLOW_LOGS disabled!" "${regx}" "${domain}"

--- a/checks/check_extra780
+++ b/checks/check_extra780
@@ -24,27 +24,27 @@ CHECK_DOC_extra780='https://docs.aws.amazon.com/elasticsearch-service/latest/dev
 CHECK_CAF_EPIC_extra780='IAM'
 
 extra780(){
-  for regx in $REGIONS; do
-    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query 'DomainNames[].DomainName' --output text 2>&1)
-    if [[ $(echo "$LIST_OF_DOMAINS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-        textInfo "$regx: Access Denied trying to list domain names" "$regx"
+  for regx in ${REGIONS}; do
+    LIST_OF_DOMAINS=$("${AWSCLI}" es list-domain-names ${PROFILE_OPT} --region "${regx}" --query 'DomainNames[].DomainName' --output text 2>&1)
+    if [[ $(echo "${LIST_OF_DOMAINS}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+        textInfo "${regx}: Access Denied trying to list domain names" "${regx}"
         continue
     fi
-    if [[ $LIST_OF_DOMAINS ]]; then
-      for domain in $LIST_OF_DOMAINS;do
-        CHECK_IF_COGNITO_ENABLED=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.CognitoOptions.Enabled' --output text 2>&1)
-        if [[ $(echo "$CHECK_IF_COGNITO_ENABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-            textInfo "$regx: Access Denied trying to get ES domain $domain" "$regx"
+    if [[ "${LIST_OF_DOMAINS}" ]]; then
+      for domain in ${LIST_OF_DOMAINS}; do
+        CHECK_IF_COGNITO_ENABLED=$("${AWSCLI}" es describe-elasticsearch-domain --domain-name "${domain}" ${PROFILE_OPT} --region "${regx}" --query 'DomainStatus.CognitoOptions.Enabled' --output text 2>&1)
+        if [[ $(echo "${CHECK_IF_COGNITO_ENABLED}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+            textInfo "${regx}: Access Denied trying to get ES domain ${domain}" "${regx}"
             continue
         fi
-        if [[ "${CHECK_IF_COGNITO_ENABLED,,}" == "true" ]];then
-          textPass "$regx: Amazon ES domain $domain has Amazon Cognito authentication for Kibana enabled" "$regx" "$domain"
+        if [[ $(echo "${CHECK_IF_COGNITO_ENABLED}" | tr '[:upper:]' '[:lower:]') == "true" ]]; then
+          textPass "${regx}: Amazon ES domain ${domain} has Amazon Cognito authentication for Kibana enabled" "${regx}" "${domain}"
         else
-          textFail "$regx: Amazon ES domain $domain does not have Amazon Cognito authentication for Kibana enabled" "$regx" "$domain"
+          textFail "${regx}: Amazon ES domain ${domain} does not have Amazon Cognito authentication for Kibana enabled" "${regx}" "${domain}"
         fi
       done
     else
-      textInfo "$regx: No Amazon ES domain found" "$regx"
+      textInfo "${regx}: No Amazon ES domain found" "${regx}"
     fi
   done
 }

--- a/checks/check_extra780
+++ b/checks/check_extra780
@@ -37,7 +37,7 @@ extra780(){
             textInfo "${regx}: Access Denied trying to get ES domain ${domain}" "${regx}"
             continue
         fi
-        if [[ $(echo "${CHECK_IF_COGNITO_ENABLED}" | tr '[:upper:]' '[:lower:]') == "true" ]]; then
+        if [[ $(tr '[:upper:]' '[:lower:]' <<< "${CHECK_IF_COGNITO_ENABLED}") == "true" ]]; then
           textPass "${regx}: Amazon ES domain ${domain} has Amazon Cognito authentication for Kibana enabled" "${regx}" "${domain}"
         else
           textFail "${regx}: Amazon ES domain ${domain} does not have Amazon Cognito authentication for Kibana enabled" "${regx}" "${domain}"

--- a/checks/check_extra785
+++ b/checks/check_extra785
@@ -29,28 +29,28 @@ CHECK_CAF_EPIC_extra785='Infrastructure Security'
 # I have to investigate further
 
 extra785(){
-  for regx in $REGIONS; do
-    LIST_OF_DOMAINS=$($AWSCLI es list-domain-names $PROFILE_OPT --region $regx --query 'DomainNames[].DomainName' --output text 2>&1)
-    if [[ $(echo "$LIST_OF_DOMAINS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-        textInfo "$regx: Access Denied trying to list domain names" "$regx"
+  for regx in ${REGIONS}; do
+    LIST_OF_DOMAINS=$("${AWSCLI}" es list-domain-names ${PROFILE_OPT} --region "${regx}" --query 'DomainNames[].DomainName' --output text 2>&1)
+    if [[ $(echo "${LIST_OF_DOMAINS}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+        textInfo "${regx}: Access Denied trying to list domain names" "${regx}"
         continue
     fi
-    if [[ $LIST_OF_DOMAINS ]]; then
-      for domain in $LIST_OF_DOMAINS;do
-        CHECK_IF_UPDATE_AVAILABLE_AND_VERSION=$($AWSCLI es describe-elasticsearch-domain --domain-name $domain $PROFILE_OPT --region $regx --query 'DomainStatus.[ServiceSoftwareOptions.UpdateAvailable,ElasticsearchVersion]' --output text 2>&1)
-        if [[ $(echo "$CHECK_IF_UPDATE_AVAILABLE_AND_VERSION" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-            textInfo "$regx: Access Denied trying to get ES domain $domain" "$regx"
+    if [[ "${LIST_OF_DOMAINS}" ]]; then
+      for domain in ${LIST_OF_DOMAINS}; do
+        CHECK_IF_UPDATE_AVAILABLE_AND_VERSION=$("${AWSCLI}" es describe-elasticsearch-domain --domain-name "${domain}" ${PROFILE_OPT} --region "${regx}" --query 'DomainStatus.[ServiceSoftwareOptions.UpdateAvailable,ElasticsearchVersion]' --output text 2>&1)
+        if [[ $(echo "${CHECK_IF_UPDATE_AVAILABLE_AND_VERSION}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+            textInfo "${regx}: Access Denied trying to get ES domain ${domain}" "${regx}"
             continue
         fi
-        read update_status es_version <<< "$CHECK_IF_UPDATE_AVAILABLE_AND_VERSION" &&
-        if [[ ${update_status,,} != "false" ]];then
-          textInfo "$regx: Amazon ES domain $domain v$es_version has updates available" "$regx" "$domain"
+        read -r update_status es_version <<< "${CHECK_IF_UPDATE_AVAILABLE_AND_VERSION}" &&
+        if [[ $(echo "${update_status}" | tr '[:upper:]' '[:lower:]') != "false" ]]; then
+          textInfo "${regx}: Amazon ES domain ${domain} v${es_version} has updates available" "${regx}" "${domain}"
         else
-          textPass "$regx: Amazon ES domain $domain v$es_version does not have have updates available" "$regx" "$domain"
+          textPass "${regx}: Amazon ES domain ${domain} v${es_version} does not have have updates available" "${regx}" "${domain}"
         fi
       done
     else
-      textInfo "$regx: No Amazon ES domain found" "$regx"
+      textInfo "${regx}: No Amazon ES domain found" "${regx}"
     fi
   done
 }

--- a/checks/check_extra785
+++ b/checks/check_extra785
@@ -43,7 +43,7 @@ extra785(){
             continue
         fi
         read -r update_status es_version <<< "${CHECK_IF_UPDATE_AVAILABLE_AND_VERSION}" &&
-        if [[ $(echo "${update_status}" | tr '[:upper:]' '[:lower:]') != "false" ]]; then
+        if [[ $(tr '[:upper:]' '[:lower:]' <<< "${update_status}") != "false" ]]; then
           textInfo "${regx}: Amazon ES domain ${domain} v${es_version} has updates available" "${regx}" "${domain}"
         else
           textPass "${regx}: Amazon ES domain ${domain} v${es_version} does not have have updates available" "${regx}" "${domain}"

--- a/checks/check_sample
+++ b/checks/check_sample
@@ -52,6 +52,8 @@
 #  - ${var:N:len}  : Return 'len' characters from position 'N'
 #  - ${var^^}      : Convert to upper-case all characters
 #  - ${var,,}      : Convert to lower-case all characters
+#  - ATTENTION: macOS original bash version "GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin19)" doesn't support some variable expansion above.
+#               Please make sure to test it.
 #  - For more examples and how to use it please refer to https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion
 # Check code with ShellCheck for best practices:
 #  - https://www.shellcheck.net/


### PR DESCRIPTION
### Context 

Bash variable expansion doesn't work on old bash version from macOS


### Description

Change lower case transformation from bash variable expansion to `tr '[:upper:]' '[:lower:]'` command.
Fix issue #1058 


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
