### PR TITLE
fix(globalaccelerator): Region must be us-west-2

### DIFF
--- a/providers/aws/services/globalaccelerator/globalaccelerator_service.py
+++ b/providers/aws/services/globalaccelerator/globalaccelerator_service.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
+
 from lib.logger import logger
-from providers.aws.aws_provider import get_region_global_service
 
 
 ################### GlobalAccelerator
@@ -9,7 +9,10 @@ class GlobalAccelerator:
         self.service = "globalaccelerator"
         self.session = audit_info.audit_session
         self.audited_account = audit_info.audited_account
-        self.region = get_region_global_service(audit_info)
+        # Global Accelerator is a global service that supports endpoints in multiple AWS Regions
+        # but you must specify the US West (Oregon) Region to create, update, or otherwise work with accelerators.
+        # That is, for example, specify --region us-west-2 on AWS CLI commands.
+        self.region = "us-west-2"
         self.client = self.session.client(self.service, self.region)
         self.accelerators = {}
         self.__list_accelerators__()

--- a/providers/aws/services/globalaccelerator/globalaccelerator_service_test.py
+++ b/providers/aws/services/globalaccelerator/globalaccelerator_service_test.py
@@ -1,14 +1,15 @@
+import botocore
+from boto3 import session
+from mock import patch
+from moto.core import DEFAULT_ACCOUNT_ID
+
 from providers.aws.lib.audit_info.models import AWS_Audit_Info
 from providers.aws.services.globalaccelerator.globalaccelerator_service import (
     GlobalAccelerator,
 )
-from mock import patch
-from moto.core import DEFAULT_ACCOUNT_ID
-import botocore
-from boto3 import session
 
 # Mock Test Region
-AWS_REGION = "eu-west-1"
+AWS_REGION = "us-west-2"
 
 # Mocking Access Analyzer Calls
 make_api_call = botocore.client.BaseClient._make_api_call


### PR DESCRIPTION
### Description

As per AWS API documentation:
```
Global Accelerator is a global service that supports endpoints in multiple AWS Regions but you must specify the US West (Oregon) Region to create, update, or otherwise work with accelerators. That is, for example, specify --region us-west-2 on AWS CLI commands.
```
### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
