### PR TITLE
Remove false positive for check_extra767

### DIFF
--- a/checks/check_extra767
+++ b/checks/check_extra767
@@ -24,22 +24,22 @@ CHECK_DOC_extra767='https://docs.aws.amazon.com/AmazonCloudFront/latest/Develope
 CHECK_CAF_EPIC_extra767='Data Protection'
 
 extra767(){
-    LIST_OF_DISTRIBUTIONS=$($AWSCLI cloudfront list-distributions --query 'DistributionList.Items[*].Id' $PROFILE_OPT --output text|grep -v ^None)
+    LIST_OF_DISTRIBUTIONS=$($AWSCLI cloudfront list-distributions --query 'DistributionList.Items[*].Id' ${PROFILE_OPT} --output text | grep -v ^None)
     if [[ $LIST_OF_DISTRIBUTIONS ]];then
-      for dist in $LIST_OF_DISTRIBUTIONS; do
-        CHECK_ALLOWED_METHODS=$($AWSCLI cloudfront get-distribution --id $dist --query Distribution.DistributionConfig.DefaultCacheBehavior.DefaultCacheBehavior.AllowedMethods.Items $PROFILE_OPT --output text)
-        if [[ "$CHECK_ALLOWED_METHODS" == *"POST"* ]]; then
-            CHECK_FLE=$($AWSCLI cloudfront get-distribution --id $dist --query Distribution.DistributionConfig.DefaultCacheBehavior.FieldLevelEncryptionId $PROFILE_OPT --output text)
-            if [[ $CHECK_FLE ]]; then
-                textPass "CloudFront distribution $dist has Field Level Encryption enabled" "$regx" "$dist"
+      for distribution in $LIST_OF_DISTRIBUTIONS; do
+        CHECK_ALLOWED_METHODS=$($AWSCLI cloudfront get-distribution --id "${distribution}" --query Distribution.DistributionConfig.DefaultCacheBehavior.AllowedMethods.Items ${PROFILE_OPT} --output text)
+        if [[ "$CHECK_ALLOWED_METHODS" =~ "POST" ]]; then
+            CHECK_FIELD_LEVEL_ENCRYPTION=$($AWSCLI cloudfront get-distribution --id "${distribution}" --query Distribution.DistributionConfig.DefaultCacheBehavior.FieldLevelEncryptionId ${PROFILE_OPT} --output text)
+            if [[ $CHECK_FIELD_LEVEL_ENCRYPTION ]]; then
+                textPass "CloudFront distribution ${distribution} has Field Level Encryption enabled" "${REGION}" "${distribution}"
             else
-                textFail "CloudFront distribution $dist has Field Level Encryption disabled!" "$regx" "$dist"
+                textFail "CloudFront distribution ${distribution} has Field Level Encryption disabled!" "${REGION}" "${distribution}"
             fi
         else
-            textInfo "CloudFront distribution $dist does not support POST requests"
+            textInfo "CloudFront distribution ${distribution} does not support POST requests"
         fi
       done
     else
-      textInfo "No CloudFront distributions found" "$regx"
+      textInfo "No CloudFront distributions found" "${REGION}"
     fi
 }

--- a/checks/check_extra767
+++ b/checks/check_extra767
@@ -24,12 +24,26 @@ CHECK_DOC_extra767='https://docs.aws.amazon.com/AmazonCloudFront/latest/Develope
 CHECK_CAF_EPIC_extra767='Data Protection'
 
 extra767(){
-    LIST_OF_DISTRIBUTIONS=$($AWSCLI cloudfront list-distributions --query 'DistributionList.Items[*].Id' ${PROFILE_OPT} --output text | grep -v ^None)
+    LIST_OF_DISTRIBUTIONS=$("${AWSCLI}" cloudfront list-distributions --query 'DistributionList.Items[*].Id' ${PROFILE_OPT} --output text | grep -v ^None)
+    if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "$LIST_OF_BUCKETS"; then
+        textInfo "${REGION}: Access Denied Trying to list CloudFront distributions" "${REGION}"
+        exit
+    fi
     if [[ $LIST_OF_DISTRIBUTIONS ]];then
       for distribution in $LIST_OF_DISTRIBUTIONS; do
-        CHECK_ALLOWED_METHODS=$($AWSCLI cloudfront get-distribution --id "${distribution}" --query Distribution.DistributionConfig.DefaultCacheBehavior.AllowedMethods.Items ${PROFILE_OPT} --output text)
+        CHECK_ALLOWED_METHODS=$("${AWSCLI}" cloudfront get-distribution --id "${distribution}" --query Distribution.DistributionConfig.DefaultCacheBehavior.AllowedMethods.Items ${PROFILE_OPT} --output text)
+        if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${CHECK_ALLOWED_METHODS}"; then
+            textInfo "${REGION}: Access Denied Trying to get CloudFront distributions" "${REGION}"
+            continue
+        fi
+        
         if [[ "$CHECK_ALLOWED_METHODS" =~ "POST" ]]; then
-            CHECK_FIELD_LEVEL_ENCRYPTION=$($AWSCLI cloudfront get-distribution --id "${distribution}" --query Distribution.DistributionConfig.DefaultCacheBehavior.FieldLevelEncryptionId ${PROFILE_OPT} --output text)
+            CHECK_FIELD_LEVEL_ENCRYPTION=$("${AWSCLI}" cloudfront get-distribution --id "${distribution}" --query Distribution.DistributionConfig.DefaultCacheBehavior.FieldLevelEncryptionId ${PROFILE_OPT} --output text)
+            if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${CHECK_ALLOWED_METHODS}"; then
+                textInfo "${REGION}: Access Denied Trying to get CloudFront distributions" "${REGION}"
+                continue
+            fi
+            
             if [[ $CHECK_FIELD_LEVEL_ENCRYPTION ]]; then
                 textPass "CloudFront distribution ${distribution} has Field Level Encryption enabled" "${REGION}" "${distribution}"
             else

--- a/checks/check_extra767
+++ b/checks/check_extra767
@@ -25,7 +25,7 @@ CHECK_CAF_EPIC_extra767='Data Protection'
 
 extra767(){
     LIST_OF_DISTRIBUTIONS=$("${AWSCLI}" cloudfront list-distributions --query 'DistributionList.Items[*].Id' ${PROFILE_OPT} --output text | grep -v ^None)
-    if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "$LIST_OF_BUCKETS"; then
+    if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_OF_DISTRIBUTIONS}"; then
         textInfo "${REGION}: Access Denied Trying to list CloudFront distributions" "${REGION}"
         exit
     fi
@@ -39,7 +39,7 @@ extra767(){
         
         if [[ "$CHECK_ALLOWED_METHODS" =~ "POST" ]]; then
             CHECK_FIELD_LEVEL_ENCRYPTION=$("${AWSCLI}" cloudfront get-distribution --id "${distribution}" --query Distribution.DistributionConfig.DefaultCacheBehavior.FieldLevelEncryptionId ${PROFILE_OPT} --output text)
-            if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${CHECK_ALLOWED_METHODS}"; then
+            if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${CHECK_FIELD_LEVEL_ENCRYPTION}"; then
                 textInfo "${REGION}: Access Denied Trying to get CloudFront distributions" "${REGION}"
                 continue
             fi

--- a/checks/check_extra767
+++ b/checks/check_extra767
@@ -27,11 +27,16 @@ extra767(){
     LIST_OF_DISTRIBUTIONS=$($AWSCLI cloudfront list-distributions --query 'DistributionList.Items[*].Id' $PROFILE_OPT --output text|grep -v ^None)
     if [[ $LIST_OF_DISTRIBUTIONS ]];then
       for dist in $LIST_OF_DISTRIBUTIONS; do
-        CHECK_FLE=$($AWSCLI cloudfront get-distribution --id $dist --query Distribution.DistributionConfig.DefaultCacheBehavior.FieldLevelEncryptionId $PROFILE_OPT --output text)
-        if [[ $CHECK_FLE ]]; then
-          textPass "CloudFront distribution $dist has Field Level Encryption enabled" "$regx" "$dist"
+        CHECK_ALLOWED_METHODS=$($AWSCLI cloudfront get-distribution --id $dist --query Distribution.DistributionConfig.DefaultCacheBehavior.DefaultCacheBehavior.AllowedMethods.Items $PROFILE_OPT --output text)
+        if [[ "$CHECK_ALLOWED_METHODS" == *"POST"* ]]; then
+            CHECK_FLE=$($AWSCLI cloudfront get-distribution --id $dist --query Distribution.DistributionConfig.DefaultCacheBehavior.FieldLevelEncryptionId $PROFILE_OPT --output text)
+            if [[ $CHECK_FLE ]]; then
+                textPass "CloudFront distribution $dist has Field Level Encryption enabled" "$regx" "$dist"
+            else
+                textFail "CloudFront distribution $dist has Field Level Encryption disabled!" "$regx" "$dist"
+            fi
         else
-          textFail "CloudFront distribution $dist has Field Level Encryption disabled!" "$regx" "$dist"
+            textInfo "CloudFront distribution $dist does not support POST requests"
         fi
       done
     else

--- a/checks/check_extra767
+++ b/checks/check_extra767
@@ -36,10 +36,10 @@ extra767(){
                 textFail "CloudFront distribution ${distribution} has Field Level Encryption disabled!" "${REGION}" "${distribution}"
             fi
         else
-            textInfo "CloudFront distribution ${distribution} does not support POST requests"
+            textPass "CloudFront distribution ${distribution} does not support POST requests"
         fi
       done
     else
-      textInfo "No CloudFront distributions found" "${REGION}"
+      textPass "No CloudFront distributions found" "${REGION}"
     fi
 }


### PR DESCRIPTION
Exclude distributions that does not support `POST` requests
From AWS documentation: 
"Field-level encryption configurations help you protect specific data that viewers upload in `POST` requests."

And we cannot enable field-level encryption if the distribution does not support `POST` method