### PR TITLE
fix(s3_regions): verify if there are filter regions

### DIFF
--- a/providers/aws/services/s3/s3_service.py
+++ b/providers/aws/services/s3/s3_service.py
@@ -39,7 +39,11 @@ class S3:
                     "LocationConstraint"
                 ]
                 if not bucket_region:  # If us-east-1, bucket_region is none
-                    buckets.append(Bucket(bucket["Name"], "us-east-1"))
+                    bucket_region = "us-east-1"
+                # Check if there are filter regions
+                if current_audit_info.audited_regions:
+                    if bucket_region in current_audit_info.audited_regions:
+                        buckets.append(Bucket(bucket["Name"], bucket_region))
                 else:
                     buckets.append(Bucket(bucket["Name"], bucket_region))
             return buckets


### PR DESCRIPTION
### Context 

When running S3 all buckets where listed despite the audited regions.

### Description

Only list the buckets from the audited regions, if any.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
