### PR TITLE
feat(default_regions): Set profile region as default for global regions.

### DIFF
--- a/providers/aws/aws_provider.py
+++ b/providers/aws/aws_provider.py
@@ -39,7 +39,9 @@ class AWS_Provider:
                 # Here we need the botocore session since it needs to use refreshable credentials
                 assumed_botocore_session = get_session()
                 assumed_botocore_session._credentials = assumed_refreshable_credentials
-                assumed_botocore_session.set_config_variable("region", "us-east-1")
+                assumed_botocore_session.set_config_variable(
+                    "region", audit_info.profile_region
+                )
 
                 return session.Session(
                     profile_name=audit_info.profile,
@@ -89,6 +91,7 @@ def provider_set_session(
         audited_account=None,
         audited_partition=None,
         profile=input_profile,
+        profile_region=None,
         credentials=None,
         assumed_role_info=AWS_Assume_Role(
             role_arn=input_role,
@@ -149,6 +152,12 @@ def provider_set_session(
     else:
         logger.info("Audit session is the original one")
         current_audit_info.audit_session = current_audit_info.original_session
+
+    # Setting default region of session
+    if current_audit_info.audit_session.region_name:
+        current_audit_info.profile_region = current_audit_info.audit_session.region_name
+    else:
+        current_audit_info.profile_region = "us-east-1"
 
 
 def validate_credentials(validate_session):

--- a/providers/aws/models.py
+++ b/providers/aws/models.py
@@ -26,6 +26,7 @@ class AWS_Audit_Info:
     audited_account: int
     audited_partition: str
     profile: str
+    profile_region: str
     credentials: AWS_Credentials
     assumed_role_info: AWS_Assume_Role
     audited_regions: list

--- a/providers/aws/services/ec2/ec2_service.py
+++ b/providers/aws/services/ec2/ec2_service.py
@@ -69,7 +69,9 @@ class EC2:
                 for snapshot in page["Snapshots"]:
                     snapshots.append(snapshot)
         except Exception as error:
-            logger.error(f"{error.__class__.__name__} -- {error}")
+            logger.error(
+                f"{regional_client.region} -- {error.__class__.__name__}: {error}"
+            )
         else:
             regional_client.snapshots = snapshots
 

--- a/providers/aws/services/iam/iam_disable_30_days_credentials/iam_disable_30_days_credentials.py
+++ b/providers/aws/services/iam/iam_disable_30_days_credentials/iam_disable_30_days_credentials.py
@@ -23,17 +23,17 @@ class iam_disable_30_days_credentials(Check):
                         if time_since_insertion.days > maximum_expiration_days:
                             report.status = "FAIL"
                             report.result_extended = f"User {user['UserName']} has not logged into the console in the past 30 days"
-                            report.region = "us-east-1"
+                            report.region = iam_client.region
                         else:
                             report.status = "PASS"
                             report.result_extended = f"User {user['UserName']} has logged into the console in the past 30 days"
-                            report.region = "us-east-1"
+                            report.region = iam_client.region
                     except KeyError:
                         pass
                 else:
                     report.status = "PASS"
                     report.result_extended = f"User {user['UserName']} has not a console password or is unused."
-                    report.region = "us-east-1"
+                    report.region = iam_client.region
 
                 # Append report
                 findings.append(report)
@@ -41,7 +41,7 @@ class iam_disable_30_days_credentials(Check):
             report = Check_Report()
             report.status = "PASS"
             report.result_extended = "There is no IAM users"
-            report.region = "us-east-1"
+            report.region = iam_client.region
             findings.append(report)
 
         return findings

--- a/providers/aws/services/iam/iam_disable_90_days_credentials/iam_disable_90_days_credentials.py
+++ b/providers/aws/services/iam/iam_disable_90_days_credentials/iam_disable_90_days_credentials.py
@@ -23,17 +23,17 @@ class iam_disable_90_days_credentials(Check):
                         if time_since_insertion.days > maximum_expiration_days:
                             report.status = "FAIL"
                             report.result_extended = f"User {user['UserName']} has not logged into the console in the past 90 days"
-                            report.region = "us-east-1"
+                            report.region = iam_client.region
                         else:
                             report.status = "PASS"
                             report.result_extended = f"User {user['UserName']} has logged into the console in the past 90 days"
-                            report.region = "us-east-1"
+                            report.region = iam_client.region
                     except KeyError:
                         pass
                 else:
                     report.status = "PASS"
                     report.result_extended = f"User {user['UserName']} has not a console password or is unused."
-                    report.region = "us-east-1"
+                    report.region = iam_client.region
 
                 # Append report
                 findings.append(report)
@@ -41,6 +41,6 @@ class iam_disable_90_days_credentials(Check):
             report = Check_Report()
             report.status = "PASS"
             report.result_extended = "There is no IAM users"
-            report.region = "us-east-1"
+            report.region = iam_client.region
 
         return findings

--- a/providers/aws/services/iam/iam_service.py
+++ b/providers/aws/services/iam/iam_service.py
@@ -10,6 +10,7 @@ class IAM:
         self.service = "iam"
         self.session = audit_info.audit_session
         self.client = self.session.client(self.service)
+        self.region = audit_info.profile_region
         self.users = self.__get_users__()
         self.roles = self.__get_roles__()
         self.customer_managed_policies = self.__get_customer_managed_policies__()
@@ -26,7 +27,7 @@ class IAM:
         try:
             get_roles_paginator = self.client.get_paginator("list_roles")
         except Exception as error:
-            logger.error(f"{error.__class__.__name__} -- {error}")
+            logger.error(f"{self.region} -- {error.__class__.__name__}: {error}")
         else:
             roles = []
             for page in get_roles_paginator.paginate():
@@ -41,7 +42,7 @@ class IAM:
             try:
                 report_status = self.client.generate_credential_report()
             except Exception as error:
-                logger.error(f"{error.__class__.__name__} -- {error}")
+                logger.error(f"{self.region} -- {error.__class__.__name__}: {error}")
             else:
                 if report_status["State"] == "COMPLETE":
                     report_is_completed = True
@@ -52,7 +53,7 @@ class IAM:
         try:
             get_groups_paginator = self.client.get_paginator("list_groups")
         except Exception as error:
-            logger.error(f"{error.__class__.__name__} -- {error}")
+            logger.error(f"{self.region} -- {error.__class__.__name__}: {error}")
         else:
             groups = []
             for page in get_groups_paginator.paginate():
@@ -67,7 +68,7 @@ class IAM:
                 "list_policies"
             )
         except Exception as error:
-            logger.error(f"{error.__class__.__name__} -- {error}")
+            logger.error(f"{self.region} -- {error.__class__.__name__}: {error}")
         else:
             customer_managed_policies = []
             for page in get_customer_managed_policies_paginator.paginate(Scope="Local"):
@@ -80,7 +81,7 @@ class IAM:
         try:
             get_users_paginator = self.client.get_paginator("list_users")
         except Exception as error:
-            logger.error(f"{error.__class__.__name__} -- {error}")
+            logger.error(f"{self.region} -- {error.__class__.__name__}: {error}")
         else:
             users = []
             for page in get_users_paginator.paginate():
@@ -93,5 +94,5 @@ class IAM:
 try:
     iam_client = IAM(current_audit_info)
 except Exception as error:
-    logger.critical(f"{error.__class__.__name__} -- {error}")
+    logger.critical(f"{error.__class__.__name__} --  {error}")
     sys.exit()


### PR DESCRIPTION
### Context 

For global services such as IAM, set the region to the default one within the user's profile, instead of hard coding us-east-1.

### Description

- Set region of global services to profile region.
- Add region names to logging.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
