### PR TITLE
fix(BucketLocation): Recover bucket policy using the right region endpoint

### DIFF
--- a/checks/check_extra7172
+++ b/checks/check_extra7172
@@ -24,33 +24,43 @@ CHECK_DOC_extra7172='https://docs.aws.amazon.com/AmazonS3/latest/userguide/about
 CHECK_CAF_EPIC_extra7172='Logging and Monitoring'
 
 extra7172(){
-  # "Check if S3 buckets have server access logging enabled "
-  LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets $PROFILE_OPT --query Buckets[*].Name --output text 2>&1)
-  if [[ $(echo "$LIST_OF_BUCKETS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-    textInfo "$REGION: Access Denied Trying to list buckets" "$REGION"
+  # "Check if S3 buckets have server access logging enabled"
+  LIST_OF_BUCKETS=$("${AWSCLI}" s3api list-buckets ${PROFILE_OPT} --query Buckets[*].Name --region "${REGION}" --output text 2>&1)
+  if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "$LIST_OF_BUCKETS"; then
+    textInfo "${REGION}: Access Denied Trying to list buckets" "${REGION}"
     exit
   fi
   if [[ $LIST_OF_BUCKETS ]]; then
     for bucket in $LIST_OF_BUCKETS;do
-      BUCKET_ACLS_DISABLED=$($AWSCLI s3api get-bucket-ownership-controls --bucket $bucket $PROFILE_OPT --output text 2>&1)
-      if [[ $(echo "$BUCKET_ACLS_DISABLED" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-        textInfo "$REGION: Access Denied Trying to Get Bucket Ownership Controls for $bucket" "$REGION" "$bucket"
+      # Recover Bucket region
+      BUCKET_REGION=$("${AWSCLI}" ${PROFILE_OPT} s3api get-bucket-location --bucket "${bucket}" --region "${REGION}" --query LocationConstraint --output text)
+      if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${BUCKET_REGION}"; then
+          textInfo "${REGION}: Access Denied trying to get bucket location for ${bucket}" "${REGION}"
+      fi
+      # If None use default region
+      if [[ "${BUCKET_REGION}" == "None" ]]; then
+        BUCKET_REGION="${REGION}"
+      fi
+
+      BUCKET_ACLS_DISABLED=$(${AWSCLI} ${PROFILE_OPT} s3api get-bucket-ownership-controls --bucket "${bucket}" --region "${BUCKET_REGION}" --output text 2>&1)
+      if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${BUCKET_ACLS_DISABLED}" ; then
+        textInfo "${BUCKET_REGION}: Access Denied Trying to Get Bucket Ownership Controls for ${bucket}" "${BUCKET_REGION}" "${bucket}"
         continue
-      elif [[ $(echo "$BUCKET_ACLS_DISABLED" | grep -E 'IllegalLocationConstraintException') ]]; then
-        textInfo "$REGION: Location Constraint Trying to Get Bucket Ownership Controls for $bucket" "$REGION" "$bucket"
+      elif grep -q -E 'IllegalLocationConstraintException' <<< "${BUCKET_ACLS_DISABLED}"; then
+        textInfo "${BUCKET_REGION}: Location Constraint Trying to Get Bucket Ownership Controls for ${bucket}" "${BUCKET_REGION}" "${bucket}"
         continue
       fi
-      if [[ $(echo "$BUCKET_ACLS_DISABLED" | grep "BucketOwnerEnforced") ]]; then
-        textPass "$REGION: Bucket $bucket has bucket ACLs disabled!" "$REGION" "$bucket"
-      elif [[ $(echo "$BUCKET_ACLS_DISABLED" | grep "BucketOwnerPreferred") ]]; then
-        textFail "$REGION: Bucket $bucket has bucket ACLs enabled!" "$REGION" "$bucket"
-      elif [[ $(echo "$BUCKET_ACLS_DISABLED" | grep "OwnershipControlsNotFoundError") ]]; then
-        textFail "$REGION: Bucket $bucket has bucket ACLs enabled!" "$REGION" "$bucket"
+      if grep -q "BucketOwnerEnforced" <<< "${BUCKET_ACLS_DISABLED}"; then
+        textPass "${BUCKET_REGION}: Bucket ${bucket} has bucket ACLs disabled!" "${BUCKET_REGION}" "${bucket}"
+      elif grep -q "BucketOwnerPreferred" <<< "${BUCKET_ACLS_DISABLED}"; then
+        textFail "${BUCKET_REGION}: Bucket ${bucket} has bucket ACLs enabled!" "${BUCKET_REGION}" "${bucket}"
+      elif grep -q "OwnershipControlsNotFoundError" <<< "${BUCKET_ACLS_DISABLED}"; then
+        textFail "${BUCKET_REGION}: Bucket ${bucket} has bucket ACLs enabled!" "${BUCKET_REGION}" "${bucket}"
       else
-        textFail "$REGION: Bucket $bucket returned an unknown error" "$REGION" "$bucket"
+        textFail "${BUCKET_REGION}: Bucket ${bucket} returned an unknown error" "${BUCKET_REGION}" "${bucket}"
       fi
     done
   else
-    textInfo "$REGION: No S3 Buckets found" "$REGION"
+    textInfo "${REGION}: No S3 Buckets found" "${REGION}"
   fi
 }

--- a/checks/check_extra718
+++ b/checks/check_extra718
@@ -25,21 +25,32 @@ CHECK_CAF_EPIC_extra718='Logging and Monitoring'
 
 extra718(){
   # "Check if S3 buckets have server access logging enabled "
-  LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets $PROFILE_OPT --query Buckets[*].Name --output text|xargs -n1)
+  LIST_OF_BUCKETS=$("${AWSCLI}" s3api list-buckets ${PROFILE_OPT} --query Buckets[*].Name --output text|xargs -n1)
   if [[ $LIST_OF_BUCKETS ]]; then
     for bucket in $LIST_OF_BUCKETS;do
-      BUCKET_SERVER_LOG_ENABLED=$($AWSCLI s3api get-bucket-logging --bucket $bucket $PROFILE_OPT --query [LoggingEnabled] --output text 2>&1)
-      if [[ $(echo "$BUCKET_SERVER_LOG_ENABLED" | grep AccessDenied) ]]; then
-        textInfo "$REGION: Access Denied Trying to Get Bucket Logging for $bucket" "$REGION" "$bucket"
+      # Recover Bucket region
+      BUCKET_REGION=$("${AWSCLI}" ${PROFILE_OPT} s3api get-bucket-location --bucket "${bucket}" --region "${REGION}" --query LocationConstraint --output text)
+      if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${BUCKET_REGION}"; then
+          textInfo "${REGION}: Access Denied trying to get bucket location for ${bucket}" "${REGION}"
+          continue
+      fi
+      # If None use default region
+      if [[ "${BUCKET_REGION}" == "None" ]]; then
+        BUCKET_REGION="${REGION}"
+      fi
+
+      BUCKET_SERVER_LOG_ENABLED=$("${AWSCLI}" s3api get-bucket-logging --bucket "${bucket}" ${PROFILE_OPT} --region "${BUCKET_REGION}" --query [LoggingEnabled] --output text 2>&1)
+      if grep -q AccessDenied <<< "${BUCKET_SERVER_LOG_ENABLED}"; then
+        textInfo "${BUCKET_REGION}: Access Denied Trying to Get Bucket Logging for ${bucket}" "${BUCKET_REGION}" "${bucket}"
         continue
       fi
-      if [[ $(echo "$BUCKET_SERVER_LOG_ENABLED" | grep "^None$") ]]; then
-        textFail "$REGION: Bucket $bucket has server access logging disabled!" "$REGION" "$bucket"
+      if grep -q "^None$" <<< "${BUCKET_SERVER_LOG_ENABLED}"; then
+        textFail "${BUCKET_REGION}: Bucket ${bucket} has server access logging disabled!" "${BUCKET_REGION}" "${bucket}"
       else
-        textPass "$REGION: Bucket $bucket has server access logging enabled" "$REGION" "$bucket"
+        textPass "${BUCKET_REGION}: Bucket ${bucket} has server access logging enabled" "${BUCKET_REGION}" "${bucket}"
       fi
     done
   else
-    textInfo "$REGION: No S3 Buckets found" "$REGION" "$bucket"
+    textInfo "${REGION}: No S3 Buckets found" "${REGION}" "${bucket}"
   fi
 }

--- a/checks/check_extra734
+++ b/checks/check_extra734
@@ -25,12 +25,12 @@ CHECK_DOC_extra734='https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encry
 CHECK_CAF_EPIC_extra734='Data Protection'
 
 extra734(){
-  LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets $PROFILE_OPT --region $REGION --query Buckets[*].Name --output text|xargs -n1)
+  LIST_OF_BUCKETS=$("${AWSCLI}" s3api list-buckets ${PROFILE_OPT} --region "${REGION}" --query Buckets[*].Name --output text|xargs -n1)
   if [[ $LIST_OF_BUCKETS ]]; then
     for bucket in $LIST_OF_BUCKETS;do
-      BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location $PROFILE_OPT --region $REGION --bucket $bucket --output text 2>&1)
-      if [[ $(echo "$BUCKET_LOCATION" | grep AccessDenied) ]]; then
-        textInfo "$BUCKET_LOCATION: Access Denied Trying to Get Bucket Location for $bucket" "$BUCKET_LOCATION" "$bucket"
+      BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location ${PROFILE_OPT} --region "${REGION}" --bucket "${bucket}" --output text 2>&1)
+      if grep -q 'AccessDenied' <<< "${BUCKET_LOCATION}"; then
+        textInfo "${REGION}: Access Denied Trying to Get Bucket Location for ${bucket}" "${REGION}" "${bucket}"
         continue
       fi
       if [[ $BUCKET_LOCATION == "None" ]]; then
@@ -44,48 +44,52 @@ extra734(){
       #  OR
       # - Have bucket policy denying s3:PutObject when s3:x-amz-server-side-encryption is absent
       # query to get if has encryption enabled or not
-      RESULT=$($AWSCLI s3api get-bucket-encryption $PROFILE_OPT --region $BUCKET_LOCATION --bucket $bucket --query ServerSideEncryptionConfiguration.Rules[].ApplyServerSideEncryptionByDefault[].SSEAlgorithm --output text 2>&1)
-      if [[ $(echo "$RESULT" | grep AccessDenied) ]]; then
-        textInfo "$BUCKET_LOCATION: Access Denied Trying to Get Encryption for $bucket" "$BUCKET_LOCATION" "$bucket"
+      RESULT=$("${AWSCLI}" s3api get-bucket-encryption ${PROFILE_OPT} --region ${BUCKET_LOCATION} --bucket "${bucket}" --query ServerSideEncryptionConfiguration.Rules[].ApplyServerSideEncryptionByDefault[].SSEAlgorithm --output text 2>&1)
+      if grep -q 'AccessDenied' <<< "${RESULT}"; then
+        textInfo "${BUCKET_LOCATION}: Access Denied Trying to Get Encryption for ${bucket}" "${BUCKET_LOCATION}" "${bucket}"
         continue
-      fi
-
-      if [[ $RESULT == "AES256" || $RESULT == "aws:kms" ]];
+      elif grep -q 'ServerSideEncryptionConfigurationNotFoundError' <<< "${RESULT}"
       then
-        textPass "$BUCKET_LOCATION: Bucket $bucket is enabled for default encryption with $RESULT" "$BUCKET_LOCATION" "$bucket"
+        textFail "${BUCKET_LOCATION}: Server Side Encryption configuration is not configured for ${bucket}" "${BUCKET_LOCATION}" "${bucket}"
         continue
       fi
 
-      TEMP_SSE_POLICY_FILE=$(mktemp -t prowler-${ACCOUNT_NUM}-${bucket}.policy.XXXXXXXXXX)
+      if [[ "${RESULT}" == "AES256" || "${RESULT}" == "aws:kms" ]];
+      then
+        textPass "${BUCKET_LOCATION}: Bucket $bucket is enabled for default encryption with ${RESULT}" "${BUCKET_LOCATION}" "${bucket}"
+        continue
+      fi
+
+      TEMP_SSE_POLICY_FILE=$(mktemp -t prowler-"${ACCOUNT_NUM}"-"${bucket}".policy.XXXXXXXXXX)
 
       # get bucket policy
-      $AWSCLI s3api get-bucket-policy $PROFILE_OPT --bucket $bucket --region $BUCKET_LOCATION --output text --query Policy > $TEMP_SSE_POLICY_FILE 2>&1
-      if [[ $(grep AccessDenied $TEMP_SSE_POLICY_FILE) ]]; then
-        textInfo "$BUCKET_LOCATION: Access Denied Trying to Get Bucket Policy for $bucket" "$BUCKET_LOCATION" "$bucket"
-        rm -f $TEMP_SSE_POLICY_FILE
+      "${AWSCLI}" s3api get-bucket-policy ${PROFILE_OPT} --bucket "${bucket}" --region "${BUCKET_LOCATION}" --output text --query Policy > "${TEMP_SSE_POLICY_FILE}" 2>&1
+      if grep -q 'AccessDenied' <<< "${TEMP_SSE_POLICY_FILE}"; then
+        textInfo "${BUCKET_LOCATION}: Access Denied Trying to Get Bucket Policy for ${bucket}" "${BUCKET_LOCATION}" "${bucket}"
+        rm -f "${TEMP_SSE_POLICY_FILE}"
         continue
       fi
-      if [[ $(grep NoSuchBucketPolicy $TEMP_SSE_POLICY_FILE) ]]; then
-        textFail "$BUCKET_LOCATION: No bucket policy for $bucket" "$BUCKET_LOCATION" "$bucket"
-        rm -f $TEMP_SSE_POLICY_FILE
+      if grep -q 'NoSuchBucketPolicy' <<< "${TEMP_SSE_POLICY_FILE}"; then
+        textFail "${BUCKET_LOCATION}: No bucket policy for ${bucket}" "${BUCKET_LOCATION}" "${bucket}"
+        rm -f "${TEMP_SSE_POLICY_FILE}"
         continue
       fi
 
       # check if the S3 policy forces SSE s3:x-amz-server-side-encryption:true
-      CHECK_BUCKET_SSE_POLICY_PRESENT=$(cat $TEMP_SSE_POLICY_FILE | jq --arg arn "arn:${AWS_PARTITION}:s3:::${bucket}/*" '.Statement[]|select(.Effect=="Deny" and ((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*") and .Action=="s3:PutObject" and .Resource==$arn and .Condition.StringNotEquals."s3:x-amz-server-side-encryption" != null)')
-      if [[ $CHECK_BUCKET_SSE_POLICY_PRESENT == "" ]]; then
-        textFail "$BUCKET_LOCATION: Bucket $bucket does not enforce encryption!" "$BUCKET_LOCATION" "$bucket"
-        rm -f $TEMP_SSE_POLICY_FILE
+      CHECK_BUCKET_SSE_POLICY_PRESENT=$(jq --arg arn "arn:${AWS_PARTITION}:s3:::${bucket}/*" '.Statement[]|select(.Effect=="Deny" and ((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*") and .Action=="s3:PutObject" and .Resource==$arn and .Condition.StringNotEquals."s3:x-amz-server-side-encryption" != null)' < "${TEMP_SSE_POLICY_FILE}")
+      if [[ "${CHECK_BUCKET_SSE_POLICY_PRESENT}" == "" ]]; then
+        textFail "${BUCKET_LOCATION}: Bucket ${bucket} does not enforce encryption!" "${BUCKET_LOCATION}" "${bucket}"
+        rm -f "${TEMP_SSE_POLICY_FILE}"
         continue
       fi
-      CHECK_BUCKET_SSE_POLICY_VALUE=$(echo "$CHECK_BUCKET_SSE_POLICY_PRESENT" | jq -r '.Condition.StringNotEquals."s3:x-amz-server-side-encryption"')
+      CHECK_BUCKET_SSE_POLICY_VALUE=$(jq -r '.Condition.StringNotEquals."s3:x-amz-server-side-encryption"' <<< "${CHECK_BUCKET_SSE_POLICY_PRESENT}")
 
-      textPass "$BUCKET_LOCATION: Bucket $bucket has S3 bucket policy to enforce encryption with $CHECK_BUCKET_SSE_POLICY_VALUE" "$BUCKET_LOCATION" "$bucket"
+      textPass "${BUCKET_LOCATION}: Bucket ${bucket} has S3 bucket policy to enforce encryption with ${CHECK_BUCKET_SSE_POLICY_VALUE}" "${BUCKET_LOCATION}" "${bucket}"
 
-      rm -f $TEMP_SSE_POLICY_FILE
+      rm -f "${TEMP_SSE_POLICY_FILE}"
     done
 
   else
-    textInfo "$REGION No S3 Buckets found" "$REGION"
+    textInfo "${REGION}: No S3 Buckets found" "${REGION}"
   fi
 }

--- a/checks/check_extra763
+++ b/checks/check_extra763
@@ -25,21 +25,32 @@ CHECK_CAF_EPIC_extra763='Data Protection'
 
 extra763(){
   # "Check if S3 buckets have object versioning enabled "
-  LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets $PROFILE_OPT --query Buckets[*].Name --output text|xargs -n1)
+  LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets ${PROFILE_OPT} --region "${REGION}" --query Buckets[*].Name --output text|xargs -n1)
   if [[ $LIST_OF_BUCKETS ]]; then
-    for bucket in $LIST_OF_BUCKETS;do
-      BUCKET_VERSIONING_ENABLED=$($AWSCLI s3api get-bucket-versioning --bucket $bucket $PROFILE_OPT --query Status --output text 2>&1)
-      if [[ $(echo "$BUCKET_VERSIONING_ENABLED" | grep AccessDenied) ]]; then
-        textInfo "Access Denied Trying to Get Bucket Versioning for $bucket"
+    for bucket in $LIST_OF_BUCKETS; do
+      # Recover Bucket region
+      BUCKET_REGION=$("${AWSCLI}" ${PROFILE_OPT} s3api get-bucket-location --bucket "${bucket}" --region "${REGION}" --query LocationConstraint --output text)
+      if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${BUCKET_REGION}"; then
+          textInfo "${REGION}: Access Denied trying to get bucket location for ${bucket}" "${REGION}"
+          continue
+      fi
+      # If None use default region
+      if [[ "${BUCKET_REGION}" == "None" ]]; then
+        BUCKET_REGION="${REGION}"
+      fi
+
+      BUCKET_VERSIONING_ENABLED=$("${AWSCLI}" s3api get-bucket-versioning --bucket "${bucket}" ${PROFILE_OPT} --region "${BUCKET_REGION}" --query Status --output text 2>&1)
+      if grep -q 'AccessDenied' <<< "${BUCKET_VERSIONING_ENABLED}"; then
+        textInfo "${BUCKET_REGION}: Access Denied Trying to Get Bucket Versioning for $bucket"
         continue
       fi
-      if [[ $(echo "$BUCKET_VERSIONING_ENABLED" | grep "^Enabled$") ]]; then
-        textPass "Bucket $bucket has versioning enabled" "$REGION" "$bucket"
+      if  grep -q "^Enabled$" <<< "${BUCKET_VERSIONING_ENABLED}"; then
+        textPass "${BUCKET_REGION}: Bucket ${bucket} has versioning enabled" "${BUCKET_REGION}" "${bucket}"
       else
-        textFail "Bucket $bucket has versioning disabled!" "$REGION" "$bucket"
+        textFail "${BUCKET_REGION}: Bucket ${bucket} has versioning disabled!" "${BUCKET_REGION}" "${bucket}"
       fi
     done
   else
-    textInfo "No S3 Buckets found"
+    textInfo "${REGION}: No S3 Buckets found" "${REGION}"
   fi
 }

--- a/checks/check_extra764
+++ b/checks/check_extra764
@@ -31,10 +31,10 @@ extra764(){
     for bucket in $LIST_OF_BUCKETS;do
       BUCKET_LOCATION=$(${AWSCLI} s3api get-bucket-location ${PROFILE_OPT} --region ${REGION} --bucket ${bucket} --output text 2>&1)
       if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${BUCKET_LOCATION}"; then
-        textInfo "Access Denied Trying to Get Bucket Location for ${bucket}" "${REGION}" "${bucket}"
+        textInfo "${REGION}: Access Denied Trying to Get Bucket Location for ${bucket}" "${REGION}" "${bucket}"
         continue
       elif grep -E 'NoSuchBucket' <<< "${BUCKET_LOCATION}"; then
-        textInfo "NoSuchBucket error Bucket ${bucket} does not exist" "${REGION}" "${bucket}"
+        textInfo "${REGION}: NoSuchBucket error Bucket ${bucket} does not exist" "${REGION}" "${bucket}"
         continue
       fi
       if [[ "${BUCKET_LOCATION}" == "None" ]]; then
@@ -44,13 +44,13 @@ extra764(){
         BUCKET_LOCATION="eu-west-1"
       fi
       # get bucket policy
-      TEMP_STP_POLICY_FILE=$(${AWSCLI} s3api get-bucket-policy ${PROFILE_OPT} --bucket ${bucket} --output text --query Policy --region ${BUCKET_LOCATION} 2>&1)
+      TEMP_STP_POLICY_FILE=$(${AWSCLI} s3api get-bucket-policy ${PROFILE_OPT} --bucket "${bucket}" --output text --query Policy --region "${BUCKET_LOCATION}" 2>&1)
       if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${TEMP_STP_POLICY_FILE}"; then
-        textInfo "Access Denied Trying to Get Bucket Policy for ${bucket}" "${REGION}" "${bucket}"
+        textInfo "${BUCKET_LOCATION}: Access Denied Trying to Get Bucket Policy for ${bucket}" "${BUCKET_LOCATION}" "${bucket}"
         continue
       fi
-      if grep -q "NoSuchBucketPolicy" <<< $TEMP_STP_POLICY_FILE ; then
-        textFail "No bucket policy for ${bucket}" "${BUCKET_LOCATION}" "${bucket}"
+      if grep -q "NoSuchBucketPolicy" <<< "${TEMP_STP_POLICY_FILE}" ; then
+        textFail "${BUCKET_LOCATION}: No bucket policy for ${bucket}" "${BUCKET_LOCATION}" "${bucket}"
         continue
       fi
 
@@ -60,16 +60,16 @@ extra764(){
         CHECK_BUCKET_STP_POLICY_PRESENT=$(jq --arg arn "arn:${AWS_PARTITION}:s3:::${bucket}" \
           '.Statement[]|select((((.Principal|type == "object") and .Principal.AWS == "*") or ((.Principal|type == "string") and .Principal == "*")) and .Effect=="Deny" and (.Action=="s3:*" or .Action=="*") and (.Resource|type == "array") and (.Resource|map({(.):0})[]|has($arn)) and (.Resource|map({(.):0})[]|has($arn+"/*")) and .Condition.Bool."aws:SecureTransport" == "false")' <<< "${TEMP_STP_POLICY_FILE}")
         if [[ "${CHECK_BUCKET_STP_POLICY_PRESENT}" ]]; then
-          textPass "Bucket ${bucket} has S3 bucket policy to deny requests over insecure transport" "${BUCKET_LOCATION}" "${bucket}"
+          textPass "${BUCKET_LOCATION}: Bucket ${bucket} has S3 bucket policy to deny requests over insecure transport" "${BUCKET_LOCATION}" "${bucket}"
         else
-          textFail "Bucket ${bucket} allows requests over insecure transport" "${BUCKET_LOCATION}" "${bucket}"
+          textFail "${BUCKET_LOCATION}: Bucket ${bucket} allows requests over insecure transport" "${BUCKET_LOCATION}" "${bucket}"
         fi
       else
-          textInfo "Bucket ${bucket} returned an unknown error" "${REGION}" "${bucket}"
+          textInfo "${BUCKET_LOCATION}: Bucket ${bucket} returned an unknown error" "${BUCKET_LOCATION}" "${bucket}"
       fi
     done
 
   else
-    textInfo "No S3 Buckets found"
+    textInfo "${REGION}: No S3 Buckets found" "${REGION}"
   fi
 }


### PR DESCRIPTION
### Motivation

Prowler checks that reviews AWS S3 in the new AWS regions needs `-r` to point API calls to these specific regions. If this option is not included the error shown is `IllegalLocationConstraintException` 

The affected checks are the following:

- 7.18 [extra718] Check if S3 buckets have server access logging enabled
- 7.34 [extra734] Check if S3 buckets have default encryption (SSE) enabled or use a bucket policy to enforce it
- 7.63 [extra763] Check if S3 buckets have object versioning enabled
- 7.64 [extra764] Check if S3 buckets have secure transport policy
- 7.172 [extra7172] Check if S3 buckets have ACLs enabled

### Description

Recover the bucket location in each S3 check to point API calls to the region where the S3 Bucket is located.

Also, for check `extra734` I've included a new error check for the following exception `ServerSideEncryptionConfigurationNotFoundError`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
