### PR TITLE
fix(quit): Replace with `sys.exit()`

### DIFF
--- a/lib/check/models.py
+++ b/lib/check/models.py
@@ -1,3 +1,4 @@
+import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List
@@ -30,7 +31,7 @@ def load_check_metadata(metadata_file: str) -> dict:
         check_metadata = Check_Metadata_Model.parse_file(metadata_file)
     except ValidationError as error:
         logger.critical(f"Metadata from {metadata_file} is not valid: {error}")
-        quit()
+        sys.exit()
     else:
         return check_metadata
 

--- a/lib/utils/utils.py
+++ b/lib/utils/utils.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from io import TextIOWrapper
 from typing import Any
 
@@ -11,7 +12,7 @@ def open_file(input_file: str) -> TextIOWrapper:
         f = open(input_file)
     except Exception as e:
         logger.critical(f"{input_file}: {e.__class__.__name__}")
-        quit()
+        sys.exit()
     else:
         return f
 
@@ -22,6 +23,6 @@ def parse_json_file(input_file: TextIOWrapper) -> Any:
         json_file = json.load(input_file)
     except Exception as e:
         logger.critical(f"{input_file.name}: {e.__class__.__name__}")
-        quit()
+        sys.exit()
     else:
         return json_file

--- a/providers/aws/aws_provider.py
+++ b/providers/aws/aws_provider.py
@@ -1,3 +1,5 @@
+import sys
+
 from arnparse import arnparse
 from boto3 import session
 from botocore.credentials import RefreshableCredentials
@@ -49,7 +51,7 @@ class AWS_Provider:
                 return session.Session(profile_name=audit_info.profile)
         except Exception as error:
             logger.critical(f"{error.__class__.__name__} -- {error}")
-            quit()
+            sys.exit()
 
     # Refresh credentials method using assume role
     # This method is called "adding ()" to the name, so it cannot accept arguments
@@ -119,7 +121,7 @@ def provider_set_session(
 
         except Exception as error:
             logger.critical(f"{error.__class__.__name__} -- {error}")
-            quit()
+            sys.exit()
 
         else:
             logger.info(
@@ -155,7 +157,7 @@ def validate_credentials(validate_session):
         caller_identity = validate_credentials_client.get_caller_identity()
     except Exception as error:
         logger.critical(f"{error.__class__.__name__} -- {error}")
-        quit()
+        sys.exit()
     else:
         return caller_identity
 
@@ -182,7 +184,7 @@ def assume_role():
             )
     except Exception as error:
         logger.critical(f"{error.__class__.__name__} -- {error}")
-        quit()
+        sys.exit()
 
     else:
         return assumed_credentials

--- a/providers/aws/services/iam/iam_service.py
+++ b/providers/aws/services/iam/iam_service.py
@@ -1,3 +1,5 @@
+import sys
+
 from lib.logger import logger
 from providers.aws.aws_provider import current_audit_info
 
@@ -92,4 +94,4 @@ try:
     iam_client = IAM(current_audit_info)
 except Exception as error:
     logger.critical(f"{error.__class__.__name__} -- {error}")
-    quit()
+    sys.exit()

--- a/prowler
+++ b/prowler
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import sys
 
 from colorama import Fore, Style
 
@@ -109,22 +110,22 @@ if __name__ == "__main__":
     # Role assumption input options tests
     if args.session_duration not in range(900, 43200):
         logger.critical("Value for -T option must be between 900 and 43200")
-        quit()
+        sys.exit()
     if args.session_duration != 3600 or args.external_id:
         if not args.role:
             logger.critical("To use -I/-T options -R option is needed")
-            quit()
+            sys.exit()
 
     if args.version:
         print_version()
-        quit()
+        sys.exit()
 
     if args.no_banner:
         print_banner()
 
     if args.list_groups:
         list_groups(provider)
-        quit()
+        sys.exit()
 
     # Load checks metadata
     logger.debug("Loading checks metadata from .metadata.json files")
@@ -161,11 +162,11 @@ if __name__ == "__main__":
                 logger.error(
                     f"Check {error} was not found for the {provider.upper()} provider"
                 )
-        quit()
+        sys.exit()
 
     # Setting output options
     set_output_options(args.quiet)
-    
+
     # Set global session
     provider_set_session(
         args.profile,
@@ -174,7 +175,6 @@ if __name__ == "__main__":
         args.external_id,
         args.filter_region,
     )
-    
 
     # Execute checks
     if len(checks_to_execute):


### PR DESCRIPTION
### Context 

We must not use `quit()` in a production environment. 

Rationale: https://stackoverflow.com/questions/19747371/python-exit-commands-why-so-many-and-when-should-each-be-used


### Description

- Replace `quit()` with `sys.exit()`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
