### PR TITLE
fix(csv_separator): Change CSV separator to pipe

### DIFF
--- a/include/default_variables
+++ b/include/default_variables
@@ -46,7 +46,7 @@ export OUTPUT_DATE
 # Default Prowler Options
 QUIET=0
 export QUIET
-SEP=','
+SEP='|'
 export SEP
 KEEPCREDREPORT=0
 export KEEPCREDREPORT


### PR DESCRIPTION
News seperator "PIPE"

### Context 

Exporting on CSV has many problems due some descriptions that includes the comma "," and break the separators count.

### Description

Just, simple change the variable "SEP" from "," to "|".

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
