### PR TITLE
fix(checks): Include missing output in checks

### DIFF
--- a/checks/check116
+++ b/checks/check116
@@ -29,21 +29,26 @@ CHECK_CAF_EPIC_check116='IAM'
 check116(){
   # "Ensure IAM policies are attached only to groups or roles (Scored)"
   LIST_USERS=$($AWSCLI iam list-users --query 'Users[*].UserName' --output text $PROFILE_OPT --region $REGION)
-  for user in $LIST_USERS;do
-    USER_ATTACHED_POLICY=$($AWSCLI iam list-attached-user-policies --output text $PROFILE_OPT --region $REGION --user-name $user)
-    USER_INLINE_POLICY=$($AWSCLI iam list-user-policies --output text $PROFILE_OPT --region $REGION --user-name $user)
-    if [[ $USER_ATTACHED_POLICY ]] || [[ $USER_INLINE_POLICY ]]
-    then
-      if [[ $USER_ATTACHED_POLICY ]]
+  if [[ "${LIST_USERS}" ]]
+  then
+    for user in $LIST_USERS;do
+      USER_ATTACHED_POLICY=$($AWSCLI iam list-attached-user-policies --output text $PROFILE_OPT --region $REGION --user-name $user)
+      USER_INLINE_POLICY=$($AWSCLI iam list-user-policies --output text $PROFILE_OPT --region $REGION --user-name $user)
+      if [[ $USER_ATTACHED_POLICY ]] || [[ $USER_INLINE_POLICY ]]
       then
-        textFail "$REGION: $user has managed policy directly attached" "$REGION" "$user"
+        if [[ $USER_ATTACHED_POLICY ]]
+        then
+          textFail "$REGION: $user has managed policy directly attached" "$REGION" "$user"
+        fi
+        if [[ $USER_INLINE_POLICY ]]
+        then
+          textFail "$REGION: $user has inline policy directly attached" "$REGION" "$user"
+        fi
+      else
+        textPass "$REGION: No policies attached to user $user" "$REGION" "$user"
       fi
-      if [[ $USER_INLINE_POLICY ]]
-      then
-        textFail "$REGION: $user has inline policy directly attached" "$REGION" "$user"
-      fi
-    else
-      textPass "$REGION: No policies attached to user $user" "$REGION" "$user"
-    fi
-  done
+    done
+  else
+    textPass "$REGION: No users found" "$REGION" "No users found"
+  fi
 }

--- a/checks/check_extra71
+++ b/checks/check_extra71
@@ -30,27 +30,32 @@ extra71(){
   # "Ensure users of groups with AdministratorAccess policy have MFA tokens enabled "
   ADMIN_GROUPS=''
   AWS_GROUPS=$($AWSCLI $PROFILE_OPT iam list-groups --output text --region $REGION --query 'Groups[].GroupName')
-  for grp in $AWS_GROUPS; do
-    # aws --profile onlinetraining iam list-attached-group-policies --group-name Administrators --query 'AttachedPolicies[].PolicyArn' | grep 'arn:aws:iam::aws:policy/AdministratorAccess'
-    # list-attached-group-policies
-    CHECK_ADMIN_GROUP=$($AWSCLI $PROFILE_OPT --region $REGION iam list-attached-group-policies --group-name $grp --output json --query 'AttachedPolicies[].PolicyArn' | grep  "arn:${AWS_PARTITION}:iam::aws:policy/AdministratorAccess")
-    if [[ $CHECK_ADMIN_GROUP ]]; then
-      ADMIN_GROUPS="$ADMIN_GROUPS $grp"
-      textInfo "$REGION: $grp group provides administrative access" "$REGION" "$grp"
-      ADMIN_USERS=$($AWSCLI $PROFILE_OPT iam get-group --region $REGION --group-name $grp --output json --query 'Users[].UserName' | grep '"' | cut -d'"' -f2 )
-      for auser in $ADMIN_USERS; do
-        # users in group are Administrators
-        # users
-        # check for user MFA device in credential report
-        USER_MFA_ENABLED=$( cat $TEMP_REPORT_FILE | grep "^$auser," | cut -d',' -f8)
-        if [[ "true" == $USER_MFA_ENABLED ]]; then
-          textPass "$REGION: $auser / MFA Enabled / admin via group $grp" "$REGION" "$grp"
-        else
-          textFail "$REGION: $auser / MFA DISABLED / admin via group $grp" "$REGION" "$grp"
-        fi
-      done
-    else
-      textInfo "$REGION: $grp group provides non-administrative access" "$REGION" "$grp"
-    fi
-  done
+  if [[ ${AWS_GROUPS} ]]
+  then
+    for grp in $AWS_GROUPS; do
+      # aws --profile onlinetraining iam list-attached-group-policies --group-name Administrators --query 'AttachedPolicies[].PolicyArn' | grep 'arn:aws:iam::aws:policy/AdministratorAccess'
+      # list-attached-group-policies
+      CHECK_ADMIN_GROUP=$($AWSCLI $PROFILE_OPT --region $REGION iam list-attached-group-policies --group-name $grp --output json --query 'AttachedPolicies[].PolicyArn' | grep  "arn:${AWS_PARTITION}:iam::aws:policy/AdministratorAccess")
+      if [[ $CHECK_ADMIN_GROUP ]]; then
+        ADMIN_GROUPS="$ADMIN_GROUPS $grp"
+        textInfo "$REGION: $grp group provides administrative access" "$REGION" "$grp"
+        ADMIN_USERS=$($AWSCLI $PROFILE_OPT iam get-group --region $REGION --group-name $grp --output json --query 'Users[].UserName' | grep '"' | cut -d'"' -f2 )
+        for auser in $ADMIN_USERS; do
+          # users in group are Administrators
+          # users
+          # check for user MFA device in credential report
+          USER_MFA_ENABLED=$( cat $TEMP_REPORT_FILE | grep "^$auser," | cut -d',' -f8)
+          if [[ "true" == $USER_MFA_ENABLED ]]; then
+            textPass "$REGION: $auser / MFA Enabled / admin via group $grp" "$REGION" "$grp"
+          else
+            textFail "$REGION: $auser / MFA DISABLED / admin via group $grp" "$REGION" "$grp"
+          fi
+        done
+      else
+        textInfo "$REGION: $grp group provides non-administrative access" "$REGION" "$grp"
+      fi
+    done
+  else
+    textPass "$REGION: There is no IAM groups" "$REGION"
+  fi
 }

--- a/checks/check_extra789
+++ b/checks/check_extra789
@@ -32,36 +32,41 @@ extra789(){
                                 ${PROFILE_OPT} \
                                 --query "ServiceDetails[?Owner=='${ACCOUNT_NUM}'].ServiceId" \
                                 --region ${regx} \
-                                --output text | xargs 2>&1)
-    if [[ $(echo "$ENDPOINT_SERVICES_IDS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-        textInfo "$regx: Access Denied trying to describe VPC endpoint services" "$regx"
-        continue
-    fi
+                                --output text 2>&1)
+        if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${ENDPOINT_SERVICES_IDS}"; then
+            textInfo "$regx: Access Denied trying to describe VPC endpoint services" "$regx"
+            continue
+        fi
 
-        for ENDPOINT_SERVICE_ID in ${ENDPOINT_SERVICES_IDS}; do
+        if [[ ${ENDPOINT_SERVICES_IDS} ]]
+        then
+            for ENDPOINT_SERVICE_ID in ${ENDPOINT_SERVICES_IDS}; do
 
-            ENDPOINT_CONNECTION_LIST=$(${AWSCLI} ec2 describe-vpc-endpoint-connections \
-                                        ${PROFILE_OPT} \
-                                        --query "VpcEndpointConnections[?VpcEndpointState=='available'].VpcEndpointOwner" \
-                                        --region ${regx} \
-                                        --output text | xargs
-                                        )
+                ENDPOINT_CONNECTION_LIST=$(${AWSCLI} ec2 describe-vpc-endpoint-connections \
+                                            ${PROFILE_OPT} \
+                                            --query "VpcEndpointConnections[?VpcEndpointState=='available'].VpcEndpointOwner" \
+                                            --region ${regx} \
+                                            --output text | xargs
+                                            )
 
-            for ENDPOINT_CONNECTION in ${ENDPOINT_CONNECTION_LIST}; do
-                for ACCOUNT_ID in ${TRUSTED_ACCOUNT_IDS}; do
-                    if [[ "${ACCOUNT_ID}" == "${ENDPOINT_CONNECTION}" ]]; then
-                        textPass "${regx}: Found trusted account in VPC endpoint service connection ${ENDPOINT_CONNECTION}" "${regx}" "${ENDPOINT_CONNECTION}"
-                        # Algorithm:
-                        # Remove all trusted ACCOUNT_IDs from ENDPOINT_CONNECTION_LIST.
-                        # As a result, the ENDPOINT_CONNECTION_LIST finally contains only unknown/untrusted account ids.
-                        ENDPOINT_CONNECTION_LIST=("${ENDPOINT_CONNECTION_LIST[@]/$ENDPOINT_CONNECTION}") # remove hit from allowlist
-                    fi
+                for ENDPOINT_CONNECTION in ${ENDPOINT_CONNECTION_LIST}; do
+                    for ACCOUNT_ID in ${TRUSTED_ACCOUNT_IDS}; do
+                        if [[ "${ACCOUNT_ID}" == "${ENDPOINT_CONNECTION}" ]]; then
+                            textPass "${regx}: Found trusted account in VPC endpoint service connection ${ENDPOINT_CONNECTION}" "${regx}" "${ENDPOINT_CONNECTION}"
+                            # Algorithm:
+                            # Remove all trusted ACCOUNT_IDs from ENDPOINT_CONNECTION_LIST.
+                            # As a result, the ENDPOINT_CONNECTION_LIST finally contains only unknown/untrusted account ids.
+                            ENDPOINT_CONNECTION_LIST=("${ENDPOINT_CONNECTION_LIST[@]/$ENDPOINT_CONNECTION}") # remove hit from allowlist
+                        fi
+                    done
+                done
+
+                for UNTRUSTED_CONNECTION in ${ENDPOINT_CONNECTION_LIST}; do
+                    textFail "${regx}: Found untrusted account in VPC endpoint service connection ${UNTRUSTED_CONNECTION}" "${regx}" "${ENDPOINT_CONNECTION}"
                 done
             done
-
-            for UNTRUSTED_CONNECTION in ${ENDPOINT_CONNECTION_LIST}; do
-                textFail "${regx}: Found untrusted account in VPC endpoint service connection ${UNTRUSTED_CONNECTION}" "${regx}" "${ENDPOINT_CONNECTION}"
-            done
-        done
+        else
+            textPass "${regx}: There is no VPC endpoints" "${regx}"
+        fi
     done
 }

--- a/checks/check_extra790
+++ b/checks/check_extra790
@@ -32,39 +32,43 @@ extra790(){
                                 ${PROFILE_OPT} \
                                 --query "ServiceDetails[?Owner=='${ACCOUNT_NUM}'].ServiceId" \
                                 --region ${regx} \
-                                --output text | xargs 2>&1)
-    if [[ $(echo "$ENDPOINT_SERVICES_IDS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
-        textInfo "$regx: Access Denied trying to describe VPC endpoint services" "$regx"
-        continue
-    fi
+                                --output text 2>&1)
+        if grep -q -E 'AccessDenied|UnauthorizedOperation|AuthorizationError' <<< "${ENDPOINT_SERVICES_IDS}" ; then
+            textInfo "$regx: Access Denied trying to describe VPC endpoint services" "$regx"
+            continue
+        fi
+        if [[ ${ENDPOINT_SERVICES_IDS} ]]
+        then
+            for ENDPOINT_SERVICE_ID in ${ENDPOINT_SERVICES_IDS}; do
+                ENDPOINT_PERMISSIONS_LIST=$(${AWSCLI} ec2 describe-vpc-endpoint-service-permissions \
+                                            ${PROFILE_OPT} \
+                                            --service-id ${ENDPOINT_SERVICE_ID} \
+                                            --query "AllowedPrincipals[*].Principal" \
+                                            --region ${regx} \
+                                            --output text | xargs
+                                            )
 
-        for ENDPOINT_SERVICE_ID in ${ENDPOINT_SERVICES_IDS}; do
-            ENDPOINT_PERMISSIONS_LIST=$(${AWSCLI} ec2 describe-vpc-endpoint-service-permissions \
-                                        ${PROFILE_OPT} \
-                                        --service-id ${ENDPOINT_SERVICE_ID} \
-                                        --query "AllowedPrincipals[*].Principal" \
-                                        --region ${regx} \
-                                        --output text | xargs
-                                        )
+                for ENDPOINT_PERMISSION in ${ENDPOINT_PERMISSIONS_LIST}; do
+                    # Take only account id from ENDPOINT_PERMISSION: arn:aws:iam::965406151242:root
+                    ENDPOINT_PERMISSION_ACCOUNT_ID=$(echo ${ENDPOINT_PERMISSION} | cut -d':' -f5 | xargs)
 
-            for ENDPOINT_PERMISSION in ${ENDPOINT_PERMISSIONS_LIST}; do
-                # Take only account id from ENDPOINT_PERMISSION: arn:aws:iam::965406151242:root
-                ENDPOINT_PERMISSION_ACCOUNT_ID=$(echo ${ENDPOINT_PERMISSION} | cut -d':' -f5 | xargs)
+                    for ACCOUNT_ID in ${TRUSTED_ACCOUNT_IDS}; do
+                        if [[ "${ACCOUNT_ID}" == "${ENDPOINT_PERMISSION_ACCOUNT_ID}" ]]; then
+                            textPass "${regx}: Found trusted account in VPC endpoint service permission ${ENDPOINT_PERMISSION}" "${regx}"
+                            # Algorithm:
+                            # Remove all trusted ACCOUNT_IDs from ENDPOINT_PERMISSIONS_LIST.
+                            # As a result, the ENDPOINT_PERMISSIONS_LIST finally contains only unknown/untrusted account ids.
+                            ENDPOINT_PERMISSIONS_LIST=("${ENDPOINT_PERMISSIONS_LIST[@]/$ENDPOINT_PERMISSION}")
+                        fi
+                    done
+                done
 
-                for ACCOUNT_ID in ${TRUSTED_ACCOUNT_IDS}; do
-                    if [[ "${ACCOUNT_ID}" == "${ENDPOINT_PERMISSION_ACCOUNT_ID}" ]]; then
-                        textPass "${regx}: Found trusted account in VPC endpoint service permission ${ENDPOINT_PERMISSION}" "${regx}"
-                        # Algorithm:
-                        # Remove all trusted ACCOUNT_IDs from ENDPOINT_PERMISSIONS_LIST.
-                        # As a result, the ENDPOINT_PERMISSIONS_LIST finally contains only unknown/untrusted account ids.
-                        ENDPOINT_PERMISSIONS_LIST=("${ENDPOINT_PERMISSIONS_LIST[@]/$ENDPOINT_PERMISSION}")
-                    fi
+                for UNTRUSTED_PERMISSION in ${ENDPOINT_PERMISSIONS_LIST}; do
+                    textFail "${regx}: Found untrusted account in VPC endpoint service permission ${UNTRUSTED_PERMISSION}" "${regx}" "${UNTRUSTED_PERMISSION}"
                 done
             done
-
-            for UNTRUSTED_PERMISSION in ${ENDPOINT_PERMISSIONS_LIST}; do
-                textFail "${regx}: Found untrusted account in VPC endpoint service permission ${UNTRUSTED_PERMISSION}" "${regx}" "${UNTRUSTED_PERMISSION}"
-            done
-        done
+        else
+            textPass "${regx}: There is no VPC endpoints services" "${regx}"
+        fi
     done
 }


### PR DESCRIPTION
### Context 

The following checks
- extra71
- extra790
- extra789
- check116

Don't return a PASS when they don't find resources to check


### Description

Now the checks return a PASS when there are no users/endpoints ...


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
