### PR TITLE
fix(remediation): Fix empty remediation fields for checks 7164, 7144 and 7163

### DIFF
--- a/checks/check_extra7144
+++ b/checks/check_extra7144
@@ -18,8 +18,8 @@ CHECK_SEVERITY_extra7144="Medium"
 CHECK_ASFF_RESOURCE_TYPE_extra7144="AwsCloudWatch"
 CHECK_ALTERNATE_check7144="extra7144"
 CHECK_SERVICENAME_extra7144="cloudwatch"
-CHECK_RISK_extra7144=''
-CHECK_REMEDIATION_extra7144=''
+CHECK_RISK_extra7144='Cross-Account access to CloudWatch could increase the risk of compromising information between accounts'
+CHECK_REMEDIATION_extra7144='Grant usage permission on a per-resource basis to enforce least privilege and Zero Trust principles'
 CHECK_DOC_extra7144='https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Cross-Account-Cross-Region.html'
 CHECK_CAF_EPIC_extra7144='Logging and Monitoring'
 

--- a/checks/check_extra7163
+++ b/checks/check_extra7163
@@ -33,7 +33,7 @@ CHECK_ASFF_RESOURCE_TYPE_extra7163="AwsSecretsManagerSecret"
 CHECK_ALTERNATE_extra7163="extra7163"
 CHECK_SERVICENAME_extra7163="secretsmanager"
 CHECK_RISK_extra7163="Rotating secrets minimizes exposure to attacks using stolen keys."
-CHECK_REMEDITATION_extra7163="Enable key rotation on Secrets Manager key."
+CHECK_REMEDIATION_extra7163="Enable key rotation on Secrets Manager key."
 CHECK_DOC_extra7163="https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets_strategies.html"
 CHECK_CAF_EPIC_extra7163="Data Protection"
 

--- a/checks/check_extra7164
+++ b/checks/check_extra7164
@@ -18,7 +18,7 @@
 #       --log-group-name <value>
 #       --kms-key-id <value>
 #       [--cli-input-json <value>]
-#       [--generate-cli-skeleton <value>]  
+#       [--generate-cli-skeleton <value>]
 
 CHECK_ID_extra7164="7.164"
 CHECK_TITLE_extra7164="[extra7164] Check if CloudWatch log groups are protected by AWS KMS "
@@ -29,7 +29,7 @@ CHECK_ASFF_RESOURCE_TYPE_extra7164="Logs"
 CHECK_ALTERNATE_extra7164="extra7164"
 CHECK_SERVICENAME_extra7164="logs"
 CHECK_RISK_extra7164="Using customer managed KMS to encrypt CloudWatch log group provide additional confidentiality and control over the log data"
-CHECK_REMEDITATION_extra7164="Associate KMS Key with Cloudwatch log group."
+CHECK_REMEDIATION_extra7164="Associate KMS Key with Cloudwatch log group."
 CHECK_DOC_extra7164="https://docs.aws.amazon.com/cli/latest/reference/logs/associate-kms-key.html"
 CHECK_CAF_EPIC_extra7164="Data Protection"
 


### PR DESCRIPTION
### Context 

We need to fix some checks with empty `REMEDIATION` values.

### Description

Fix empty remediation fields for checks `7164`, `7144` and `7163`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
