### PR TITLE
Updated multi-org ProwlerRole.yaml to match current Prowler additions policy

### DIFF
--- a/util/org-multi-account/ProwlerRole.yaml
+++ b/util/org-multi-account/ProwlerRole.yaml
@@ -75,30 +75,20 @@ Resources:
                 Effect: Allow
                 Resource: "*"
                 Action:
-                  - access-analyzer:List*
-                  - apigateway:Get*
-                  - apigatewayv2:Get*
-                  - aws-marketplace:ViewSubscriptions
-                  - dax:ListTables
                   - ds:ListAuthorizedApplications
-                  - ds:DescribeRoles
                   - ec2:GetEbsEncryptionByDefault
                   - ecr:Describe*
-                  - lambda:GetAccountSettings
-                  - lambda:GetFunctionConfiguration
-                  - lambda:GetLayerVersionPolicy
-                  - lambda:GetPolicy
-                  - opsworks-cm:Describe*
-                  - opsworks:Describe*
-                  - secretsmanager:ListSecretVersionIds
-                  - sns:List*
-                  - sqs:ListQueueTags
-                  - states:ListActivities
+                  - elasticfilesystem:DescribeBackupPolicy
+                  - glue:GetConnections
+                  - glue:GetSecurityConfiguration
+                  - glue:SearchTables
+                  - lambda:GetFunction
+                  - s3:GetAccountPublicAccessBlock
+                  - shield:DescribeProtection
+                  - shield:GetSubscriptionState
+                  - ssm:GetDocument
                   - support:Describe*
                   - tag:GetTagKeys
-                  - shield:GetSubscriptionState
-                  - shield:DescribeProtection
-                  - elasticfilesystem:DescribeBackupPolicy
         - PolicyName: Prowler-S3-Reports
           PolicyDocument:
             Version: 2012-10-17


### PR DESCRIPTION
### Context 

I noticed that the IAM roles for the multi-account were outdated. This will be a small update to the IAM policy resource to keep consistent with the most up to date IAM policy list for Prowler.


### Description

'ProwlerRole.yaml' CF template for multi-account example solution was updated to reflect the current 'prowler-additions-policy.json'.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
