### PR TITLE
fix(extra7147): Handle unsupported AWS regions for Glacier

### DIFF
--- a/checks/check_extra7147
+++ b/checks/check_extra7147
@@ -25,27 +25,32 @@ CHECK_CAF_EPIC_extra7147='Data Protection'
 
 extra7147(){
   for regx in $REGIONS; do
-  LIST_OF_VAULTS=$($AWSCLI glacier list-vaults $PROFILE_OPT --region $regx --account-id $ACCOUNT_NUM --query VaultList[*].VaultName --output text 2>&1|xargs -n1)
-  if [[ $(echo "$LIST_OF_VAULTS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-      textInfo "$regx: Access Denied trying to list vaults" "$regx"
+  LIST_OF_VAULTS=$($AWSCLI glacier list-vaults ${PROFILE_OPT} --region "${regx}" --account-id "${ACCOUNT_NUM}" --query VaultList[*].VaultName --output text 2>&1|xargs -n1)
+  if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "$LIST_OF_VAULTS"; then
+      textInfo "$regx: Access Denied trying to list vaults" "${regx}"
+      continue
+  fi
+  # Check for unsupported regions
+  if grep -q -E 'error' <<< "${LIST_OF_VAULTS}"; then
+      textInfo "$regx: An error occurred when calling the ListVaults operation - check if this region is supported" "${regx}"
       continue
   fi
   if [[ $LIST_OF_VAULTS ]]; then
     for vault in $LIST_OF_VAULTS;do
-      VAULT_POLICY_STATEMENTS=$($AWSCLI glacier $PROFILE_OPT get-vault-access-policy --region $regx --account-id $ACCOUNT_NUM --vault-name $vault --output json --query policy.Policy 2>&1)
+      VAULT_POLICY_STATEMENTS=$($AWSCLI glacier ${PROFILE_OPT} get-vault-access-policy --region "${regx}" --account-id "${ACCOUNT_NUM}" --vault-name "${vault}" --output json --query policy.Policy 2>&1)
       if [[ $VAULT_POLICY_STATEMENTS == *GetVaultAccessPolicy* ]]; then
-        textInfo "$regx: Vault $vault doesn't have any policy" "$regx" "$vault"
+        textInfo "${regx}: Vault $vault doesn't have any policy" "${regx}" "$vault"
       else
-        VAULT_POLICY_BAD_STATEMENTS=$(echo $VAULT_POLICY_STATEMENTS | jq '. | fromjson' | jq '.Statement[] | select(.Effect=="Allow") | select(.Principal=="*" or .Principal.AWS=="*" or .Principal.CanonicalUser=="*")')
+        VAULT_POLICY_BAD_STATEMENTS=$(jq '. | fromjson' <<< "${VAULT_POLICY_STATEMENTS}" | jq '.Statement[] | select(.Effect=="Allow") | select(.Principal=="*" or .Principal.AWS=="*" or .Principal.CanonicalUser=="*")')
         if [[ $VAULT_POLICY_BAD_STATEMENTS != "" ]]; then
-          textFail "$regx: Vault $vault has policy which allows access to everyone" "$regx" "$vault"
+          textFail "${regx}: Vault $vault has policy which allows access to everyone" "${regx}" "$vault"
         else
-          textPass "$regx: Vault $vault has policy which does not allow access to everyone" "$regx" "$vault"
+          textPass "${regx}: Vault $vault has policy which does not allow access to everyone" "${regx}" "$vault"
         fi
       fi
     done
   else
-    textInfo "$regx: No Glacier vaults found" "$regx"
+    textInfo "${regx}: No Glacier vaults found" "${regx}"
   fi
  done
 }


### PR DESCRIPTION
### Motivation

Right now if `extra7147` is executed against `ap-southeast-3` an unhandled exception pops up because AWS Glacier is not supported in this region.
![Screenshot 2022-04-11 at 10 37 21](https://user-images.githubusercontent.com/16007882/162700592-54278b7c-0708-48fc-b925-7ca846965602.png)

Prowler output:
![7937c8f6-470f-4cba-a2ac-76c2d1212da1](https://user-images.githubusercontent.com/16007882/162700661-1181731f-9c9e-4a7f-928d-abac1449a1f6.png)

### Description
Handle unsupported AWS regions for Glacier.
![Screenshot 2022-04-11 at 10 53 41](https://user-images.githubusercontent.com/16007882/162700915-5e960ada-00e3-457b-befa-7ae39d40abe8.png)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
