### PR TITLE
fix(extra7162): Query AWS log groups using LOG_GROUP_RETENTION_PERIOD_DAYS

### DIFF
--- a/checks/check_extra7162
+++ b/checks/check_extra7162
@@ -25,30 +25,38 @@ CHECK_CAF_EPIC_extra7162='Data Retention'
 
 extra7162() {
     # "Check if CloudWatch Log Groups have a retention policy of 365 days"
-    declare -i LOG_GROUP_RETENTION_PERIOD_DAYS=365
-    for regx in $REGIONS; do
-        LIST_OF_365_RETENTION_LOG_GROUPS=$($AWSCLI logs describe-log-groups $PROFILE_OPT --region $regx --query 'logGroups[?retentionInDays=="${LOG_GROUP_RETENTION_PERIOD_DAYS}"].[logGroupName]' --output text 2>&1)
-        if [[ $(echo "$LIST_OF_365_RETENTION_LOG_GROUPS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-            textInfo "$regx: Access Denied trying to describe log groups" "$regx"
+    local LOG_GROUP_RETENTION_PERIOD_DAYS="365"
+    for regx in ${REGIONS}; do
+        LIST_OF_365_RETENTION_LOG_GROUPS=$("${AWSCLI}" logs describe-log-groups ${PROFILE_OPT} --region "${regx}" --query "logGroups[?retentionInDays==\`${LOG_GROUP_RETENTION_PERIOD_DAYS}\`].[logGroupName]" --output text 2>&1)
+        if grep -E -q 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_OF_365_RETENTION_LOG_GROUPS}"; then
+            textInfo "${regx}: Access Denied trying to describe log groups" "${regx}"
             continue
         fi
-        if [[ $LIST_OF_365_RETENTION_LOG_GROUPS ]]; then
-            for log in $LIST_OF_365_RETENTION_LOG_GROUPS; do
-                textPass "$regx: $log Log Group has 365 days retention period!" "$regx" "$log"
+        if [[ ${LIST_OF_365_RETENTION_LOG_GROUPS} ]]; then
+            for log in ${LIST_OF_365_RETENTION_LOG_GROUPS}; do
+                textPass "${regx}: ${log} Log Group has 365 days retention period!" "${regx}" "${log}"
             done
         fi
-        LIST_OF_NON_365_RETENTION_LOG_GROUPS=$($AWSCLI logs describe-log-groups $PROFILE_OPT --region $regx --query 'logGroups[?retentionInDays!="${LOG_GROUP_RETENTION_PERIOD_DAYS}"].[logGroupName]' --output text)
-        if [[ $LIST_OF_NON_365_RETENTION_LOG_GROUPS ]]; then
-            for log in $LIST_OF_NON_365_RETENTION_LOG_GROUPS; do
-                textFail "$regx: $log Log Group does not have 365 days retention period!" "$regx" "$log"
+        LIST_OF_NON_365_RETENTION_LOG_GROUPS=$("${AWSCLI}" logs describe-log-groups ${PROFILE_OPT} --region "${regx}" --query "logGroups[?retentionInDays!=\`${LOG_GROUP_RETENTION_PERIOD_DAYS}\`].[logGroupName]" --output text 2>&1)
+        if grep -E -q 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_OF_NON_365_RETENTION_LOG_GROUPS}"; then
+            textInfo "${regx}: Access Denied trying to describe log groups" "${regx}"
+            continue
+        fi
+        if [[ ${LIST_OF_NON_365_RETENTION_LOG_GROUPS} ]]; then
+            for log in ${LIST_OF_NON_365_RETENTION_LOG_GROUPS}; do
+                textFail "${regx}: ${log} Log Group does not have 365 days retention period!" "${regx}" "${log}"
             done
         fi
-        REGION_NO_LOG_GROUP=$($AWSCLI logs describe-log-groups $PROFILE_OPT --region $regx --output text)
-        if [[ $REGION_NO_LOG_GROUP ]]; then
+        REGION_NO_LOG_GROUP=$("${AWSCLI}" logs describe-log-groups ${PROFILE_OPT} --region "${regx}" --output text)
+        if grep -E -q 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${REGION_NO_LOG_GROUP}"; then
+            textInfo "${regx}: Access Denied trying to describe log groups" "${regx}"
+            continue
+        fi
+        if [[ ${REGION_NO_LOG_GROUP} ]]; then
             :
         else
-            textInfo "$regx does not have a Log Group!" "$regx"
-    
+            textInfo "${regx} does not have a Log Group!" "${regx}"
+
         fi
     done
 }


### PR DESCRIPTION
### Description

Modify AWS `describe-log-groups` query using `jmespath` to use the local variable LOG_GROUP_RETENTION_PERIOD_DAYS="365"`.

This PR fixes https://github.com/prowler-cloud/prowler/issues/1229 

I've also included a proper error handling for the AWS CLI.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
