### PR TITLE
fix(allowlist_db): Improve DynamoDB regex for allowlisting.

### DIFF
--- a/include/allowlist
+++ b/include/allowlist
@@ -16,7 +16,7 @@ allowlist(){
   if grep -q -E "^s3://([^/]+)/(.*?([^/]+))$" <<< "${ALLOWLIST_FILE}"; then
     allowlist_S3
   # Check if the file is a DynamoDB ARN
-  elif grep -q -E "^arn:aws:dynamodb:\w+(?:-\w+)+:\d{12}:table\/[A-Za-z0-9]+$" <<< "${ALLOWLIST_FILE}"; then
+  elif grep -q -E "^arn:aws:dynamodb:\w+(?:-\w+)+:\d{12}:table\/[A-Za-z0-9-._]+$" <<< "${ALLOWLIST_FILE}"; then
     allowlist_DynamoDB
   else
     # Check if the file is a DynamoDB ARN


### PR DESCRIPTION
### Context 

Right now, Prowler only support dynamodb tables with alphanumeric names.


### Description

Names are between 3 and 255 characters, containing only letters, numbers, underscores (_), hyphens (-), and periods (.).


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
