### PR TITLE
check empty array in SECURITYGROUPS object

### DIFF
--- a/checks/check_extra75
+++ b/checks/check_extra75
@@ -34,9 +34,6 @@ extra75(){
         textInfo "$regx: Access Denied trying to describe security groups" "$regx"
         continue
     fi
-    if [[ $SECURITYGROUPS == "null" ]]; then
-      continue
-    fi
     if [[ $(echo "$SECURITYGROUPS" | jq '."SecurityGroups" | length') -eq 0 ]]; then
       textInfo "$regx: No Security Groups found in $regx"
       continue

--- a/checks/check_extra75
+++ b/checks/check_extra75
@@ -37,6 +37,10 @@ extra75(){
     if [[ $SECURITYGROUPS == "null" ]]; then
       continue
     fi
+    if [[ $(echo "$SECURITYGROUPS" | jq '."SecurityGroups" | length') -eq 0 ]]; then
+      textInfo "$regx: No Security Groups found in $regx"
+      continue
+    fi
     SECURITYGROUP_NAMES=$(echo $SECURITYGROUPS | jq '.SecurityGroups|map({(.GroupId): (.GroupName)})|add')
     LIST_OF_SECURITYGROUPS=$(echo $SECURITYGROUP_NAMES | jq -r 'to_entries|sort_by(.key)|.[]|.key')
     for SG_ID in $LIST_OF_SECURITYGROUPS; do

--- a/checks/check_extra75
+++ b/checks/check_extra75
@@ -35,7 +35,7 @@ extra75(){
         continue
     fi
     if [[ $(echo "$SECURITYGROUPS" | jq '."SecurityGroups" | length') -eq 0 ]]; then
-      textInfo "$regx: No Security Groups found in $regx"
+      textInfo "$regx: No Security Groups found in $regx" "$regx"
       continue
     fi
     SECURITYGROUP_NAMES=$(echo $SECURITYGROUPS | jq '.SecurityGroups|map({(.GroupId): (.GroupName)})|add')


### PR DESCRIPTION
DESCRIPTION
Logic was checking an object to see if it is null. This should be checking for the array in the object to see if it is empty.

BEFORE:
7.5 [extra75] Ensure there are no Security Groups not being used - ec2 [Informational]
jq: error (at :1): null (null) has no keys
jq: error (at :1): null (null) has no keys
jq: error (at :1): null (null) has no keys
jq: error (at :1): null (null) has no keys
jq: error (at :1): null (null) has no keys
PASS! eu-west-1: sg-00002cf0000000000 is being used

AFTER:
7.5 [extra75] Ensure there are no Security Groups not being used - ec2 [Informational]
INFO! af-south-1: No Security Groups found in af-south-1
INFO! eu-north-1: No Security Groups found in eu-north-1
INFO! ap-south-1: No Security Groups found in ap-south-1
INFO! eu-west-3: No Security Groups found in eu-west-3
INFO! eu-west-2: No Security Groups found in eu-west-2
PASS! eu-west-1: sg-00002cf0000000000 is being used

Context
I was using this check and was confused as to why only 100 results were returned. I noticed this error was also an issue.

License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.