### PR TITLE
feat(checks): New IAM privilege escalation check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,8 @@ repos:
       - id: no-commit-to-branch
       - id: pretty-format-json
         args: ['--autofix']
+
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.8.0
+    hooks:
+    -   id: shellcheck

--- a/checks/check_extra7181
+++ b/checks/check_extra7181
@@ -26,6 +26,22 @@ CHECK_REMEDIATION_extra7181='Grant usage permission on a per-resource basis and 
 CHECK_DOC_extra7181='https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccessKey.html'
 CHECK_CAF_EPIC_extra7181='IAM'
 
+ # que pasa si la política tiene como resource una lista ["*"] --> se podria quitar esto Resource == '*'
+                    # Does the tool analyze both users and roles, or just one or the other? --> AttachmentCount
+                    # Does the tool take a principal-centric or policy-centric approach? --> misma revision para las inlines en otro check
+                    # Does the tool handle resource constraints?
+                    # Does the tool consider the permissions of service roles?
+                    # Does the tool handle transitive privesc paths (i.e., attack chains)?
+
+                    # Does the tool handle the DENY effect as expected?
+                    # Does the tool handle NotAction as expected?
+                    # Does the tool handle Condition constraints?
+                                        # Does the tool handle service control policy (SCP) restrictions? --> esto nada, es otro servicio
+
+
+                    # --query "PolicyVersion.Document.Statement[?(not_null(Action) && Effect == 'Allow' && Resource == '*')].Action[]" \
+                    # "PolicyVersion.Document.Statement[?(not_null(Action) && Effect == 'Allow')].Action[]"
+
 extra7181() {
     # Incluir como un recurso consultable para la remediación y la doc
     local PRIVILEGE_ESCALATION_IAM_ACTIONS="iam:AddUserToGroup|iam:AttachRolePolicy|iam:AttachUserPolicy|iam:CreateAccessKey|iam:CreatePolicyVersion|iam:CreateLoginProfile|iam:PassRole|iam:PutGroupPolicy|iam:PutRolePolicy|iam:PutUserPolicy|iam:SetDefaultPolicyVersion|iam:UpdateAssumeRolePolicy|iam:UpdateLoginProfile|sts:AssumeRole|ec2:RunInstances|lambda:CreateEventSourceMapping|lambda:CreateFunction|lambda:InvokeFunction|lambda:UpdateFunctionCode|dynamodb:CreateTable|dynamodb:PutItem|glue:CreateDevEndpoint|glue:UpdateDevEndpoint|cloudformation:CreateStack|datapipeline:CreatePipeline"
@@ -35,8 +51,9 @@ extra7181() {
     LIST_CUSTOM_POLICIES=$(${AWSCLI} iam list-policies ${PROFILE_OPT} \
     --region "${REGION}" \
     --scope Local \
-    --query 'Policies[?AttachmentCount > `0`].[Arn,DefaultVersionId]' \
+    --query 'Policies[*].[Arn,DefaultVersionId]' \
     --output text)
+    # --query 'Policies[?AttachmentCount > `0`].[Arn,DefaultVersionId]' \
     # Check errors
     if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_CUSTOM_POLICIES}"; then
         textInfo "${REGION}: Access Denied trying to list IAM policies" "${REGION}"
@@ -49,20 +66,22 @@ extra7181() {
                     --policy-arn "${POLICY_ARN}" \
                     --version-id "${POLICY_DEFAULT_VERSION}" \
                     --region "${REGION}" \
-                    --query "PolicyVersion.Document.Statement[?(not_null(Action) && Effect == 'Allow' && Resource == '*')].Action[]" \
-                    --output text)
-                    # que pasa si la política tiene como resource una lista ["*"]
-                    # Does the tool analyze both users and roles, or just one or the other?
-                    # Does the tool take a principal-centric or policy-centric approach?
-                    # Does the tool handle resource constraints?
-                    # Does the tool consider the permissions of service roles?
-                    # Does the tool handle transitive privesc paths (i.e., attack chains)?
-                    # Does the tool handle the DENY effect as expected?
-                    # Does the tool handle NotAction as expected?
-                    # Does the tool handle Condition constraints?
-                    # Does the tool handle service control policy (SCP) restrictions?
+                    --query "PolicyVersion.Document.Statement[?(not_null(Action) || not_null(NotAction))]" \
+                    --output json)
+                    # --query "PolicyVersion.Document.Statement[?(not_null(Action) && (Effect == 'Allow' && Effect == 'Deny'))].Action[]" \
+                    # --output json)
 
-                POLICY_PRIVILEGE_ESCALATION_ACTIONS=$(grep -o -E "${PRIVILEGE_ESCALATION_IAM_ACTIONS}" <<< "${POLICY_PRIVILEGED_ACTIONS}")
+                    # (not_null(Action) && (Effect == 'Allow' && Effect == 'Deny') no aplica ya
+
+                # que pasa si action es un objeto en vez de una lista
+                ACTIONS=$(jq -r '.[] | select(.Action != null) | .Action | .[]' <<< ${POLICY_PRIVILEGED_ACTIONS})
+                # echo $ACTIONS
+                NOT_ACTIONS=$(jq -r '.[] | select(.NotAction != null) | .NotAction | .[]' <<< ${POLICY_PRIVILEGED_ACTIONS})
+                # echo $NOT_ACTIONS
+                PRIVILEGED_ACTIONS=$(echo "${ACTIONS//'"'/} ${NOT_ACTIONS//'"'/}" | xargs -n1 | sort -u | xargs)
+                # echo $PRIVILEGED_ACTIONS
+
+                POLICY_PRIVILEGE_ESCALATION_ACTIONS=$(grep -o -E "${PRIVILEGE_ESCALATION_IAM_ACTIONS}" <<< "${PRIVILEGED_ACTIONS}")
                 if [[ -n "${POLICY_PRIVILEGE_ESCALATION_ACTIONS}" ]]; then
                     textFail "${REGION}: ${POLICY_ARN} allows for privilige escalation using the following actions: ${POLICY_PRIVILEGE_ESCALATION_ACTIONS//$'\n'/ }" "$REGION" "${POLICY_NAME}"
                 else

--- a/checks/check_extra7181
+++ b/checks/check_extra7181
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Prowler - the handy cloud security tool (copyright 2019) by Toni de la Fuente
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+
+
+CHECK_ID_extra7181="7.181"
+CHECK_TITLE_extra7181="[extra7181] Ensure IAM policies not allow for Privilege Escalation"
+CHECK_SCORED_extra7181="NOT_SCORED"
+CHECK_CIS_LEVEL_extra7181="EXTRA"
+CHECK_SEVERITY_extra7181="Medium"
+CHECK_ASFF_RESOURCE_TYPE_extra7181="AwsIamPolicy"
+CHECK_ALTERNATE_check7181="extra7181"
+CHECK_SERVICENAME_extra7181="iam"
+CHECK_RISK_extra7181='Users with some IAM permissions are allowed to elevate their privileges up to administrator rights.'
+CHECK_REMEDIATION_extra7181='Grant usage permission on a per-resource basis and applying least privilege principle.'
+CHECK_DOC_extra7181='https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccessKey.html'
+CHECK_CAF_EPIC_extra7181='IAM'
+
+extra7181() {
+    # Incluir como un recurso consultable para la remediación y la doc
+    local PRIVILEGE_ESCALATION_IAM_ACTIONS="iam:AddUserToGroup|iam:AttachRolePolicy|iam:AttachUserPolicy|iam:CreateAccessKey|iam:CreatePolicyVersion|iam:CreateLoginProfile|iam:PassRole|iam:PutGroupPolicy|iam:PutRolePolicy|iam:PutUserPolicy|iam:SetDefaultPolicyVersion|iam:UpdateAssumeRolePolicy|iam:UpdateLoginProfile|sts:AssumeRole|ec2:RunInstances|lambda:CreateEventSourceMapping|lambda:CreateFunction|lambda:InvokeFunction|lambda:UpdateFunctionCode|dynamodb:CreateTable|dynamodb:PutItem|glue:CreateDevEndpoint|glue:UpdateDevEndpoint|cloudformation:CreateStack|datapipeline:CreatePipeline"
+
+  # Use --scope Local to list only Customer Managed Policies
+  # Query AttachmentCount > 0  to check if this policy is in use, so attached to any user, group or role
+    LIST_CUSTOM_POLICIES=$(${AWSCLI} iam list-policies ${PROFILE_OPT} \
+    --region "${REGION}" \
+    --scope Local \
+    --query 'Policies[?AttachmentCount > `0`].[Arn,DefaultVersionId]' \
+    --output text)
+    # Check errors
+    if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_CUSTOM_POLICIES}"; then
+        textInfo "${REGION}: Access Denied trying to list IAM policies" "${REGION}"
+    else
+        if [[ $LIST_CUSTOM_POLICIES ]]; then
+            while read -r POLICY_ARN POLICY_DEFAULT_VERSION; do
+                # POLICY_NAME="${POLICY_ARN///}"
+                POLICY_PRIVILEGED_ACTIONS=$($AWSCLI iam get-policy-version ${PROFILE_OPT} \
+                    --output json \
+                    --policy-arn "${POLICY_ARN}" \
+                    --version-id "${POLICY_DEFAULT_VERSION}" \
+                    --region "${REGION}" \
+                    --query "PolicyVersion.Document.Statement[?(not_null(Action) && Effect == 'Allow' && Resource == '*')].Action[]" \
+                    --output text)
+                    # que pasa si la política tiene como resource una lista ["*"]
+                    # Does the tool analyze both users and roles, or just one or the other?
+                    # Does the tool take a principal-centric or policy-centric approach?
+                    # Does the tool handle resource constraints?
+                    # Does the tool consider the permissions of service roles?
+                    # Does the tool handle transitive privesc paths (i.e., attack chains)?
+                    # Does the tool handle the DENY effect as expected?
+                    # Does the tool handle NotAction as expected?
+                    # Does the tool handle Condition constraints?
+                    # Does the tool handle service control policy (SCP) restrictions?
+
+                POLICY_PRIVILEGE_ESCALATION_ACTIONS=$(grep -o -E "${PRIVILEGE_ESCALATION_IAM_ACTIONS}" <<< "${POLICY_PRIVILEGED_ACTIONS}")
+                if [[ -n "${POLICY_PRIVILEGE_ESCALATION_ACTIONS}" ]]; then
+                    textFail "${REGION}: ${POLICY_ARN} allows for privilige escalation using the following actions: ${POLICY_PRIVILEGE_ESCALATION_ACTIONS//$'\n'/ }" "$REGION" "${POLICY_NAME}"
+                else
+                    textPass "${REGION}: Custom Policy ${POLICY_ARN} not allows privilige escalation" "$REGION" "${POLICY_NAME}"
+                fi
+            done<<<"${LIST_CUSTOM_POLICIES}"
+        else
+            textPass "$REGION: No Customer Managed Policies attached found" "$REGION"
+        fi
+    fi
+}

--- a/checks/check_extra7181
+++ b/checks/check_extra7181
@@ -11,8 +11,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-
-
 CHECK_ID_extra7181="7.181"
 CHECK_TITLE_extra7181="[extra7181] Ensure IAM policies not allow for Privilege Escalation"
 CHECK_SCORED_extra7181="NOT_SCORED"
@@ -26,70 +24,66 @@ CHECK_REMEDIATION_extra7181='Grant usage permission on a per-resource basis and 
 CHECK_DOC_extra7181='https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccessKey.html'
 CHECK_CAF_EPIC_extra7181='IAM'
 
- # que pasa si la política tiene como resource una lista ["*"] --> se podria quitar esto Resource == '*'
-                    # Does the tool analyze both users and roles, or just one or the other? --> AttachmentCount
-                    # Does the tool take a principal-centric or policy-centric approach? --> misma revision para las inlines en otro check
-                    # Does the tool handle resource constraints?
-                    # Does the tool consider the permissions of service roles?
-                    # Does the tool handle transitive privesc paths (i.e., attack chains)?
+# Does the tool analyze both users and roles, or just one or the other? --> Everything using AttachementCount.
+# Does the tool take a principal-centric or policy-centric approach? --> Policy-centric approach.
+# Does the tool handle resource constraints? --> We don't check if the policy affects all resources or not, we check everything.
+# Does the tool consider the permissions of service roles? --> Just checks policies.
+# Does the tool handle transitive privesc paths (i.e., attack chains)? --> Not yet.
+# Does the tool handle the DENY effect as expected? --> Yes, it checks DENY's statements with Action and NotAction.
+# Does the tool handle NotAction as expected? --> Yes
+# Does the tool handle Condition constraints? --> Not yet.
+# Does the tool handle service control policy (SCP) restrictions? --> No, SCP are within Organizations AWS API.
 
-                    # Does the tool handle the DENY effect as expected?
-                    # Does the tool handle NotAction as expected?
-                    # Does the tool handle Condition constraints?
-                                        # Does the tool handle service control policy (SCP) restrictions? --> esto nada, es otro servicio
-
-
-                    # --query "PolicyVersion.Document.Statement[?(not_null(Action) && Effect == 'Allow' && Resource == '*')].Action[]" \
-                    # "PolicyVersion.Document.Statement[?(not_null(Action) && Effect == 'Allow')].Action[]"
 
 extra7181() {
-    # Incluir como un recurso consultable para la remediación y la doc
     local PRIVILEGE_ESCALATION_IAM_ACTIONS="iam:AddUserToGroup|iam:AttachRolePolicy|iam:AttachUserPolicy|iam:CreateAccessKey|iam:CreatePolicyVersion|iam:CreateLoginProfile|iam:PassRole|iam:PutGroupPolicy|iam:PutRolePolicy|iam:PutUserPolicy|iam:SetDefaultPolicyVersion|iam:UpdateAssumeRolePolicy|iam:UpdateLoginProfile|sts:AssumeRole|ec2:RunInstances|lambda:CreateEventSourceMapping|lambda:CreateFunction|lambda:InvokeFunction|lambda:UpdateFunctionCode|dynamodb:CreateTable|dynamodb:PutItem|glue:CreateDevEndpoint|glue:UpdateDevEndpoint|cloudformation:CreateStack|datapipeline:CreatePipeline"
 
-  # Use --scope Local to list only Customer Managed Policies
-  # Query AttachmentCount > 0  to check if this policy is in use, so attached to any user, group or role
+    # Use --scope Local to list only Customer Managed Policies
+    # Query 'Policies[?AttachmentCount > `0`]'  to check if this policy is in use, so attached to any user, group or role
     LIST_CUSTOM_POLICIES=$(${AWSCLI} iam list-policies ${PROFILE_OPT} \
     --region "${REGION}" \
     --scope Local \
     --query 'Policies[*].[Arn,DefaultVersionId]' \
     --output text)
-    # --query 'Policies[?AttachmentCount > `0`].[Arn,DefaultVersionId]' \
+
     # Check errors
     if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_CUSTOM_POLICIES}"; then
         textInfo "${REGION}: Access Denied trying to list IAM policies" "${REGION}"
     else
         if [[ $LIST_CUSTOM_POLICIES ]]; then
             while read -r POLICY_ARN POLICY_DEFAULT_VERSION; do
-                # POLICY_NAME="${POLICY_ARN///}"
                 POLICY_PRIVILEGED_ACTIONS=$($AWSCLI iam get-policy-version ${PROFILE_OPT} \
                     --output json \
                     --policy-arn "${POLICY_ARN}" \
                     --version-id "${POLICY_DEFAULT_VERSION}" \
                     --region "${REGION}" \
-                    --query "PolicyVersion.Document.Statement[?(not_null(Action) || not_null(NotAction))]" \
+                    --query "PolicyVersion.Document.Statement[]" \
                     --output json)
-                    # --query "PolicyVersion.Document.Statement[?(not_null(Action) && (Effect == 'Allow' && Effect == 'Deny'))].Action[]" \
-                    # --output json)
 
-                    # (not_null(Action) && (Effect == 'Allow' && Effect == 'Deny') no aplica ya
+                if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${POLICY_PRIVILEGED_ACTIONS}"; then
+                    textInfo "${REGION}: Access Denied trying to get policy version" "${REGION}"
+                    continue
+                fi
 
-                # que pasa si action es un objeto en vez de una lista
-                ACTIONS=$(jq -r '.[] | select(.Action != null) | .Action | .[]' <<< ${POLICY_PRIVILEGED_ACTIONS})
-                # echo $ACTIONS
-                NOT_ACTIONS=$(jq -r '.[] | select(.NotAction != null) | .NotAction | .[]' <<< ${POLICY_PRIVILEGED_ACTIONS})
-                # echo $NOT_ACTIONS
-                PRIVILEGED_ACTIONS=$(echo "${ACTIONS//'"'/} ${NOT_ACTIONS//'"'/}" | xargs -n1 | sort -u | xargs)
-                # echo $PRIVILEGED_ACTIONS
+                ALLOWED_ACTIONS=$(jq -r '.[] | select(."Effect" == "Allow") | .Action // empty' <<< "${POLICY_PRIVILEGED_ACTIONS}" | sed 's/\[//;s/\]//;s/,/ /;s/ //g;/^$/d')
+                DENIED_ACTIONS=$(jq -r '.[] | select(."Effect" == "Deny") | .Action // empty' <<< "${POLICY_PRIVILEGED_ACTIONS}" | sed 's/\[//;s/\]//;s/,/ /;s/ //g;/^$/d')
+                DENIED_NOT_ACTIONS=$(jq -r '.[] | select(."Effect" == "Deny") | .NotAction // empty' <<< "${POLICY_PRIVILEGED_ACTIONS}" | sed 's/\[//;s/\]//;s/,/ /;s/ //g;/^$/d')
 
+                # First, we need to perform a left join with ALLOWED_ACTIONS and DENIED_ACTIONS
+                LEFT_ACTIONS=$(diff <(echo "${ALLOWED_ACTIONS}") <(echo "${DENIED_ACTIONS}") | grep "^<" | sed 's/< //;s/"//g')
+                # I love (and hate) process substitution in bash
+                # Then, we need to find the DENIED_NOT_ACTIONS in LEFT_ACTIONS
+                PRIVILEGED_ACTIONS=$(comm -1 -2  <(sort <<< "${DENIED_NOT_ACTIONS}") <(sort <<< "${LEFT_ACTIONS}"))
+                # Finally, check if there is a privilege escalation action within this policy
                 POLICY_PRIVILEGE_ESCALATION_ACTIONS=$(grep -o -E "${PRIVILEGE_ESCALATION_IAM_ACTIONS}" <<< "${PRIVILEGED_ACTIONS}")
                 if [[ -n "${POLICY_PRIVILEGE_ESCALATION_ACTIONS}" ]]; then
-                    textFail "${REGION}: ${POLICY_ARN} allows for privilige escalation using the following actions: ${POLICY_PRIVILEGE_ESCALATION_ACTIONS//$'\n'/ }" "$REGION" "${POLICY_NAME}"
+                    textFail "${REGION}: Customer Managed Policy ${POLICY_ARN} allows for privilege escalation using the following actions: ${POLICY_PRIVILEGE_ESCALATION_ACTIONS//$'\n'/ }" "${REGION}" "${POLICY_NAME}"
                 else
-                    textPass "${REGION}: Custom Policy ${POLICY_ARN} not allows privilige escalation" "$REGION" "${POLICY_NAME}"
+                    textPass "${REGION}: Customer Managed Policy ${POLICY_ARN} not allows privilege escalation" "${REGION}" "${POLICY_NAME}"
                 fi
             done<<<"${LIST_CUSTOM_POLICIES}"
         else
-            textPass "$REGION: No Customer Managed Policies attached found" "$REGION"
+            textInfo "${REGION}: No Customer Managed Policies attached found" "${REGION}"
         fi
     fi
 }

--- a/checks/check_extra7181
+++ b/checks/check_extra7181
@@ -36,7 +36,7 @@ CHECK_CAF_EPIC_extra7181='IAM'
 
 
 extra7181() {
-    local PRIVILEGE_ESCALATION_IAM_ACTIONS="iam:AddUserToGroup|iam:AttachRolePolicy|iam:AttachUserPolicy|iam:CreateAccessKey|iam:CreatePolicyVersion|iam:CreateLoginProfile|iam:PassRole|iam:PutGroupPolicy|iam:PutRolePolicy|iam:PutUserPolicy|iam:SetDefaultPolicyVersion|iam:UpdateAssumeRolePolicy|iam:UpdateLoginProfile|sts:AssumeRole|ec2:RunInstances|lambda:CreateEventSourceMapping|lambda:CreateFunction|lambda:InvokeFunction|lambda:UpdateFunctionCode|dynamodb:CreateTable|dynamodb:PutItem|glue:CreateDevEndpoint|glue:UpdateDevEndpoint|cloudformation:CreateStack|datapipeline:CreatePipeline"
+    local PRIVILEGE_ESCALATION_IAM_ACTIONS="iam:AttachGroupPolicy|iam:SetDefaultPolicyVersion2|iam:AddUserToGroup|iam:AttachRolePolicy|iam:AttachUserPolicy|iam:CreateAccessKey|iam:CreatePolicyVersion|iam:CreateLoginProfile|iam:PassRole|iam:PutGroupPolicy|iam:PutRolePolicy|iam:PutUserPolicy|iam:SetDefaultPolicyVersion|iam:UpdateAssumeRolePolicy|iam:UpdateLoginProfile|sts:AssumeRole|ec2:RunInstances|lambda:CreateEventSourceMapping|lambda:CreateFunction|lambda:InvokeFunction|lambda:UpdateFunctionCode|dynamodb:CreateTable|dynamodb:PutItem|glue:CreateDevEndpoint|glue:GetDevEndpoint|glue:GetDevEndpoints|glue:UpdateDevEndpoint|cloudformation:CreateStack|cloudformation:DescribeStacks|datapipeline:CreatePipeline|datapipeline:PutPipelineDefinition|datapipeline:ActivatePipeline"
 
     # Use --scope Local to list only Customer Managed Policies
     # Query 'Policies[?AttachmentCount > `0`]'  to check if this policy is in use, so attached to any user, group or role

--- a/checks/check_extra7185
+++ b/checks/check_extra7185
@@ -71,7 +71,6 @@ extra7181() {
 
                 # First, we need to perform a left join with ALLOWED_ACTIONS and DENIED_ACTIONS
                 LEFT_ACTIONS=$(diff <(echo "${ALLOWED_ACTIONS}") <(echo "${DENIED_ACTIONS}") | grep "^<" | sed 's/< //;s/"//g')
-                # I love (and hate) process substitution in bash
                 # Then, we need to find the DENIED_NOT_ACTIONS in LEFT_ACTIONS
                 PRIVILEGED_ACTIONS=$(comm -1 -2  <(sort <<< "${DENIED_NOT_ACTIONS}") <(sort <<< "${LEFT_ACTIONS}"))
                 # Finally, check if there is a privilege escalation action within this policy

--- a/checks/check_extra7185
+++ b/checks/check_extra7185
@@ -12,7 +12,7 @@
 # specific language governing permissions and limitations under the License.
 
 CHECK_ID_extra7181="7.181"
-CHECK_TITLE_extra7181="[extra7181] Ensure IAM policies not allow for Privilege Escalation"
+CHECK_TITLE_extra7181="[extra7181] Ensure no custom IAM policies allow actions that may lead into Privilege Escalation"
 CHECK_SCORED_extra7181="NOT_SCORED"
 CHECK_CIS_LEVEL_extra7181="EXTRA"
 CHECK_SEVERITY_extra7181="Medium"

--- a/checks/check_extra7185
+++ b/checks/check_extra7185
@@ -41,7 +41,6 @@ extra7181() {
     # Use --scope Local to list only Customer Managed Policies
     # Query 'Policies[?AttachmentCount > `0`]'  to check if this policy is in use, so attached to any user, group or role
     LIST_CUSTOM_POLICIES=$(${AWSCLI} iam list-policies ${PROFILE_OPT} \
-    --region "${REGION}" \
     --scope Local \
     --query 'Policies[*].[Arn,DefaultVersionId]' \
     --output text)

--- a/checks/check_extra7185
+++ b/checks/check_extra7185
@@ -52,10 +52,8 @@ extra7181() {
         if [[ $LIST_CUSTOM_POLICIES ]]; then
             while read -r POLICY_ARN POLICY_DEFAULT_VERSION; do
                 POLICY_PRIVILEGED_ACTIONS=$($AWSCLI iam get-policy-version ${PROFILE_OPT} \
-                    --output json \
                     --policy-arn "${POLICY_ARN}" \
                     --version-id "${POLICY_DEFAULT_VERSION}" \
-                    --region "${REGION}" \
                     --query "PolicyVersion.Document.Statement[]" \
                     --output json)
 

--- a/checks/check_extra7185
+++ b/checks/check_extra7185
@@ -11,18 +11,18 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-CHECK_ID_extra7181="7.181"
-CHECK_TITLE_extra7181="[extra7181] Ensure no custom IAM policies allow actions that may lead into Privilege Escalation"
-CHECK_SCORED_extra7181="NOT_SCORED"
-CHECK_CIS_LEVEL_extra7181="EXTRA"
-CHECK_SEVERITY_extra7181="Medium"
-CHECK_ASFF_RESOURCE_TYPE_extra7181="AwsIamPolicy"
-CHECK_ALTERNATE_check7181="extra7181"
-CHECK_SERVICENAME_extra7181="iam"
-CHECK_RISK_extra7181='Users with some IAM permissions are allowed to elevate their privileges up to administrator rights.'
-CHECK_REMEDIATION_extra7181='Grant usage permission on a per-resource basis and applying least privilege principle.'
-CHECK_DOC_extra7181='https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccessKey.html'
-CHECK_CAF_EPIC_extra7181='IAM'
+CHECK_ID_extra7185="7.185"
+CHECK_TITLE_extra7185="[extra7185] Ensure no custom IAM policies allow actions that may lead into Privilege Escalation"
+CHECK_SCORED_extra7185="NOT_SCORED"
+CHECK_CIS_LEVEL_extra7185="EXTRA"
+CHECK_SEVERITY_extra7185="Medium"
+CHECK_ASFF_RESOURCE_TYPE_extra7185="AwsIamPolicy"
+CHECK_ALTERNATE_check7185="extra7185"
+CHECK_SERVICENAME_extra7185="iam"
+CHECK_RISK_extra7185='Users with some IAM permissions are allowed to elevate their privileges up to administrator rights.'
+CHECK_REMEDIATION_extra7185='Grant usage permission on a per-resource basis and applying least privilege principle.'
+CHECK_DOC_extra7185='https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccessKey.html'
+CHECK_CAF_EPIC_extra7185='IAM'
 
 # Does the tool analyze both users and roles, or just one or the other? --> Everything using AttachementCount.
 # Does the tool take a principal-centric or policy-centric approach? --> Policy-centric approach.
@@ -35,7 +35,7 @@ CHECK_CAF_EPIC_extra7181='IAM'
 # Does the tool handle service control policy (SCP) restrictions? --> No, SCP are within Organizations AWS API.
 
 
-extra7181() {
+extra7185() {
     local PRIVILEGE_ESCALATION_IAM_ACTIONS="iam:AttachGroupPolicy|iam:SetDefaultPolicyVersion2|iam:AddUserToGroup|iam:AttachRolePolicy|iam:AttachUserPolicy|iam:CreateAccessKey|iam:CreatePolicyVersion|iam:CreateLoginProfile|iam:PassRole|iam:PutGroupPolicy|iam:PutRolePolicy|iam:PutUserPolicy|iam:SetDefaultPolicyVersion|iam:UpdateAssumeRolePolicy|iam:UpdateLoginProfile|sts:AssumeRole|ec2:RunInstances|lambda:CreateEventSourceMapping|lambda:CreateFunction|lambda:InvokeFunction|lambda:UpdateFunctionCode|dynamodb:CreateTable|dynamodb:PutItem|glue:CreateDevEndpoint|glue:GetDevEndpoint|glue:GetDevEndpoints|glue:UpdateDevEndpoint|cloudformation:CreateStack|cloudformation:DescribeStacks|datapipeline:CreatePipeline|datapipeline:PutPipelineDefinition|datapipeline:ActivatePipeline"
 
     # Use --scope Local to list only Customer Managed Policies

--- a/checks/check_extra7185
+++ b/checks/check_extra7185
@@ -12,7 +12,7 @@
 # specific language governing permissions and limitations under the License.
 
 CHECK_ID_extra7185="7.185"
-CHECK_TITLE_extra7185="[extra7185] Ensure no custom IAM policies allow actions that may lead into Privilege Escalation"
+CHECK_TITLE_extra7185="[extra7185] Ensure no Customer Managed IAM policies allow actions that may lead into Privilege Escalation"
 CHECK_SCORED_extra7185="NOT_SCORED"
 CHECK_CIS_LEVEL_extra7185="EXTRA"
 CHECK_SEVERITY_extra7185="Medium"

--- a/checks/check_extra7185
+++ b/checks/check_extra7185
@@ -73,7 +73,7 @@ extra7185() {
                 # Finally, check if there is a privilege escalation action within this policy
                 POLICY_PRIVILEGE_ESCALATION_ACTIONS=$(grep -o -E "${PRIVILEGE_ESCALATION_IAM_ACTIONS}" <<< "${PRIVILEGED_ACTIONS}")
                 if [[ -n "${POLICY_PRIVILEGE_ESCALATION_ACTIONS}" ]]; then
-                    textFail "${REGION}: Customer Managed Policy ${POLICY_ARN} allows for privilege escalation using the following actions: ${POLICY_PRIVILEGE_ESCALATION_ACTIONS//$'\n'/ }" "${REGION}" "${POLICY_NAME}"
+                    textFail "${REGION}: Customer Managed IAM Policy ${POLICY_ARN} allows for privilege escalation using the following actions: ${POLICY_PRIVILEGE_ESCALATION_ACTIONS//$'\n'/ }" "${REGION}" "${POLICY_NAME}"
                 else
                     textPass "${REGION}: Customer Managed Policy ${POLICY_ARN} not allows privilege escalation" "${REGION}" "${POLICY_NAME}"
                 fi

--- a/checks/check_extra7185
+++ b/checks/check_extra7185
@@ -75,7 +75,7 @@ extra7185() {
                 if [[ -n "${POLICY_PRIVILEGE_ESCALATION_ACTIONS}" ]]; then
                     textFail "${REGION}: Customer Managed IAM Policy ${POLICY_ARN} allows for privilege escalation using the following actions: ${POLICY_PRIVILEGE_ESCALATION_ACTIONS//$'\n'/ }" "${REGION}" "${POLICY_NAME}"
                 else
-                    textPass "${REGION}: Customer Managed Policy ${POLICY_ARN} not allows privilege escalation" "${REGION}" "${POLICY_NAME}"
+                    textPass "${REGION}: Customer Managed IAM Policy ${POLICY_ARN} not allows for privilege escalation" "${REGION}" "${POLICY_NAME}"
                 fi
             done<<<"${LIST_CUSTOM_POLICIES}"
         else

--- a/checks/check_extra7185
+++ b/checks/check_extra7185
@@ -79,7 +79,7 @@ extra7185() {
                 fi
             done<<<"${LIST_CUSTOM_POLICIES}"
         else
-            textInfo "${REGION}: No Customer Managed Policies attached found" "${REGION}"
+            textInfo "${REGION}: No Customer Managed IAM policies found" "${REGION}"
         fi
     fi
 }


### PR DESCRIPTION
### Context 

We need a way to test if some IAM policies allows for privilege escalation.

Thanks to @skmr808 for his work on this IAM check

### Description

A new Prowler checks that reviews all Customer Managed IAM policies to check if contains a permissions that could allow for privilege execution.

The policies reviewed are the following:
iam:AttachGroupPolicy
- iam:SetDefaultPolicyVersion2
- iam:AddUserToGroup
- iam:AttachRolePolicy
- iam:AttachUserPolicy
- iam:CreateAccessKey
- iam:CreatePolicyVersion
- iam:CreateLoginProfile
- iam:PassRole
- iam:PutGroupPolicy
- iam:PutRolePolicy
- iam:PutUserPolicy
- iam:SetDefaultPolicyVersion
- iam:UpdateAssumeRolePolicy
- iam:UpdateLoginProfile
- sts:AssumeRole
- ec2:RunInstances
- lambda:CreateEventSourceMapping
- lambda:CreateFunction
- lambda:InvokeFunction
- lambda:UpdateFunctionCode
- dynamodb:CreateTable
- dynamodb:PutItem
- glue:CreateDevEndpoint
- glue:GetDevEndpoint
- glue:GetDevEndpoints
- glue:UpdateDevEndpoint
- cloudformation:CreateStack
- cloudformation:DescribeStacks
- datapipeline:CreatePipeline
- datapipeline:PutPipelineDefinition
- datapipeline:ActivatePipeline


Also, I've included `shellcheck` in `pre-commit`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
