### PR TITLE
fix(extra740): remove additional info and fix max_items

### DIFF
--- a/checks/check_extra740
+++ b/checks/check_extra740
@@ -31,7 +31,7 @@ extra740(){
   for regx in ${REGIONS}; do
     UNENCRYPTED_SNAPSHOTS=$(${AWSCLI} ec2 describe-snapshots ${PROFILE_OPT} \
     --region ${regx} --owner-ids ${ACCOUNT_NUM} --output text \
-    --query 'Snapshots[?Encrypted==`false`]|[*].{Id:SnapshotId}' 2>&1 \
+    --query 'Snapshots[?Encrypted==`false`]|[*].{Id:SnapshotId}' --max-items $MAXITEMS 2>&1 \
      | grep -v None )
     if [[ $(echo "$UNENCRYPTED_SNAPSHOTS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
         textInfo "$regx: Access Denied trying to describe snapshots" "$regx"
@@ -40,57 +40,25 @@ extra740(){
 
     ENCRYPTED_SNAPSHOTS=$(${AWSCLI} ec2 describe-snapshots ${PROFILE_OPT} \
     --region ${regx} --owner-ids ${ACCOUNT_NUM} --output text \
-    --query 'Snapshots[?Encrypted==`true`]|[*].{Id:SnapshotId}' 2>&1 \
+    --query 'Snapshots[?Encrypted==`true`]|[*].{Id:SnapshotId}' --max-items $MAXITEMS 2>&1 \
      | grep -v None )
     if [[ $(echo "$ENCRYPTED_SNAPSHOTS" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
         textInfo "$regx: Access Denied trying to describe snapshots" "$regx"
         continue
     fi
-    typeset -i unencrypted
-    typeset -i encrypted
-    unencrypted=0
-    encrypted=0
 
     if [[ ${UNENCRYPTED_SNAPSHOTS} ]]; then
       for snapshot in ${UNENCRYPTED_SNAPSHOTS}; do
-          unencrypted=${unencrypted}+1
-          if [ "${unencrypted}" -le "${MAXITEMS}" ]; then
-            textFail "${regx}: ${snapshot} is not encrypted!" "${regx}" "${snapshot}"
-          fi
+        textFail "${regx}: ${snapshot} is not encrypted!" "${regx}" "${snapshot}"
       done
     fi
     if [[ ${ENCRYPTED_SNAPSHOTS} ]]; then
       for snapshot in ${ENCRYPTED_SNAPSHOTS}; do
-          encrypted=${encrypted}+1
-          if [ "${encrypted}" -le "${MAXITEMS}" ]; then
-            textPass "${regx}: ${snapshot} is encrypted." "${regx}" "${snapshot}"
-          fi
+        textPass "${regx}: ${snapshot} is encrypted." "${regx}" "${snapshot}"
       done
     fi
-    if [[ "${encrypted}" = "0" ]] && [[ "${unencrypted}" = "0" ]] ; then
-      textInfo "${regx}: No EBS volume snapshots" "${regx}"
-    else
-      typeset -i total
-      total=${encrypted}+${unencrypted}
-      if [[ "${unencrypted}" -ge "${MAXITEMS}" ]]; then
-        textFail "${unencrypted} unencrypted snapshots out of ${total} snapshots found. Only the first ${MAXITEMS} unencrypted snapshots are reported!" "${regx}"
-      fi
-      if [[ "${encrypted}" -ge "${MAXITEMS}" ]]; then
-        textPass "${encrypted} encrypted snapshots out of ${total} snapshots found. Only the first ${MAXITEMS} encrypted snapshots are reported." "${regx}"
-      fi
-      # Bit of 'bc' magic to print something like 10.42% or 0.85% or similar. 'bc' has a
-      # bug where it will never print leading zeros. So 0.5 is output as ".5". This has a
-      # little extra clause to print a 0 if 0 < x < 1.
-      ratio=$(echo "scale=2; p=(100*${encrypted}/(${encrypted}+${unencrypted})); if(p<1 && p>0) print 0;print p, \"%\";" | bc 2>/dev/null)
-      exit=$?
-
-      # maybe 'bc' doesn't exist, or it exits with an error
-      if [[ "${exit}" = "0" ]]
-      then
-        textInfo "${regx}: ${ratio} encrypted EBS volumes (${encrypted} out of ${total})" "${regx}"
-      else
-        textInfo "${regx}: ${unencrypted} unencrypted EBS volume snapshots out of ${total} total snapshots" "${regx}"
-      fi
+    if [[ -z ${ENCRYPTED_SNAPSHOTS} ]] && [[ -z ${UNENCRYPTED_SNAPSHOTS} ]] ; then
+      textInfo "${regx}: No EBS volume snapshots." "${regx}"
     fi
   done
 }


### PR DESCRIPTION
### Context 

Check extra740 has additional info and show more than a line per resource.

Fix https://github.com/prowler-cloud/prowler/issues/1400 

### Description

The additional info was removed and max_items was added to the CLI calls.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
