### PR TITLE
fix(appstream): Handle timeout errors

### DIFF
--- a/checks/check_extra7190
+++ b/checks/check_extra7190
@@ -28,7 +28,7 @@ CHECK_CAF_EPIC_extra7190="Infrastructure Security"
 extra7190(){
   for regx in $REGIONS; do
     LIST_OF_FLEETS_WITH_MAX_SESSION_DURATION_ABOVE_RECOMMENDED=$("${AWSCLI}" appstream describe-fleets $PROFILE_OPT --region "${regx}" --query 'Fleets[?MaxUserDurationInSeconds>=`36000`].Arn' --output text 2>&1)
-    if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError|Could not connect to the endpoint URL' <<< "${LIST_OF_FLEETS_WITH_MAX_SESSION_DURATION_ABOVE_RECOMMENDED}"; then
+    if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError|Could not connect to the endpoint URL|Connect timeout on endpoint URL' <<< "${LIST_OF_FLEETS_WITH_MAX_SESSION_DURATION_ABOVE_RECOMMENDED}"; then
         textInfo "${regx}: Access Denied trying to describe appstream fleet(s)" "${regx}"
         continue
     fi

--- a/checks/check_extra7191
+++ b/checks/check_extra7191
@@ -28,7 +28,7 @@ CHECK_CAF_EPIC_extra7191="Infrastructure Security"
 extra7191(){
   for regx in $REGIONS; do
     LIST_OF_FLEETS_WITH_SESSION_DISCONNECT_DURATION_ABOVE_RECOMMENDED=$("${AWSCLI}" appstream describe-fleets $PROFILE_OPT --region "${regx}" --query 'Fleets[?DisconnectTimeoutInSeconds>`300`].Arn' --output text 2>&1)
-    if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError|Could not connect to the endpoint URL' <<< "${LIST_OF_FLEETS_WITH_SESSION_DISCONNECT_DURATION_ABOVE_RECOMMENDED}"; then
+    if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError|Could not connect to the endpoint URL|Connect timeout on endpoint URL' <<< "${LIST_OF_FLEETS_WITH_SESSION_DISCONNECT_DURATION_ABOVE_RECOMMENDED}"; then
         textInfo "${regx}: Access Denied trying to describe appstream fleet(s)" "${regx}"
         continue
     fi

--- a/checks/check_extra7192
+++ b/checks/check_extra7192
@@ -28,7 +28,7 @@ CHECK_CAF_EPIC_extra7192="Infrastructure Security"
 extra7192(){
   for regx in $REGIONS; do
     LIST_OF_FLEETS_WITH_SESSION_IDLE_DISCONNECT_DURATION_ABOVE_RECOMMENDED=$("${AWSCLI}" appstream describe-fleets $PROFILE_OPT --region "${regx}" --query 'Fleets[?IdleDisconnectTimeoutInSeconds>`600`].Arn' --output text 2>&1)
-    if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError|Could not connect to the endpoint URL' <<< "${LIST_OF_FLEETS_WITH_SESSION_IDLE_DISCONNECT_DURATION_ABOVE_RECOMMENDED}"; then
+    if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError|Could not connect to the endpoint URL|Connect timeout on endpoint URL' <<< "${LIST_OF_FLEETS_WITH_SESSION_IDLE_DISCONNECT_DURATION_ABOVE_RECOMMENDED}"; then
         textInfo "${regx}: Access Denied trying to describe appstream fleet(s)" "${regx}"
         continue
     fi

--- a/checks/check_extra7193
+++ b/checks/check_extra7193
@@ -28,7 +28,7 @@ CHECK_CAF_EPIC_extra7193="Infrastructure Security"
 extra7193(){
   for regx in $REGIONS; do
     LIST_OF_FLEETS_WITH_DEFAULT_INTERNET_ACCESS_ENABLED=$("${AWSCLI}" appstream describe-fleets $PROFILE_OPT --region "${regx}" --query 'Fleets[?EnableDefaultInternetAccess==`true`].Arn' --output text 2>&1)
-    if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError|Could not connect to the endpoint URL' <<< "${LIST_OF_FLEETS_WITH_DEFAULT_INTERNET_ACCESS_ENABLED}"; then
+    if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError|Could not connect to the endpoint URL|Connect timeout on endpoint URL' <<< "${LIST_OF_FLEETS_WITH_DEFAULT_INTERNET_ACCESS_ENABLED}"; then
         textInfo "${regx}: Access Denied trying to describe appstream fleet(s)" "${regx}"
         continue
     fi


### PR DESCRIPTION
### Context 

Due to https://github.com/prowler-cloud/prowler/issues/1293 checks `extra7190`, `extra7191`, `extra7192` and `extra7193` doesn't handle correctly timeout errors from AWS AppStream service.

### Description

Handle the following AWS AppStream error: `Connect timeout on endpoint URL: "https://appstream2.sa-east-1.amazonaws.com/"'`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
