### PR TITLE
chore: change default log level

### DIFF
--- a/prowler
+++ b/prowler
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--log-level",
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-        default="ERROR",
+        default="CRITICAL",
         help="Select Log Level",
     )
     parser.add_argument(


### PR DESCRIPTION
### Description

Set `CRITICAL` as the default log level

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
