### PR TITLE
Issue1293: Updated region detection for appstream service scans

### DIFF
--- a/checks/check_extra712
+++ b/checks/check_extra712
@@ -24,12 +24,20 @@ CHECK_DOC_extra712='https://docs.aws.amazon.com/macie/latest/user/getting-starte
 CHECK_CAF_EPIC_extra712='Data Protection'
 
  extra712(){ 
-#     "No API commands available to check if Macie is enabled," 
-#     "just looking if IAM Macie related permissions exist.  " 
-   MACIE_IAM_ROLES_CREATED=$($AWSCLI iam list-roles $PROFILE_OPT --query 'Roles[*].Arn'|grep AWSMacieServiceCustomer|wc -l) 
-   if [[ $MACIE_IAM_ROLES_CREATED -eq 2 ]];then 
-     textPass "$REGION: Macie related IAM roles exist so it might be enabled. Check it out manually" "$REGION"
-else
-     textFail "$REGION: No Macie related IAM roles found. It is most likely not to be enabled" "$REGION"
-fi
-}
+      # Macie supports get-macie-session which tells the current status, if not Disabled. 
+      #  Capturing the STDOUT can help determine when Disabled.
+     MACIE_QUERY=$($AWSCLI macie2 get-macie-session 2>&1)
+
+     if [[ $MACIE_QUERY == *"ENABLED"* ]]; then
+          textPass "$REGION: Macie is enabled." "$REGION"
+
+     elif [[ $MACIE_QUERY == *"PAUSED"* ]]; then
+          textFail "$REGION: Macie is currently in a SUSPENDED state." "$REGION"
+
+     elif [[ $MACIE_QUERY == *"Macie is not enabled"* ]]; then
+          textFail "$REGION: Macie is not enabled." "$REGION"
+
+     else
+          textFail "$REGION: Unexpected error while querying AWS Macie." "$REGION"
+     fi
+ }

--- a/checks/check_extra712
+++ b/checks/check_extra712
@@ -23,21 +23,22 @@ CHECK_REMEDIATION_extra712='Enable Amazon Macie and create appropriate jobs to d
 CHECK_DOC_extra712='https://docs.aws.amazon.com/macie/latest/user/getting-started.html'
 CHECK_CAF_EPIC_extra712='Data Protection'
 
- extra712(){ 
-      # Macie supports get-macie-session which tells the current status, if not Disabled. 
+ extra712(){
+      # Macie supports get-macie-session which tells the current status, if not Disabled.
       #  Capturing the STDOUT can help determine when Disabled.
-     MACIE_QUERY=$($AWSCLI macie2 get-macie-session 2>&1)
+     for region in $REGIONS; do
+          MACIE_STATUS=$($AWSCLI macie2 get-macie-session ${PROFILE_OPT} --region "$region" --query status --output text 2>&1)
+          if [[ "$MACIE_STATUS" == "ENABLED" ]]; then
+               textPass "$region: Macie is enabled." "$region"
 
-     if [[ $MACIE_QUERY == *"ENABLED"* ]]; then
-          textPass "$REGION: Macie is enabled." "$REGION"
+          elif [[ "$MACIE_STATUS" == "PAUSED" ]]; then
+               textFail "$region: Macie is currently in a SUSPENDED state." "$region"
 
-     elif [[ $MACIE_QUERY == *"PAUSED"* ]]; then
-          textFail "$REGION: Macie is currently in a SUSPENDED state." "$REGION"
+          elif grep -q -E 'Macie is not enabled' <<< "${MACIE_STATUS}"; then
+               textFail "$region: Macie is not enabled." "$region"
 
-     elif [[ $MACIE_QUERY == *"Macie is not enabled"* ]]; then
-          textFail "$REGION: Macie is not enabled." "$REGION"
-
-     else
-          textFail "$REGION: Unexpected error while querying AWS Macie." "$REGION"
-     fi
- }
+          elif grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${MACIE_STATUS}"; then
+               textInfo "$region: Access Denied trying to get AWS Macie information." "$region"
+          fi
+     done
+     }

--- a/checks/check_extra7190
+++ b/checks/check_extra7190
@@ -26,7 +26,21 @@ CHECK_DOC_extra7190='https://docs.aws.amazon.com/appstream2/latest/developerguid
 CHECK_CAF_EPIC_extra7190="Infrastructure Security"
 
 extra7190(){
-  for regx in $REGIONS; do
+
+  # Get the latest regions for AppStream. Any region that exists in both the application version and the global $REGIONS, include in the report. Skip mis-matches.
+  APP_REGIONS=`curl -s https://api.regional-table.region-services.aws.a2z.com/index.json | jq -r '.prices[].attributes|select(."aws:serviceName" == "Amazon AppStream 2.0") | ."aws:region"'`
+  
+  # Generate the list of regions to scan
+  declare -a SCAN_REGIONS=()
+  for EACH_REGION in $REGIONS
+  do
+    if [[ $APP_REGIONS == *$EACH_REGION* ]]; then
+      # adding $EACH_REGION to the queue
+      SCAN_REGIONS+=("$EACH_REGION ")
+    fi
+  done
+
+  for regx in ${SCAN_REGIONS[@]}; do
     LIST_OF_FLEETS_WITH_MAX_SESSION_DURATION_ABOVE_RECOMMENDED=$("${AWSCLI}" appstream describe-fleets $PROFILE_OPT --region "${regx}" --query 'Fleets[?MaxUserDurationInSeconds>=`36000`].Arn' --output text 2>&1)
     if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError|Could not connect to the endpoint URL' <<< "${LIST_OF_FLEETS_WITH_MAX_SESSION_DURATION_ABOVE_RECOMMENDED}"; then
         textInfo "${regx}: Access Denied trying to describe appstream fleet(s)" "${regx}"

--- a/checks/check_extra7191
+++ b/checks/check_extra7191
@@ -26,7 +26,21 @@ CHECK_DOC_extra7191='https://docs.aws.amazon.com/appstream2/latest/developerguid
 CHECK_CAF_EPIC_extra7191="Infrastructure Security"
 
 extra7191(){
-  for regx in $REGIONS; do
+
+  # Get the latest regions for AppStream. Any region that exists in both the application version and the global $REGIONS, include in the report. Skip mis-matches.
+  APP_REGIONS=`curl -s https://api.regional-table.region-services.aws.a2z.com/index.json | jq -r '.prices[].attributes|select(."aws:serviceName" == "Amazon AppStream 2.0") | ."aws:region"'`
+  
+  # Generate the list of regions to scan
+  declare -a SCAN_REGIONS=()
+  for EACH_REGION in $REGIONS
+  do
+    if [[ $APP_REGIONS == *$EACH_REGION* ]]; then
+      # adding $EACH_REGION to the queue
+      SCAN_REGIONS+=("$EACH_REGION ")
+    fi
+  done
+
+  for regx in ${SCAN_REGIONS[@]}; do
     LIST_OF_FLEETS_WITH_SESSION_DISCONNECT_DURATION_ABOVE_RECOMMENDED=$("${AWSCLI}" appstream describe-fleets $PROFILE_OPT --region "${regx}" --query 'Fleets[?DisconnectTimeoutInSeconds>`300`].Arn' --output text 2>&1)
     if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError|Could not connect to the endpoint URL' <<< "${LIST_OF_FLEETS_WITH_SESSION_DISCONNECT_DURATION_ABOVE_RECOMMENDED}"; then
         textInfo "${regx}: Access Denied trying to describe appstream fleet(s)" "${regx}"

--- a/checks/check_extra7192
+++ b/checks/check_extra7192
@@ -26,7 +26,21 @@ CHECK_DOC_extra7192='https://docs.aws.amazon.com/appstream2/latest/developerguid
 CHECK_CAF_EPIC_extra7192="Infrastructure Security"
 
 extra7192(){
-  for regx in $REGIONS; do
+
+  # Get the latest regions for AppStream. Any region that exists in both the application version and the global $REGIONS, include in the report. Skip mis-matches.
+  APP_REGIONS=`curl -s https://api.regional-table.region-services.aws.a2z.com/index.json | jq -r '.prices[].attributes|select(."aws:serviceName" == "Amazon AppStream 2.0") | ."aws:region"'`
+  
+  # Generate the list of regions to scan
+  declare -a SCAN_REGIONS=()
+  for EACH_REGION in $REGIONS
+  do
+    if [[ $APP_REGIONS == *$EACH_REGION* ]]; then
+      # adding $EACH_REGION to the queue
+      SCAN_REGIONS+=("$EACH_REGION ")
+    fi
+  done
+
+  for regx in ${SCAN_REGIONS[@]}; do
     LIST_OF_FLEETS_WITH_SESSION_IDLE_DISCONNECT_DURATION_ABOVE_RECOMMENDED=$("${AWSCLI}" appstream describe-fleets $PROFILE_OPT --region "${regx}" --query 'Fleets[?IdleDisconnectTimeoutInSeconds>`600`].Arn' --output text 2>&1)
     if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError|Could not connect to the endpoint URL' <<< "${LIST_OF_FLEETS_WITH_SESSION_IDLE_DISCONNECT_DURATION_ABOVE_RECOMMENDED}"; then
         textInfo "${regx}: Access Denied trying to describe appstream fleet(s)" "${regx}"

--- a/checks/check_extra7193
+++ b/checks/check_extra7193
@@ -26,7 +26,21 @@ CHECK_DOC_extra7193='https://docs.aws.amazon.com/appstream2/latest/developerguid
 CHECK_CAF_EPIC_extra7193="Infrastructure Security"
 
 extra7193(){
-  for regx in $REGIONS; do
+
+  # Get the latest regions for AppStream. Any region that exists in both the application version and the global $REGIONS, include in the report. Skip mis-matches.
+  APP_REGIONS=`curl -s https://api.regional-table.region-services.aws.a2z.com/index.json | jq -r '.prices[].attributes|select(."aws:serviceName" == "Amazon AppStream 2.0") | ."aws:region"'`
+  
+  # Generate the list of regions to scan
+  declare -a SCAN_REGIONS=()
+  for EACH_REGION in $REGIONS
+  do
+    if [[ $APP_REGIONS == *$EACH_REGION* ]]; then
+      # adding $EACH_REGION to the queue
+      SCAN_REGIONS+=("$EACH_REGION ")
+    fi
+  done
+
+  for regx in ${SCAN_REGIONS[@]}; do
     LIST_OF_FLEETS_WITH_DEFAULT_INTERNET_ACCESS_ENABLED=$("${AWSCLI}" appstream describe-fleets $PROFILE_OPT --region "${regx}" --query 'Fleets[?EnableDefaultInternetAccess==`true`].Arn' --output text 2>&1)
     if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError|Could not connect to the endpoint URL' <<< "${LIST_OF_FLEETS_WITH_DEFAULT_INTERNET_ACCESS_ENABLED}"; then
         textInfo "${regx}: Access Denied trying to describe appstream fleet(s)" "${regx}"


### PR DESCRIPTION
### Context 

Address concerns in #1293 

The service does not exist in all AWS regions, so results were unreliable.

### Description

Added logic to the individual scans to compare the AWS Regions available to the account with the AWS Regions the service is available in to ensure only valid regions are scanned.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
