### PR TITLE
feat(shub_compatibility): send finding to filter regions and change checkType to list

### DIFF
--- a/lib/check/fixtures/metadata.json
+++ b/lib/check/fixtures/metadata.json
@@ -5,7 +5,7 @@
   ],
   "CheckID": "iam_disable_30_days_credentials",
   "CheckTitle": "Ensure credentials unused for 30 days or greater are disabled",
-  "CheckType": "Software and Configuration Checks",
+  "CheckType": ["Software and Configuration Checks"],
   "Compliance": [
     {
       "Control": [

--- a/lib/check/models.py
+++ b/lib/check/models.py
@@ -57,7 +57,7 @@ class Check_Metadata_Model(BaseModel):
     # CheckName: str
     CheckTitle: str
     # CheckAlias: str
-    CheckType: str
+    CheckType: List[str]
     ServiceName: str
     SubServiceName: str
     ResourceIdTemplate: str

--- a/lib/outputs/outputs.py
+++ b/lib/outputs/outputs.py
@@ -211,7 +211,7 @@ def fill_json_asff(finding_output, audit_info, finding):
     )
     finding_output.GeneratorId = "prowler-" + finding.check_metadata.CheckID
     finding_output.AwsAccountId = audit_info.audited_account
-    finding_output.Types = [finding.check_metadata.CheckType]
+    finding_output.Types = finding.check_metadata.CheckType
     finding_output.FirstObservedAt = (
         finding_output.UpdatedAt
     ) = finding_output.CreatedAt = timestamp_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -229,7 +229,7 @@ def fill_json_asff(finding_output, audit_info, finding):
     # Add ED to PASS or FAIL (PASSED/FAILED)
     finding_output.Compliance = Compliance(
         Status=finding.status + "ED",
-        RelatedRequirements=[finding.check_metadata.CheckType],
+        RelatedRequirements=finding.check_metadata.CheckType,
     )
     finding_output.Remediation = {
         "Recommendation": finding.check_metadata.Remediation.Recommendation

--- a/providers/aws/aws_provider.py
+++ b/providers/aws/aws_provider.py
@@ -322,3 +322,10 @@ def generate_regional_clients(service, audit_info):
         regional_clients[region] = regional_client
         # regional_clients.append(regional_client)
     return regional_clients
+
+
+def get_region_global_service(audit_info):
+    # Check if global service to send the finding to first audited region
+    if audit_info.audited_regions:
+        return audit_info.audited_regions[0]
+    return audit_info.profile_region

--- a/providers/aws/aws_provider.py
+++ b/providers/aws/aws_provider.py
@@ -304,7 +304,7 @@ def get_organizations_metadata(
         return organizations_info
 
 
-def generate_regional_clients(service, audit_info):
+def generate_regional_clients(service: str, audit_info: AWS_Audit_Info) -> dict:
     regional_clients = {}
     # Get json locally
     f = open_file(aws_services_json_file)
@@ -324,7 +324,7 @@ def generate_regional_clients(service, audit_info):
     return regional_clients
 
 
-def get_region_global_service(audit_info):
+def get_region_global_service(audit_info: AWS_Audit_Info) -> str:
     # Check if global service to send the finding to first audited region
     if audit_info.audited_regions:
         return audit_info.audited_regions[0]

--- a/providers/aws/aws_provider_test.py
+++ b/providers/aws/aws_provider_test.py
@@ -7,6 +7,7 @@ from moto import mock_iam, mock_organizations, mock_sts
 from providers.aws.aws_provider import (
     assume_role,
     get_organizations_metadata,
+    get_region_global_service,
     validate_credentials,
 )
 from providers.aws.models import AWS_Assume_Role, AWS_Audit_Info
@@ -166,3 +167,25 @@ class Test_AWS_Provider:
         )
         org.account_details_org.should.equal(org_id)
         org.account_details_tags.should.equal("key:value,")
+
+    def test_get_region_global_service(self):
+        # Create mock audit_info
+        input_audit_info = AWS_Audit_Info(
+            original_session=None,
+            audit_session=None,
+            audited_account="123456789012",
+            audited_identity_arn="test-arn",
+            audited_user_id="test",
+            audited_partition="aws",
+            profile="default",
+            profile_region="eu-west-1",
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["eu-west-2", "eu-west-1"],
+            organizations_metadata=None,
+        )
+
+        assert (
+            get_region_global_service(input_audit_info)
+            == input_audit_info.audited_regions[0]
+        )

--- a/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot.metadata.json
+++ b/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "ec2_ebs_public_snapshot",
   "CheckTitle": "Ensure there are no EBS Snapshots set as Public.",
-  "CheckType": "Data Protection",
+  "CheckType": ["Data Protection"],
   "ServiceName": "ec2",
   "SubServiceName": "snapshot",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted.metadata.json
+++ b/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "ec2_ebs_snapshots_encrypted",
   "CheckTitle": "Check if EBS snapshots are encrypted.",
-  "CheckType": "Data Protection",
+  "CheckType": ["Data Protection"],
   "ServiceName": "ec2",
   "SubServiceName": "snapshot",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip.metadata.json
+++ b/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "ec2_instance_public_ip",
   "CheckTitle": "Check for EC2 Instances with Public IP.",
-  "CheckType": "Infrastructure Security",
+  "CheckType": ["Infrastructure Security"],
   "ServiceName": "ec2",
   "SubServiceName": "instance",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22.metadata.json
+++ b/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "ec2_networkacl_allow_ingress_tcp_port_22",
   "CheckTitle": "Ensure no Network ACLs allow ingress from 0.0.0.0/0 to SSH port 22",
-  "CheckType": "Infrastructure Security",
+  "CheckType": ["Infrastructure Security"],
   "ServiceName": "ec2",
   "SubServiceName": "networkacl",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389.metadata.json
+++ b/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "ec2_networkacl_allow_ingress_tcp_port_3389",
   "CheckTitle": "Ensure no Network ACLs allow ingress from 0.0.0.0/0 to Microsoft RDP port 3389",
-  "CheckType": "Infrastructure Security",
+  "CheckType": ["Infrastructure Security"],
   "ServiceName": "ec2",
   "SubServiceName": "networkacl",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port.metadata.json
+++ b/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "ec2_securitygroup_allow_ingress_from_internet_to_any_port",
   "CheckTitle": "Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to any port.",
-  "CheckType": "Infrastructure Security",
+  "CheckType": ["Infrastructure Security"],
   "ServiceName": "ec2",
   "SubServiceName": "securitygroup",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21.metadata.json
+++ b/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21",
   "CheckTitle": "Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to FTP ports 20 or 21.",
-  "CheckType": "Infrastructure Security",
+  "CheckType": ["Infrastructure Security"],
   "ServiceName": "ec2",
   "SubServiceName": "securitygroup",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.metadata.json
+++ b/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22",
   "CheckTitle": "Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to SSH port 22.",
-  "CheckType": "Infrastructure Security",
+  "CheckType": ["Infrastructure Security"],
   "ServiceName": "ec2",
   "SubServiceName": "securitygroup",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.metadata.json
+++ b/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389",
   "CheckTitle": "Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to port 3389.",
-  "CheckType": "Infrastructure Security",
+  "CheckType": ["Infrastructure Security"],
   "ServiceName": "ec2",
   "SubServiceName": "securitygroup",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306.metadata.json
+++ b/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306",
   "CheckTitle": "Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to MySQL port 3306.",
-  "CheckType": "Infrastructure Security",
+  "CheckType": ["Infrastructure Security"],
   "ServiceName": "ec2",
   "SubServiceName": "securitygroups",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483.metadata.json
+++ b/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483.metadata.json
@@ -3,7 +3,7 @@
 
   "CheckID": "ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483",
   "CheckTitle": "Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to Oracle ports 1521 or 2483.",
-  "CheckType": "Infrastructure Security",
+  "CheckType": ["Infrastructure Security"],
   "ServiceName": "ec2",
   "SubServiceName": "securitygroup",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/iam/iam_administrator_access_with_mfa/iam_administrator_access_with_mfa.metadata.json
+++ b/providers/aws/services/iam/iam_administrator_access_with_mfa/iam_administrator_access_with_mfa.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "iam_administrator_access_with_mfa",
   "CheckTitle": "Ensure users of groups with AdministratorAccess policy have MFA tokens enabled",
-  "CheckType": "Infrastructure Security",
+  "CheckType": ["Infrastructure Security"],
   "ServiceName": "iam",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/iam/iam_avoid_root_usage/iam_avoid_root_usage.metadata.json
+++ b/providers/aws/services/iam/iam_avoid_root_usage/iam_avoid_root_usage.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "iam_avoid_root_usage",
   "CheckTitle": "Avoid the use of the root accounts",
-  "CheckType": "Software and Configuration Checks/Industry and Regulatory Standards/CIS AWS Foundations Benchmark",
+  "CheckType": ["Software and Configuration Checks", "Industry and Regulatory Standards" ,"CIS AWS Foundations Benchmark"],
   "ServiceName": "iam",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/iam/iam_disable_30_days_credentials/iam_disable_30_days_credentials.metadata.json
+++ b/providers/aws/services/iam/iam_disable_30_days_credentials/iam_disable_30_days_credentials.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "iam_disable_30_days_credentials",
   "CheckTitle": "Ensure credentials unused for 30 days or greater are disabled",
-  "CheckType": "Software and Configuration Checks",
+  "CheckType": ["Software and Configuration Checks"],
   "ServiceName": "iam",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/iam/iam_disable_90_days_credentials/iam_disable_90_days_credentials.metadata.json
+++ b/providers/aws/services/iam/iam_disable_90_days_credentials/iam_disable_90_days_credentials.metadata.json
@@ -2,7 +2,7 @@
   "Categories": [],
   "CheckID": "iam_disable_90_days_credentials",
   "CheckTitle": "Ensure credentials unused for 90 days or greater are disabled",
-  "CheckType": "Software and Configuration Checks",
+  "CheckType": ["Software and Configuration Checks"],
   "Compliance": [
     {
       "Control": [

--- a/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key.metadata.json
+++ b/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "iam_no_root_access_key",
   "CheckTitle": "Ensure no root account access key exists",
-  "CheckType": "Software and Configuration Checks/Industry and Regulatory Standards/CIS AWS Foundations Benchmark",
+  "CheckType": ["Software and Configuration Checks", "Industry and Regulatory Standards" ,"CIS AWS Foundations Benchmark"],
   "ServiceName": "iam",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/iam/iam_password_policy_expires_passwords_within_90_days_or_less/iam_password_policy_expires_passwords_within_90_days_or_less.metadata.json
+++ b/providers/aws/services/iam/iam_password_policy_expires_passwords_within_90_days_or_less/iam_password_policy_expires_passwords_within_90_days_or_less.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "iam-password-policy-expires-passwords-within-90-days-or-less",
   "CheckTitle": "Ensure IAM password policy expires passwords within 90 days or less",
-  "CheckType": "Software and Configuration Checks/Industry and Regulatory Standards/CIS AWS Foundations Benchmark",
+  "CheckType": ["Software and Configuration Checks", "Industry and Regulatory Standards" ,"CIS AWS Foundations Benchmark"],
   "ServiceName": "iam",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation.metadata.json
+++ b/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "iam_policy_allows_privilege_escalation",
   "CheckTitle": "Ensure no Customer Managed IAM policies allow actions that may lead into Privilege Escalation",
-  "CheckType": "Software and Configuration Checks/Industry and Regulatory Standards/CIS AWS Foundations Benchmark",
+  "CheckType": ["Software and Configuration Checks", "Industry and Regulatory Standards" ,"CIS AWS Foundations Benchmark"],
   "ServiceName": "iam",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.metadata.json
+++ b/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "iam_root_hardware_mfa_enabled",
   "CheckTitle": "Ensure hardware MFA is enabled for the root account",
-  "CheckType": "Software and Configuration Checks/Industry and Regulatory Standards/CIS AWS Foundations Benchmark",
+  "CheckType": ["Software and Configuration Checks", "Industry and Regulatory Standards" ,"CIS AWS Foundations Benchmark"],
   "ServiceName": "iam",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/iam/iam_root_mfa_enabled/iam_root_mfa_enabled.metadata.json
+++ b/providers/aws/services/iam/iam_root_mfa_enabled/iam_root_mfa_enabled.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "iam_root_mfa_enabled",
   "CheckTitle": "Ensure MFA is enabled for the root account",
-  "CheckType": "Software and Configuration Checks/Industry and Regulatory Standards/CIS AWS Foundations Benchmark",
+  "CheckType": ["Software and Configuration Checks", "Industry and Regulatory Standards" ,"CIS AWS Foundations Benchmark"],
   "ServiceName": "iam",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.metadata.json
+++ b/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "iam_rotate_access_key_90_days",
   "CheckTitle": "Ensure access keys are rotated every 90 days or less",
-  "CheckType": "Software and Configuration Checks/Industry and Regulatory Standards/CIS AWS Foundations Benchmark",
+  "CheckType": ["Software and Configuration Checks", "Industry and Regulatory Standards" ,"CIS AWS Foundations Benchmark"],
   "ServiceName": "iam",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/iam/iam_service.py
+++ b/providers/aws/services/iam/iam_service.py
@@ -2,7 +2,7 @@ import csv
 from dataclasses import dataclass
 
 from lib.logger import logger
-from providers.aws.aws_provider import current_audit_info
+from providers.aws.aws_provider import current_audit_info, get_region_global_service
 
 
 ################## IAM
@@ -12,7 +12,7 @@ class IAM:
         self.session = audit_info.audit_session
         self.account = audit_info.audited_account
         self.client = self.session.client(self.service)
-        self.region = audit_info.profile_region
+        self.region = get_region_global_service(audit_info)
         self.users = self.__get_users__()
         self.roles = self.__get_roles__()
         self.account_summary = self.__get_account_summary__()

--- a/providers/aws/services/iam/iam_user_hardware_mfa_enabled/iam_user_hardware_mfa_enabled.metadata.json
+++ b/providers/aws/services/iam/iam_user_hardware_mfa_enabled/iam_user_hardware_mfa_enabled.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "iam_user_hardware_mfa_enabled",
   "CheckTitle": "Check if IAM users have Hardware MFA enabled.",
-  "CheckType": "Software and Configuration Checks/Industry and Regulatory Standards/CIS AWS Foundations Benchmark",
+  "CheckType": ["Software and Configuration Checks", "Industry and Regulatory Standards" ,"CIS AWS Foundations Benchmark"],
   "ServiceName": "iam",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access.metadata.json
+++ b/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "iam_user_mfa_enabled_console_access",
   "CheckTitle": "Ensure multi-factor authentication (MFA) is enabled for all IAM users that have a console password.",
-  "CheckType": "Software and Configuration Checks/Industry and Regulatory Standards/CIS AWS Foundations Benchmark",
+  "CheckType": ["Software and Configuration Checks", "Industry and Regulatory Standards" ,"CIS AWS Foundations Benchmark"],
   "ServiceName": "iam",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/iam/iam_user_two_active_access_key/iam_user_two_active_access_key.metadata.json
+++ b/providers/aws/services/iam/iam_user_two_active_access_key/iam_user_two_active_access_key.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "iam_user_two_active_access_key",
   "CheckTitle": "Check if IAM users have two active access keys",
-  "CheckType": "Software and Configuration Checks/Industry and Regulatory Standards/CIS AWS Foundations Benchmark",
+  "CheckType": ["Software and Configuration Checks", "Industry and Regulatory Standards" ,"CIS AWS Foundations Benchmark"],
   "ServiceName": "iam",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/s3/s3_bucket_object_versioning/s3_bucket_object_versioning.metadata.json
+++ b/providers/aws/services/s3/s3_bucket_object_versioning/s3_bucket_object_versioning.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "s3_bucket_object_versioning",
   "CheckTitle": "Check if S3 buckets have object versioning enabled",
-  "CheckType": "Data Protection",
+  "CheckType": ["Data Protection"],
   "ServiceName": "s3",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",

--- a/providers/aws/services/s3/s3_bucket_server_access_logging_enabled/s3_bucket_server_access_logging_enabled.metadata.json
+++ b/providers/aws/services/s3/s3_bucket_server_access_logging_enabled/s3_bucket_server_access_logging_enabled.metadata.json
@@ -2,7 +2,7 @@
   "Provider": "aws",
   "CheckID": "s3_bucket_server_access_logging_enabled",
   "CheckTitle": "Check if S3 buckets have server access logging enabled",
-  "CheckType": "Logging and Monitoring",
+  "CheckType": ["Logging and Monitoring"],
   "ServiceName": "s3",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",


### PR DESCRIPTION
### Context 

When checking global services we need to tell Prowler where to send the findings.
Also, SecurityHub change the RelatedRequirements attribute to a list.

### Description

- When using -f, send SecurityHub finding of global services to the first filter region.
- Change checkType attribute of metadata to list.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
