### PR TITLE
fix(checks): Handle AWS Gov Cloud regions

### DIFF
--- a/checks/check11
+++ b/checks/check11
@@ -25,23 +25,27 @@ CHECK_DOC_check11='http://docs.aws.amazon.com/IAM/latest/UserGuide/best-practice
 CHECK_CAF_EPIC_check11='IAM'
 
 check11(){
-  # "Avoid the use of the root account (Scored)."
-  MAX_DAYS=-1
-  last_login_dates=$(cat $TEMP_REPORT_FILE | awk -F, '{ print $1,$5,$11,$16 }' | grep '<root_account>' | cut -d' ' -f2,3,4)
+  if [[ "${REGION}" == "us-gov-west-1" || "${REGION}" == "us-gov-east-1" ]]; then
+        textInfo "${REGION}: This is an AWS GovCloud account and there is no root account to perform checks."
+  else
+    # "Avoid the use of the root account (Scored)."
+    MAX_DAYS=-1
+    last_login_dates=$(cat $TEMP_REPORT_FILE | awk -F, '{ print $1,$5,$11,$16 }' | grep '<root_account>' | cut -d' ' -f2,3,4)
 
-  failures=0
-  for date in $last_login_dates; do
-    if [[ ${date%T*} =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]];then
-      days_not_in_use=$(how_many_days_from_today ${date%T*})
-      if [ "$days_not_in_use" -gt "$MAX_DAYS" ];then
-          failures=1
-          textFail "$REGION: Root user in the account was last accessed ${MAX_DAYS#-} day ago" "$REGION" "root"
-          break
+    failures=0
+    for date in $last_login_dates; do
+      if [[ ${date%T*} =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]];then
+        days_not_in_use=$(how_many_days_from_today ${date%T*})
+        if [ "$days_not_in_use" -gt "$MAX_DAYS" ];then
+            failures=1
+            textFail "$REGION: Root user in the account was last accessed ${MAX_DAYS#-} day ago" "$REGION" "root"
+            break
+        fi
       fi
-    fi
-  done
+    done
 
-  if [[ $failures == 0 ]]; then
-      textPass "$REGION: Root user in the account wasn't accessed in the last ${MAX_DAYS#-} days" "$REGION" "root"
+    if [[ $failures == 0 ]]; then
+        textPass "$REGION: Root user in the account wasn't accessed in the last ${MAX_DAYS#-} days" "$REGION" "root"
+    fi
   fi
 }

--- a/checks/check113
+++ b/checks/check113
@@ -25,11 +25,15 @@ CHECK_DOC_check113='https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-use
 CHECK_CAF_EPIC_check113='IAM'
 
 check113(){
-  # "Ensure MFA is enabled for the root account (Scored)"
-  COMMAND113=$($AWSCLI iam get-account-summary $PROFILE_OPT --region $REGION --output json --query 'SummaryMap.AccountMFAEnabled')
-  if [ "$COMMAND113" == "1" ]; then
-    textPass "$REGION: Virtual MFA is enabled for root" "$REGION" "MFA"
+  if [[ "${REGION}" == "us-gov-west-1" || "${REGION}" == "us-gov-east-1" ]]; then
+    textInfo "${REGION}: This is an AWS GovCloud account and there is no root account to perform checks."
   else
-    textFail "$REGION: MFA is not ENABLED for root account" "$REGION" "MFA"
+    # "Ensure MFA is enabled for the root account (Scored)"
+    COMMAND113=$($AWSCLI iam get-account-summary $PROFILE_OPT --region $REGION --output json --query 'SummaryMap.AccountMFAEnabled')
+    if [ "$COMMAND113" == "1" ]; then
+      textPass "$REGION: Virtual MFA is enabled for root" "$REGION" "MFA"
+    else
+      textFail "$REGION: MFA is not ENABLED for root account" "$REGION" "MFA"
+    fi
   fi
 }

--- a/checks/check114
+++ b/checks/check114
@@ -25,16 +25,20 @@ CHECK_DOC_check114='https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-use
 CHECK_CAF_EPIC_check114='IAM'
 
 check114(){
-  # "Ensure hardware MFA is enabled for the root account (Scored)"
-  COMMAND113=$($AWSCLI iam get-account-summary $PROFILE_OPT --region $REGION --output json --query 'SummaryMap.AccountMFAEnabled')
-  if [ "$COMMAND113" == "1" ]; then
-    COMMAND114=$($AWSCLI iam list-virtual-mfa-devices $PROFILE_OPT --region $REGION --output text --assignment-status Assigned --query 'VirtualMFADevices[*].[SerialNumber]' | grep "^arn:${AWS_PARTITION}:iam::[0-9]\{12\}:mfa/root-account-mfa-device$")
-    if [[ "$COMMAND114" ]]; then
-      textFail "$REGION: Only Virtual MFA is enabled for root" "$REGION" "MFA"
-    else
-      textPass "$REGION: Hardware MFA is enabled for root" "$REGION" "MFA"
-    fi
+  if [[ "${REGION}" == "us-gov-west-1" || "${REGION}" == "us-gov-east-1" ]]; then
+    textInfo "${REGION}: This is an AWS GovCloud account and there is no root account to perform checks."
   else
-    textFail "$REGION: MFA is not ENABLED for root account" "$REGION" "MFA"
+    # "Ensure hardware MFA is enabled for the root account (Scored)"
+    COMMAND113=$($AWSCLI iam get-account-summary $PROFILE_OPT --region $REGION --output json --query 'SummaryMap.AccountMFAEnabled')
+    if [ "$COMMAND113" == "1" ]; then
+      COMMAND114=$($AWSCLI iam list-virtual-mfa-devices $PROFILE_OPT --region $REGION --output text --assignment-status Assigned --query 'VirtualMFADevices[*].[SerialNumber]' | grep "^arn:${AWS_PARTITION}:iam::[0-9]\{12\}:mfa/root-account-mfa-device$")
+      if [[ "$COMMAND114" ]]; then
+        textFail "$REGION: Only Virtual MFA is enabled for root" "$REGION" "MFA"
+      else
+        textPass "$REGION: Hardware MFA is enabled for root" "$REGION" "MFA"
+      fi
+    else
+      textFail "$REGION: MFA is not ENABLED for root account" "$REGION" "MFA"
+    fi
   fi
 }

--- a/checks/check115
+++ b/checks/check115
@@ -25,6 +25,10 @@ CHECK_DOC_check115='https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credenti
 CHECK_CAF_EPIC_check115='IAM'
 
 check115(){
-  # "Ensure security questions are registered in the AWS account (Not Scored)"
-  textInfo "No command available for check 1.15. Login to the AWS Console as root & click on the Account. Name -> My Account -> Configure Security Challenge Questions."
+  if [[ "${REGION}" == "us-gov-west-1" || "${REGION}" == "us-gov-east-1" ]]; then
+    textInfo "${REGION}: This is an AWS GovCloud account and there is no root account to perform checks."
+  else
+    # "Ensure security questions are registered in the AWS account (Not Scored)"
+    textInfo "${REGION}: No command available for check 1.15. Login to the AWS Console as root & click on the Account. Name -> My Account -> Configure Security Challenge Questions."
+  fi
 }

--- a/checks/check117
+++ b/checks/check117
@@ -25,7 +25,11 @@ CHECK_DOC_check117='https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2
 CHECK_CAF_EPIC_check117='IAM'
 
 check117(){
-  # "Maintain current contact details (Scored)"
-  # No command available
-  textInfo "No command available for check 1.17. See section 1.17 on the CIS Benchmark guide for details."
+  if [[ "${REGION}" == "us-gov-west-1" || "${REGION}" == "us-gov-east-1" ]]; then
+    textInfo "${REGION}: This is an AWS GovCloud account and there is no root account to perform checks."
+  else
+    # "Maintain current contact details (Scored)"
+    # No command available
+    textInfo "No command available for check 1.17. See section 1.17 on the CIS Benchmark guide for details."
+  fi
 }

--- a/checks/check118
+++ b/checks/check118
@@ -25,7 +25,11 @@ CHECK_DOC_check118='https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2
 CHECK_CAF_EPIC_check118='IAM'
 
 check118(){
-  # "Ensure security contact information is registered (Scored)"
-  # No command available
-  textInfo "No command available for check 1.18. See section 1.18 on the CIS Benchmark guide for details."
+  if [[ "${REGION}" == "us-gov-west-1" || "${REGION}" == "us-gov-east-1" ]]; then
+    textInfo "${REGION}: This is an AWS GovCloud account and there is no root account to perform checks."
+  else
+    # "Ensure security contact information is registered (Scored)"
+    # No command available
+    textInfo "No command available for check 1.18. See section 1.18 on the CIS Benchmark guide for details."
+  fi
 }

--- a/checks/check33
+++ b/checks/check33
@@ -52,5 +52,9 @@ CHECK_DOC_check33='https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cl
 CHECK_CAF_EPIC_check33='Logging and Monitoring'
 
 check33(){
-  check3x '\$\.userIdentity\.type\s*=\s*"Root".+\$\.userIdentity\.invokedBy NOT EXISTS.+\$\.eventType\s*!=\s*"AwsServiceEvent"'
+  if [[ "${REGION}" == "us-gov-west-1" || "${REGION}" == "us-gov-east-1" ]]; then
+    textInfo "${REGION}: This is an AWS GovCloud account and there is no root account to perform checks."
+  else
+    check3x '\$\.userIdentity\.type\s*=\s*"Root".+\$\.userIdentity\.invokedBy NOT EXISTS.+\$\.eventType\s*!=\s*"AwsServiceEvent"'
+  fi
 }


### PR DESCRIPTION
### Context 

We need to handle checks in AWS Gov Cloud regions `us-gov-west-1` and `us-gov-east-1` since there is no root account in those regions.

Fix https://github.com/prowler-cloud/prowler/issues/823

### Description

Handle AWS Gov Cloud regions in the following checks to skip execution and notify that doesn't apply:
```
- 1.1 iam [check11] Avoid the use of the root account [High] [group1, cislevel1, cislevel2, gdpr, pci, iso27001, ffiec]
- 3.3 iam [check33] Ensure a log metric filter and alarm exist for usage of root account [Medium] [group3, cislevel1, cislevel2, gdpr, hipaa, iso27001, ffiec, soc2, ens]
- 1.13 iam [check113] Ensure MFA is enabled for the root account [Critical] [group1, cislevel1, cislevel2, gdpr, hipaa, pci, iso27001, ffiec, soc2]
- 1.14 iam [check114] Ensure hardware MFA is enabled for the root account [Critical] [group1, cislevel2, gdpr, pci, iso27001]
- 1.15 support [check115] Ensure security questions are registered in the AWS account [Medium] [group1, cislevel1, cislevel2, iso27001]
- 1.17 support [check117] Maintain current contact details [Medium] [group1, cislevel1, cislevel2]
- 1.18 support [check118] Ensure security contact information is registered [Medium] [group1, cislevel1, cislevel2]
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
