### PR TITLE
feat(assume-role): Properly handle External ID variable

### DIFF
--- a/include/assume_role
+++ b/include/assume_role
@@ -55,7 +55,7 @@ assume_role(){
         --role-session-name ProwlerAssessmentSession \
         --duration-seconds $SESSION_DURATION_TO_ASSUME \
         --region $REGION_FOR_STS \
-        "${ROLE_EXTERNAL_ID_OPTION}" > $TEMP_STS_ASSUMED_FILE 2>"${TEMP_STS_ASSUMED_ERROR}"
+        ${ROLE_EXTERNAL_ID_OPTION} > $TEMP_STS_ASSUMED_FILE 2>"${TEMP_STS_ASSUMED_ERROR}"
     then
         STS_ERROR="$(cat ${TEMP_STS_ASSUMED_ERROR} | tr '\n' ' ')"
         textFail "${STS_ERROR}"


### PR DESCRIPTION
### Context 

3.0-dev branch has an alternative patch

for master branch, the external id is simply broken. this quick change of 2 characters keeps all existing code as-is and ensure the master branch functions as was always intended

### Description

The fix is that the `--external-id` just needs to be an treated as argument, not a string literal as it currently is. The only way a literal can work is if the string is run through `eval`, which it isn't, and using `eval` for something easily avoided (as this PR shows) is not advisable

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
