### PR TITLE
feat(output): Report generation data, color legend and assumed role information

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -3,7 +3,7 @@ from os import getcwd
 
 timestamp = datetime.today()
 timestamp_utc = datetime.now(timezone.utc).replace(tzinfo=timezone.utc)
-prowler_version = "3.0-alfa"
+prowler_version = "3.0-alpha"
 
 # Groups
 groups_file = "groups.json"

--- a/lib/banner.py
+++ b/lib/banner.py
@@ -14,6 +14,21 @@ def print_banner():
 | |_) | | | (_) \ V  V /| |  __/ |
 | .__/|_|  \___/ \_/\_/ |_|\___|_|v{prowler_version}
 |_|{Fore.BLUE} the handy cloud security tool
-{Fore.YELLOW} Date: {timestamp.strftime("%Y-%m-%d %H:%M:%S")}{Style.RESET_ALL}
+
+{Fore.YELLOW}Date: {timestamp.strftime("%Y-%m-%d %H:%M:%S")}{Style.RESET_ALL}
+
+Color code for results:
+ - {Fore.YELLOW}INFO (Information){Style.RESET_ALL}
+ - {Fore.GREEN}PASS (Recommended value){Style.RESET_ALL}
+ - {Fore.YELLOW}WARNING (Ignored by allowlist){Style.RESET_ALL}
+ - {Fore.RED}FAIL (Fix required){Style.RESET_ALL}
 """
     print(banner)
+    # printColorsCode
+
+
+# echo -e "\n$NORMAL Color code for results: "
+#     echo -e " - $NOTICE INFO (Information)$NORMAL"
+#     echo -e " - $OK PASS (Recommended value)$NORMAL"
+#     echo -e " - $WARNING WARNING (Ignored by allowlist)$NORMAL"
+#     echo -e " - $BAD FAIL (Fix required)$NORMAL"

--- a/lib/banner.py
+++ b/lib/banner.py
@@ -24,11 +24,3 @@ Color code for results:
  - {Fore.RED}FAIL (Fix required){Style.RESET_ALL}
 """
     print(banner)
-    # printColorsCode
-
-
-# echo -e "\n$NORMAL Color code for results: "
-#     echo -e " - $NOTICE INFO (Information)$NORMAL"
-#     echo -e " - $OK PASS (Recommended value)$NORMAL"
-#     echo -e " - $WARNING WARNING (Ignored by allowlist)$NORMAL"
-#     echo -e " - $BAD FAIL (Fix required)$NORMAL"

--- a/providers/aws/aws_provider_test.py
+++ b/providers/aws/aws_provider_test.py
@@ -71,6 +71,8 @@ class Test_AWS_Provider:
             audit_session=None,
             audited_account=None,
             audited_partition=None,
+            audited_identity_arn=None,
+            audited_user_id=None,
             profile=None,
             profile_region=None,
             credentials=None,

--- a/providers/aws/models.py
+++ b/providers/aws/models.py
@@ -33,6 +33,8 @@ class AWS_Audit_Info:
     original_session: session.Session
     audit_session: session.Session
     audited_account: int
+    audited_identity_arn: str
+    audited_user_id: str
     audited_partition: str
     profile: str
     profile_region: str


### PR DESCRIPTION
### Description

We want to include the color scheme legend and the AWS report generation information to the v3.

**Color code:**

```
Color code for results:
- INFO (Information)
- PASS (Recommended value)
- WARNING (Ignored by allowlist)
- FAIL (Fix required)
```

**Report generation:**

```
This report is being generated using credentials below:

AWS-CLI Profile: [default] AWS API Region: [us-west-2] AWS Filter Region: [all]
AWS Account: [111111222222] UserId: [<redacted>:<redacted>]
Caller Identity ARN: [arn:aws:sts::111111222222:assumed-role/<redacted>]
Assumed Role ARN: [arn:aws:sts::111111222222:assumed-role/<redacted>]
```

I've also included a new line to show the Assumed Role ARN in the case of -A.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
