### PR TITLE
fix(apigatewayv2): handle BadRequestException

### DIFF
--- a/checks/check_extra7156
+++ b/checks/check_extra7156
@@ -29,7 +29,7 @@ extra7156(){
     # "Check if API Gateway V2 has Access Logging enabled "
     for regx in $REGIONS; do
         LIST_OF_API_GW=$($AWSCLI apigatewayv2 get-apis $PROFILE_OPT --region $regx --query Items[*].ApiId --output text 2>&1)
-        if [[ $(echo "$LIST_OF_API_GW" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+        if [[ $(echo "$LIST_OF_API_GW" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError|BadRequestException') ]]; then
             textInfo "$regx: Access Denied trying to get APIs" "$regx"
             continue
         fi

--- a/checks/check_extra7157
+++ b/checks/check_extra7157
@@ -26,7 +26,7 @@ CHECK_CAF_EPIC_extra7157='IAM'
 extra7157(){
   for regx in $REGIONS; do
     LIST_OF_API_GW=$($AWSCLI apigatewayv2 get-apis $PROFILE_OPT --region $regx --query "Items[*].ApiId" --output text 2>&1)
-    if [[ $(echo "$LIST_OF_API_GW" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+    if [[ $(echo "$LIST_OF_API_GW" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError|BadRequestException') ]]; then
         textInfo "$regx: Access Denied trying to get APIs" "$regx"
         continue
     fi


### PR DESCRIPTION
### Context 

In checks extra7156 and extra7157 there is a BadRequestException for the regions that does not have apigatewayv2.


### Description

Handle BadRequestException correctly to solve the issue.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
