### PR TITLE
fix(cloudshell): Git clone with --depth 1

### DIFF
--- a/util/cloudshell/shortcut.sh
+++ b/util/cloudshell/shortcut.sh
@@ -15,14 +15,14 @@ mkdir ${account}-results
 
 # Prowler
 cd ~
-git clone https://github.com/prowler-cloud/prowler
+git clone --depth 1 https://github.com/prowler-cloud/prowler
 pip3 install detect-secrets --user
 cd prowler 
 screen -dmS prowler sh -c "./prowler -M csv,html;cd ~;zip -r ${account}-results/prowler-${account}.zip /home/cloudshell-user/prowler/output"
 
 # ScoutSuite
 cd ~
-git clone https://github.com/nccgroup/ScoutSuite
+git clone --depth 1 https://github.com/nccgroup/ScoutSuite
 cd ScoutSuite
 sudo yum install python-pip -y
 sudo pip install virtualenv


### PR DESCRIPTION
### Description

Fix https://github.com/prowler-cloud/prowler/issues/1376

Include the `git clone --depth 1` not to get all the Prowler repository history.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
