### PR TITLE
fix(iam): Set user's region in findings

### DIFF
--- a/providers/aws/services/iam/iam_administrator_access_with_mfa/iam_administrator_access_with_mfa.py
+++ b/providers/aws/services/iam/iam_administrator_access_with_mfa/iam_administrator_access_with_mfa.py
@@ -12,7 +12,7 @@ class iam_administrator_access_with_mfa(Check):
                 report = Check_Report(self.metadata)
                 report.resource_id = group.name
                 report.resource_arn = group.arn
-                report.region = "us-east-1"
+                report.region = iam_client.region
                 if group.attached_policies:
                     admin_policy = False
                     for group_policy in group.attached_policies:

--- a/providers/aws/services/iam/iam_avoid_root_usage/iam_avoid_root_usage.py
+++ b/providers/aws/services/iam/iam_avoid_root_usage/iam_avoid_root_usage.py
@@ -15,7 +15,7 @@ class iam_avoid_root_usage(Check):
             for user in response:
                 if user["user"] == "<root_account>":
                     report = Check_Report(self.metadata)
-                    report.region = "us-east-1"
+                    report.region = iam_client.region
                     report.resource_id = user["user"]
                     report.resource_arn = user["arn"]
                     if (

--- a/providers/aws/services/iam/iam_disable_30_days_credentials/iam_disable_30_days_credentials.py
+++ b/providers/aws/services/iam/iam_disable_30_days_credentials/iam_disable_30_days_credentials.py
@@ -16,7 +16,7 @@ class iam_disable_30_days_credentials(Check):
                 report = Check_Report(self.metadata)
                 report.resource_id = user.name
                 report.resource_arn = user.arn
-                report.region = "us-east-1"
+                report.region = iam_client.region
                 if user.password_last_used and user.password_last_used != "":
                     try:
                         time_since_insertion = (

--- a/providers/aws/services/iam/iam_disable_90_days_credentials/iam_disable_90_days_credentials.py
+++ b/providers/aws/services/iam/iam_disable_90_days_credentials/iam_disable_90_days_credentials.py
@@ -14,7 +14,7 @@ class iam_disable_90_days_credentials(Check):
         if response:
             for user in response:
                 report = Check_Report(self.metadata)
-                report.region = "us-east-1"
+                report.region = iam_client.region
                 report.resource_id = user.name
                 report.resource_arn = user.arn
                 if user.password_last_used and user.password_last_used != "":
@@ -46,7 +46,7 @@ class iam_disable_90_days_credentials(Check):
             report = Check_Report(self.metadata)
             report.status = "PASS"
             report.status_extended = "There is no IAM users."
-            report.region = "us-east-1"
+            report.region = iam_client.region
             findings.append(report)
 
         return findings

--- a/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key.py
+++ b/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key.py
@@ -10,7 +10,7 @@ class iam_no_root_access_key(Check):
         for user in response:
             if user["user"] == "<root_account>":
                 report = Check_Report(self.metadata)
-                report.region = "us-east-1"
+                report.region = iam_client.region
                 report.resource_id = user["user"]
                 report.resource_arn = user["arn"]
                 if (

--- a/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.py
+++ b/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.py
@@ -7,7 +7,7 @@ class iam_root_hardware_mfa_enabled(Check):
         findings = []
         virtual_mfa = False
         report = Check_Report(self.metadata)
-        report.region = "us-east-1"
+        report.region = iam_client.region
         report.resource_id = "root"
         report.resource_arn = f"arn:aws:iam::{iam_client.account}:root"
 

--- a/providers/aws/services/iam/iam_root_mfa_enabled/iam_root_mfa_enabled.py
+++ b/providers/aws/services/iam/iam_root_mfa_enabled/iam_root_mfa_enabled.py
@@ -10,7 +10,7 @@ class iam_root_mfa_enabled(Check):
             for user in iam_client.credential_report:
                 if user["user"] == "<root_account>":
                     report = Check_Report(self.metadata)
-                    report.region = "us-east-1"
+                    report.region = iam_client.region
                     report.resource_id = user["user"]
                     report.resource_arn = user["arn"]
                     if user["mfa_active"] == "false":

--- a/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.py
+++ b/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.py
@@ -14,7 +14,7 @@ class iam_rotate_access_key_90_days(Check):
         if response:
             for user in response:
                 report = Check_Report(self.metadata)
-                report.region = "us-east-1"
+                report.region = iam_client.region
                 report.resource_id = user["user"]
                 report.resource_arn = user["arn"]
                 if (
@@ -57,7 +57,7 @@ class iam_rotate_access_key_90_days(Check):
             report = Check_Report(self.metadata)
             report.status = "PASS"
             report.status_extended = "There is no IAM users."
-            report.region = "us-east-1"
+            report.region = iam_client.region
             findings.append(report)
 
         return findings

--- a/providers/aws/services/iam/iam_user_hardware_mfa_enabled/iam_user_hardware_mfa_enabled.py
+++ b/providers/aws/services/iam/iam_user_hardware_mfa_enabled/iam_user_hardware_mfa_enabled.py
@@ -12,7 +12,7 @@ class iam_user_hardware_mfa_enabled(Check):
                 report = Check_Report(self.metadata)
                 report.resource_id = user.name
                 report.resource_arn = user.arn
-                report.region = "us-east-1"
+                report.region = iam_client.region
                 if user.mfa_devices:
                     for mfa_device in user.mfa_devices:
                         if mfa_device.type == "mfa" or mfa_device.type == "sms-mfa":

--- a/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access.py
+++ b/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access.py
@@ -12,7 +12,7 @@ class iam_user_mfa_enabled_console_access(Check):
                 report = Check_Report(self.metadata)
                 report.resource_id = user["user"]
                 report.resource_arn = user["arn"]
-                report.region = "us-east-1"
+                report.region = iam_client.region
                 if user["password_enabled"] != "not_supported":
                     if user["mfa_active"] == "false":
                         report.status = "FAIL"

--- a/providers/aws/services/iam/iam_user_two_active_access_key/iam_user_two_active_access_key.py
+++ b/providers/aws/services/iam/iam_user_two_active_access_key/iam_user_two_active_access_key.py
@@ -12,7 +12,7 @@ class iam_user_two_active_access_key(Check):
                 report = Check_Report(self.metadata)
                 report.resource_id = user["user"]
                 report.resource_arn = user["arn"]
-                report.region = "us-east-1"
+                report.region = iam_client.region
                 if (
                     user["access_key_1_active"] == "true"
                     and user["access_key_2_active"] == "true"


### PR DESCRIPTION
### Description

Set the finding’s region as the user’s profile region for every IAM check and not with the default `us-east-1`.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
