### PR TITLE
fix(copyToS3): Upload to S3 only when indicated.

### DIFF
--- a/include/outputs_bucket
+++ b/include/outputs_bucket
@@ -13,23 +13,14 @@
 
 if [[ $OUTPUT_BUCKET ]]; then
   # output mode has to be set to other than text
-  if [[ "${MODES[@]}" =~ "html" ]] || [[ "${MODES[@]}" =~ "csv" ]] || [[ "${MODES[@]}" =~ "json" ]] || [[ "${MODES[@]}" =~ "json-asff" ]]; then
-      OUTPUT_BUCKET_WITHOUT_FOLDERS=$(echo $OUTPUT_BUCKET | awk -F'/' '{ print $1 }')
-#      OUTPUT_BUCKET_STATUS=$($AWSCLI s3api head-bucket --bucket "$OUTPUT_BUCKET" 2>&1 || true)
-#      if [[ -z $OUTPUT_BUCKET_STATUS ]]; then 
-#        echo "$OPTRED ERROR!$OPTNORMAL wrong bucket name or not right permissions."
-#        exit 1
-#      else 
-        # need to make sure last / is not set to avoid // in S3
-        if [[ $OUTPUT_BUCKET != *"/" ]]; then 
-          OUTPUT_BUCKET="$OUTPUT_BUCKET"
-        else
-          OUTPUT_BUCKET=${OUTPUT_BUCKET::-1}
-        fi 
-#      fi
-  else
-    echo "$OPTRED ERROR!$OPTNORMAL - Mode (-M) has to be set as well. Use -h for help."
+  if [[ "${MODES[*]}" =~ "text" ]]; then     
+    echo "$OPTRED ERROR!$OPTNORMAL - Mode (-M) can't be text when using custom output bucket. Use -h for help."
     exit 1
+  else
+    # need to make sure last / is not set to avoid // in S3
+    if [[ $OUTPUT_BUCKET == *"/" ]]; then 
+      OUTPUT_BUCKET=${OUTPUT_BUCKET::-1}
+    fi
   fi 
 fi
 

--- a/prowler
+++ b/prowler
@@ -694,7 +694,9 @@ if [[ $GROUP_ID_READ ]];then
     if [[ $OUTPUT_BUCKET_NOASSUME ]]; then
       restoreInitialAWSCredentials
     fi
-    copyToS3
+    if [[ $OUTPUT_BUCKET ]]; then
+      copyToS3
+    fi
     exit $EXITCODE
   else
     textFail "Group ${GROUP_ID_READ} does not exist. Use a valid check group ID i.e.: group1, extras, forensics-ready, etc."
@@ -725,7 +727,9 @@ if [[ $CHECK_ID ]];then
   if [[ $OUTPUT_BUCKET_NOASSUME ]]; then
     restoreInitialAWSCredentials
   fi
-  copyToS3
+  if [[ $OUTPUT_BUCKET ]]; then
+    copyToS3
+  fi
   scoring
   cleanTemp
   exit $EXITCODE
@@ -742,6 +746,8 @@ cleanTemp
 if [[ $OUTPUT_BUCKET_NOASSUME ]]; then
   restoreInitialAWSCredentials
 fi
-copyToS3
+if [[ $OUTPUT_BUCKET ]]; then
+  copyToS3
+fi
 
 exit $EXITCODE


### PR DESCRIPTION
### Context 

Prowler fails with ERROR! - Invalid output format copying to S3 when a custom output bucket is not introduced. This PR is related to [Issue #1133](https://github.com/prowler-cloud/prowler/issues/1133).

### Description

To solve this error, copyToS3 function is executed only when an output bucket is introduced (with flags -B or -D)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
