### PR TITLE
fix(readme): Fix correct permissions for DynamoDB allowlist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ S3 URIs are also supported as allowlist file, e.g. `s3://bucket/prefix/allowlist
 >Make sure that the used credentials have s3:GetObject permissions in the S3 path where the allowlist file is located.
 
 DynamoDB table ARNs are also supported as allowlist file, e.g. `arn:aws:dynamodb:us-east-1:111111222222:table/allowlist`
->Make sure that the table has `account_id` as partition key and `rule` as sort key, and that the used credentials have dynamodb:Scan permissions in the table.
+>Make sure that the table has `account_id` as partition key and `rule` as sort key, and that the used credentials have `dynamodb:PartiQLSelect` permissions in the table.
 ><p align="left"><img src="https://user-images.githubusercontent.com/38561120/165769502-296f9075-7cc8-445e-8158-4b21804bfe7e.png" alt="image" width="397" height="252" /></p>
 
 >The field `account_id` can contains either an account ID or an `*` (which applies to all the accounts that use this table as a whitelist). As in the traditional allowlist file, the `rule` field must contain `checkID:resourcename` pattern.


### PR DESCRIPTION
### Context 

The [issue](https://github.com/prowler-cloud/prowler/issues/1146) found that the permissions required for the dynamoDB allowlist is `dynamodb:PartiQLSelect`.


### Description

The readme is changed for the correct required permissions when using dynamoDB allowlist.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
