### PR TITLE
feat(provider): Set default cloud provider

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
         language: system
 
       - id: safety
-        name: bandit
+        name: safety
         description: 'Safety is a tool that checks your installed dependencies for known security vulnerabilities'
         entry: bash -c 'safety check'
         language: system

--- a/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access.py
+++ b/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access.py
@@ -6,31 +6,23 @@ class iam_user_mfa_enabled_console_access(Check):
     def execute(self) -> Check_Report:
         findings = []
         response = iam_client.credential_report
-
-        if response:
-            for user in response:
-                report = Check_Report(self.metadata)
-                report.resource_id = user["user"]
-                report.resource_arn = user["arn"]
-                report.region = "us-east-1"
-                if user["password_enabled"] != "not_supported":
-                    if user["mfa_active"] == "false":
-                        report.status = "FAIL"
-                        report.status_extended = f"User {user['user']} has Console Password enabled but MFA disabled."
-                    else:
-                        report.status = "PASS"
-                        report.status_extended = f"User {user['user']} has Console Password enabled and MFA enabled."
+        for user in response:
+            report = Check_Report(self.metadata)
+            report.resource_id = user["user"]
+            report.resource_arn = user["arn"]
+            report.region = "us-east-1"
+            if user["password_enabled"] != "not_supported":
+                if user["mfa_active"] == "false":
+                    report.status = "FAIL"
+                    report.status_extended = f"User {user['user']} has Console Password enabled but MFA disabled."
                 else:
                     report.status = "PASS"
-                    report.status_extended = (
-                        f"User {user['user']} has not Console Password enabled."
-                    )
-                findings.append(report)
-        else:
-            report = Check_Report(self.metadata)
-            report.status = "PASS"
-            report.status_extended = "There is no IAM users."
-            report.region = iam_client.region
+                    report.status_extended = f"User {user['user']} has Console Password enabled and MFA enabled."
+            else:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"User {user['user']} has not Console Password enabled."
+                )
             findings.append(report)
 
         return findings

--- a/prowler
+++ b/prowler
@@ -32,7 +32,13 @@ from providers.aws.aws_provider import (
 if __name__ == "__main__":
     # CLI Arguments
     parser = argparse.ArgumentParser()
-    parser.add_argument("provider", choices=["aws"], help="Specify Provider")
+    parser.add_argument(
+        "provider",
+        choices=["aws"],
+        nargs="?",
+        default="aws",
+        help="Specify Cloud Provider",
+    )
 
     # Arguments to set checks to run
     # The following arguments needs to be set exclusivelly


### PR DESCRIPTION
### Description

Set the default cloud provider for the `provider` argument.

So, right now there is no need to input the positional argument, you can run `./prowler`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
