### PR TITLE
fix(detect-secrets): Include missing colon to link values

### DIFF
--- a/checks/check_extra742
+++ b/checks/check_extra742
@@ -27,42 +27,44 @@ extra742(){
   SECRETS_TEMP_FOLDER="$PROWLER_DIR/secrets-$ACCOUNT_NUM"
   if [[ ! -d $SECRETS_TEMP_FOLDER ]]; then
     # this folder is deleted once this check is finished
-    mkdir $SECRETS_TEMP_FOLDER
+    mkdir "${SECRETS_TEMP_FOLDER}"
   fi
 
   for regx in $REGIONS; do
-    CFN_STACKS=$($AWSCLI cloudformation describe-stacks $PROFILE_OPT --region $regx --output json 2>&1)
-    if [[ $(echo "$CFN_STACKS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+    CFN_STACKS=$("${AWSCLI}" cloudformation describe-stacks $PROFILE_OPT --region "${regx}" --output json 2>&1)
+    if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "$CFN_STACKS" ; then
         textInfo "$regx: Access Denied trying to describe stacks" "$regx"
         continue
-    fi 
-    LIST_OF_CFN_STACKS=$(echo $CFN_STACKS | jq -r '.Stacks[].StackName')
+    fi
+    LIST_OF_CFN_STACKS=$(jq -r '.Stacks[].StackName' <<< "${CFN_STACKS}")
     if [[ $LIST_OF_CFN_STACKS ]];then
-      for stack in $LIST_OF_CFN_STACKS; do
-        CFN_OUTPUTS_FILE="$SECRETS_TEMP_FOLDER/extra742-$stack-$regx-outputs.txt"
-        echo $CFN_STACKS | jq --arg s "$stack" -r '.Stacks[] | select( .StackName == $s ) | .Outputs[]? | "\(.OutputKey) \(.OutputValue)"' > $CFN_OUTPUTS_FILE
-
-        if [ -s $CFN_OUTPUTS_FILE ];then
-          # This finds ftp or http URLs with credentials and common keywords
-          # FINDINGS=$(egrep -i '[[:alpha:]]*://[[:alnum:]]*:[[:alnum:]]*@.*/|key|secret|token|pass' $CFN_OUTPUTS_FILE |wc -l|tr -d '\ ')
-          # New implementation using https://github.com/Yelp/detect-secrets
-          FINDINGS=$(secretsDetector file $CFN_OUTPUTS_FILE)
+      for stackName in $LIST_OF_CFN_STACKS; do
+        CFN_OUTPUTS_FILE="$SECRETS_TEMP_FOLDER/extra742-${stackName}-${regx}-outputs.txt"
+        # OutputKey and OutputValue are separated by a colon because secrets-detector needs a way to link both values
+        jq --arg stackName "$stackName" -r '.Stacks[] | select( .StackName == $stackName ) | .Outputs[]? | "\(.OutputKey):\(.OutputValue)"' <<< "${CFN_STACKS}" > "${CFN_OUTPUTS_FILE}"
+        if [ -s "${CFN_OUTPUTS_FILE}" ];then
+          FINDINGS=$(secretsDetector file "${CFN_OUTPUTS_FILE}")
             if [[ $FINDINGS -eq 0 ]]; then
-              textPass "$regx: No secrets found in stack $stack Outputs" "$regx" "$stack"
-              # delete file if nothing interesting is there
-              rm -f $CFN_OUTPUTS_FILE
+              textPass "$regx: No secrets found in stack ${stackName} Outputs" "$regx" "${stackName}"
+              # Delete file if nothing interesting is there
+              rm -f "${CFN_OUTPUTS_FILE}"
             else
-              textFail "$regx: Potential secret found in stack $stack Outputs" "$regx" "$stack"
-              # delete file to not leave trace, user must look at the CFN Stack
-              rm -f $CFN_OUTPUTS_FILE
+              textFail "$regx: Potential secret found in stack ${stackName} Outputs" "$regx" "${stackName}"
+              # Delete file to not leave trace, user must look at the CFN Stack
+              rm -f "${CFN_OUTPUTS_FILE}"
             fi
         else
-          textInfo "$regx: CloudFormation stack $stack has no Outputs" "$regx"
+          textInfo "$regx: CloudFormation stack ${stackName} has no Outputs" "$regx"
         fi
       done
     else
       textInfo "$regx: No CloudFormation stacks found" "$regx"
     fi
   done
-  rm -rf $SECRETS_TEMP_FOLDER
+
+  # Cleanup temporary folder
+  if [[ -d $SECRETS_TEMP_FOLDER ]]
+  then
+    rm -rf "${SECRETS_TEMP_FOLDER}"
+  fi
 }


### PR DESCRIPTION
### Context 

`extra742` uses `detect-secrets` to find possible secret values within strings or whole files.

### Description

Right now, this checks passes to `detect-secrets` the following values extracted from CloudFormation Stack Outputs:
```
Output1 Value1
Output2 Value2
Output3 Value3
```
The problem is that `detect-secrets` can't link output values with their related values.

![Screenshot 2022-03-18 at 13 35 35](https://user-images.githubusercontent.com/16007882/159004043-bc057342-8ba4-4cb9-a3b8-813ed5f5548e.png)


To fix this we've included a `:` to link values:
```
Output1:Value1
Output2:Value2
Output3:Value3
```
![Screenshot 2022-03-18 at 13 36 00](https://user-images.githubusercontent.com/16007882/159004087-8ba24575-ef99-4097-b786-cdca381ecbc9.png)

With that `detect-secrets` can identify possible secrets.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
