### PR TITLE
fix(credential_report): Do not generate for 117 and 118

### DIFF
--- a/include/execute_check
+++ b/include/execute_check
@@ -86,10 +86,14 @@ execute_check() {
   ignores="$(awk "/${1}/{print}" <(echo "${ALLOWLIST}"))"
 
   if [ ${alternate_name} ];then
-    if [[ ${alternate_name} == check1* || ${alternate_name} == extra71 || ${alternate_name} == extra774 || ${alternate_name} == extra7123 ]];then
-      if [ ! -s $TEMP_REPORT_FILE ];then
-        genCredReport
-        saveReport
+    # Credential Report is not required for checks check17 and check118
+    if [[ ${alternate_name} != check117 && ${alternate_name} != check118 ]]
+    then
+      if [[ ${alternate_name} == check1* || ${alternate_name} == extra71 || ${alternate_name} == extra774 || ${alternate_name} == extra7123 ]];then
+        if [ ! -s $TEMP_REPORT_FILE ];then
+          genCredReport
+          saveReport
+        fi
       fi
     fi
     show_check_title ${alternate_name}


### PR DESCRIPTION
### Context 

```
1.17 [check117] Maintain current contact details - support [Medium]
1.18 [check118] Ensure security contact information is registered - support [Medium]
```

`check117` and `check118` does not need the credential report to run because the AWS account information is retrieved via AWS CLI.

### Description

Exclude the IAM credential report generation for the `check117` and `check118`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
