### PR TITLE
check_extra7113: Fix wrong listing of RDS instances in regions without databases

### DIFF
--- a/checks/check_extra7113
+++ b/checks/check_extra7113
@@ -52,7 +52,7 @@ extra7113(){
         fi
       done
     else
-      textInfo "$regx: No RDS instances found" "$regx" "$rdsinstance"
+      textInfo "$regx: No RDS instances found" "$regx" 
     fi
   done
 }


### PR DESCRIPTION
### Context 

Remove listing of databases in wrong regions.


### Description

This simple fix, removes the listing of a database from one region (as example database exists in eu-central-1), in another region (as example in region eu-west-1, which is enabled, but didn't host a single database).


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
