### PR TITLE
fix(loader): Fix runs with no check exclusions

### DIFF
--- a/include/loader
+++ b/include/loader
@@ -78,9 +78,14 @@ get_checks() {
                         for CHECK_IDENTIFIER in ${GROUP_CHECKS[I]//,/ }
                         do
                             # Include every check if not present
-                            if [[ ! "${CHECK_LIST_BY_GROUP[*]}" =~ ${CHECK_IDENTIFIER} ]] && ! grep -E -w -q "${EXCLUDE_CHECK_ID//,/|}" <<< "${CHECK_IDENTIFIER}"
+                            if [ -z "$EXCLUDE_CHECK_ID" ]
                             then
                                 CHECK_LIST_BY_GROUP+=("${CHECK_IDENTIFIER}")
+                            else
+                                if ! grep -E -w -q "${EXCLUDE_CHECK_ID//,/|}" <<< "${CHECK_IDENTIFIER}"
+                                then
+                                    CHECK_LIST_BY_GROUP+=("${CHECK_IDENTIFIER}")
+                                fi
                             fi
                         done
                     fi


### PR DESCRIPTION
### Context 

This minor change addresses the issue in #1290 where Prowler fails to run with a group argument and no exclusions supplied.


### Description

The issue could be related to my shell (Bash 5.1.16) or grep (BSD grep) 2.5.1-FreeBSD.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
