### PR TITLE
fix(allowlist_db): Improve DynamoDB regex for allowlisting.

### DIFF
--- a/include/allowlist
+++ b/include/allowlist
@@ -16,7 +16,7 @@ allowlist(){
   if grep -q -E "^s3://([^/]+)/(.*?([^/]+))$" <<< "${ALLOWLIST_FILE}"; then
     allowlist_S3
   # Check if the file is a DynamoDB ARN
-  elif grep -q -E "^arn:aws:dynamodb:\w+(?:-\w+)+:\d{12}:table\/[A-Za-z0-9]+$" <<< "${ALLOWLIST_FILE}"; then
+  elif grep -q -E "^arn:aws:dynamodb:\w+(?:-\w+)+:\d{12}:table\/[-._A-Za-z0-9]+$" <<< "${ALLOWLIST_FILE}"; then
     allowlist_DynamoDB
   else
     # Check if the file is a DynamoDB ARN
@@ -45,7 +45,7 @@ allowlist_DynamoDB() {
   echo -e "${NOTICE} Getting allowlist from DynamoDB table ${ALLOWLIST_FILE} ...${NORMAL}"
   DYNAMO_REGION=$(cut -d ":" -f 4 <<< "${ALLOWLIST_FILE}")
   DYNAMO_TABLE=$(cut -d "/" -f 2 <<< "${ALLOWLIST_FILE}")
-  DYNAMO_ITEMS=$(${AWSCLI} dynamodb execute-statement --statement "SELECT rule FROM ${DYNAMO_TABLE} WHERE account_id=""'""${ACCOUNT_NUM}""'"" or account_id='*'" ${PROFILE_OPT} --region ${DYNAMO_REGION} --output json 2>&1 )
+  DYNAMO_ITEMS=$(${AWSCLI} dynamodb execute-statement --statement "SELECT rule FROM \"${DYNAMO_TABLE}\" WHERE account_id=""'""${ACCOUNT_NUM}""'"" or account_id='*'" ${PROFILE_OPT} --region ${DYNAMO_REGION} --output json 2>&1 )
   if grep -q -E 'AccessDenied|UnauthorizedOperation|ResourceNotFoundException' <<< "${DYNAMO_ITEMS}"; then
     echo "${BAD} FAIL! Access Denied trying to get allowlist from the DynamoDB, please make sure it is correct and/or you have permissions to scan the table ${DYNAMO_TABLE}.${NORMAL}"
     EXITCODE=1


### PR DESCRIPTION
### Context 

Right now, Prowler only support dynamodb tables with alphanumeric names.

### Description

Names are between 3 and 255 characters, containing only letters, numbers, underscores (_), hyphens (-), and periods (.).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
