### PR TITLE
fix(codebuild_update): AWS CLI and permissions update.

### DIFF
--- a/include/securityhub_integration
+++ b/include/securityhub_integration
@@ -93,11 +93,11 @@ sendToSecurityHub(){
 
   local finding_id=$(echo ${findings} | jq -r .Id )
   SECURITYHUB_NEW_FINDINGS_IDS+=( "$finding_id" )
-  BATCH_IMPORT_RESULT=$($AWSCLI securityhub --region "$region" $PROFILE_OPT batch-import-findings --findings "${findings}")
+  BATCH_IMPORT_RESULT=$($AWSCLI securityhub --region "$region" $PROFILE_OPT batch-import-findings --findings "${findings}" 2>&1)
   
   # Check for success if imported
   if [[ -z "${BATCH_IMPORT_RESULT}" ]] || ! jq -e '.SuccessCount == 1' <<< "${BATCH_IMPORT_RESULT}" > /dev/null 2>&1; then
-    echo -e "\n$RED ERROR!$NORMAL Failed to send check output to AWS Security Hub\n"
+    echo "${BAD} ERROR! Failed to send check output to AWS Security Hub.${NORMAL}"
   fi
 
 }

--- a/util/codebuild/codebuild-prowler-audit-account-cfn.yaml
+++ b/util/codebuild/codebuild-prowler-audit-account-cfn.yaml
@@ -243,7 +243,7 @@ Resources:
             Statement:
               - Action: securityhub:BatchImportFindings
                 Effect: Allow
-                Resource: !Sub 'arn:${AWS::Partition}:securityhub:${AWS::Region}::product/prowler/prowler'
+                Resource: !Sub 'arn:${AWS::Partition}:securityhub:*::product/prowler/prowler'
 
   CodeBuildLogPolicy:
     Type: AWS::IAM::Policy
@@ -298,6 +298,12 @@ Resources:
               commands:
                 - echo "Installing Prowler and dependencies..."
                 - pip3 install detect-secrets 
+                # uninstall awscli version 1
+                - pip3 uninstall -y awscli
+                # install awscli version 2
+                - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+                - unzip awscliv2.zip
+                - ./aws/install
             build:
               commands:
                 - echo "Running Prowler as ./prowler $PROWLER_OPTIONS"


### PR DESCRIPTION
### Context 

Regarding [Issue 1182](https://github.com/prowler-cloud/prowler/issues/1182), codebuild execution exits with errors.

### Description

To avoid this, this PR has the following changes:

- Handle AccessDenied error when sending findings to Security Hub.
- Force installation of AWS CLI v2.
- Solve IAM permission for allowing Codebuild to send findings to all regions.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
