### PR TITLE
fix(extra712): changed Macie service detection

### DIFF
--- a/checks/check_extra712
+++ b/checks/check_extra712
@@ -24,12 +24,20 @@ CHECK_DOC_extra712='https://docs.aws.amazon.com/macie/latest/user/getting-starte
 CHECK_CAF_EPIC_extra712='Data Protection'
 
  extra712(){ 
-#     "No API commands available to check if Macie is enabled," 
-#     "just looking if IAM Macie related permissions exist.  " 
-   MACIE_IAM_ROLES_CREATED=$($AWSCLI iam list-roles $PROFILE_OPT --query 'Roles[*].Arn'|grep AWSMacieServiceCustomer|wc -l) 
-   if [[ $MACIE_IAM_ROLES_CREATED -eq 2 ]];then 
-     textPass "$REGION: Macie related IAM roles exist so it might be enabled. Check it out manually" "$REGION"
-else
-     textFail "$REGION: No Macie related IAM roles found. It is most likely not to be enabled" "$REGION"
-fi
-}
+      # Macie supports get-macie-session which tells the current status, if not Disabled. 
+      #  Capturing the STDOUT can help determine when Disabled.
+     MACIE_QUERY=$($AWSCLI macie2 get-macie-session 2>&1)
+
+     if [[ $MACIE_QUERY == *"ENABLED"* ]]; then
+          textPass "$REGION: Macie is enabled." "$REGION"
+
+     elif [[ $MACIE_QUERY == *"PAUSED"* ]]; then
+          textFail "$REGION: Macie is currently in a SUSPENDED state." "$REGION"
+
+     elif [[ $MACIE_QUERY == *"Macie is not enabled"* ]]; then
+          textFail "$REGION: Macie is not enabled." "$REGION"
+
+     else
+          textFail "$REGION: Unexpected error while querying AWS Macie." "$REGION"
+     fi
+ }

--- a/checks/check_extra712
+++ b/checks/check_extra712
@@ -23,21 +23,22 @@ CHECK_REMEDIATION_extra712='Enable Amazon Macie and create appropriate jobs to d
 CHECK_DOC_extra712='https://docs.aws.amazon.com/macie/latest/user/getting-started.html'
 CHECK_CAF_EPIC_extra712='Data Protection'
 
- extra712(){ 
-      # Macie supports get-macie-session which tells the current status, if not Disabled. 
+ extra712(){
+      # Macie supports get-macie-session which tells the current status, if not Disabled.
       #  Capturing the STDOUT can help determine when Disabled.
-     MACIE_QUERY=$($AWSCLI macie2 get-macie-session 2>&1)
+     for region in $REGIONS; do
+          MACIE_STATUS=$($AWSCLI macie2 get-macie-session ${PROFILE_OPT} --region "$region" --query status --output text 2>&1)
+          if [[ "$MACIE_STATUS" == "ENABLED" ]]; then
+               textPass "$region: Macie is enabled." "$region"
 
-     if [[ $MACIE_QUERY == *"ENABLED"* ]]; then
-          textPass "$REGION: Macie is enabled." "$REGION"
+          elif [[ "$MACIE_STATUS" == "PAUSED" ]]; then
+               textFail "$region: Macie is currently in a SUSPENDED state." "$region"
 
-     elif [[ $MACIE_QUERY == *"PAUSED"* ]]; then
-          textFail "$REGION: Macie is currently in a SUSPENDED state." "$REGION"
+          elif grep -q -E 'Macie is not enabled' <<< "${MACIE_STATUS}"; then
+               textFail "$region: Macie is not enabled." "$region"
 
-     elif [[ $MACIE_QUERY == *"Macie is not enabled"* ]]; then
-          textFail "$REGION: Macie is not enabled." "$REGION"
-
-     else
-          textFail "$REGION: Unexpected error while querying AWS Macie." "$REGION"
-     fi
- }
+          elif grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${MACIE_STATUS}"; then
+               textInfo "$region: Access Denied trying to get AWS Macie information." "$region"
+          fi
+     done
+     }


### PR DESCRIPTION
### Context 

Reference issue 1279 in regards to a better way of determining Macie status.


### Description

Instead of looking for an IAM role and guessing that Macie may be enabled, directly querying get-macie-session status will determine the current state.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
