### PR TITLE
feat(codebuild_timeout): Increase codebuild timeout to maximum.

### DIFF
--- a/util/codebuild/codebuild-prowler-audit-account-cfn.yaml
+++ b/util/codebuild/codebuild-prowler-audit-account-cfn.yaml
@@ -337,7 +337,7 @@ Resources:
             Type: PLAINTEXT
       Description: Run Prowler assessment
       ServiceRole: !GetAtt CodeBuildServiceRole.Arn
-      TimeoutInMinutes: 300
+      TimeoutInMinutes: 480
 
   ProwlerLogGroup:
     Type: 'AWS::Logs::LogGroup'


### PR DESCRIPTION
### Context 

To prevent timeout in Codebuild like in https://github.com/prowler-cloud/prowler/issues/1182, we have increment the timeout to the maximum that is 8 hours.

### Description

Change TimeoutInMinutes of Codebuild build to 480 minutes (8 hours).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
