### PR TITLE
feat(util): K8s cronjob sample files

### DIFF
--- a/util/k8s/README.md
+++ b/util/k8s/README.md
@@ -1,0 +1,11 @@
+Simple instructions to add a cronjob on K8S to execute a prowler and save the results on AWS S3.
+
+Files: 
+cronjob.yml  -> is a cronjob for K8S, you must set the frequency and probes from yours scans.
+secret.yml   -> is a secret file with AWS ID/Secret and the name of bucket
+
+To apply:
+
+kubectl -f cronjob.yml
+kubectl -f secret.yml
+ 

--- a/util/k8s/cronjob.yml
+++ b/util/k8s/cronjob.yml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: devsecops-prowler-cronjob-secret
+  namespace: defectdojo
+spec:
+#Cron Time is set according to server time, ensure server time zone and set accordingly.
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 1
+  schedule: "5 3 * * 0,2,4"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: prowler
+            image: toniblyx/prowler:latest
+            imagePullPolicy: Always
+            command: 
+            - "./prowler"
+            args: [ "-g", "hipaa", "-M", "csv,json,html", "-B", "$(awsS3Bucket)" ]
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name:  devsecops-prowler-cronjob-secret
+                  key: awsId
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name:  devsecops-prowler-cronjob-secret
+                  key: awsSecretKey
+            - name: awsS3Bucket 
+              valueFrom:
+                secretKeyRef:
+                  name:  devsecops-prowler-cronjob-secret
+                  key: awsS3Bucket 
+            imagePullPolicy: IfNotPresent
+          restartPolicy: OnFailure
+      backoffLimit: 3

--- a/util/k8s/secret.yml
+++ b/util/k8s/secret.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: devsecops-prowler-cronjob-secret
+  namespace: defectdojo
+type: Opaque
+stringData:
+  awsId: myAWSSecretID
+  awsSecretKey: myAWSSecretKey
+  awsS3Bucket: myAWSS3Bucket


### PR DESCRIPTION
Simple instructions to add a cronjob on K8S to execute a prowler and save the results on AWS S3.

Files: 
cronjob.yml  -> is a cronjob for K8S, you must set the frequency and probes from yours scans.
secret.yml   -> is a secret file with AWS ID/Secret and the name of bucket

To apply:

kubectl -f cronjob.yml
kubectl -f secret.yml
