### PR TITLE
fix(codebuild): expired token error

### DIFF
--- a/include/aws_profile_loader
+++ b/include/aws_profile_loader
@@ -31,26 +31,14 @@ aws_profile_loader() {
     elif [[ -n $AWS_CONTAINER_CREDENTIALS_RELATIVE_URI ]] && [[ -z $INSTANCE_PROFILE ]]
     then
         PROFILE="INSTANCE-PROFILE"
-        CONTAINER_METADATA=$(curl -s 169.254.170.2"${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}")
-        AWS_ACCESS_KEY_ID=$(jq -r '.AccessKeyId' <<< "${CONTAINER_METADATA}")
-        export AWS_ACCESS_KEY_ID
-        AWS_SECRET_ACCESS_KEY=$(jq -r '.SecretAccessKey' <<< "${CONTAINER_METADATA}")
-        export AWS_SECRET_ACCESS_KEY
-        AWS_SESSION_TOKEN=$(jq -r '.Token' <<< "${CONTAINER_METADATA}")
-        export AWS_SESSION_TOKEN
+        set_metadata_credentials "169.254.170.2${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}"
     elif [[ $AWS_WEB_IDENTITY_TOKEN_FILE ]]; then
         PROFILE=""
         PROFILE_OPT=""
     elif [[ $INSTANCE_PROFILE ]]
     then
         PROFILE="INSTANCE-PROFILE"
-        INSTANCE_METADATA=$(curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/"${INSTANCE_PROFILE}")
-        AWS_ACCESS_KEY_ID=$(jq -r '.AccessKeyId' <<< "${INSTANCE_METADATA}")
-        export AWS_ACCESS_KEY_ID
-        AWS_SECRET_ACCESS_KEY=$(jq -r '.SecretAccessKey' <<< "${INSTANCE_METADATA}")
-        export AWS_SECRET_ACCESS_KEY
-        AWS_SESSION_TOKEN=$(jq -r '.Token' <<< "${INSTANCE_METADATA}")
-        export AWS_SESSION_TOKEN
+        set_metadata_credentials "http://169.254.169.254/latest/meta-data/iam/security-credentials/${INSTANCE_PROFILE}"
     elif [[ $AWS_EXECUTION_ENV == "CloudShell" ]]
     then
         PROFILE_OPT=""
@@ -84,4 +72,16 @@ get_regions() {
     EXITCODE=1
     exit $EXITCODE
   fi
+}
+
+# Function to set metadata credentials
+set_metadata_credentials() {
+    INSTANCE_METADATA_URI="${1}"
+    INSTANCE_METADATA=$(curl -s "${INSTANCE_METADATA_URI}")
+    AWS_ACCESS_KEY_ID=$(jq -r '.AccessKeyId' <<< "${INSTANCE_METADATA}")
+    export AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY=$(jq -r '.SecretAccessKey' <<< "${INSTANCE_METADATA}")
+    export AWS_SECRET_ACCESS_KEY
+    AWS_SESSION_TOKEN=$(jq -r '.Token' <<< "${INSTANCE_METADATA}")
+    export AWS_SESSION_TOKEN
 }

--- a/include/execute_check
+++ b/include/execute_check
@@ -16,7 +16,7 @@
 
 # Function to execute the check
 execute_check() {
-  if [[ -n "${ACCOUNT_TO_ASSUME}" || -n "${ROLE_TO_ASSUME}" || $PROFILE == "INSTANCE-PROFILE" ]]; then
+  if [[ -n "${ACCOUNT_TO_ASSUME}" || -n "${ROLE_TO_ASSUME}" || "${PROFILE}" == "INSTANCE-PROFILE" ]]; then
     # echo ******* I am here again to check on my role *******
     # Following logic looks for time remaining in the session and review it
     # if it is less than 600 seconds, 10 minutes.
@@ -28,8 +28,8 @@ execute_check() {
       unset AWS_ACCESS_KEY_ID
       unset AWS_SECRET_ACCESS_KEY
       unset AWS_SESSION_TOKEN
-      if [[ $PROFILE == "INSTANCE-PROFILE" ]]; then
-        if [[ -n $AWS_CONTAINER_CREDENTIALS_RELATIVE_URI ]]; then
+      if [[ "${PROFILE}" == "INSTANCE-PROFILE" ]]; then
+        if [[ -n "${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}" ]]; then
           INSTANCE_METADATA_URI="169.254.170.2${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}"
         else
           INSTANCE_METADATA_URI="http://169.254.169.254/latest/meta-data/iam/security-credentials/${INSTANCE_PROFILE}"

--- a/include/execute_check
+++ b/include/execute_check
@@ -16,7 +16,7 @@
 
 # Function to execute the check
 execute_check() {
-  if [[ -n "${ACCOUNT_TO_ASSUME}" || -n "${ROLE_TO_ASSUME}" ]]; then
+  if [[ -n "${ACCOUNT_TO_ASSUME}" || -n "${ROLE_TO_ASSUME}" || $PROFILE == "INSTANCE-PROFILE" ]]; then
     # echo ******* I am here again to check on my role *******
     # Following logic looks for time remaining in the session and review it
     # if it is less than 600 seconds, 10 minutes.
@@ -28,7 +28,16 @@ execute_check() {
       unset AWS_ACCESS_KEY_ID
       unset AWS_SECRET_ACCESS_KEY
       unset AWS_SESSION_TOKEN
-      assume_role
+      if [[ $PROFILE == "INSTANCE-PROFILE" ]]; then
+        if [[ -n $AWS_CONTAINER_CREDENTIALS_RELATIVE_URI ]]; then
+          INSTANCE_METADATA_URI="169.254.170.2${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}"
+        else
+          INSTANCE_METADATA_URI="http://169.254.169.254/latest/meta-data/iam/security-credentials/${INSTANCE_PROFILE}"
+        fi
+        set_metadata_credentials "${INSTANCE_METADATA_URI}"
+      else
+        assume_role
+      fi
     fi
   fi
 


### PR DESCRIPTION
### Context 

According to issues https://github.com/prowler-cloud/prowler/issues/1259 and https://github.com/prowler-cloud/prowler/issues/1182, Codebuild jobs that run more than 60 minutes use expired AWS credentials.

### Description

Refresh credentials when the Codebuild session is expired.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
