### PR TITLE
fix(IllegalLocationConstraintException): Recover bucket policy using the right region endpoint

### DIFF
--- a/checks/check_extra771
+++ b/checks/check_extra771
@@ -24,35 +24,45 @@ CHECK_DOC_extra771='https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_p
 CHECK_CAF_EPIC_extra771='IAM'
 
 extra771(){
-  LIST_OF_BUCKETS=$("${AWSCLI}" s3api list-buckets $PROFILE_OPT --region "${REGION}" --query "sort_by(Buckets, &Name)[].Name" --output text 2>&1)
-  if [[ $(echo "${LIST_OF_BUCKETS}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+  LIST_OF_BUCKETS=$("${AWSCLI}" s3api list-buckets ${PROFILE_OPT} --region "${REGION}" --query "sort_by(Buckets, &Name)[].Name" --output text 2>&1)
+  if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_OF_BUCKETS}"; then
       textInfo "${REGION}: Access Denied trying to list buckets" "${REGION}"
       return
   fi
   if [[ "${LIST_OF_BUCKETS}" ]]; then
     for bucket in ${LIST_OF_BUCKETS};do
-      BUCKET_POLICY_STATEMENTS=$("${AWSCLI}" s3api $PROFILE_OPT get-bucket-policy --region "${REGION}" --bucket "${bucket}" --output json --query Policy 2>&1)
-      if [[ $(echo "${BUCKET_POLICY_STATEMENTS}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+      # Recover Bucket region
+      BUCKET_REGION=$("${AWSCLI}" ${PROFILE_OPT} s3api get-bucket-location --bucket "${bucket}" --query LocationConstraint --output text)
+      if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${BUCKET_POLICY_STATEMENTS}"; then
+          textInfo "${REGION}: Access Denied trying to get bucket policy for ${bucket}" "${REGION}"
+      fi
+      # If None use default region
+      if [[ "${BUCKET_REGION}" == "None" ]]; then
+        BUCKET_REGION="${REGION}"
+      fi
+      # Recover Bucket policy statements
+      BUCKET_POLICY_STATEMENTS=$("${AWSCLI}" s3api ${PROFILE_OPT} get-bucket-policy --region "${BUCKET_REGION}" --bucket "${bucket}" --output json --query Policy 2>&1)
+      if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${BUCKET_POLICY_STATEMENTS}"; then
           textInfo "${REGION}: Access Denied trying to get bucket policy for ${bucket}" "${REGION}"
           continue
       fi
-      if [[ $(echo "${BUCKET_POLICY_STATEMENTS}" | grep 'NoSuchBucketPolicy') ]]; then
-        textInfo "$REGION: Bucket policy does not exist for bucket $bucket" "$REGION"
+      if grep -q -E 'NoSuchBucketPolicy'<<< "${BUCKET_POLICY_STATEMENTS}"; then
+        textInfo "${REGION}: Bucket policy does not exist for bucket ${bucket}" "${REGION}"
       else
-        BUCKET_POLICY_BAD_STATEMENTS=$(echo "${BUCKET_POLICY_STATEMENTS}" | jq --compact-output --arg arn "arn:${AWS_PARTITION}:s3:::$bucket" 'fromjson | .Statement[]|select(
-                                                                                                                                                                            .Effect=="Allow" and
-                                                                                                                                                                            (
-                                                                                                                                                                                ( (.Principal|type == "object") and (.Principal.AWS == "*") ) or
-                                                                                                                                                                                ( (.Principal|type == "string") and (.Principal == "*") )
-                                                                                                                                                                            ) and
-                                                                                                                                                                            (
-                                                                                                                                                                                ( (.Action|type == "string") and (.Action|startswith("s3:Put")) ) or
-                                                                                                                                                                                ( (.Action|type == "string") and (.Action|startswith("s3:*")) ) or
-                                                                                                                                                                                ( (.Action|type == "array") and (.Action[]|startswith("s3:Put")) ) or
-                                                                                                                                                                                ( (.Action|type == "array") and (.Action[]|startswith("s3:*")) )
-                                                                                                                                                                            ) and
-                                                                                                                                                                            .Condition == null
-                                                                                                                                                                          )' | tr '\n' ' ')
+        BUCKET_POLICY_BAD_STATEMENTS=$(jq --compact-output --arg arn "arn:${AWS_PARTITION}:s3:::$bucket" 'fromjson | .Statement[]|select(
+                                        .Effect=="Allow" and
+                                        (
+                                            ( (.Principal|type == "object") and (.Principal.AWS == "*") ) or
+                                            ( (.Principal|type == "string") and (.Principal == "*") )
+                                        ) and
+                                        (
+                                            ( (.Action|type == "string") and (.Action|startswith("s3:Put")) ) or
+                                            ( (.Action|type == "string") and (.Action|startswith("s3:*")) ) or
+                                            ( (.Action|type == "array") and (.Action[]|startswith("s3:Put")) ) or
+                                            ( (.Action|type == "array") and (.Action[]|startswith("s3:*")) )
+                                        ) and
+                                        .Condition == null
+                                      )' <<< "${BUCKET_POLICY_STATEMENTS}" | tr '\n' ' ')
         # Make sure JSON comma characted will not break CSV output. Replace "," by word "[comma]"
         BUCKET_POLICY_BAD_STATEMENTS="${BUCKET_POLICY_BAD_STATEMENTS//,/[comma]}"
         if [[ "${BUCKET_POLICY_BAD_STATEMENTS}" != "" ]]; then
@@ -63,6 +73,6 @@ extra771(){
       fi
     done
   else
-    textInfo "${REGION}: No S3 Buckets found"
+    textInfo "${REGION}: No S3 Buckets found" "${REGION}"
   fi
 }


### PR DESCRIPTION
### Context 

`extra771` was failing due to the following error:

`An error occurred (IllegalLocationConstraintException) when calling the GetBucketPolicy operation: The af-south-1 location constraint is incompatible for the region specific endpoint this request was sent to.'`

### Description

The solution to this problem is to recover the bucket location using `s3api get-bucket-location` and then use to query the right AWS region endpoint.

Also, I've improved the error handling logic.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
