### PR TITLE
fix(junit_xml output): Fix xml output integration.

### DIFF
--- a/include/execute_check
+++ b/include/execute_check
@@ -84,12 +84,12 @@ execute_check() {
       fi
     fi
     show_check_title ${alternate_name}
-    if is_junit_output_enabled; then
+    if [[ " ${MODE} " =~ "junit-xml" ]]; then
       prepare_junit_check_output "$1"
     fi
     # Execute the check
     IGNORES="${ignores}" CHECK_NAME="$1" ${alternate_name}
-    if is_junit_output_enabled; then
+    if [[ " ${MODE} " =~ "junit-xml" ]]; then
       finalise_junit_check_output "$1"
     fi
 
@@ -108,13 +108,13 @@ execute_check() {
         fi
       fi
       show_check_title "$1"
-      if is_junit_output_enabled; then
+      if [[ " ${MODE} " =~ "junit-xml" ]]; then
         prepare_junit_check_output "$1"
       fi
       # Execute the check
       IGNORES="${ignores}" CHECK_NAME="$1" $1
 
-      if is_junit_output_enabled; then
+      if [[ " ${MODE} " =~ "junit-xml" ]]; then
         finalise_junit_check_output "$1"
       fi
 

--- a/include/junit_integration
+++ b/include/junit_integration
@@ -20,14 +20,6 @@ JUNIT_FAILURES_COUNT="0"
 JUNIT_SKIPPED_COUNT="0"
 JUNIT_ERRORS_COUNT="0"
 
-is_junit_output_enabled() {
-  if [[ " ${MODE} " =~ "junit-xml" ]]; then
-    true
-  else
-    false
-  fi
-}
-
 xml_escape() {
   sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/\"/\&quot;/g; s/'"'"'/\&#39;/g' <<< "$1"
 }

--- a/include/outputs
+++ b/include/outputs
@@ -170,7 +170,7 @@ general_output() {
         if [[ "${SEND_TO_SECURITY_HUB}" -eq 1 ]]; then
             sendToSecurityHub "${JSON_ASFF_OUTPUT}" "${REGION_FROM_CHECK}"
         fi
-    elif is_junit_output_enabled
+    elif [[ "${MODE_TYPE}" == "junit-xml" ]]
     then
         if [ "${CHECK_RESULT}" == 'PASS' ]
         then

--- a/include/validate_options
+++ b/include/validate_options
@@ -96,7 +96,7 @@ validate_assume_role() {
 
 # JUnit output if -M junit-xml
 validate_junit_output() {
-    if is_junit_output_enabled
+    if [[ " ${MODE} " =~ "junit-xml" ]];
     then
         prepare_junit_output
     fi

--- a/prowler
+++ b/prowler
@@ -329,6 +329,7 @@ validate_custom_checks
 
 # Add headers to certain output files
 output_files_init
+validate_junit_output
 
 # Execute checks
 for CHECK in "${TOTAL_CHECKS[@]}"


### PR DESCRIPTION
### Context 

According to [Issue#1182](https://github.com/prowler-cloud/prowler/issues/1182), junit xml integration was not working.


### Description

This error was solved by removing is_junit_output_enabled function.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
