### PR TITLE
fix(inventory): Variable assigning syntax in inventory mode

### DIFF
--- a/include/quick_inventory
+++ b/include/quick_inventory
@@ -101,7 +101,7 @@ quick_inventory(){
 
         if [ "${region}" == "us-east-1" ]; then
             TOTAL_IAM_RESOURCES_FOUND=$(grep -c :"iam": "${TEMP_INVENTORY_FILE}-${region}")
-            TOTAL_RESOURCES_FOUND_REGION=$(("${TOTAL_RESOURCES_FOUND_REGION}-${region}"+${TOTAL_IAM_RESOURCES_FOUND}))
+            TOTAL_RESOURCES_FOUND_REGION=$((${TOTAL_RESOURCES_FOUND_REGION}-${region}+${TOTAL_IAM_RESOURCES_FOUND}))
         fi 
 
         echo -e "${OK}${TOTAL_RESOURCES_FOUND_REGION}${NORMAL} resources!"


### PR DESCRIPTION
### Context 

An improper variable assigning results in an error when it tries to concatenate values greater than 0. When it fails, stdout throws an error AND prowler starts a scan, even when the user requested only `prowler -i` (Inventory)

### Description

The variable had extra quotes around { }, and it resulted in an error when `${TOTAL_RESOURCES_FOUND_REGION}-${region}` is not zero. The error I get is the following: 

`- us-east-1: ./prowler/include/quick_inventory: line 104: "33-us-east-1"+1: syntax error: operand expected (error token is ""33-us-east-1"+1")` when a region has > 0 objects.

But for some reason prowler stops the inventory, and starts a normal scan, even though I just ran `./prowler -i`. This is solved by removing the double quotes. Everything runs as expected now.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
