### PR TITLE
IAM check116 and check122 modified to log also PASS results

### DIFF
--- a/checks/check116
+++ b/checks/check116
@@ -29,20 +29,21 @@ CHECK_CAF_EPIC_check116='IAM'
 check116(){
   # "Ensure IAM policies are attached only to groups or roles (Scored)"
   LIST_USERS=$($AWSCLI iam list-users --query 'Users[*].UserName' --output text $PROFILE_OPT --region $REGION)
-  C116_NUM_USERS=0
   for user in $LIST_USERS;do
-    USER_POLICY=$($AWSCLI iam list-attached-user-policies --output text $PROFILE_OPT --region $REGION --user-name $user)
-    if [[ $USER_POLICY ]]; then
-      textFail "$REGION: $user has managed policy directly attached" "$REGION" "$user"
-      C116_NUM_USERS=$(expr $C116_NUM_USERS + 1)
-    fi
-    USER_POLICY=$($AWSCLI iam list-user-policies --output text $PROFILE_OPT --region $REGION --user-name $user)
-    if [[ $USER_POLICY ]]; then
-      textFail "$REGION: $user has inline policy directly attached" "$REGION" "$user"
-      C116_NUM_USERS=$(expr $C116_NUM_USERS + 1)
+    USER_ATTACHED_POLICY=$($AWSCLI iam list-attached-user-policies --output text $PROFILE_OPT --region $REGION --user-name $user)
+    USER_INLINE_POLICY=$($AWSCLI iam list-user-policies --output text $PROFILE_OPT --region $REGION --user-name $user)
+    if [[ $USER_ATTACHED_POLICY ]] || [[ $USER_INLINE_POLICY ]]
+    then
+      if [[ $USER_ATTACHED_POLICY ]]
+      then
+        textFail "$REGION: $user has managed policy directly attached" "$REGION" "$user"
+      fi
+      if [[ $USER_INLINE_POLICY ]]
+      then
+        textFail "$REGION: $user has inline policy directly attached" "$REGION" "$user"
+      fi
+    else
+      textPass "$REGION: No policies attached to user $user" "$REGION" "$user"
     fi
   done
-  if [[ $C116_NUM_USERS -eq 0 ]]; then
-    textPass "$REGION: No policies attached to users" "$REGION" "$user"
-  fi
 }

--- a/checks/check122
+++ b/checks/check122
@@ -35,14 +35,14 @@ check122(){
       POLICY_WITH_FULL=$($AWSCLI iam get-policy-version --output text --policy-arn $POLICY_ARN --version-id $POLICY_VERSION --query "[PolicyVersion.Document.Statement] | [] | [?Action!=null] | [?Effect == 'Allow' && Resource == '*' && Action == '*']" $PROFILE_OPT --region $REGION)
       if [[ $POLICY_WITH_FULL ]]; then
         POLICIES_ALLOW_LIST="$POLICIES_ALLOW_LIST $POLICY_ARN"
+      else
+        textPass "$REGION: Policy ${policy//,/[comma]} that does not allow full \"*:*\" administrative privileges" "${REGION}" "${policy}"
       fi
     done
     if [[ $POLICIES_ALLOW_LIST ]]; then
       for policy in $POLICIES_ALLOW_LIST; do
-        textFail "$REGION: Policy ${policy//,/[comma]} allows \"*:*\"" "$REGION" "$policy"
+        textFail "$REGION: Policy ${policy//,/[comma]} allows \"*:*\"" "${REGION}" "${policy}"
       done
-    else
-        textPass "$REGION: No custom policy found that allow full \"*:*\" administrative privileges" "$REGION"
     fi
   else
     textPass "$REGION: No custom policies found" "$REGION"


### PR DESCRIPTION
### Context 

To have enriched information regarding IAM it is needed to modify some checks to extract detailed PASS records


### Description

Change the logic of various checks to include the resource id when result = PASS


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
