### PR TITLE
fix(session_duration): Use jq with TZ=UTC

### DIFF
--- a/include/assume_role
+++ b/include/assume_role
@@ -18,7 +18,7 @@ assume_role(){
         # If profile is not defined, restore original credentials from environment variables, if they exists!
         restoreInitialAWSCredentials
     fi
-    
+
     # Both variables are mandatory to be set together
     if [[ -z $ROLE_TO_ASSUME || -z $ACCOUNT_TO_ASSUME ]]; then
         echo "$OPTRED ERROR!$OPTNORMAL - Both Account ID (-A) and IAM Role to assume (-R) must be set"
@@ -62,12 +62,12 @@ assume_role(){
         EXITCODE=1
         exit $EXITCODE
     fi
-    
+
     # echo FILE WITH TEMP CREDS: $TEMP_STS_ASSUMED_FILE
-    
+
     # The profile shouldn't be used for CLI
     PROFILE=""
-    PROFILE_OPT=""   
+    PROFILE_OPT=""
 
     # Set AWS environment variables with assumed role credentials
     ASSUME_AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' "${TEMP_STS_ASSUMED_FILE}")
@@ -76,7 +76,7 @@ assume_role(){
     export AWS_SECRET_ACCESS_KEY=$ASSUME_AWS_SECRET_ACCESS_KEY
     ASSUME_AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken'  "${TEMP_STS_ASSUMED_FILE}")
     export AWS_SESSION_TOKEN=$ASSUME_AWS_SESSION_TOKEN
-    ASSUME_AWS_SESSION_EXPIRATION=$(convert_date_to_timestamp "$(jq -r '.Credentials.Expiration' "${TEMP_STS_ASSUMED_FILE}")")
+    ASSUME_AWS_SESSION_EXPIRATION=$(jq -r '.Credentials.Expiration | sub("\\+00:00";"Z") | fromdateiso8601'  "${TEMP_STS_ASSUMED_FILE}")
     export AWS_SESSION_EXPIRATION=$ASSUME_AWS_SESSION_EXPIRATION
 
     cleanSTSAssumeFile
@@ -88,11 +88,11 @@ cleanSTSAssumeFile() {
 }
 
 backupInitialAWSCredentials() {
-    if [[ $(printenv AWS_ACCESS_KEY_ID) && $(printenv AWS_SECRET_ACCESS_KEY) && $(printenv AWS_SESSION_TOKEN) ]]; then 
+    if [[ $(printenv AWS_ACCESS_KEY_ID) && $(printenv AWS_SECRET_ACCESS_KEY) && $(printenv AWS_SESSION_TOKEN) ]]; then
         INITIAL_AWS_ACCESS_KEY_ID=$(printenv AWS_ACCESS_KEY_ID)
         INITIAL_AWS_SECRET_ACCESS_KEY=$(printenv AWS_SECRET_ACCESS_KEY)
         INITIAL_AWS_SESSION_TOKEN=$(printenv AWS_SESSION_TOKEN)
-    fi    
+    fi
 }
 
 restoreInitialAWSCredentials() {

--- a/include/default_variables
+++ b/include/default_variables
@@ -29,6 +29,8 @@ MODE="text"
 SEND_TO_SECURITY_HUB=0
 
 # Date & Time
+TZ=UTC
+export TZ
 PROWLER_START_TIME=$( date -u +"%Y-%m-%dT%H:%M:%S%z" )
 OUTPUT_DATE=$(date -u +"%Y%m%d%H%M%S")
 

--- a/include/execute_check
+++ b/include/execute_check
@@ -21,10 +21,9 @@ execute_check() {
     # Following logic looks for time remaining in the session and review it
     # if it is less than 600 seconds, 10 minutes.
     CURRENT_TIMESTAMP=$(date -u "+%s")
-    SESSION_TIME_REMAINING=$(expr $AWS_SESSION_EXPIRATION - $CURRENT_TIMESTAMP)
-    # echo SESSION TIME REMAINING IN SECONDS: $SESSION_TIME_REMAINING
+    SESSION_TIME_REMAINING=$(("${AWS_SESSION_EXPIRATION}" - "${CURRENT_TIMESTAMP}"))
     MINIMUM_REMAINING_TIME_ALLOWED=600
-    if (( $MINIMUM_REMAINING_TIME_ALLOWED > $SESSION_TIME_REMAINING )); then
+    if (( "${MINIMUM_REMAINING_TIME_ALLOWED}" > "${SESSION_TIME_REMAINING}" )); then
       # echo LESS THAN 10 MIN LEFT: RE-ASSUMING...
       unset AWS_ACCESS_KEY_ID
       unset AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
### Context 

We have been experiencing some issues with `jq` and different timezones due to how `jq` handles UTC and local time zones.

### Description

This PR aims to fix this behaviour in every system using `jq` with the timezone environment variable set to UTC `TZ=UTC`

Fix https://github.com/prowler-cloud/prowler/issues/1186

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
