### PR TITLE
fix(typo): Max session duration error message

### DIFF
--- a/include/assume_role
+++ b/include/assume_role
@@ -29,7 +29,7 @@ assume_role(){
     if [[ -z $SESSION_DURATION_TO_ASSUME ]]; then
         SESSION_DURATION_TO_ASSUME="3600"
     elif [[ "${SESSION_DURATION_TO_ASSUME}" -gt "43200" ]] || [[ "${SESSION_DURATION_TO_ASSUME}" -lt "900" ]]; then
-        echo "$OPTRED ERROR!$OPTNORMAL - Role session duration must be more than 900 seconds and less than 4300 seconds"
+        echo "$OPTRED ERROR!$OPTNORMAL - Role session duration must be more than 900 seconds and less than 43200 seconds"
         exit 1
     fi
 


### PR DESCRIPTION
### Context 

In assume_role library the error message says that maximum session duration is 4300 seconds instead of 43200, which is the right value.

### Description

Modify this error message with the right value.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
