### PR TITLE
fix(bucket_region): check extra764 doesn't handle bucket region properly

### DIFF
--- a/checks/check_extra764
+++ b/checks/check_extra764
@@ -26,49 +26,49 @@ CHECK_CAF_EPIC_extra764='Data Protection'
 
 
 extra764(){
-  LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets $PROFILE_OPT --query Buckets[*].Name --output text --region $REGION|xargs -n1)
+  LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets ${PROFILE_OPT} --query Buckets[*].Name --output text --region ${REGION}|xargs -n1)
   if [[ $LIST_OF_BUCKETS ]]; then
     for bucket in $LIST_OF_BUCKETS;do
       TEMP_STP_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-${bucket}.policy.XXXXXXXXXX)
-      BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location $PROFILE_OPT --region $REGION --bucket $bucket --output text 2>&1)
-      if [[ $(echo "$BUCKET_LOCATION" | grep AccessDenied) ]]; then
-        textInfo "Access Denied Trying to Get Bucket Location for $bucket"
+      BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location $PROFILE_OPT --region ${REGION} --bucket ${bucket} --output text 2>&1)
+      if grep AccessDenied <<< "${BUCKET_LOCATION}"; then
+        textInfo "Access Denied Trying to Get Bucket Location for ${bucket}"
         continue
       fi
-      if [[ $BUCKET_LOCATION == "None" ]]; then
+      if [[ "${BUCKET_LOCATION}" == "None" ]]; then
         BUCKET_LOCATION="us-east-1"
       fi
-      if [[ $BUCKET_LOCATION == "EU" ]]; then
+      if [[ "${BUCKET_LOCATION}" == "EU" ]]; then
         BUCKET_LOCATION="eu-west-1"
       fi
       # get bucket policy
-      $AWSCLI s3api get-bucket-policy $PROFILE_OPT --bucket $bucket --output text --query Policy --region $BUCKET_LOCATION > $TEMP_STP_POLICY_FILE 2>&1
-      if [[ $(grep AccessDenied $TEMP_STP_POLICY_FILE) ]]; then
-        textInfo "Access Denied Trying to Get Bucket Policy for $bucket"
-        rm -f $TEMP_STP_POLICY_FILE
+      $AWSCLI s3api get-bucket-policy $PROFILE_OPT --bucket "${bucket}" --output text --query Policy --region "${BUCKET_LOCATION}" > "${TEMP_STP_POLICY_FILE}" 2>&1
+      if grep AccessDenied <<< "${TEMP_STP_POLICY_FILE}"; then
+        textInfo "Access Denied Trying to Get Bucket Policy for ${bucket}"
+        rm -f "${TEMP_STP_POLICY_FILE}"
         continue
       fi
       if [[ $(grep NoSuchBucketPolicy $TEMP_STP_POLICY_FILE) ]]; then
-        textFail "No bucket policy for $bucket" "us-east-1" "$bucket"
-        rm -f $TEMP_STP_POLICY_FILE
+        textFail "No bucket policy for ${bucket}" "${BUCKET_LOCATION}" "${bucket}"
+        rm -f "${TEMP_STP_POLICY_FILE}"
         continue
       fi
 
       # https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-policy-for-config-rule/
       # checking if $TEMP_STP_POLICY_FILE is a valid json before converting it to json with jq
-      policy_str=$(cat "$TEMP_STP_POLICY_FILE")
-      if jq -e . >/dev/null 2>&1 <<< "$policy_str"; then
-        CHECK_BUCKET_STP_POLICY_PRESENT=$(cat $TEMP_STP_POLICY_FILE | jq --arg arn "arn:${AWS_PARTITION}:s3:::${bucket}" \
+      policy_str=$(cat "${TEMP_STP_POLICY_FILE}")
+      if jq -e . >/dev/null 2>&1 <<< "${policy_str}"; then
+        CHECK_BUCKET_STP_POLICY_PRESENT=$(cat "${TEMP_STP_POLICY_FILE}" | jq --arg arn "arn:${AWS_PARTITION}:s3:::${bucket}" \
           '.Statement[]|select((((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and .Effect=="Deny" and (.Action=="s3:*" or .Action=="*") and (.Resource|type == "array") and (.Resource|map({(.):0})[]|has($arn)) and (.Resource|map({(.):0})[]|has($arn+"/*")) and .Condition.Bool."aws:SecureTransport" == "false")')
-        if [[ $CHECK_BUCKET_STP_POLICY_PRESENT ]]; then
-          textPass "Bucket $bucket has S3 bucket policy to deny requests over insecure transport" "us-east-1" "$bucket"
+        if [[ "${CHECK_BUCKET_STP_POLICY_PRESENT}" ]]; then
+          textPass "Bucket ${bucket} has S3 bucket policy to deny requests over insecure transport" "${BUCKET_LOCATION}" "${bucket}"
         else
-          textFail "Bucket $bucket allows requests over insecure transport" "us-east-1" "$bucket"
+          textFail "Bucket ${bucket} allows requests over insecure transport" "${BUCKET_LOCATION}" "${bucket}"
         fi
       else
-          textInfo "Unknown Error occurred: $policy_str"
+          textInfo "Unknown Error occurred: ${policy_str}"
       fi
-      rm -fr $TEMP_STP_POLICY_FILE
+      rm -fr "${TEMP_STP_POLICY_FILE}"
     done
 
   else

--- a/checks/check_extra764
+++ b/checks/check_extra764
@@ -26,12 +26,12 @@ CHECK_CAF_EPIC_extra764='Data Protection'
 
 
 extra764(){
-  LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets ${PROFILE_OPT} --query Buckets[*].Name --output text --region ${REGION}|xargs -n1)
+  LIST_OF_BUCKETS=$(${AWSCLI} s3api list-buckets ${PROFILE_OPT} --query Buckets[*].Name --output text --region ${REGION}|xargs -n1)
   if [[ $LIST_OF_BUCKETS ]]; then
     for bucket in $LIST_OF_BUCKETS;do
       TEMP_STP_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-${bucket}.policy.XXXXXXXXXX)
-      BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location $PROFILE_OPT --region ${REGION} --bucket ${bucket} --output text 2>&1)
-      if grep AccessDenied <<< "${BUCKET_LOCATION}"; then
+      BUCKET_LOCATION=$(${AWSCLI} s3api get-bucket-location ${PROFILE_OPT} --region ${REGION} --bucket ${bucket} --output text 2>&1)
+      if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${BUCKET_LOCATION}"; then
         textInfo "Access Denied Trying to Get Bucket Location for ${bucket}"
         continue
       fi
@@ -42,13 +42,13 @@ extra764(){
         BUCKET_LOCATION="eu-west-1"
       fi
       # get bucket policy
-      $AWSCLI s3api get-bucket-policy $PROFILE_OPT --bucket "${bucket}" --output text --query Policy --region "${BUCKET_LOCATION}" > "${TEMP_STP_POLICY_FILE}" 2>&1
-      if grep AccessDenied <<< "${TEMP_STP_POLICY_FILE}"; then
+      TEMP_STP_POLICY_FILE=$(${AWSCLI} s3api get-bucket-policy ${PROFILE_OPT} --bucket ${bucket} --output text --query Policy --region ${BUCKET_LOCATION} 2>&1)
+      if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${TEMP_STP_POLICY_FILE}"; then
         textInfo "Access Denied Trying to Get Bucket Policy for ${bucket}"
         rm -f "${TEMP_STP_POLICY_FILE}"
         continue
       fi
-      if [[ $(grep NoSuchBucketPolicy $TEMP_STP_POLICY_FILE) ]]; then
+      if grep -q "NoSuchBucketPolicy" <<< $TEMP_STP_POLICY_FILE ; then
         textFail "No bucket policy for ${bucket}" "${BUCKET_LOCATION}" "${bucket}"
         rm -f "${TEMP_STP_POLICY_FILE}"
         continue
@@ -56,17 +56,16 @@ extra764(){
 
       # https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-policy-for-config-rule/
       # checking if $TEMP_STP_POLICY_FILE is a valid json before converting it to json with jq
-      policy_str=$(cat "${TEMP_STP_POLICY_FILE}")
-      if jq -e . >/dev/null 2>&1 <<< "${policy_str}"; then
-        CHECK_BUCKET_STP_POLICY_PRESENT=$(cat "${TEMP_STP_POLICY_FILE}" | jq --arg arn "arn:${AWS_PARTITION}:s3:::${bucket}" \
-          '.Statement[]|select((((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and .Effect=="Deny" and (.Action=="s3:*" or .Action=="*") and (.Resource|type == "array") and (.Resource|map({(.):0})[]|has($arn)) and (.Resource|map({(.):0})[]|has($arn+"/*")) and .Condition.Bool."aws:SecureTransport" == "false")')
+      if jq -e . >/dev/null 2>&1 <<< "${TEMP_STP_POLICY_FILE}"; then
+        CHECK_BUCKET_STP_POLICY_PRESENT=$(jq --arg arn "arn:${AWS_PARTITION}:s3:::${bucket}" \
+          '.Statement[]|select((((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and .Effect=="Deny" and (.Action=="s3:*" or .Action=="*") and (.Resource|type == "array") and (.Resource|map({(.):0})[]|has($arn)) and (.Resource|map({(.):0})[]|has($arn+"/*")) and .Condition.Bool."aws:SecureTransport" == "false")' <<< "${TEMP_STP_POLICY_FILE}")
         if [[ "${CHECK_BUCKET_STP_POLICY_PRESENT}" ]]; then
           textPass "Bucket ${bucket} has S3 bucket policy to deny requests over insecure transport" "${BUCKET_LOCATION}" "${bucket}"
         else
           textFail "Bucket ${bucket} allows requests over insecure transport" "${BUCKET_LOCATION}" "${bucket}"
         fi
       else
-          textInfo "Unknown Error occurred: ${policy_str}"
+          textInfo "Unknown Error occurred: ${TEMP_STP_POLICY_FILE}"
       fi
       rm -fr "${TEMP_STP_POLICY_FILE}"
     done


### PR DESCRIPTION
### Context 

When running the check extra764 for S3 it picks up the global region instead of the region the bucket is created in.


### Description

Return the correct region as it has done for the rest S3 checks.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
