### PR TITLE
fix(README): include more details about db connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,11 @@ Install psql
 
 #### Audit ID Field
 
-Prowler can add an optional `audit_id` field to identify each audit that has been made in the database. You can do this by adding the `-u audit_id` flag to the prowler command.
+To use Prowler postgres connector it is needed to set the -u flag to include  `audit_id` field into the query. This field helps to identify each audit that has been made in the database. This field needs to be an UUID V4 to match the table schema.
+For example:  
+```
+./prowler -M csv -d postgresql -u e5a0f214-8bf9-4600-a0c3-ff659b30e6c0
+```
 
 #### Credentials
 
@@ -427,7 +431,7 @@ prowler_start_time text
 ```
 
 - Execute Prowler with `-d` flag, for example:
-  `./prowler -M csv -d postgresql`
+  `./prowler -M csv -d postgresql -u e5a0f214-8bf9-4600-a0c3-ff659b30e6c0`
   > _Note_: This command creates a `csv` output file and stores the Prowler output in the configured PostgreSQL DB. It's an example, `-d` flag **does not** require `-M` to run.
 
 ## Output Formats


### PR DESCRIPTION
### Context 

Includes more details about the db connector.


### Description

To work, the db connector needs the `-u` flag set, and in the docs it is detailed as optional. Changing that.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
