### PR TITLE
fix(ec2_instance_public_ip): Format resource_id

### DIFF
--- a/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip.py
+++ b/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip.py
@@ -14,13 +14,13 @@ class ec2_instance_public_ip(Check):
                     if instance.public_ip:
                         report.status = "FAIL"
                         report.status_extended = f"EC2 instance {instance.id} has a Public IP: {instance.public_ip} ({instance.public_dns})."
-                        report.resource_id = {instance.id}
+                        report.resource_id = instance.id
                     else:
                         report.status = "PASS"
                         report.status_extended = (
                             f"EC2 instance {instance.id} has not a Public IP."
                         )
-                        report.resource_id = {instance.id}
+                        report.resource_id = instance.id
                     findings.append(report)
             else:
                 report = Check_Report(self.metadata)


### PR DESCRIPTION
### Description

Fix typo in the `resource_id` for the `ec2_instance_public_ip` check.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
