### PR TITLE
fix(check_network_acl): check with all rules together

### DIFF
--- a/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22.py
+++ b/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22.py
@@ -9,20 +9,10 @@ class ec2_networkacl_allow_ingress_tcp_port_22(Check):
         tcp_protocol = "6"
         check_port = 22
         for network_acl in ec2_client.network_acls:
-            public = False
             report = Check_Report(self.metadata)
             report.region = network_acl.region
-            for entry in network_acl.entries:
-                # For IPv4
-                if "CidrBlock" in entry:
-                    public = check_network_acl(entry, tcp_protocol, check_port, "IPv4")
-                # For IPv6
-                if "Ipv6CidrBlock" in entry:
-                    public = check_network_acl(entry, tcp_protocol, check_port, "IPv6")
-                # If some entry allows it, that ACL is not securely configured
-                if public:
-                    break
-            if not public:
+            # If some entry allows it, that ACL is not securely configured
+            if not check_network_acl(network_acl.entries, tcp_protocol, check_port):
                 report.status = "PASS"
                 report.status_extended = f"Network ACL {network_acl.id} has not SSH port 22 open to the Internet."
                 report.resource_id = network_acl.id

--- a/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389.py
+++ b/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389.py
@@ -9,17 +9,10 @@ class ec2_networkacl_allow_ingress_tcp_port_3389(Check):
         tcp_protocol = "6"
         check_port = 3389
         for network_acl in ec2_client.network_acls:
-            public = False
             report = Check_Report(self.metadata)
             report.region = network_acl.region
-            for entry in network_acl.entries:
-                # For IPv4
-                if "CidrBlock" in entry:
-                    public = check_network_acl(entry, tcp_protocol, check_port, "IPv4")
-                # For IPv6
-                if "Ipv6CidrBlock" in entry:
-                    public = check_network_acl(entry, tcp_protocol, check_port, "IPv6")
-            if not public:
+            # If some entry allows it, that ACL is not securely configured
+            if not check_network_acl(network_acl.entries, tcp_protocol, check_port):
                 report.status = "PASS"
                 report.status_extended = f"Network ACL {network_acl.id} has not Microsoft RDP port 3389 open to the Internet."
                 report.resource_id = network_acl.id

--- a/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21.py
+++ b/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21.py
@@ -1,6 +1,6 @@
 from lib.check.models import Check, Check_Report
-from providers.aws.services.ec2.ec2_service import check_security_group, ec2_client
-
+from providers.aws.services.ec2.ec2_service import ec2_client
+from providers.aws.services.ec2.lib.security_groups import check_security_group
 
 class ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21(Check):
     def execute(self):

--- a/providers/aws/services/ec2/lib/network_acls_test.py
+++ b/providers/aws/services/ec2/lib/network_acls_test.py
@@ -1,0 +1,1106 @@
+from providers.aws.services.ec2.lib.network_acls import check_network_acl
+
+default_deny_entry_ingress_IPv4 = {
+    "CidrBlock": '0.0.0.0/0',
+    "Egress": False,
+    "NetworkAclId": "acl-072d520d07e1c1471",
+    "Protocol": "-1",
+    "RuleAction": 'deny',
+    "RuleNumber": 32767}
+
+default_deny_entry_ingress_IPv6 = {
+    "Ipv6CidrBlock": '::/0',
+    "Egress": False,
+    "NetworkAclId": "acl-072d520d07e1c1471",
+    "Protocol": "-1",
+    "RuleAction": 'deny',
+    "RuleNumber": 32768}
+
+default_deny_entry_egress_IPv4 = {
+    "CidrBlock": '0.0.0.0/0',
+    "Egress": True,
+    "NetworkAclId": "acl-072d520d07e1c1471",
+    "Protocol": "-1",
+    "RuleAction": 'deny',
+    "RuleNumber": 32767}
+
+default_deny_entry_egress_IPv6 = {
+    "Ipv6CidrBlock": '::/0',
+    "Egress": True,
+    "NetworkAclId": "acl-072d520d07e1c1471",
+    "Protocol": "-1",
+    "RuleAction": 'deny',
+    "RuleNumber": 32768}
+
+allow_all_entry_ingress_IPv4 = {
+    "CidrBlock": '0.0.0.0/0',
+    "Egress": False,
+    "NetworkAclId": "acl-072d520d07e1c1471",
+    "Protocol": "-1",
+    "RuleAction": 'allow',
+    "RuleNumber": 32766}
+
+allow_all_entry_ingress_IPv6 = {
+    "Ipv6CidrBlock": '::/0',
+    "Egress": False,
+    "NetworkAclId": "acl-072d520d07e1c1471",
+    "Protocol": "-1",
+    "RuleAction": 'allow',
+    "RuleNumber": 32766}
+
+
+class Test_Network_Acls_IPv4_Only:
+    def test_check_IPv4_only_ingress_port_default_entries_deny(self):
+        check_port = 22
+        tcp_protocol = "-1"
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == False
+
+    def test_check_IPv4_only_ingress_port_with_allow_port(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 100})
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_only_ingress_port_with_deny_port(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "RuleNumber": 100})
+
+        # Allow All IPv4
+        entries.append(allow_all_entry_ingress_IPv4)
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == False
+
+    def test_check_IPv4_only_ingress_port_with_deny_port_in_range(self):
+        check_port = 22
+        port_from = 21
+        port_to = 24
+        tcp_protocol = "6"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "PortRange": {
+                "From": port_from,
+                "To": port_to
+            },
+            "RuleNumber": 100})
+
+        # Allow All IPv4
+        entries.append(allow_all_entry_ingress_IPv4)
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == False
+
+    def test_check_IPv4_only_ingress_port_with_deny_port_out_range(self):
+        check_port = 22
+        port_from = 31
+        port_to = 34
+        tcp_protocol = "6"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "PortRange": {
+                "From": port_from,
+                "To": port_to
+            },
+            "RuleNumber": 100})
+
+        # Allow All IPv4
+        entries.append(allow_all_entry_ingress_IPv4)
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_only_ingress_port_with_deny_port_order_incorrect(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "RuleNumber": 102})
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 101})
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_only_ingress_port_with_deny_port_order_correct(self):
+
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "RuleNumber": 101})
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 102})
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == False
+
+    def test_check_IPv4_only_ingress_port_with_allow_port_but_egress(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": True,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 100})
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == False
+
+class Test_Network_Acls_IPv4_IPv6:
+    def test_check_IPv4_IPv6_ingress_port_default_entries_deny_both(self):
+        check_port = 22
+        tcp_protocol = "-1"
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == False
+
+    def test_check_IPv4_IPv6_ingress_port_with_allow_port_IPv4(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 100})
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_IPv6_ingress_port_with_allow_port_IPV6(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 100})
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_IPv6_ingress_port_with_allow_port_both(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 100})
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 101})
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_IPv6_ingress_port_with_deny_port_IPv4(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "RuleNumber": 100})
+
+        # Allow All IPv4
+        entries.append(allow_all_entry_ingress_IPv4)
+
+        # Allow All IPv6
+        entries.append(allow_all_entry_ingress_IPv6)
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_IPv6_ingress_port_with_deny_port_IPv6(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "RuleNumber": 100})
+
+        # Allow All IPv4
+        entries.append(allow_all_entry_ingress_IPv4)
+
+        # Allow All IPv6
+        entries.append(allow_all_entry_ingress_IPv6)
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_IPv6_ingress_port_with_deny_port_both(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "RuleNumber": 100})
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "RuleNumber": 101})
+
+        # Allow All IPv4
+        entries.append(allow_all_entry_ingress_IPv4)
+
+        # Allow All IPv6
+        entries.append(allow_all_entry_ingress_IPv6)
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == False
+
+    def test_check_IPv4_IPv6_ingress_port_with_deny_port_in_range_IPv4(self):
+        check_port = 22
+        port_from = 21
+        port_to = 24
+        tcp_protocol = "6"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "PortRange": {
+                "From": port_from,
+                "To": port_to
+            },
+            "RuleNumber": 100})
+
+        # Allow All IPv4
+        entries.append(allow_all_entry_ingress_IPv4)
+
+        # Allow All IPv6
+        entries.append(allow_all_entry_ingress_IPv6)
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_IPv6_ingress_port_with_deny_port_in_range_IPv6(self):
+        check_port = 22
+        port_from = 21
+        port_to = 24
+        tcp_protocol = "6"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "PortRange": {
+                "From": port_from,
+                "To": port_to
+            },
+            "RuleNumber": 100})
+
+        # Allow All IPv4
+        entries.append(allow_all_entry_ingress_IPv4)
+
+        # Allow All IPv6
+        entries.append(allow_all_entry_ingress_IPv6)
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_IPv6_ingress_port_with_deny_port_in_range_both(self):
+        check_port = 22
+        port_from = 21
+        port_to = 24
+        tcp_protocol = "6"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "PortRange": {
+                "From": port_from,
+                "To": port_to
+            },
+            "RuleNumber": 100})
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "PortRange": {
+                "From": port_from,
+                "To": port_to
+            },
+            "RuleNumber": 101})
+
+        # Allow All IPv4
+        entries.append(allow_all_entry_ingress_IPv4)
+
+        # Allow All IPv6
+        entries.append(allow_all_entry_ingress_IPv6)
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == False
+
+    def test_check_IPv4_IPv6_ingress_port_with_deny_port_out_range_IPv4(self):
+        check_port = 22
+        port_from = 31
+        port_to = 34
+        tcp_protocol = "6"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "PortRange": {
+                "From": port_from,
+                "To": port_to
+            },
+            "RuleNumber": 100})
+
+        # Allow All IPv4
+        entries.append(allow_all_entry_ingress_IPv4)
+
+        # Allow All IPv6
+        entries.append(allow_all_entry_ingress_IPv6)
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_IPv6_ingress_port_with_deny_port_out_range_IPv6(self):
+        check_port = 22
+        port_from = 31
+        port_to = 34
+        tcp_protocol = "6"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "PortRange": {
+                "From": port_from,
+                "To": port_to
+            },
+            "RuleNumber": 100})
+
+        # Allow All IPv4
+        entries.append(allow_all_entry_ingress_IPv4)
+
+        # Allow All IPv6
+        entries.append(allow_all_entry_ingress_IPv6)
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_IPv6_ingress_port_with_deny_port_out_range_both(self):
+        check_port = 22
+        port_from = 31
+        port_to = 34
+        tcp_protocol = "6"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "PortRange": {
+                "From": port_from,
+                "To": port_to
+            },
+            "RuleNumber": 100})
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "PortRange": {
+                "From": port_from,
+                "To": port_to
+            },
+            "RuleNumber": 101})
+
+        # Allow All IPv4
+        entries.append(allow_all_entry_ingress_IPv4)
+
+        # Allow All IPv6
+        entries.append(allow_all_entry_ingress_IPv6)
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_IPv6_ingress_port_with_deny_port_order_incorrect_IPv4(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "RuleNumber": 102})
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 101})
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_IPv6_ingress_port_with_deny_port_order_incorrect_IPv6(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "RuleNumber": 102})
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 101})
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_IPv6_ingress_port_with_deny_port_order_incorrect_both(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "RuleNumber": 102})
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 101})
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "RuleNumber": 202})
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 201})
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == True
+
+    def test_check_IPv4_IPv6_ingress_port_with_deny_port_order_correct_IPv4(self):
+
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "RuleNumber": 101})
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 102})
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == False
+
+    def test_check_IPv4_IPv6_ingress_port_with_deny_port_order_correct_IPv6(self):
+
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "RuleNumber": 101})
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 102})
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == False
+
+    def test_check_IPv4_IPv6_ingress_port_with_deny_port_order_correct_both(self):
+
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "RuleNumber": 101})
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 102})
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'deny',
+            "RuleNumber": 201})
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": False,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 202})
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == False
+
+    def test_check_IPv4_IPv6_ingress_port_with_allow_port_but_egress_IPv4(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": True,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 100})
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == False
+
+    def test_check_IPv4_IPv6_ingress_port_with_allow_port_but_egress_IPv6(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": True,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 100})
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == False
+
+    def test_check_IPv4_IPv6_ingress_port_with_allow_port_but_egress_both(self):
+        check_port = 22
+        tcp_protocol = "-1"
+
+        entries = []
+
+        # Default IPv4 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv4)
+
+        # Default IPv4 Egress Deny
+        entries.append(default_deny_entry_egress_IPv4)
+
+        # Default IPv6 Ingress Deny
+        entries.append(default_deny_entry_ingress_IPv6)
+
+        # Default IPv6 Egress Deny
+        entries.append(default_deny_entry_egress_IPv6)
+
+        entries.append({
+            "Ipv6CidrBlock": '::/0',
+            "Egress": True,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 100})
+
+        entries.append({
+            "CidrBlock": '0.0.0.0/0',
+            "Egress": True,
+            "NetworkAclId": "acl-072d520d07e1c1471",
+            "Protocol": tcp_protocol,
+            "RuleAction": 'allow',
+            "RuleNumber": 101})
+
+        assert check_network_acl(entries,
+                                 tcp_protocol, check_port) == False


### PR DESCRIPTION
### Context 

Checking the behaviour of the network ACL rule checker, it seems that it only checks one rule at a time and in order. This is incorrect from my point of view. The result of a network ACL check should use all your rules together, also check the priority of these rules and don't forget the deny rules.

### Description

#### 1st Topic : Priority Rules and Explicit Deny Rules

As you can see in the AWS documentation [Network ACL Priority](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html) priority is very important when applying Network ACL rules. 

<img width="1057" alt="image" src="https://user-images.githubusercontent.com/43682773/187087188-2b05a53a-9afb-4453-bb8b-791decece239.png">

The Boto3 API and the AWS client are returning for the same ACL network the rules in ascending order. Therefore, the code is checking the rules in order but it would be nice if the code ordered them. Even if this order is respected, the explicit deny rules are not checked. Note that users sometimes play with activating and deactivating rules temporarily, so it is normal to find explicit deny rules. 

Several examples with false positives:

- Explicit deny rule with high priority:

![image](https://user-images.githubusercontent.com/43682773/187089233-3e88eab2-0c0c-40b8-9cf1-39eb573af576.png)

![image](https://user-images.githubusercontent.com/43682773/187089224-19aff17c-0d3b-42e3-b974-a473579eb1cb.png)

- All traffic denied with a higher priority than the allowed rule:

![image](https://user-images.githubusercontent.com/43682773/187089347-480ecbf8-9ab7-4d40-8159-4a88639fea24.png)

![image](https://user-images.githubusercontent.com/43682773/187089224-19aff17c-0d3b-42e3-b974-a473579eb1cb.png)

- First deny and later allowed:

![image](https://user-images.githubusercontent.com/43682773/187089581-41b4c478-d44a-432e-8149-4340e64bdafe.png)

![image](https://user-images.githubusercontent.com/43682773/187089224-19aff17c-0d3b-42e3-b974-a473579eb1cb.png)

#### 2nd Topic : Explicit deny rule with IPv4 only or IPv4 and IPv6 together

Rules for IPv6 can be added without the Network ACL being applied to an IPv6 enabled subnet. As soon as there is a rule with the public address ::/0, it is assumed that IPv6 access is also checked, even if it is not actually activated.
It is necessary to check IPv6 rules separately from IPv4 rules. For example, in cases where there are explicit deny for IPv6 and not for IPv4 and vice versa. If for IPv6 there is a rule that allows public access ::/0, you don't need to very any further. If everything is correct for IPv6, you will have to check IPv4 rules.

I have implemented a new check_network_acl which I think is more complete and fix these problems. I changed the 2 checks that use it too.

I have attached a test file to verify various situations described above.

*** I think same problem exists in the master branch but I have not verified it in depth.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
