### PR TITLE
fix(secrets_library): Verify if detect-secrets library is missing

### DIFF
--- a/checks/check_extra7141
+++ b/checks/check_extra7141
@@ -31,32 +31,37 @@ extra7141(){
   fi
 
   for regx in ${REGIONS}; do
-    SSM_DOCS=$("${AWSCLI}" ${PROFILE_OPT} --region "${regx}" ssm list-documents --filters 'Key=Owner,Values=Self' --query 'DocumentIdentifiers[].Name' --output text 2>&1)
-    if [[ $(echo "${SSM_DOCS}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-        textInfo "${regx}: Access Denied trying to list documents" "${regx}"
-        continue
-    fi
-    if [[ ${SSM_DOCS} ]];then
-      for ssmdoc in ${SSM_DOCS}; do 
-        SSM_DOC_FILE="${SECRETS_TEMP_FOLDER}/extra7141-${ssmdoc}-${regx}-content.txt"
-        "${AWSCLI}" ${PROFILE_OPT} --region "${regx}" ssm get-document --name "${ssmdoc}" --output text --document-format JSON > "${SSM_DOC_FILE}" 2>&1
-        if [[ $(grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' "${SSM_DOC_FILE}") ]]; then
-            textInfo "${regx}: Access Denied trying to get document" "${regx}"
-            continue
-        fi
-        FINDINGS=$(secretsDetector file "${SSM_DOC_FILE}")
-        if [[ "${FINDINGS}" -eq 0 ]]; then
-          textPass "${regx}: No secrets found in SSM Document ${ssmdoc}" "${regx}" "${ssmdoc}"
-          # delete file if nothing interesting is there
-          rm -f "${SSM_DOC_FILE}"
-        else
-          textFail "${regx}: Potential secret found SSM Document ${ssmdoc}" "${regx}" "${ssmdoc}"
-          # delete file to not leave trace, user must look at the CFN Stack
-          rm -f "${SSM_DOC_FILE}"
-        fi
-      done
+    CHECK_DETECT_SECRETS_INSTALLATION=$(secretsDetector)
+    if [[ $? -eq 241 ]]; then
+      textInfo "$regx: python library detect-secrets not found. Make sure it is installed correctly." "$regx"
     else
-      textInfo "${regx}: No SSM Document found." "${regx}"
+      SSM_DOCS=$("${AWSCLI}" ${PROFILE_OPT} --region "${regx}" ssm list-documents --filters 'Key=Owner,Values=Self' --query 'DocumentIdentifiers[].Name' --output text 2>&1)
+      if [[ $(echo "${SSM_DOCS}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+          textInfo "${regx}: Access Denied trying to list documents" "${regx}"
+          continue
+      fi
+      if [[ ${SSM_DOCS} ]];then
+        for ssmdoc in ${SSM_DOCS}; do 
+          SSM_DOC_FILE="${SECRETS_TEMP_FOLDER}/extra7141-${ssmdoc}-${regx}-content.txt"
+          "${AWSCLI}" ${PROFILE_OPT} --region "${regx}" ssm get-document --name "${ssmdoc}" --output text --document-format JSON > "${SSM_DOC_FILE}" 2>&1
+          if [[ $(grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' "${SSM_DOC_FILE}") ]]; then
+              textInfo "${regx}: Access Denied trying to get document" "${regx}"
+              continue
+          fi
+          FINDINGS=$(secretsDetector file "${SSM_DOC_FILE}")
+          if [[ "${FINDINGS}" -eq 0 ]]; then
+            textPass "${regx}: No secrets found in SSM Document ${ssmdoc}" "${regx}" "${ssmdoc}"
+            # delete file if nothing interesting is there
+            rm -f "${SSM_DOC_FILE}"
+          else
+            textFail "${regx}: Potential secret found SSM Document ${ssmdoc}" "${regx}" "${ssmdoc}"
+            # delete file to not leave trace, user must look at the CFN Stack
+            rm -f "${SSM_DOC_FILE}"
+          fi
+        done
+      else
+        textInfo "${regx}: No SSM Document found." "${regx}"
+      fi
     fi
   done
   rm -rf "${SECRETS_TEMP_FOLDER}"

--- a/checks/check_extra741
+++ b/checks/check_extra741
@@ -31,39 +31,44 @@ extra741(){
   fi
 
   for regx in $REGIONS; do
-    LIST_OF_EC2_INSTANCES=$($AWSCLI ec2 describe-instances $PROFILE_OPT --region $regx --query Reservations[*].Instances[*].InstanceId --output text --max-items $MAXITEMS 2>&1| grep -v None)
-    if [[ $(echo "$LIST_OF_EC2_INSTANCES" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-        textInfo "$regx: Access Denied trying to describe instances" "$regx"
-        continue
-    fi 
-    if [[ $LIST_OF_EC2_INSTANCES ]];then
-      for instance in $LIST_OF_EC2_INSTANCES; do
-        EC2_USERDATA_FILE="$SECRETS_TEMP_FOLDER/extra741-$instance-userData.decoded"
-        EC2_USERDATA=$($AWSCLI ec2 describe-instance-attribute --attribute userData $PROFILE_OPT --region $regx --instance-id $instance --query UserData.Value --output text| grep -v ^None | decode_report > $EC2_USERDATA_FILE)
-        if [ -s "$EC2_USERDATA_FILE" ];then
-          # This finds ftp or http URLs with credentials and common keywords
-          # FINDINGS=$(egrep -i '[[:alpha:]]*://[[:alnum:]]*:[[:alnum:]]*@.*/|key|secret|token|pass' $EC2_USERDATA_FILE |wc -l|tr -d '\ ')
-          # New implementation using https://github.com/Yelp/detect-secrets
-          # Test if user data is a valid GZIP file, if so gunzip first
-          if gunzip -t "$EC2_USERDATA_FILE" > /dev/null 2>&1; then
-            mv "$EC2_USERDATA_FILE" "$EC2_USERDATA_FILE.gz" ; gunzip "$EC2_USERDATA_FILE.gz"
-          fi
-          FINDINGS=$(secretsDetector file "$EC2_USERDATA_FILE")
-          if [[ $FINDINGS -eq 0 ]]; then
-            textPass "$regx: No secrets found in $instance User Data" "$regx" "$instance"
-            # delete file if nothing interesting is there
-            rm -f "$EC2_USERDATA_FILE"
-          else
-            textFail "$regx: Potential secret found in $instance User Data" "$regx" "$instance"
-            # delete file to not leave trace, user must look at the instance User Data
-            rm -f "$EC2_USERDATA_FILE"
-          fi
-        else
-          textPass "$regx: No secrets found in $instance User Data or it is empty" "$regx" "$instance"
-        fi
-      done
+    CHECK_DETECT_SECRETS_INSTALLATION=$(secretsDetector)
+    if [[ $? -eq 241 ]]; then
+      textInfo "$regx: python library detect-secrets not found. Make sure it is installed correctly." "$regx"
     else
-      textInfo "$regx: No EC2 instances found" "$regx"
+      LIST_OF_EC2_INSTANCES=$($AWSCLI ec2 describe-instances $PROFILE_OPT --region $regx --query Reservations[*].Instances[*].InstanceId --output text --max-items $MAXITEMS 2>&1| grep -v None)
+      if [[ $(echo "$LIST_OF_EC2_INSTANCES" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+          textInfo "$regx: Access Denied trying to describe instances" "$regx"
+          continue
+      fi 
+      if [[ $LIST_OF_EC2_INSTANCES ]];then
+        for instance in $LIST_OF_EC2_INSTANCES; do
+          EC2_USERDATA_FILE="$SECRETS_TEMP_FOLDER/extra741-$instance-userData.decoded"
+          EC2_USERDATA=$($AWSCLI ec2 describe-instance-attribute --attribute userData $PROFILE_OPT --region $regx --instance-id $instance --query UserData.Value --output text| grep -v ^None | decode_report > $EC2_USERDATA_FILE)
+          if [ -s "$EC2_USERDATA_FILE" ];then
+            # This finds ftp or http URLs with credentials and common keywords
+            # FINDINGS=$(egrep -i '[[:alpha:]]*://[[:alnum:]]*:[[:alnum:]]*@.*/|key|secret|token|pass' $EC2_USERDATA_FILE |wc -l|tr -d '\ ')
+            # New implementation using https://github.com/Yelp/detect-secrets
+            # Test if user data is a valid GZIP file, if so gunzip first
+            if gunzip -t "$EC2_USERDATA_FILE" > /dev/null 2>&1; then
+              mv "$EC2_USERDATA_FILE" "$EC2_USERDATA_FILE.gz" ; gunzip "$EC2_USERDATA_FILE.gz"
+            fi
+            FINDINGS=$(secretsDetector file "$EC2_USERDATA_FILE")
+            if [[ $FINDINGS -eq 0 ]]; then
+              textPass "$regx: No secrets found in $instance User Data" "$regx" "$instance"
+              # delete file if nothing interesting is there
+              rm -f "$EC2_USERDATA_FILE"
+            else
+              textFail "$regx: Potential secret found in $instance User Data" "$regx" "$instance"
+              # delete file to not leave trace, user must look at the instance User Data
+              rm -f "$EC2_USERDATA_FILE"
+            fi
+          else
+            textPass "$regx: No secrets found in $instance User Data or it is empty" "$regx" "$instance"
+          fi
+        done
+      else
+        textInfo "$regx: No EC2 instances found" "$regx"
+      fi
     fi
   done
   rm -rf $SECRETS_TEMP_FOLDER

--- a/checks/check_extra742
+++ b/checks/check_extra742
@@ -31,34 +31,39 @@ extra742(){
   fi
 
   for regx in $REGIONS; do
-    CFN_STACKS=$("${AWSCLI}" cloudformation describe-stacks $PROFILE_OPT --region "${regx}" --output json 2>&1)
-    if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "$CFN_STACKS" ; then
-        textInfo "$regx: Access Denied trying to describe stacks" "$regx"
-        continue
-    fi
-    LIST_OF_CFN_STACKS=$(jq -r '.Stacks[].StackName' <<< "${CFN_STACKS}")
-    if [[ $LIST_OF_CFN_STACKS ]];then
-      for stackName in $LIST_OF_CFN_STACKS; do
-        CFN_OUTPUTS_FILE="$SECRETS_TEMP_FOLDER/extra742-${stackName}-${regx}-outputs.txt"
-        # OutputKey and OutputValue are separated by a colon because secrets-detector needs a way to link both values
-        jq --arg stackName "$stackName" -r '.Stacks[] | select( .StackName == $stackName ) | .Outputs[]? | "\(.OutputKey):\(.OutputValue)"' <<< "${CFN_STACKS}" > "${CFN_OUTPUTS_FILE}"
-        if [ -s "${CFN_OUTPUTS_FILE}" ];then
-          FINDINGS=$(secretsDetector file "${CFN_OUTPUTS_FILE}")
-            if [[ $FINDINGS -eq 0 ]]; then
-              textPass "$regx: No secrets found in stack ${stackName} Outputs" "$regx" "${stackName}"
-              # Delete file if nothing interesting is there
-              rm -f "${CFN_OUTPUTS_FILE}"
-            else
-              textFail "$regx: Potential secret found in stack ${stackName} Outputs" "$regx" "${stackName}"
-              # Delete file to not leave trace, user must look at the CFN Stack
-              rm -f "${CFN_OUTPUTS_FILE}"
-            fi
-        else
-          textInfo "$regx: CloudFormation stack ${stackName} has no Outputs" "$regx"
-        fi
-      done
+    CHECK_DETECT_SECRETS_INSTALLATION=$(secretsDetector)
+    if [[ $? -eq 241 ]]; then
+      textInfo "$regx: python library detect-secrets not found. Make sure it is installed correctly." "$regx"
     else
-      textInfo "$regx: No CloudFormation stacks found" "$regx"
+      CFN_STACKS=$("${AWSCLI}" cloudformation describe-stacks $PROFILE_OPT --region "${regx}" --output json 2>&1)
+      if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "$CFN_STACKS" ; then
+          textInfo "$regx: Access Denied trying to describe stacks" "$regx"
+          continue
+      fi
+      LIST_OF_CFN_STACKS=$(jq -r '.Stacks[].StackName' <<< "${CFN_STACKS}")
+      if [[ $LIST_OF_CFN_STACKS ]];then
+        for stackName in $LIST_OF_CFN_STACKS; do
+          CFN_OUTPUTS_FILE="$SECRETS_TEMP_FOLDER/extra742-${stackName}-${regx}-outputs.txt"
+          # OutputKey and OutputValue are separated by a colon because secrets-detector needs a way to link both values
+          jq --arg stackName "$stackName" -r '.Stacks[] | select( .StackName == $stackName ) | .Outputs[]? | "\(.OutputKey):\(.OutputValue)"' <<< "${CFN_STACKS}" > "${CFN_OUTPUTS_FILE}"
+          if [ -s "${CFN_OUTPUTS_FILE}" ];then
+            FINDINGS=$(secretsDetector file "${CFN_OUTPUTS_FILE}")
+              if [[ $FINDINGS -eq 0 ]]; then
+                textPass "$regx: No secrets found in stack ${stackName} Outputs" "$regx" "${stackName}"
+                # Delete file if nothing interesting is there
+                rm -f "${CFN_OUTPUTS_FILE}"
+              else
+                textFail "$regx: Potential secret found in stack ${stackName} Outputs" "$regx" "${stackName}"
+                # Delete file to not leave trace, user must look at the CFN Stack
+                rm -f "${CFN_OUTPUTS_FILE}"
+              fi
+          else
+            textInfo "$regx: CloudFormation stack ${stackName} has no Outputs" "$regx"
+          fi
+        done
+      else
+        textInfo "$regx: No CloudFormation stacks found" "$regx"
+      fi
     fi
   done
 

--- a/checks/check_extra759
+++ b/checks/check_extra759
@@ -31,33 +31,38 @@ extra759(){
   fi
 
   for regx in $REGIONS; do
-    LIST_OF_FUNCTIONS=$($AWSCLI lambda list-functions $PROFILE_OPT --region $regx --query Functions[*].FunctionName --output text 2>&1)
-    if [[ $(echo "$LIST_OF_FUNCTIONS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-        textInfo "$regx: Access Denied trying to list functions" "$regx"
-        continue
-    fi 
-    if [[ $LIST_OF_FUNCTIONS ]]; then
-      for lambdafunction in $LIST_OF_FUNCTIONS;do
-        LAMBDA_FUNCTION_VARIABLES_FILE="$SECRETS_TEMP_FOLDER/extra759-$lambdafunction-$regx-variables.txt"
-        LAMBDA_FUNCTION_VARIABLES=$($AWSCLI lambda $PROFILE_OPT --region $regx get-function-configuration --function-name $lambdafunction --query 'Environment.Variables' --output json > $LAMBDA_FUNCTION_VARIABLES_FILE)
-        if [ -s $LAMBDA_FUNCTION_VARIABLES_FILE ];then
-        # Implementation using https://github.com/Yelp/detect-secrets
-        FINDINGS=$(secretsDetector file $LAMBDA_FUNCTION_VARIABLES_FILE)
-          if [[ $FINDINGS -eq 0 ]]; then
-            textPass "$regx: No secrets found in Lambda function $lambdafunction variables" "$regx" "$lambdafunction"
-            # delete file if nothing interesting is there
-            rm -f $LAMBDA_FUNCTION_VARIABLES_FILE
-          else
-            textFail "$regx: Potential secret found in Lambda function $lambdafunction variables" "$regx" "$lambdafunction"
-            # delete file to not leave trace, user must look at the function
-            rm -f $LAMBDA_FUNCTION_VARIABLES_FILE
-          fi
-        else
-          textInfo "$regx: Lambda function $stalambdafunction has not variables" "$regx"
-        fi
-      done
+    CHECK_DETECT_SECRETS_INSTALLATION=$(secretsDetector)
+    if [[ $? -eq 241 ]]; then
+      textInfo "$regx: python library detect-secrets not found. Make sure it is installed correctly." "$regx"
     else
-      textInfo "$regx: No Lambda functions found" "$regx"
+      LIST_OF_FUNCTIONS=$($AWSCLI lambda list-functions $PROFILE_OPT --region $regx --query Functions[*].FunctionName --output text 2>&1)
+      if [[ $(echo "$LIST_OF_FUNCTIONS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+          textInfo "$regx: Access Denied trying to list functions" "$regx"
+          continue
+      fi 
+      if [[ $LIST_OF_FUNCTIONS ]]; then
+        for lambdafunction in $LIST_OF_FUNCTIONS;do
+          LAMBDA_FUNCTION_VARIABLES_FILE="$SECRETS_TEMP_FOLDER/extra759-$lambdafunction-$regx-variables.txt"
+          LAMBDA_FUNCTION_VARIABLES=$($AWSCLI lambda $PROFILE_OPT --region $regx get-function-configuration --function-name $lambdafunction --query 'Environment.Variables' --output json > $LAMBDA_FUNCTION_VARIABLES_FILE)
+          if [ -s $LAMBDA_FUNCTION_VARIABLES_FILE ];then
+          # Implementation using https://github.com/Yelp/detect-secrets
+          FINDINGS=$(secretsDetector file $LAMBDA_FUNCTION_VARIABLES_FILE)
+            if [[ $FINDINGS -eq 0 ]]; then
+              textPass "$regx: No secrets found in Lambda function $lambdafunction variables" "$regx" "$lambdafunction"
+              # delete file if nothing interesting is there
+              rm -f $LAMBDA_FUNCTION_VARIABLES_FILE
+            else
+              textFail "$regx: Potential secret found in Lambda function $lambdafunction variables" "$regx" "$lambdafunction"
+              # delete file to not leave trace, user must look at the function
+              rm -f $LAMBDA_FUNCTION_VARIABLES_FILE
+            fi
+          else
+            textInfo "$regx: Lambda function $stalambdafunction has not variables" "$regx"
+          fi
+        done
+      else
+        textInfo "$regx: No Lambda functions found" "$regx"
+      fi
     fi
   done
   rm -rf $SECRETS_TEMP_FOLDER

--- a/checks/check_extra760
+++ b/checks/check_extra760
@@ -31,58 +31,63 @@ extra760(){
   fi
 
   for regx in ${REGIONS}; do
-    LIST_OF_FUNCTIONS=$("${AWSCLI}" lambda list-functions ${PROFILE_OPT} --region "${regx}" --query 'Functions[*].FunctionName' --output text 2>&1)
-    if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_OF_FUNCTIONS}"; then
-      textInfo "${regx}: Access Denied trying to list Lambda functions" "${regx}"
-      continue
-    fi
-    if [[ -n "${LIST_OF_FUNCTIONS}" && $(tr '[:upper:]' '[:lower:]' <<< "${LIST_OF_FUNCTIONS}") != "none" ]]; then
-      for lambdafunction in ${LIST_OF_FUNCTIONS}; do
-        LAMBDA_FUNCTION_FOLDER="${SECRETS_TEMP_FOLDER}/extra760-${lambdafunction}-${regx}"
-        LAMBDA_FUNCTION_FILE="${lambdafunction}-code.zip"
-        LAMBDA_CODE_LOCATION=$("${AWSCLI}" lambda get-function ${PROFILE_OPT} --region "${regx}" --function-name "${lambdafunction}" --query 'Code.Location' --output text 2>&1)
-        if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LAMBDA_CODE_LOCATION}"; then
-          textInfo "${regx}: Access Denied trying to get Lambda functions" "${regx}" "${lambdafunction}"
-          continue
-        fi
-        
-        mkdir "${LAMBDA_FUNCTION_FOLDER}"
-        
-        # DOWNLOAD the code in a zip file
-        CURL_ERROR=$(curl -s --show-error "${LAMBDA_CODE_LOCATION}" -o "${LAMBDA_FUNCTION_FOLDER}/${LAMBDA_FUNCTION_FILE}" 2>&1)
-        if [[ -n "${CURL_ERROR}" ]]; then
-          textInfo "${regx}: Error trying to get Lambda function code for ${lambdafunction} - ${CURL_ERROR}" "${regx}" "${lambdafunction}"
-          # delete files to not leave trace, user must look at the function
-          if [[ -d "${LAMBDA_FUNCTION_FOLDER}" ]]; then
-            rm -fr "${LAMBDA_FUNCTION_FOLDER}"
-          fi
-          continue
-        fi
-        if ! grep -q 'Zip archive data' <(file "${LAMBDA_FUNCTION_FOLDER}/${LAMBDA_FUNCTION_FILE}"); then
-          textInfo "${regx}: Error trying to get Lambda function code for ${lambdafunction}. File is not a Zip" "${regx}" "${lambdafunction}"
-          # delete files to not leave trace, user must look at the function
-          if [[ -d "${LAMBDA_FUNCTION_FOLDER}" ]]; then
-            rm -fr "${LAMBDA_FUNCTION_FOLDER}"
-          fi
-          continue
-        fi
-
-        unzip -qq "${LAMBDA_FUNCTION_FOLDER}/${LAMBDA_FUNCTION_FILE}" -d "${LAMBDA_FUNCTION_FOLDER}" && {
-          FINDINGS=$(secretsDetector folder "${LAMBDA_FUNCTION_FOLDER}")
-          if [[ ${FINDINGS} -eq 0 ]]; then
-            textPass "${regx}: No secrets found in Lambda function ${lambdafunction} code" "${regx}" "${lambdafunction}"
-          else
-            textFail "${regx}: Potential secret found in Lambda function ${lambdafunction} code" "${regx}" "${lambdafunction}"
-          fi
-        }
-
-        # delete files to not leave trace, user must look at the function
-        if [[ -d "${LAMBDA_FUNCTION_FOLDER}" ]]; then
-          rm -fr "${LAMBDA_FUNCTION_FOLDER}"
-        fi
-      done
+    CHECK_DETECT_SECRETS_INSTALLATION=$(secretsDetector)
+    if [[ $? -eq 241 ]]; then
+      textInfo "$regx: python library detect-secrets not found. Make sure it is installed correctly." "$regx"
     else
-      textInfo "${regx}: No Lambda functions found" "${regx}"
+      LIST_OF_FUNCTIONS=$("${AWSCLI}" lambda list-functions ${PROFILE_OPT} --region "${regx}" --query 'Functions[*].FunctionName' --output text 2>&1)
+      if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_OF_FUNCTIONS}"; then
+        textInfo "${regx}: Access Denied trying to list Lambda functions" "${regx}"
+        continue
+      fi
+      if [[ -n "${LIST_OF_FUNCTIONS}" && $(tr '[:upper:]' '[:lower:]' <<< "${LIST_OF_FUNCTIONS}") != "none" ]]; then
+        for lambdafunction in ${LIST_OF_FUNCTIONS}; do
+          LAMBDA_FUNCTION_FOLDER="${SECRETS_TEMP_FOLDER}/extra760-${lambdafunction}-${regx}"
+          LAMBDA_FUNCTION_FILE="${lambdafunction}-code.zip"
+          LAMBDA_CODE_LOCATION=$("${AWSCLI}" lambda get-function ${PROFILE_OPT} --region "${regx}" --function-name "${lambdafunction}" --query 'Code.Location' --output text 2>&1)
+          if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LAMBDA_CODE_LOCATION}"; then
+            textInfo "${regx}: Access Denied trying to get Lambda functions" "${regx}" "${lambdafunction}"
+            continue
+          fi
+          
+          mkdir "${LAMBDA_FUNCTION_FOLDER}"
+          
+          # DOWNLOAD the code in a zip file
+          CURL_ERROR=$(curl -s --show-error "${LAMBDA_CODE_LOCATION}" -o "${LAMBDA_FUNCTION_FOLDER}/${LAMBDA_FUNCTION_FILE}" 2>&1)
+          if [[ -n "${CURL_ERROR}" ]]; then
+            textInfo "${regx}: Error trying to get Lambda function code for ${lambdafunction} - ${CURL_ERROR}" "${regx}" "${lambdafunction}"
+            # delete files to not leave trace, user must look at the function
+            if [[ -d "${LAMBDA_FUNCTION_FOLDER}" ]]; then
+              rm -fr "${LAMBDA_FUNCTION_FOLDER}"
+            fi
+            continue
+          fi
+          if ! grep -q 'Zip archive data' <(file "${LAMBDA_FUNCTION_FOLDER}/${LAMBDA_FUNCTION_FILE}"); then
+            textInfo "${regx}: Error trying to get Lambda function code for ${lambdafunction}. File is not a Zip" "${regx}" "${lambdafunction}"
+            # delete files to not leave trace, user must look at the function
+            if [[ -d "${LAMBDA_FUNCTION_FOLDER}" ]]; then
+              rm -fr "${LAMBDA_FUNCTION_FOLDER}"
+            fi
+            continue
+          fi
+
+          unzip -qq "${LAMBDA_FUNCTION_FOLDER}/${LAMBDA_FUNCTION_FILE}" -d "${LAMBDA_FUNCTION_FOLDER}" && {
+            FINDINGS=$(secretsDetector folder "${LAMBDA_FUNCTION_FOLDER}")
+            if [[ ${FINDINGS} -eq 0 ]]; then
+              textPass "${regx}: No secrets found in Lambda function ${lambdafunction} code" "${regx}" "${lambdafunction}"
+            else
+              textFail "${regx}: Potential secret found in Lambda function ${lambdafunction} code" "${regx}" "${lambdafunction}"
+            fi
+          }
+
+          # delete files to not leave trace, user must look at the function
+          if [[ -d "${LAMBDA_FUNCTION_FOLDER}" ]]; then
+            rm -fr "${LAMBDA_FUNCTION_FOLDER}"
+          fi
+        done
+      else
+        textInfo "${regx}: No Lambda functions found" "${regx}"
+      fi
     fi
   done
 

--- a/checks/check_extra768
+++ b/checks/check_extra768
@@ -29,38 +29,43 @@ extra768(){
     mkdir $SECRETS_TEMP_FOLDER
   fi
   for regx in $REGIONS; do
-    # Get a list of all task definition families first:
-    FAMILIES=$($AWSCLI ecs list-task-definition-families $PROFILE_OPT --region $regx --status ACTIVE 2>&1 )
-    if [[ $(echo "$FAMILIES" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-        textInfo "$regx: Access Denied trying to list task definition families" "$regx"
-        continue
-    fi 
-    if [[ $(echo $FAMILIES | jq -r .families[]) ]]; then
-      for FAMILY in $(echo $FAMILIES | jq -r .families[]);do
-        # Get the full task definition arn:
-        TASK_DEFINITION_TEMP=$($AWSCLI ecs list-task-definitions $PROFILE_OPT --region $regx --family-prefix $FAMILY --sort DESC --max-items 1 | jq -r .taskDefinitionArns[0])
-        # We only care about the task definition name:
-        IFS='/' read -r -a splitArn <<< "$TASK_DEFINITION_TEMP"
-        TASK_DEFINITION=${splitArn[1]}
-        TASK_DEFINITION_ENV_VARIABLES_FILE="$SECRETS_TEMP_FOLDER/extra768-$TASK_DEFINITION-$regx-variables.txt"
-        TASK_DEFINITION_ENV_VARIABLES=$($AWSCLI ecs $PROFILE_OPT --region $regx describe-task-definition --task-definition $TASK_DEFINITION --query 'taskDefinition.containerDefinitions[*].environment' --output text > $TASK_DEFINITION_ENV_VARIABLES_FILE)
-        if [ -s $TASK_DEFINITION_ENV_VARIABLES_FILE ];then
-          # Implementation using https://github.com/Yelp/detect-secrets
-          FINDINGS=$(secretsDetector file $TASK_DEFINITION_ENV_VARIABLES_FILE)
-          if [[ $FINDINGS -eq 0 ]]; then
-            textPass "$regx: No secrets found in ECS task definition $TASK_DEFINITION variables" "$regx" "$TASK_DEFINITION"
-            # delete file if nothing interesting is there
-            rm -f $TASK_DEFINITION_ENV_VARIABLES_FILE
-          else
-            textFail "$regx: Potential secret found in ECS task definition $TASK_DEFINITION variables" "$regx" "$TASK_DEFINITION"
-          fi
-        else
-          textInfo "$regx: ECS task definition $TASK_DEFINITION has no variables" "$regx" "$TASK_DEFINITION"
-          rm -f $TASK_DEFINITION_ENV_VARIABLES_FILE
-        fi
-      done
+    CHECK_DETECT_SECRETS_INSTALLATION=$(secretsDetector)
+    if [[ $? -eq 241 ]]; then
+      textInfo "$regx: python library detect-secrets not found. Make sure it is installed correctly." "$regx"
     else
-      textInfo "$regx: No ECS task definitions found" "$regx"
+      # Get a list of all task definition families first:
+      FAMILIES=$($AWSCLI ecs list-task-definition-families $PROFILE_OPT --region $regx --status ACTIVE 2>&1 )
+      if [[ $(echo "$FAMILIES" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+          textInfo "$regx: Access Denied trying to list task definition families" "$regx"
+          continue
+      fi 
+      if [[ $(echo $FAMILIES | jq -r .families[]) ]]; then
+        for FAMILY in $(echo $FAMILIES | jq -r .families[]);do
+          # Get the full task definition arn:
+          TASK_DEFINITION_TEMP=$($AWSCLI ecs list-task-definitions $PROFILE_OPT --region $regx --family-prefix $FAMILY --sort DESC --max-items 1 | jq -r .taskDefinitionArns[0])
+          # We only care about the task definition name:
+          IFS='/' read -r -a splitArn <<< "$TASK_DEFINITION_TEMP"
+          TASK_DEFINITION=${splitArn[1]}
+          TASK_DEFINITION_ENV_VARIABLES_FILE="$SECRETS_TEMP_FOLDER/extra768-$TASK_DEFINITION-$regx-variables.txt"
+          TASK_DEFINITION_ENV_VARIABLES=$($AWSCLI ecs $PROFILE_OPT --region $regx describe-task-definition --task-definition $TASK_DEFINITION --query 'taskDefinition.containerDefinitions[*].environment' --output text > $TASK_DEFINITION_ENV_VARIABLES_FILE)
+          if [ -s $TASK_DEFINITION_ENV_VARIABLES_FILE ];then
+            # Implementation using https://github.com/Yelp/detect-secrets
+            FINDINGS=$(secretsDetector file $TASK_DEFINITION_ENV_VARIABLES_FILE)
+            if [[ $FINDINGS -eq 0 ]]; then
+              textPass "$regx: No secrets found in ECS task definition $TASK_DEFINITION variables" "$regx" "$TASK_DEFINITION"
+              # delete file if nothing interesting is there
+              rm -f $TASK_DEFINITION_ENV_VARIABLES_FILE
+            else
+              textFail "$regx: Potential secret found in ECS task definition $TASK_DEFINITION variables" "$regx" "$TASK_DEFINITION"
+            fi
+          else
+            textInfo "$regx: ECS task definition $TASK_DEFINITION has no variables" "$regx" "$TASK_DEFINITION"
+            rm -f $TASK_DEFINITION_ENV_VARIABLES_FILE
+          fi
+        done
+      else
+        textInfo "$regx: No ECS task definitions found" "$regx"
+      fi
     fi
   done
 }

--- a/checks/check_extra775
+++ b/checks/check_extra775
@@ -30,47 +30,52 @@ extra775(){
   fi 
 
   for regx in $REGIONS; do
-    LIST_OF_EC2_AUTOSCALING=$($AWSCLI autoscaling describe-launch-configurations $PROFILE_OPT --region $regx --query LaunchConfigurations[*].LaunchConfigurationName --output text --max-items $MAXITEMS 2>&1 | grep -v None )
-    if [[ $(echo "$LIST_OF_EC2_AUTOSCALING" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-        textInfo "$regx: Access Denied trying to describe launch configurations" "$regx"
-        continue
-    fi
-    if [[ $LIST_OF_EC2_AUTOSCALING ]];then
-      for autoscaling_configuration in $LIST_OF_EC2_AUTOSCALING; do
-        EC2_AUTOSCALING_USERDATA_FILE="$SECRETS_TEMP_FOLDER/extra775-$autoscaling_configuration-userData.decoded"
-        EC2_AUTOSCALING_USERDATA=$($AWSCLI autoscaling describe-launch-configurations $PROFILE_OPT --launch-configuration-names $autoscaling_configuration --region $regx --query LaunchConfigurations[*].UserData --output text| grep -v ^None | decode_report > $EC2_AUTOSCALING_USERDATA_FILE)
-        if [ -s $EC2_AUTOSCALING_USERDATA_FILE ];then
-          FILE_FORMAT_ASCII=$(file -b $EC2_AUTOSCALING_USERDATA_FILE | grep ASCII)
-          # This finds ftp or http URLs with credentials and common keywords
-          # FINDINGS=$(egrep -i '[[:alpha:]]*://[[:alnum:]]*:[[:alnum:]]*@.*/|key|secret|token|pass' $EC2_AUTOSCALING_USERDATA_FILE |wc -l|tr -d '\ ')
-          # New implementation using https://github.com/Yelp/detect-secrets
-          if [[ $FILE_FORMAT_ASCII ]]; then
-          FINDINGS=$(secretsDetector file $EC2_AUTOSCALING_USERDATA_FILE)
-            if [[ $FINDINGS -eq 0 ]]; then
-              textPass "$regx: No secrets found in $autoscaling_configuration" "$regx" "$autoscaling_configuration"
-              # delete file if nothing interesting is there
-              rm -f $EC2_AUTOSCALING_USERDATA_FILE
-            else
-              textFail "$regx: Potential secret found in $autoscaling_configuration" "$regx" "$autoscaling_configuration"
-              # delete file to not leave trace, user must look at the autoscaling_configuration User Data
-              rm -f $EC2_AUTOSCALING_USERDATA_FILE
-            fi
-          else
-            mv $EC2_AUTOSCALING_USERDATA_FILE $EC2_AUTOSCALING_USERDATA_FILE.gz ; gunzip $EC2_AUTOSCALING_USERDATA_FILE.gz
-            FINDINGS=$(secretsDetector file $EC2_AUTOSCALING_USERDATA_FILE)
-            if [[ $FINDINGS -eq 0 ]]; then
-              textPass "$regx: No secrets found in $autoscaling_configuration User Data" "$regx" "$autoscaling_configuration"
-              rm -f $EC2_AUTOSCALING_USERDATA_FILE
-            else
-              textFail "$regx: Potential secret found in $autoscaling_configuration" "$regx" "$autoscaling_configuration"
-            fi
-          fi
-        else 
-          textPass "$regx: No secrets found in $autoscaling_configuration User Data or it is empty" "$regx" "$autoscaling_configuration"
-        fi
-      done
+    CHECK_DETECT_SECRETS_INSTALLATION=$(secretsDetector)
+    if [[ $? -eq 241 ]]; then
+      textInfo "$regx: python library detect-secrets not found. Make sure it is installed correctly." "$regx"
     else
-      textInfo "$regx: No EC2 autoscaling_configurations found" "$regx"
+      LIST_OF_EC2_AUTOSCALING=$($AWSCLI autoscaling describe-launch-configurations $PROFILE_OPT --region $regx --query LaunchConfigurations[*].LaunchConfigurationName --output text --max-items $MAXITEMS 2>&1 | grep -v None )
+      if [[ $(echo "$LIST_OF_EC2_AUTOSCALING" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+          textInfo "$regx: Access Denied trying to describe launch configurations" "$regx"
+          continue
+      fi
+      if [[ $LIST_OF_EC2_AUTOSCALING ]];then
+        for autoscaling_configuration in $LIST_OF_EC2_AUTOSCALING; do
+          EC2_AUTOSCALING_USERDATA_FILE="$SECRETS_TEMP_FOLDER/extra775-$autoscaling_configuration-userData.decoded"
+          EC2_AUTOSCALING_USERDATA=$($AWSCLI autoscaling describe-launch-configurations $PROFILE_OPT --launch-configuration-names $autoscaling_configuration --region $regx --query LaunchConfigurations[*].UserData --output text| grep -v ^None | decode_report > $EC2_AUTOSCALING_USERDATA_FILE)
+          if [ -s $EC2_AUTOSCALING_USERDATA_FILE ];then
+            FILE_FORMAT_ASCII=$(file -b $EC2_AUTOSCALING_USERDATA_FILE | grep ASCII)
+            # This finds ftp or http URLs with credentials and common keywords
+            # FINDINGS=$(egrep -i '[[:alpha:]]*://[[:alnum:]]*:[[:alnum:]]*@.*/|key|secret|token|pass' $EC2_AUTOSCALING_USERDATA_FILE |wc -l|tr -d '\ ')
+            # New implementation using https://github.com/Yelp/detect-secrets
+            if [[ $FILE_FORMAT_ASCII ]]; then
+            FINDINGS=$(secretsDetector file $EC2_AUTOSCALING_USERDATA_FILE)
+              if [[ $FINDINGS -eq 0 ]]; then
+                textPass "$regx: No secrets found in $autoscaling_configuration" "$regx" "$autoscaling_configuration"
+                # delete file if nothing interesting is there
+                rm -f $EC2_AUTOSCALING_USERDATA_FILE
+              else
+                textFail "$regx: Potential secret found in $autoscaling_configuration" "$regx" "$autoscaling_configuration"
+                # delete file to not leave trace, user must look at the autoscaling_configuration User Data
+                rm -f $EC2_AUTOSCALING_USERDATA_FILE
+              fi
+            else
+              mv $EC2_AUTOSCALING_USERDATA_FILE $EC2_AUTOSCALING_USERDATA_FILE.gz ; gunzip $EC2_AUTOSCALING_USERDATA_FILE.gz
+              FINDINGS=$(secretsDetector file $EC2_AUTOSCALING_USERDATA_FILE)
+              if [[ $FINDINGS -eq 0 ]]; then
+                textPass "$regx: No secrets found in $autoscaling_configuration User Data" "$regx" "$autoscaling_configuration"
+                rm -f $EC2_AUTOSCALING_USERDATA_FILE
+              else
+                textFail "$regx: Potential secret found in $autoscaling_configuration" "$regx" "$autoscaling_configuration"
+              fi
+            fi
+          else 
+            textPass "$regx: No secrets found in $autoscaling_configuration User Data or it is empty" "$regx" "$autoscaling_configuration"
+          fi
+        done
+      else
+        textInfo "$regx: No EC2 autoscaling_configurations found" "$regx"
+      fi
     fi
   done
   rm -rf $SECRETS_TEMP_FOLDER

--- a/include/secrets_detector
+++ b/include/secrets_detector
@@ -16,7 +16,7 @@ secretsDetector(){
     PYTHON_PIP_DETECTSECRETS=$(which detect-secrets)
     if [ -z "${PYTHON_PIP_DETECTSECRETS}" ]; then
         echo -e "\n$RED ERROR!$NORMAL python library detect-secrets not found. Make sure it is installed correctly and in your \$PATH\n"
-        EXITCODE=1
+        EXITCODE=241
         exit $EXITCODE
     else
         SECRETS_TEMP_FOLDER="$PROWLER_DIR/secrets-$ACCOUNT_NUM"


### PR DESCRIPTION
### Context 

At this moment, Prowler doesn't detect that detect-secrets is missing when running the checks extra741, extra742, extra759, extra760, extra768, extra775 and extra7141.

It handles the missing dependency as a FAIL within the check.


### Description

The exit code when the library is not installed was changed to 241, so the checks can handle it apart by printing an INFO when these checks are run.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
