### PR TITLE
Timestamp to date casting issues solved

### DIFF
--- a/include/os_detector
+++ b/include/os_detector
@@ -36,7 +36,14 @@ gnu_timestamp_to_date() {
   
   # remove fractions of a second
   TIMESTAMP_TO_CONVERT=$(cut -f1 -d"." <<<  "${1}")
-  OUTPUT_DATE=$("${DATE_CMD}" -d "${TIMESTAMP_TO_CONVERT}" +'%Y-%m-%d')
+  if ! "${DATE_CMD}" -d "${TIMESTAMP_TO_CONVERT}" +%s > /dev/null  2>&1;
+  then
+    # If input is epoch use the @
+    OUTPUT_DATE=$("${DATE_CMD}" -d @"${TIMESTAMP_TO_CONVERT}" +'%Y-%m-%d')
+  else
+    # If input is not epoch dont use @
+    OUTPUT_DATE=$("${DATE_CMD}" -d "${TIMESTAMP_TO_CONVERT}" +'%Y-%m-%d')
+  fi
   echo "${OUTPUT_DATE}"
 }
 bsd_timestamp_to_date() {

--- a/include/os_detector
+++ b/include/os_detector
@@ -36,7 +36,7 @@ gnu_timestamp_to_date() {
   
   # remove fractions of a second
   TIMESTAMP_TO_CONVERT=$(cut -f1 -d"." <<<  "${1}")
-  OUTPUT_DATE=$("${DATE_CMD}" -d @"${TIMESTAMP_TO_CONVERT}" +'%Y-%m-%d')
+  OUTPUT_DATE=$("${DATE_CMD}" -d "${TIMESTAMP_TO_CONVERT}" +'%Y-%m-%d')
   echo "${OUTPUT_DATE}"
 }
 bsd_timestamp_to_date() {


### PR DESCRIPTION
### Context 

It seems that some times returned by AWS were in epoch format, and now are returned are timestamp-like (YYMMDD HHMMSS)
In prowler gnu date handling functions  date command needs an option to handle epoch inputs, which crashes when the input is not epoch.

### Description

Use the epoch option in prowler date functions only when the input is in epoch format.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
