### PR TITLE
fix(route53domains): Set us-east-1 as region

### DIFF
--- a/providers/aws/services/route53/route53_service.py
+++ b/providers/aws/services/route53/route53_service.py
@@ -84,7 +84,9 @@ class Route53Domains:
         self.service = "route53domains"
         self.session = audit_info.audit_session
         self.audited_account = audit_info.audited_account
-        self.region = get_region_global_service(audit_info)
+        # Route53Domains is a global service that supports endpoints in multiple AWS Regions
+        # but you must specify the US East (N. Virginia) Region to create, update, or otherwise work with domains.
+        self.region = "us-east-1"
         self.client = self.session.client(self.service, self.region)
         self.domains = {}
         self.__list_domains__()


### PR DESCRIPTION
### Description

Route53Domains is a global service that supports endpoints in multiple AWS Regions but you must specify the US East (N. Virginia) Region to create, update, or otherwise work with domains.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
