### PR TITLE
fix(): Fix CloudTrail trail S3 logging public bucket false positive result when trail bucket doesn't exist

### DIFF
--- a/checks/check23
+++ b/checks/check23
@@ -57,6 +57,11 @@ check23(){
             textInfo "$regx: Trail ${TRAIL_NAME} with home region ${TRAIL_HOME_REGION} Access Denied getting bucket location for bucket $TRAIL_BUCKET" "$regx" "$TRAIL_NAME"
             continue
           fi
+          if [[ $(echo "$BUCKET_LOCATION" | grep NoSuchBucket) ]]
+          then
+            textInfo "$regx: Trail ${TRAIL_NAME} with home region ${TRAIL_HOME_REGION} S3 logging bucket $TRAIL_BUCKET does not exist" "$regx" "$TRAIL_NAME"
+            continue
+          fi
           if [[ $BUCKET_LOCATION == "None" ]]; then
               BUCKET_LOCATION="us-east-1"
           fi


### PR DESCRIPTION
### Context 

I noticed that when a trail specifies an S3 bucket and it was deleted (but still configured in the trail), the check would incorrectly mark the bucket as publicly accessible.

Running the `aws s3api get-bucket-location` command for a trail configured with a deleted bucket returns a `NoSuchBucket` error.

The bucket skips all other checks and ends up at the end of the while loop which contains the following condition:

![CleanShot 2022-11-21 at 12 38 18](https://user-images.githubusercontent.com/8602276/202932774-a2f554e4-2eca-4dde-b352-9325d7e0ebcb.png)

The condition evaluates to `false` (because the `aws s3api get-bucket-acl` command also returns the same error) and ends up assigning the trail with a publicly accessible bucket.

### Description

I added a check after the `get-bucket-location` command following the `AccessDenied` check to check for the `NoSuchBucket` error and marked the trail as having a logging bucket that does not exist.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
