### PR TITLE
feat(group): CIS Critical Security Controls v8

### DIFF
--- a/groups/group27_cisig2
+++ b/groups/group27_cisig2
@@ -2,4 +2,4 @@
 GROUP_ID[27]='cisig2'
 GROUP_NUMBER[27]='27.0'
 GROUP_TITLE[27]='CIS implimentation group 2 only - [cisig2] ********************'
-GROUP_CHECKS[27]='check113,check114,check19,check110,check12,check121,extra774,check122,check120,extra734,extra764,extra7186,extra761,extra735,extra7131,extra78,extra7161,check21,check22,check23,check24,check25,check26,check27,check28,check29,check31,check32,check33,check34,check35,check36,check37,check38,check39,check310,check311,check312,check313,check314,extra799,check43,check44'
+GROUP_CHECKS[27]='check113,check114,check19,check110,check12,check121,extra774,check122,check120,extra734,extra764,extra7186,extra761,extra735,extra7131,extra78,extra7161,check21,check22,check23,check24,check25,check26,check27,check28,check29,check31,check32,check33,check34,check35,check36,check37,check38,check39,check310,check311,check312,check313,check314,extra799,check41,check42,check43,check44,check45,check46'

--- a/groups/group27_cisig2
+++ b/groups/group27_cisig2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+GROUP_ID[27]='cisig2'
+GROUP_NUMBER[27]='27.0'
+GROUP_TITLE[27]='CIS implimentation group 2 only - [cisig2] ********************'
+GROUP_CHECKS[27]='check113,check114,check19,check110,check12,check121,extra774,check122,check120,extra734,extra764,extra7186,extra761,extra735,extra7131,extra78,extra7161,check21,check22,check23,check24,check25,check26,check27,check28,check29,check31,check32,check33,check34,check35,check36,check37,check38,check39,check310,check311,check312,check313,check314,extra799,check43,check44'

--- a/groups/group27_cisig2
+++ b/groups/group27_cisig2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 GROUP_ID[27]='cisig2'
 GROUP_NUMBER[27]='27.0'
-GROUP_TITLE[27]='CIS implimentation group 2 only - [cisig2] ********************'
+GROUP_TITLE[27]='CIS Implementation Group 2 only - [cisig2] ********************'
 GROUP_CHECKS[27]='check113,check114,check19,check110,check12,check121,extra774,check122,check120,extra734,extra764,extra7186,extra761,extra735,extra7131,extra78,extra7161,check21,check22,check23,check24,check25,check26,check27,check28,check29,check31,check32,check33,check34,check35,check36,check37,check38,check39,check310,check311,check312,check313,check314,extra799,check41,check42,check43,check44,check45,check46'


### PR DESCRIPTION
### Context 

Provides a new group for checks that meet the CIS Critical Security Controls v8 Implementation Group 2 safeguards.


### Description

This group contains the existing checks that are used to validate the CIS AWS Foundations Benchmark requirements which have been mapped to the CIS Critical Security Controls v8 Implementation Group 2 safeguards using version v1.5 of the published CIS AWS Foundations Benchmark dated 08-12-2022.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
