### PR TITLE
fix(permissions): Include missing appstream:DescribeFleets permission 

### DIFF
--- a/iam/create_role_to_assume_cfn.yaml
+++ b/iam/create_role_to_assume_cfn.yaml
@@ -7,7 +7,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 #  --stack-name "ProwlerExecRole" \
 #  --parameters "ParameterKey=AuthorisedARN,ParameterValue=arn:aws:iam::123456789012:root"
 #
-Description: | 
+Description: |
   This template creates an AWS IAM Role with an inline policy and two AWS managed policies
   attached. It sets the trust policy on that IAM Role to permit a named ARN in another AWS
   account to assume that role. The role name and the ARN of the trusted user can all be passed
@@ -48,16 +48,18 @@ Resources:
         - 'arn:aws:iam::aws:policy/SecurityAudit'
         - 'arn:aws:iam::aws:policy/job-function/ViewOnlyAccess'
       RoleName: !Sub ${ProwlerRoleName}
-      Policies: 
+      Policies:
         - PolicyName: ProwlerExecRoleAdditionalViewPrivileges
           PolicyDocument:
             Version : '2012-10-17'
             Statement:
             - Effect: Allow
               Action:
-                - 'account:GetContactInformation'
-                - 'account:GetAlternateContact'
-                - 'ds:ListAuthorizedApplications'
+                - 'account:Get*'
+                - 'appstream:DescribeFleets'
+                - 'ds:Get*'
+                - 'ds:Describe*'
+                - 'ds:List*'
                 - 'ec2:GetEbsEncryptionByDefault'
                 - 'ecr:Describe*'
                 - 'elasticfilesystem:DescribeBackupPolicy'

--- a/iam/prowler-additions-policy.json
+++ b/iam/prowler-additions-policy.json
@@ -1,37 +1,38 @@
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "ds:Get*",
-                "ds:Describe*",
-                "ds:List*",
-                "ec2:GetEbsEncryptionByDefault",
-                "ecr:Describe*",
-                "elasticfilesystem:DescribeBackupPolicy",
-                "glue:GetConnections",
-                "glue:GetSecurityConfiguration",
-                "glue:SearchTables",
-                "lambda:GetFunction",
-                "s3:GetAccountPublicAccessBlock",
-                "shield:DescribeProtection",
-                "shield:GetSubscriptionState",
-                "ssm:GetDocument",
-                "support:Describe*",
-                "tag:GetTagKeys"
-            ],
-            "Resource": "*",
-            "Effect": "Allow",
-            "Sid": "AllowMoreReadForProwler"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "apigateway:GET"
-            ],
-            "Resource": [
-                "arn:aws:apigateway:*::/restapis/*"
-            ]
-        }
-    ]
+  "Statement": [
+    {
+      "Action": [
+        "appstream:DescribeFleets",
+        "ds:Get*",
+        "ds:Describe*",
+        "ds:List*",
+        "ec2:GetEbsEncryptionByDefault",
+        "ecr:Describe*",
+        "elasticfilesystem:DescribeBackupPolicy",
+        "glue:GetConnections",
+        "glue:GetSecurityConfiguration",
+        "glue:SearchTables",
+        "lambda:GetFunction",
+        "s3:GetAccountPublicAccessBlock",
+        "shield:DescribeProtection",
+        "shield:GetSubscriptionState",
+        "ssm:GetDocument",
+        "support:Describe*",
+        "tag:GetTagKeys"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "AllowMoreReadForProwler"
+    },
+    {
+      "Action": [
+        "apigateway:GET"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:apigateway:*::/restapis/*"
+      ]
+    }
+  ],
+  "Version": "2012-10-17"
 }


### PR DESCRIPTION
### Context 

Fix https://github.com/prowler-cloud/prowler/issues/1277

### Description

Include missing `appstream:DescribeFleets` permission in the `iam/prowler-additions-policy.json`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
