### PR TITLE
feat(custom_filename): custom output filename

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -15,6 +15,6 @@ default_output_directory = getcwd() + "/output"
 
 output_file_timestamp = timestamp.strftime("%Y%m%d%H%M%S")
 timestamp_iso = timestamp.isoformat()
-csv_file_suffix = f"{output_file_timestamp}.csv"
-json_file_suffix = f"{output_file_timestamp}.json"
-json_asff_file_suffix = f"{output_file_timestamp}.asff.json"
+csv_file_suffix = ".csv"
+json_file_suffix = ".json"
+json_asff_file_suffix = ".asff.json"

--- a/lib/check/check.py
+++ b/lib/check/check.py
@@ -178,13 +178,15 @@ def set_output_options(
     output_modes: list,
     input_output_directory: str,
     security_hub_enabled: bool,
+    output_filename: str,
 ):
     global output_options
     output_options = Output_From_Options(
         is_quiet=quiet,
         output_modes=output_modes,
         output_directory=input_output_directory,
-        security_hub_enabled=security_hub_enabled
+        security_hub_enabled=security_hub_enabled,
+        output_filename=output_filename,
         # set input options here
     )
     return output_options

--- a/lib/check/models.py
+++ b/lib/check/models.py
@@ -14,6 +14,7 @@ class Output_From_Options:
     output_modes: list
     output_directory: str
     security_hub_enabled: bool
+    output_filename: str
 
 
 # Testing Pending

--- a/lib/outputs/outputs_test.py
+++ b/lib/outputs/outputs_test.py
@@ -6,6 +6,7 @@ from config.config import (
     csv_file_suffix,
     json_asff_file_suffix,
     json_file_suffix,
+    output_file_timestamp,
     prowler_version,
     timestamp_iso,
     timestamp_utc,
@@ -42,47 +43,47 @@ class Test_Outputs:
             ["csv", "json"],
             ["csv", "json", "json-asff"],
         ]
-
+        output_filename = f"prowler-output-{audited_account}-{output_file_timestamp}"
         expected = [
             {
                 "csv": open_file(
-                    f"{output_directory}/prowler-output-{audited_account}-{csv_file_suffix}",
+                    f"{output_directory}/{output_filename}{csv_file_suffix}",
                     "a",
                 )
             },
             {
                 "json": open_file(
-                    f"{output_directory}/prowler-output-{audited_account}-{json_file_suffix}",
+                    f"{output_directory}/{output_filename}{json_file_suffix}",
                     "a",
                 )
             },
             {
                 "json-asff": open_file(
-                    f"{output_directory}/prowler-output-{audited_account}-{json_asff_file_suffix}",
+                    f"{output_directory}/{output_filename}{json_asff_file_suffix}",
                     "a",
                 )
             },
             {
                 "csv": open_file(
-                    f"{output_directory}/prowler-output-{audited_account}-{csv_file_suffix}",
+                    f"{output_directory}/{output_filename}{csv_file_suffix}",
                     "a",
                 ),
                 "json": open_file(
-                    f"{output_directory}/prowler-output-{audited_account}-{json_file_suffix}",
+                    f"{output_directory}/{output_filename}{json_file_suffix}",
                     "a",
                 ),
             },
             {
                 "csv": open_file(
-                    f"{output_directory}/prowler-output-{audited_account}-{csv_file_suffix}",
+                    f"{output_directory}/{output_filename}{csv_file_suffix}",
                     "a",
                 ),
                 "json": open_file(
-                    f"{output_directory}/prowler-output-{audited_account}-{json_file_suffix}",
+                    f"{output_directory}/{output_filename}{json_file_suffix}",
                     "a",
                 ),
                 "json-asff": open_file(
-                    f"{output_directory}/prowler-output-{audited_account}-{json_asff_file_suffix}",
+                    f"{output_directory}/{output_filename}{json_asff_file_suffix}",
                     "a",
                 ),
             },
@@ -90,7 +91,11 @@ class Test_Outputs:
 
         for index, output_mode_list in enumerate(test_output_modes):
             test_output_file_descriptors = fill_file_descriptors(
-                output_mode_list, audited_account, output_directory, csv_fields
+                output_mode_list,
+                audited_account,
+                output_directory,
+                csv_fields,
+                output_filename=None,
             )
             for output_mode in output_mode_list:
                 assert (

--- a/lib/outputs/outputs_test.py
+++ b/lib/outputs/outputs_test.py
@@ -35,7 +35,7 @@ from providers.aws.models import AWS_Audit_Info
 class Test_Outputs:
     def test_fill_file_descriptors(self):
         audited_account = "123456789012"
-        output_directory = f"{os.path.dirname(os.path.realpath(__file__))}/"
+        output_directory = f"{os.path.dirname(os.path.realpath(__file__))}"
         csv_fields = generate_csv_fields()
         test_output_modes = [
             ["csv"],
@@ -93,10 +93,9 @@ class Test_Outputs:
         for index, output_mode_list in enumerate(test_output_modes):
             test_output_file_descriptors = fill_file_descriptors(
                 output_mode_list,
-                audited_account,
                 output_directory,
                 csv_fields,
-                output_filename=None,
+                output_filename,
             )
             for output_mode in output_mode_list:
                 assert (

--- a/lib/outputs/outputs_test.py
+++ b/lib/outputs/outputs_test.py
@@ -1,3 +1,4 @@
+import os
 from os import path, remove
 
 from colorama import Fore
@@ -34,7 +35,7 @@ from providers.aws.models import AWS_Audit_Info
 class Test_Outputs:
     def test_fill_file_descriptors(self):
         audited_account = "123456789012"
-        output_directory = "."
+        output_directory = f"{os.path.dirname(os.path.realpath(__file__))}/"
         csv_fields = generate_csv_fields()
         test_output_modes = [
             ["csv"],

--- a/prowler
+++ b/prowler
@@ -133,8 +133,15 @@ if __name__ == "__main__":
         choices=["csv", "json", "json-asff"],
     )
     parser.add_argument(
+        "-F",
+        "--output-filename",
+        nargs="?",
+        default=None,
+        help="Custom output report name, if not specified will use default output/prowler-output-ACCOUNT_NUM-OUTPUT_DATE.format.",
+    )
+    parser.add_argument(
         "-o",
-        "--custom-output-directory",
+        "--output-directory",
         nargs="?",
         help="Custom output directory, by default the folder where Prowler is stored",
         default=default_output_directory,
@@ -169,7 +176,8 @@ if __name__ == "__main__":
     services = args.services
     groups = args.groups
     checks_file = args.checks_file
-    output_directory = args.custom_output_directory
+    output_directory = args.output_directory
+    output_filename = args.output_filename
     severities = args.severity
     output_modes = args.output_modes
 
@@ -247,11 +255,10 @@ if __name__ == "__main__":
 
     # Setting output options
     audit_output_options = set_output_options(
-        args.quiet, output_modes, output_directory, args.security_hub
+        args.quiet, output_modes, output_directory, args.security_hub, output_filename
     )
 
-    # Check output directory, if it is default and not created -> create it
-    # If is custom and not created -> error
+    # Check output directory, if it is not created -> create it
     if output_directory:
         if not isdir(output_directory):
             if output_modes:
@@ -298,11 +305,17 @@ if __name__ == "__main__":
         for mode in output_modes:
             # Close json file if exists
             if mode == "json" or mode == "json-asff":
-                close_json(output_directory, audit_info.audited_account, mode)
+                close_json(
+                    output_filename, output_directory, audit_info.audited_account, mode
+                )
             # Send output to S3 if needed
             if args.output_bucket:
                 send_to_s3_bucket(
-                    output_directory, mode, args.output_bucket, audit_info
+                    output_filename,
+                    output_directory,
+                    mode,
+                    args.output_bucket,
+                    audit_info,
                 )
 
     # Resolve previous fails of Security Hub

--- a/prowler
+++ b/prowler
@@ -23,7 +23,7 @@ from lib.check.check import (
 )
 from lib.check.checks_loader import load_checks_to_execute
 from lib.logger import logger, set_logging_config
-from lib.outputs.outputs import close_json
+from lib.outputs.outputs import close_json, send_to_s3_bucket
 from providers.aws.aws_provider import provider_set_session
 from providers.aws.lib.security_hub import resolve_security_hub_previous_findings
 
@@ -151,6 +151,13 @@ if __name__ == "__main__":
         action="store_true",
         help="Send check output to AWS Security Hub",
     )
+    parser.add_argument(
+        "-B",
+        "--output-bucket",
+        nargs="?",
+        default=None,
+        help="Custom output bucket, requires -M <mode> and it can work also with -o flag.",
+    )
     # Parse Arguments
     args = parser.parse_args()
 
@@ -247,12 +254,8 @@ if __name__ == "__main__":
     # If is custom and not created -> error
     if output_directory:
         if not isdir(output_directory):
-            if output_directory == default_output_directory:
-                if output_modes:
-                    mkdir(default_output_directory)
-            else:
-                logger.critical("Output directory does not exist")
-                sys.exit()
+            if output_modes:
+                mkdir(output_directory)
 
     # Set global session
     audit_info = provider_set_session(
@@ -291,11 +294,16 @@ if __name__ == "__main__":
             "There are no checks to execute. Please, check your input arguments"
         )
 
-    # Close json file if exists
     if output_modes:
         for mode in output_modes:
+            # Close json file if exists
             if mode == "json" or mode == "json-asff":
                 close_json(output_directory, audit_info.audited_account, mode)
+            # Send output to S3 if needed
+            if args.output_bucket:
+                send_to_s3_bucket(
+                    output_directory, mode, args.output_bucket, audit_info
+                )
 
     # Resolve previous fails of Security Hub
     if args.security_hub:

--- a/prowler
+++ b/prowler
@@ -6,7 +6,7 @@ import sys
 from os import mkdir
 from os.path import isdir
 
-from config.config import default_output_directory
+from config.config import default_output_directory, output_file_timestamp
 from lib.banner import print_banner, print_version
 from lib.check.check import (
     bulk_load_checks_metadata,
@@ -253,11 +253,6 @@ if __name__ == "__main__":
         else:
             output_modes.append("json-asff")
 
-    # Setting output options
-    audit_output_options = set_output_options(
-        args.quiet, output_modes, output_directory, args.security_hub, output_filename
-    )
-
     # Check output directory, if it is not created -> create it
     if output_directory:
         if not isdir(output_directory):
@@ -272,6 +267,17 @@ if __name__ == "__main__":
         args.external_id,
         args.filter_region,
         args.organizations_role,
+    )
+
+    # Check if custom output filename was input, if not, set the default
+    if not output_filename:
+        output_filename = (
+            f"prowler-output-{audit_info.audited_account}-{output_file_timestamp}"
+        )
+
+    # Setting output options
+    audit_output_options = set_output_options(
+        args.quiet, output_modes, output_directory, args.security_hub, output_filename
     )
 
     # Execute checks
@@ -305,9 +311,7 @@ if __name__ == "__main__":
         for mode in output_modes:
             # Close json file if exists
             if mode == "json" or mode == "json-asff":
-                close_json(
-                    output_filename, output_directory, audit_info.audited_account, mode
-                )
+                close_json(output_filename, output_directory, mode)
             # Send output to S3 if needed
             if args.output_bucket:
                 send_to_s3_bucket(
@@ -315,7 +319,7 @@ if __name__ == "__main__":
                     output_directory,
                     mode,
                     args.output_bucket,
-                    audit_info,
+                    audit_info.audit_session,
                 )
 
     # Resolve previous fails of Security Hub


### PR DESCRIPTION
### Context 

Add flag `-F` to put a custom filename for Prowler output reports.

### Description

Add flag `-F` to put a custom filename for Prowler output reports.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
