### PR TITLE
fix(extra7195): Update title

### DIFF
--- a/checks/check_extra7195
+++ b/checks/check_extra7195
@@ -32,7 +32,7 @@
 
 
 CHECK_ID_extra7195="7.195"
-CHECK_TITLE_extra7195="[check7195] Ensure CodeArtifact internal packages do not allow external public source publishing."
+CHECK_TITLE_extra7195="[extra7195] Ensure CodeArtifact internal packages do not allow external public source publishing."
 CHECK_SCORED_extra7195="NOT_SCORED"
 CHECK_CIS_LEVEL_extra7195="EXTRA"
 CHECK_SEVERITY_extra7195="Critical"


### PR DESCRIPTION
Fixed the check title from being incorrectly set to 'check7195' rather than 'extra7195'

### Context 

I have a script that builds out 5 checklists based off of the check names returned from 'prowler -l', and then it spawns 5 subprocesses running prowler with each checklist. This was a need after running prowler using assumed roles in large environments, and my session expiring before prowler could be finished. The issue is that 'check7195' would be the 5th check in checlist_4.txt, and prowler would error out and not run that or subsequent checks.

I want to add the script as a merge request, but it is currently written in Fish shell syntax which is quite unique and wouldn't be that useful to others - so I plan on either changing it to bash or writing it in python at some point (bash would make sense since the whole tool is a bunch of bash scripts to begin with, and the syntax is nearly identical to Fish).

### Description

Just updated 1 line to use the correct check name in the title, so that it is correctly shown in 'prowler -l'

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
