### PR TITLE
feat(audit_id): add optional audit_id field to postgres connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,8 @@ Install psql
 - Ubuntu -> `sudo apt-get install postgresql-client `
 - RHEL/Centos -> `sudo yum install postgresql10`
 
+### Audit ID Field
+Prowler can add an optional `audit_id` field to identify each audit that has been made in the database. You can do this by adding the `-u audit_id` flag to the prowler command.
 #### Credentials
 There are two options to pass the PostgreSQL credentials to Prowler:
 ##### Using a .pgpass file
@@ -361,6 +363,8 @@ Configure a `~/.pgpass` file into the root folder of the user that is going to l
 Create a table in your PostgreSQL database to store the Prowler's data. You can use the following SQL statement to create the table:
 ```
 CREATE TABLE  IF NOT EXISTS prowler_findings (
+audit_id TEXT,
+finding_id TEXT,
 profile TEXT,
 account_number TEXT,
 region TEXT,
@@ -380,12 +384,12 @@ remediation TEXT,
 documentation TEXT,
 check_caf_epic TEXT,
 resource_id TEXT,
-prowler_start_time TEXT,
 account_details_email TEXT,
 account_details_name TEXT,
 account_details_arn TEXT,
 account_details_org TEXT,
-account_details_tags  TEXT
+account_details_tags TEXT,
+prowler_start_time TEXT
 );
 ```
 

--- a/include/outputs
+++ b/include/outputs
@@ -197,7 +197,11 @@ general_output() {
   #checking database provider
   if [[ ${DATABASE_PROVIDER} == 'postgresql' ]]
   then
-        postgresql_connector "${CSV_LINE}"
+        FINDING_ID="$(LC_ALL=C echo -e -n "${CHECK_RESULT_EXTENDED}" | tr -cs '[:alnum:]._~-' '_')"
+        END_STRIPPED_TITLE_TEXT=${TITLE_TEXT%%\]*}
+        CHECK_ID="${END_STRIPPED_TITLE_TEXT##\[}"
+        POSTGRES_LINE="${AUDIT_ID//,/--}${SEP}${FINDING_ID//,/--}${SEP}${PROFILE//,/--}${SEP}${ACCOUNT_NUM//,/--}${SEP}${REGION_FROM_CHECK//,/--}${SEP}${CHECK_ID//,/--}${SEP}${CHECK_RESULT//,/--}${SEP}${ITEM_SCORED//,/--}${SEP}${ITEM_CIS_LEVEL//,/--}${SEP}${TITLE_TEXT//,/--}${SEP}${CHECK_RESULT_EXTENDED//,/--}${SEP}${CHECK_ASFF_COMPLIANCE_TYPE//,/--}${SEP}${CHECK_SEVERITY//,/--}${SEP}${CHECK_SERVICENAME//,/--}${SEP}${CHECK_ASFF_RESOURCE_TYPE//,/--}${SEP}${CHECK_ASFF_TYPE//,/--}${SEP}${CHECK_RISK//,/--}${SEP}${CHECK_REMEDIATION//,/--}${SEP}${CHECK_DOC//,/--}${SEP}${CHECK_CAF_EPIC//,/--}${SEP}${CHECK_RESOURCE_ID//,/--}${SEP}${ACCOUNT_DETAILS_EMAIL//,/--}${SEP}${ACCOUNT_DETAILS_NAME//,/--}${SEP}${ACCOUNT_DETAILS_ARN//,/--}${SEP}${ACCOUNT_DETAILS_ORG//,/--}${SEP}${ACCOUNT_DETAILS_TAGS//,/--}${SEP}${PROWLER_START_TIME//,/--}"
+        postgresql_connector "${POSTGRES_LINE}"
   fi
 }
 

--- a/prowler
+++ b/prowler
@@ -130,6 +130,7 @@ USAGE:
       -h                  This help.
       -d <provider>       Send output to database through database connectors supported, currently only PostgreSQL. Prowler will get the credentials and table name from your ~/.pgpass file.
       -i                  Run Prowler Quick Inventory. The inventory will be stored in an output csv by default.
+      -u <audit_id>       Add audit_id field to use with postgres connector.
   "
   exit
 }
@@ -139,7 +140,7 @@ USAGE:
 set_aws_default_output
 
 # Parse Prowler command line options
-while getopts ":hlLkqp:r:c:C:g:f:m:M:E:x:enbVsSI:A:R:T:w:N:o:B:D:F:zZ:O:a:d:i" OPTION; do
+while getopts ":hlLkqp:r:c:C:g:f:m:M:E:x:enbVsSI:A:R:T:w:N:o:B:D:F:zZ:O:a:d:i:u:" OPTION; do
    case $OPTION in
      h )
         usage
@@ -257,6 +258,9 @@ while getopts ":hlLkqp:r:c:C:g:f:m:M:E:x:enbVsSI:A:R:T:w:N:o:B:D:F:zZ:O:a:d:i" O
         ;;
      i )
         QUICK_INVENTORY=1
+        ;;
+     u )
+        AUDIT_ID=$OPTARG
         ;;
      : )
         echo ""


### PR DESCRIPTION
### Context 

Prowler can add an optional `audit_id` field to identify each audit that has been made in the database. You can do this by adding the `-u audit_id` flag to the prowler command.

### Description

Add the `-u audit_id` flag and include it in the postgres connector along finding_id field.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
