### PR TITLE
fix(backupInitialAWSCredentials): Do nothing if no initial creds

### DIFF
--- a/include/assume_role
+++ b/include/assume_role
@@ -93,9 +93,6 @@ backupInitialAWSCredentials() {
         INITIAL_AWS_ACCESS_KEY_ID=$(printenv AWS_ACCESS_KEY_ID)
         INITIAL_AWS_SECRET_ACCESS_KEY=$(printenv AWS_SECRET_ACCESS_KEY)
         INITIAL_AWS_SESSION_TOKEN=$(printenv AWS_SESSION_TOKEN)
-    else
-        echo -e "$RED ERROR Can't Backup Initial AWS Credentials $NORMAL"
-        exit 1
     fi
 }
 


### PR DESCRIPTION
### Context 

This PR fixes https://github.com/prowler-cloud/prowler/issues/1237 because we are forcing to stop the execution if Prowler cannot backup the AWS credentials.

### Description

Remove the exit command if we can't backup the AWS credentials using the environment variables. There are some paths that doesn't need this backup because they are using an AWS profile.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
