### PR TITLE
fix(check120): correct AWS support policy name

### DIFF
--- a/checks/check120
+++ b/checks/check120
@@ -28,7 +28,7 @@ CHECK_CAF_EPIC_check120='IAM'
 
 check120(){
   # "Ensure a support role has been created to manage incidents with AWS Support (Scored)"
-  SUPPORTPOLICYARN=$($AWSCLI iam list-policies --query "Policies[?PolicyName == 'AWSSupportAccess'].Arn" $PROFILE_OPT --region $REGION --output text)
+  SUPPORTPOLICYARN=$($AWSCLI iam list-policies --query "Policies[?PolicyName == 'AWSSupportServiceRolePolicy'].Arn" $PROFILE_OPT --region $REGION --output text)
   if [[ $SUPPORTPOLICYARN ]];then
     for policyarn in $SUPPORTPOLICYARN;do
       POLICYROLES=$($AWSCLI iam list-entities-for-policy --policy-arn $policyarn $PROFILE_OPT --region $REGION --output text | awk -F$'\t' '{ print $3 }')

--- a/checks/check120
+++ b/checks/check120
@@ -23,12 +23,12 @@ CHECK_ASFF_COMPLIANCE_TYPE_check120="ens-op.acc.1.aws.iam.4"
 CHECK_SERVICENAME_check120="iam"
 CHECK_RISK_check120='AWS provides a support center that can be used for incident notification and response; as well as technical support and customer services. Create an IAM Role to allow authorized users to manage incidents with AWS Support.'
 CHECK_REMEDIATION_check120='Create an IAM role for managing incidents with AWS.'
-CHECK_DOC_check120='https://docs.aws.amazon.com/awssupport/latest/user/using-service-linked-roles-sup.html'
+CHECK_DOC_check120='https://docs.aws.amazon.com/awssupport/latest/user/accessing-support.html'
 CHECK_CAF_EPIC_check120='IAM'
 
 check120(){
   # "Ensure a support role has been created to manage incidents with AWS Support (Scored)"
-  SUPPORTPOLICYARN=$($AWSCLI iam list-policies --query "Policies[?PolicyName == 'AWSSupportServiceRolePolicy'].Arn" $PROFILE_OPT --region $REGION --output text)
+  SUPPORTPOLICYARN=$($AWSCLI iam list-policies --query "Policies[?PolicyName == 'AWSSupportAccess'].Arn" $PROFILE_OPT --region $REGION --output text)
   if [[ $SUPPORTPOLICYARN ]];then
     for policyarn in $SUPPORTPOLICYARN;do
       POLICYROLES=$($AWSCLI iam list-entities-for-policy --policy-arn $policyarn $PROFILE_OPT --region $REGION --output text | awk -F$'\t' '{ print $3 }')


### PR DESCRIPTION
According to the official documentation, which the check refers to (URL provided by the variable` $CHECK_DOC_check120`), the policy is not "`AWSSupportAccess`" but "`AWSSupportServiceRolePolicy`". The policy `AWSSupportAccess` check returns FAIL because it is not attached to any entity (The response in line 31 is empty), and it seems correct for this check to call the `AWSSupportServiceRolePolicy` instead

### Context 

I was getting FAIL for check120, even though I had the correct configuration according to this check's official AWS documentation so I decided to debug the code and found that AWSSupportServiceRolePolicy is the correct role to extract information from in order to verify this check

**NOTE: I followed only the provided URL for this check to debug and correct this** [https://docs.aws.amazon.com/awssupport/latest/user/using-service-linked-roles-sup.html](https://docs.aws.amazon.com/awssupport/latest/user/using-service-linked-roles-sup.html)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
