### PR TITLE
Fix(check122): Error when policy name contains commas

### DIFF
--- a/checks/check122
+++ b/checks/check122
@@ -30,8 +30,8 @@ check122(){
   LIST_CUSTOM_POLICIES=$($AWSCLI iam list-policies --output text $PROFILE_OPT --region $REGION --scope Local --query 'Policies[*].[Arn,DefaultVersionId]' | grep -v -e '^None$' | awk -F '\t' '{print $1","$2"\n"}')
   if [[ $LIST_CUSTOM_POLICIES ]]; then
     for policy in $LIST_CUSTOM_POLICIES; do
-      POLICY_ARN=$(echo $policy | awk 'BEGIN{FS=OFS=","}{NF--; print}')
-      POLICY_VERSION=$(echo $policy | awk -F ',' '{print $(NF)}')
+      POLICY_ARN=$(awk 'BEGIN{FS=OFS=","}{NF--; print}' <<< "${policy}")
+      POLICY_VERSION=$(awk -F ',' '{print $(NF)}' <<< "${policy}")
       POLICY_WITH_FULL=$($AWSCLI iam get-policy-version --output text --policy-arn $POLICY_ARN --version-id $POLICY_VERSION --query "[PolicyVersion.Document.Statement] | [] | [?Action!=null] | [?Effect == 'Allow' && Resource == '*' && Action == '*']" $PROFILE_OPT --region $REGION)
       if [[ $POLICY_WITH_FULL ]]; then
         POLICIES_ALLOW_LIST="$POLICIES_ALLOW_LIST $POLICY_ARN"
@@ -39,7 +39,7 @@ check122(){
     done
     if [[ $POLICIES_ALLOW_LIST ]]; then
       for policy in $POLICIES_ALLOW_LIST; do
-        textFail "$REGION: Policy $policy allows \"*:*\"" "$REGION" "$policy"
+        textFail "$REGION: Policy ${policy//,/[comma]} allows \"*:*\"" "$REGION" "$policy"
       done
     else
         textPass "$REGION: No custom policy found that allow full \"*:*\" administrative privileges" "$REGION"

--- a/checks/check122
+++ b/checks/check122
@@ -30,8 +30,8 @@ check122(){
   LIST_CUSTOM_POLICIES=$($AWSCLI iam list-policies --output text $PROFILE_OPT --region $REGION --scope Local --query 'Policies[*].[Arn,DefaultVersionId]' | grep -v -e '^None$' | awk -F '\t' '{print $1","$2"\n"}')
   if [[ $LIST_CUSTOM_POLICIES ]]; then
     for policy in $LIST_CUSTOM_POLICIES; do
-      POLICY_ARN=$(echo $policy | awk -F ',' '{print $1}')
-      POLICY_VERSION=$(echo $policy | awk -F ',' '{print $2}')
+      POLICY_ARN=$(echo $policy | awk 'BEGIN{FS=OFS=","}{NF--; print}')
+      POLICY_VERSION=$(echo $policy | awk -F ',' '{print $(NF)}')
       POLICY_WITH_FULL=$($AWSCLI iam get-policy-version --output text --policy-arn $POLICY_ARN --version-id $POLICY_VERSION --query "[PolicyVersion.Document.Statement] | [] | [?Action!=null] | [?Effect == 'Allow' && Resource == '*' && Action == '*']" $PROFILE_OPT --region $REGION)
       if [[ $POLICY_WITH_FULL ]]; then
         POLICIES_ALLOW_LIST="$POLICIES_ALLOW_LIST $POLICY_ARN"


### PR DESCRIPTION
### Context 

AWS IAM policy names allow commas (','), but check 122 does not support the case where there is a comma in the policy name.


### Description

* Change the awk command for the POLICY_VERSION variable in the script to get the version number from the last column rather than the second column.
* Change the awk command for the POLICY_ARN variable in the script to get the policy ARN from all columns except the last instead of just the first column.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
