### PR TITLE
Dockerfile build instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build command
-# docker build --platform=linux/amd64  --no-cache -t prowler:latest -f util/Dockerfile .
+# docker build --platform=linux/amd64  --no-cache -t prowler:latest -f ./Dockerfile .
 
 # hadolint ignore=DL3007
 FROM public.ecr.aws/amazonlinux/amazonlinux:latest


### PR DESCRIPTION
Build instructions referenced Dockerfile that has moved.

Could also just drop the `-f` option.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
