### PR TITLE
Refactor security groups checks

### DIFF
--- a/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port.py
+++ b/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port.py
@@ -1,5 +1,5 @@
 from lib.check.models import Check, Check_Report
-from providers.aws.services.ec2.ec2_service import ec2_client
+from providers.aws.services.ec2.ec2_service import check_security_group, ec2_client
 
 
 class ec2_securitygroup_allow_ingress_from_internet_to_any_port(Check):
@@ -12,17 +12,15 @@ class ec2_securitygroup_allow_ingress_from_internet_to_any_port(Check):
                     public = False
                     report = Check_Report(self.metadata)
                     report.region = region
+                    # Loop through every security group's ingress rule and check it
                     for ingress_rule in security_group.ingress_rules:
-                        # Check if the security group is open to the internet to all protocols
-                        if (
-                            "0.0.0.0/0" in str(ingress_rule["IpRanges"])
-                            or "::/0" in str(ingress_rule["Ipv6Ranges"])
-                        ) and ingress_rule["IpProtocol"] == "-1":
-                            public = True
-                            report.status = "FAIL"
-                            report.status_extended = f"Security group {security_group.name} ({security_group.id}) has all ports open to the Internet."
-                            report.resource_id = security_group.id
-                    if not public:
+                        public = check_security_group(ingress_rule, "-1")
+                    # Check
+                    if public:
+                        report.status = "FAIL"
+                        report.status_extended = f"Security group {security_group.name} ({security_group.id}) has all ports open to the Internet."
+                        report.resource_id = security_group.id
+                    else:
                         report.status = "PASS"
                         report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not all ports open to the Internet."
                         report.resource_id = security_group.id

--- a/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.py
+++ b/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.py
@@ -1,11 +1,11 @@
 from lib.check.models import Check, Check_Report
-from providers.aws.services.ec2.ec2_service import ec2_client
+from providers.aws.services.ec2.ec2_service import check_security_group, ec2_client
 
 
 class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22(Check):
     def execute(self):
         findings = []
-        check_port = 22
+        check_ports = [22]
         for regional_client in ec2_client.regional_clients:
             region = regional_client.region
             if regional_client.security_groups:
@@ -13,23 +13,15 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22(Check):
                     public = False
                     report = Check_Report(self.metadata)
                     report.region = region
+                    # Loop through every security group's ingress rule and check it
                     for ingress_rule in security_group.ingress_rules:
-                        if (
-                            (
-                                "0.0.0.0/0" in str(ingress_rule["IpRanges"])
-                                or "::/0" in str(ingress_rule["Ipv6Ranges"])
-                            )
-                            and (
-                                ingress_rule["FromPort"] == check_port
-                                and ingress_rule["ToPort"] == check_port
-                            )
-                            and ingress_rule["IpProtocol"] == "tcp"
-                        ):
-                            public = True
-                            report.status = "FAIL"
-                            report.status_extended = f"Security group {security_group.name} ({security_group.id}) has the SSH port 22 open to the Internet."
-                            report.resource_id = security_group.id
-                    if not public:
+                        public = check_security_group(ingress_rule, "tcp", check_ports)
+                    # Check
+                    if public:
+                        report.status = "FAIL"
+                        report.status_extended = f"Security group {security_group.name} ({security_group.id}) has the SSH port 22 open to the Internet."
+                        report.resource_id = security_group.id
+                    else:
                         report.status = "PASS"
                         report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not SSH port 22 open to the Internet."
                         report.resource_id = security_group.id

--- a/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306.py
+++ b/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306.py
@@ -1,11 +1,11 @@
 from lib.check.models import Check, Check_Report
-from providers.aws.services.ec2.ec2_service import ec2_client
+from providers.aws.services.ec2.ec2_service import check_security_group, ec2_client
 
 
 class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306(Check):
     def execute(self):
         findings = []
-        check_port = 3306
+        check_ports = [3306]
         for regional_client in ec2_client.regional_clients:
             region = regional_client.region
             if regional_client.security_groups:
@@ -13,25 +13,17 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306(Check
                     public = False
                     report = Check_Report(self.metadata)
                     report.region = region
+                    # Loop through every security group's ingress rule and check it
                     for ingress_rule in security_group.ingress_rules:
-                        if (
-                            (
-                                "0.0.0.0/0" in str(ingress_rule["IpRanges"])
-                                or "::/0" in str(ingress_rule["Ipv6Ranges"])
-                            )
-                            and (
-                                ingress_rule["FromPort"] == check_port
-                                and ingress_rule["ToPort"] == check_port
-                            )
-                            and ingress_rule["IpProtocol"] == "tcp"
-                        ):
-                            public = True
-                            report.status = "FAIL"
-                            report.status_extended = f"Security group {security_group.name} ({security_group.id}) has the MySQL port open to the Internet."
-                            report.resource_id = security_group.id
-                    if not public:
+                        public = check_security_group(ingress_rule, "tcp", check_ports)
+                    # Check
+                    if public:
+                        report.status = "FAIL"
+                        report.status_extended = f"Security group {security_group.name} ({security_group.id}) has the MySQL port 3306 open to the Internet."
+                        report.resource_id = security_group.id
+                    else:
                         report.status = "PASS"
-                        report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not MySQL ports open to the Internet."
+                        report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not MySQL port 3306 open to the Internet."
                         report.resource_id = security_group.id
                     findings.append(report)
             else:

--- a/providers/aws/services/ec2/ec2_service.py
+++ b/providers/aws/services/ec2/ec2_service.py
@@ -1,5 +1,6 @@
 import threading
 from dataclasses import dataclass
+from typing import Any
 
 from lib.logger import logger
 from providers.aws.aws_provider import current_audit_info, generate_regional_clients
@@ -232,3 +233,49 @@ class NetworkACL:
 
 
 ec2_client = EC2(current_audit_info)
+
+################## Security Groups
+# Check if the security group ingress rule has public access to the check_ports using the protocol
+def check_security_group(ingress_rule: Any, protocol: str, ports: list = []) -> bool:
+    public_IPv4 = "0.0.0.0/0"
+    public_IPv6 = "::/0"
+
+    # Check for all traffic ingress rules regardless of the protocol
+    if ingress_rule["IpProtocol"] == "-1" and (
+        (
+            "0.0.0.0/0" in str(ingress_rule["IpRanges"])
+            or "::/0" in str(ingress_rule["Ipv6Ranges"])
+        )
+    ):
+        return True
+
+    # Check for specific ports in ingress rules
+    if "FromPort" in ingress_rule:
+        # All ports
+        if ingress_rule["FromPort"] == 0 and ingress_rule["ToPort"] == 65535:
+            return True
+
+        # If there is a port range
+        if ingress_rule["FromPort"] != ingress_rule["ToPort"]:
+            # Calculate port range, adding 1
+            diff = (ingress_rule["ToPort"] - ingress_rule["FromPort"]) + 1
+            ingress_port_range = []
+            for x in range(diff):
+                ingress_port_range.append(int(ingress_rule["FromPort"]) + x)
+        # If FromPort and ToPort are the same
+        else:
+            ingress_port_range = []
+            ingress_port_range.append(int(ingress_rule["FromPort"]))
+
+        # Test Security Group
+        for port in ports:
+            if (
+                (
+                    public_IPv4 in str(ingress_rule["IpRanges"])
+                    or public_IPv6 in str(ingress_rule["Ipv6Ranges"])
+                )
+                and port in ingress_port_range
+                and ingress_rule["IpProtocol"] == protocol
+            ):
+                return True
+    return False


### PR DESCRIPTION
### Description

Refactor AWS EC2 security groups checks to only have one general function to test it, including the following missing scenarios:
- FromPort != ToPort
- 0 to 65535
- All protocols

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
