### PR TITLE
feat(check7164): 365 days or more in a Cloudwatch log retention should be consider PASS

### DIFF
--- a/checks/check_extra7162
+++ b/checks/check_extra7162
@@ -48,6 +48,7 @@ extra7162() {
                 textPass "${regx}: ${log} Log Group retention period never expires!" "${regx}" "${log}"
             done
         fi
+
         LIST_OF_NON_365_RETENTION_LOG_GROUPS=$("${AWSCLI}" logs describe-log-groups ${PROFILE_OPT} --region "${regx}" --query "logGroups[?retentionInDays<\`${LOG_GROUP_RETENTION_PERIOD_DAYS}\`].[logGroupName]" --output text 2>&1)
         if grep -E -q 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_OF_NON_365_RETENTION_LOG_GROUPS}"; then
             textInfo "${regx}: Access Denied trying to describe log groups" "${regx}"
@@ -58,6 +59,7 @@ extra7162() {
                 textFail "${regx}: ${log} Log Group does not have at least 365 days retention period!" "${regx}" "${log}"
             done
         fi
+        
         REGION_NO_LOG_GROUP=$("${AWSCLI}" logs describe-log-groups ${PROFILE_OPT} --region "${regx}" --output text)
         if grep -E -q 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${REGION_NO_LOG_GROUP}"; then
             textInfo "${regx}: Access Denied trying to describe log groups" "${regx}"

--- a/checks/check_extra7162
+++ b/checks/check_extra7162
@@ -11,7 +11,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 CHECK_ID_extra7162="7.162"
-CHECK_TITLE_extra7162="[extra7162] Check if CloudWatch Log Groups have a retention policy of 365 days"
+CHECK_TITLE_extra7162="[extra7162] Check if CloudWatch Log Groups have a retention policy of at least 365 days"
 CHECK_SCORED_extra7162="NOT_SCORED"
 CHECK_CIS_LEVEL_extra7162="EXTRA"
 CHECK_SEVERITY_extra7162="Medium"
@@ -19,7 +19,7 @@ CHECK_ASFF_RESOURCE_TYPE_extra7162="AwsLogsLogGroup"
 CHECK_ALTERNATE_check7162="extra7162"
 CHECK_SERVICENAME_extra7162="cloudwatch"
 CHECK_RISK_extra7162='If log groups have a low retention policy of less than 365 days; crucial logs and data can be lost'
-CHECK_REMEDIATION_extra7162='Add Log Retention policy of 365 days to log groups. This will persist logs and traces for a long time.'
+CHECK_REMEDIATION_extra7162='Add Log Retention policy of at least 365 days to log groups. This will persist logs and traces for a long time.'
 CHECK_DOC_extra7162='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/AWS_Logs.html'
 CHECK_CAF_EPIC_extra7162='Data Retention'
 
@@ -34,10 +34,10 @@ extra7162() {
         fi
         if [[ ${LIST_OF_365_OR_MORE_RETENTION_LOG_GROUPS} ]]; then
             for log in ${LIST_OF_365_OR_MORE_RETENTION_LOG_GROUPS}; do
-                textPass "${regx}: ${log} Log Group has at least 365 days or more retention period!" "${regx}" "${log}"
+                textPass "${regx}: ${log} Log Group has at least 365 days retention period!" "${regx}" "${log}"
             done
         fi
-        LIST_OF_NON_365_RETENTION_LOG_GROUPS=$("${AWSCLI}" logs describe-log-groups ${PROFILE_OPT} --region "${regx}" --query "logGroups[?retentionInDays!<\`${LOG_GROUP_RETENTION_PERIOD_DAYS}\`].[logGroupName]" --output text 2>&1)
+        LIST_OF_NON_365_RETENTION_LOG_GROUPS=$("${AWSCLI}" logs describe-log-groups ${PROFILE_OPT} --region "${regx}" --query "logGroups[?retentionInDays<\`${LOG_GROUP_RETENTION_PERIOD_DAYS}\`].[logGroupName]" --output text 2>&1)
         if grep -E -q 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_OF_NON_365_RETENTION_LOG_GROUPS}"; then
             textInfo "${regx}: Access Denied trying to describe log groups" "${regx}"
             continue

--- a/checks/check_extra7162
+++ b/checks/check_extra7162
@@ -37,6 +37,17 @@ extra7162() {
                 textPass "${regx}: ${log} Log Group has at least 365 days retention period!" "${regx}" "${log}"
             done
         fi
+
+        LIST_OF_NEVER_EXPIRE_RETENTION_LOG_GROUPS=$("${AWSCLI}" logs describe-log-groups ${PROFILE_OPT} --region "${regx}" --query "logGroups[?retentionInDays==null].[logGroupName]" --output text 2>&1)
+        if grep -E -q 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_OF_NEVER_EXPIRE_RETENTION_LOG_GROUPS}"; then
+            textInfo "${regx}: Access Denied trying to describe log groups" "${regx}"
+            continue
+        fi
+        if [[ ${LIST_OF_NEVER_EXPIRE_RETENTION_LOG_GROUPS} ]]; then
+            for log in ${LIST_OF_NEVER_EXPIRE_RETENTION_LOG_GROUPS}; do
+                textPass "${regx}: ${log} Log Group retention period never expires!" "${regx}" "${log}"
+            done
+        fi
         LIST_OF_NON_365_RETENTION_LOG_GROUPS=$("${AWSCLI}" logs describe-log-groups ${PROFILE_OPT} --region "${regx}" --query "logGroups[?retentionInDays<\`${LOG_GROUP_RETENTION_PERIOD_DAYS}\`].[logGroupName]" --output text 2>&1)
         if grep -E -q 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_OF_NON_365_RETENTION_LOG_GROUPS}"; then
             textInfo "${regx}: Access Denied trying to describe log groups" "${regx}"

--- a/checks/check_extra7162
+++ b/checks/check_extra7162
@@ -27,24 +27,24 @@ extra7162() {
     # "Check if CloudWatch Log Groups have a retention policy of 365 days"
     local LOG_GROUP_RETENTION_PERIOD_DAYS="365"
     for regx in ${REGIONS}; do
-        LIST_OF_365_RETENTION_LOG_GROUPS=$("${AWSCLI}" logs describe-log-groups ${PROFILE_OPT} --region "${regx}" --query "logGroups[?retentionInDays==\`${LOG_GROUP_RETENTION_PERIOD_DAYS}\`].[logGroupName]" --output text 2>&1)
-        if grep -E -q 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_OF_365_RETENTION_LOG_GROUPS}"; then
+        LIST_OF_365_OR_MORE_RETENTION_LOG_GROUPS=$("${AWSCLI}" logs describe-log-groups ${PROFILE_OPT} --region "${regx}" --query "logGroups[?retentionInDays>=\`${LOG_GROUP_RETENTION_PERIOD_DAYS}\`].[logGroupName]" --output text 2>&1)
+        if grep -E -q 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_OF_365_OR_MORE_RETENTION_LOG_GROUPS}"; then
             textInfo "${regx}: Access Denied trying to describe log groups" "${regx}"
             continue
         fi
-        if [[ ${LIST_OF_365_RETENTION_LOG_GROUPS} ]]; then
-            for log in ${LIST_OF_365_RETENTION_LOG_GROUPS}; do
-                textPass "${regx}: ${log} Log Group has 365 days retention period!" "${regx}" "${log}"
+        if [[ ${LIST_OF_365_OR_MORE_RETENTION_LOG_GROUPS} ]]; then
+            for log in ${LIST_OF_365_OR_MORE_RETENTION_LOG_GROUPS}; do
+                textPass "${regx}: ${log} Log Group has at least 365 days or more retention period!" "${regx}" "${log}"
             done
         fi
-        LIST_OF_NON_365_RETENTION_LOG_GROUPS=$("${AWSCLI}" logs describe-log-groups ${PROFILE_OPT} --region "${regx}" --query "logGroups[?retentionInDays!=\`${LOG_GROUP_RETENTION_PERIOD_DAYS}\`].[logGroupName]" --output text 2>&1)
+        LIST_OF_NON_365_RETENTION_LOG_GROUPS=$("${AWSCLI}" logs describe-log-groups ${PROFILE_OPT} --region "${regx}" --query "logGroups[?retentionInDays!<\`${LOG_GROUP_RETENTION_PERIOD_DAYS}\`].[logGroupName]" --output text 2>&1)
         if grep -E -q 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${LIST_OF_NON_365_RETENTION_LOG_GROUPS}"; then
             textInfo "${regx}: Access Denied trying to describe log groups" "${regx}"
             continue
         fi
         if [[ ${LIST_OF_NON_365_RETENTION_LOG_GROUPS} ]]; then
             for log in ${LIST_OF_NON_365_RETENTION_LOG_GROUPS}; do
-                textFail "${regx}: ${log} Log Group does not have 365 days retention period!" "${regx}" "${log}"
+                textFail "${regx}: ${log} Log Group does not have at least 365 days retention period!" "${regx}" "${log}"
             done
         fi
         REGION_NO_LOG_GROUP=$("${AWSCLI}" logs describe-log-groups ${PROFILE_OPT} --region "${regx}" --output text)


### PR DESCRIPTION
### Context 

Prowler fails when log retention period is more 365 days, b/c the validation is `==` instead of `>= `

### Description

Many customer are using modules like gruntworks in vpc So this is using a default value for log retention which is 731 days
![Screen Shot 2022-06-27 at 14 50 39](https://user-images.githubusercontent.com/19688747/176033315-5e005785-b043-43a2-b42c-68786777d5b6.png)


I think that we can considered that a cloud watch log rentention Greater than 365 days is passing. 
What do you think comunity?

Also, with this fix Log Groups that never expires are included as PASS.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
