### PR TITLE
fix(update_deprecate_runtimes): Deprecated runtimes for lambda were updated.

### DIFF
--- a/checks/check_extra762
+++ b/checks/check_extra762
@@ -27,7 +27,7 @@ extra762(){
 
   # regex to match OBSOLETE runtimes in string functionName%runtime
   # https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html
-  OBSOLETE='%(nodejs4.3|nodejs4.3-edge|nodejs6.10|nodejs8.10|dotnetcore1.0|dotnetcore2.0)'
+  OBSOLETE='%(nodejs4.3|nodejs4.3-edge|nodejs6.10|nodejs8.10|dotnetcore1.0|dotnetcore2.0|dotnetcore2.1|python3.6|python2.7|ruby2.5|nodejs10.x|nodejs)'
 
   for regx in $REGIONS; do
     LIST_OF_FUNCTIONS=$($AWSCLI lambda list-functions $PROFILE_OPT --region $regx --output text --query 'Functions[*].{R:Runtime,N:FunctionName}' 2>&1| tr "\t" "%" )


### PR DESCRIPTION
### Context 

Check extra762 does not have the whole list of deprecated runtimes like in here https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy

### Description

Update the variable OBSOLETE with all of them already deprecated (including python python3.6 that will on august).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
