### PR TITLE
fix(Dockerfile): Prowler path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN rm /usr/bin/python && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 # Set working directory
-WORKDIR /home/${USERNAME}
+WORKDIR /prowler
 
 # Copy all files
 COPY . ./


### PR DESCRIPTION
### Context 

Issue from https://github.com/prowler-cloud/prowler/issues/1249#issuecomment-1177210451

### Description

This PR fixes an issue because the container `WORKDIR` was changed from `/prowler` to `/home/prowler`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
