### PR TITLE
chore(actions): Bump Trufflehog to v3.13.0

### DIFF
--- a/.github/workflows/find-secrets.yml
+++ b/.github/workflows/find-secrets.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@v3.4.4
+        uses: trufflesecurity/trufflehog@v3.13.0
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
### Description

Upgrade the Trufflehog version to `v3.13.0`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
