### PR TITLE
feat(stable tag): Inclusion of stable tag point to last release

### DIFF
--- a/.github/workflows/build-lint-push-containers.yml
+++ b/.github/workflows/build-lint-push-containers.yml
@@ -7,7 +7,7 @@ on:
     paths-ignore:
       - '.github/**'
       - 'README.md'
-      
+
   release:
     types: [published, edited]
 
@@ -16,6 +16,7 @@ env:
   AWS_REGION_PRO: us-east-1
   IMAGE_NAME: prowler
   LATEST_TAG: latest
+  STABLE_TAG: stable
   TEMPORARY_TAG: temporary
   DOCKERFILE_PATH: ./Dockerfile
 
@@ -175,21 +176,30 @@ jobs:
           docker push ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}
           docker push ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}
       -
-        # Push the new release
+        # Tag the new release (stable and release tag)
         name: Tag (release)
         if: github.event_name == 'release'
         run: |
           docker tag ${{ env.IMAGE_NAME }}:${{ env.TEMPORARY_TAG }} ${{ secrets.PRO_ECR }}/${{ secrets.PRO_ECR_REPOSITORY }}:${{ github.event.release.tag_name }}
           docker tag ${{ env.IMAGE_NAME }}:${{ env.TEMPORARY_TAG }} ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
           docker tag ${{ env.IMAGE_NAME }}:${{ env.TEMPORARY_TAG }} ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+
+          docker tag ${{ env.IMAGE_NAME }}:${{ env.TEMPORARY_TAG }} ${{ secrets.PRO_ECR }}/${{ secrets.PRO_ECR_REPOSITORY }}:${{ env.STABLE_TAG }}
+          docker tag ${{ env.IMAGE_NAME }}:${{ env.TEMPORARY_TAG }} ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.STABLE_TAG }}
+          docker tag ${{ env.IMAGE_NAME }}:${{ env.TEMPORARY_TAG }} ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.STABLE_TAG }}
+
       -
-        # Push the new release
+        # Push the new release (stable and release tag)
         name: Push (release)
         if: github.event_name == 'release'
         run: |
           docker push ${{ secrets.PRO_ECR }}/${{ secrets.PRO_ECR_REPOSITORY }}:${{ github.event.release.tag_name }}
           docker push ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
           docker push ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+
+          docker push ${{ secrets.PRO_ECR }}/${{ secrets.PRO_ECR_REPOSITORY }}:${{ env.STABLE_TAG }}
+          docker push ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.STABLE_TAG }}
+          docker push ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.STABLE_TAG }}
       -
         name: Delete artifacts
         if: always()


### PR DESCRIPTION
### Context 

Prowler has latest and release (by number) tags it is handy to have also a stable tag pointing to the latest release of the project


### Description

Include a latest tag in GHA pointing to the latest release


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
