### PR TITLE
feat(output): Include tab for better reading

### DIFF
--- a/lib/outputs/outputs.py
+++ b/lib/outputs/outputs.py
@@ -43,16 +43,15 @@ def report(check_findings, output_options, audit_info):
         )
 
     for finding in check_findings:
-        # printing the finding ...
-
+        # Print findings by stdout
         color = set_report_color(finding.status)
         if output_options.is_quiet and "FAIL" in finding.status:
             print(
-                f"{color}{finding.status}{Style.RESET_ALL} {finding.region}: {finding.status_extended}"
+                f"\t{color}{finding.status}{Style.RESET_ALL} {finding.region}: {finding.status_extended}"
             )
         elif not output_options.is_quiet:
             print(
-                f"{color}{finding.status}{Style.RESET_ALL} {finding.region}: {finding.status_extended}"
+                f"\t{color}{finding.status}{Style.RESET_ALL} {finding.region}: {finding.status_extended}"
             )
         if file_descriptors:
 


### PR DESCRIPTION
### Description

We want to include a tab in every result to improve reading.

```
Check ID: ec2_securitygroup_allow_ingress_from_internet_to_any_port - ec2 [high]
    PASS eu-west-1: Security group test-1 has not all ports open to the Internet.
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
