### PR TITLE
fix(codebuild): expired token error

### DIFF
--- a/include/aws_profile_loader
+++ b/include/aws_profile_loader
@@ -84,4 +84,6 @@ set_metadata_credentials() {
     export AWS_SECRET_ACCESS_KEY
     AWS_SESSION_TOKEN=$(jq -r '.Token' <<< "${INSTANCE_METADATA}")
     export AWS_SESSION_TOKEN
+    ASSUME_AWS_SESSION_EXPIRATION=$(jq -r '.Expiration | sub("\\+00:00";"Z") | fromdateiso8601' <<< "${INSTANCE_METADATA}")
+    export AWS_SESSION_EXPIRATION=$ASSUME_AWS_SESSION_EXPIRATION
 }


### PR DESCRIPTION
### Context 

According to issues https://github.com/prowler-cloud/prowler/issues/1259 and https://github.com/prowler-cloud/prowler/issues/1182, Codebuild jobs that run more than 60 minutes use expired AWS credentials.


### Description

Add missing ASSUME_AWS_SESSION_EXPIRATION variable when using instance metadata.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
