### PR TITLE
fix typo: publiccly -> publicly

### DIFF
--- a/checks/check_extra79
+++ b/checks/check_extra79
@@ -21,7 +21,7 @@ CHECK_ALTERNATE_check79="extra79"
 CHECK_ALTERNATE_check709="extra79"
 CHECK_SERVICENAME_extra79="elb"
 CHECK_RISK_extra79='Publicly accessible load balancers could expose sensitive data to bad actors.'
-CHECK_REMEDIATION_extra79='Ensure the load balancer should be publicly accessible. If publiccly exposed ensure a WAF ACL is implemented.'
+CHECK_REMEDIATION_extra79='Ensure the load balancer should be publicly accessible. If publicly exposed ensure a WAF ACL is implemented.'
 CHECK_DOC_extra79='https://docs.aws.amazon.com/waf/latest/developerguide/web-acl-associating-aws-resource.html'
 CHECK_CAF_EPIC_extra79='Data Protection'
 


### PR DESCRIPTION
### Context 

This fixes a spelling error in the remediation of one of the checks.

### Description

This fixes a typo in the `extra79` check: `publiccly` should be `publicly`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.