### PR TITLE
fix(inventory): quick inventory input fixed

### DIFF
--- a/prowler
+++ b/prowler
@@ -140,7 +140,7 @@ USAGE:
 set_aws_default_output
 
 # Parse Prowler command line options
-while getopts ":hlLkqp:r:c:C:g:f:m:M:E:x:enbVsSI:A:R:T:w:N:o:B:D:F:zZ:O:a:d:i:u:" OPTION; do
+while getopts ":hlLkqp:r:c:C:g:f:m:M:E:x:enbVsSI:A:R:T:w:N:o:B:D:F:zZ:O:a:d:iu:" OPTION; do
    case $OPTION in
      h )
         usage


### PR DESCRIPTION
### Context 

Quick inventory option `-i` is not working.

### Description

`-i` option is asking for an argument but it is not needed, so remove the extra `:`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
