### PR TITLE
feat(azure): subscription as parameter

### DIFF
--- a/lib/outputs/outputs.py
+++ b/lib/outputs/outputs.py
@@ -393,6 +393,7 @@ def display_summary_table(
             entity_type = "Account"
         elif provider == "azure":
             entity_type = "Tenant Domain"
+
         if findings:
             current = {
                 "Service": "",
@@ -456,6 +457,10 @@ def display_summary_table(
             print(
                 f"\n{entity_type} {Fore.YELLOW}{audit_info.audited_account}{Style.RESET_ALL} Scan Results (severity columns are for fails only):"
             )
+            if provider == "azure":
+                print(
+                    f"\nSubscriptions scanned: {Fore.YELLOW}{' '.join(audit_info.subscriptions.keys())}{Style.RESET_ALL}"
+                )
             print(tabulate(findings_table, headers="keys", tablefmt="rounded_grid"))
             print(
                 f"{Style.BRIGHT}* You only see here those services that contains resources.{Style.RESET_ALL}"

--- a/providers/azure/lib/audit_info/models.py
+++ b/providers/azure/lib/audit_info/models.py
@@ -14,7 +14,7 @@ class Azure_Identity_Info(BaseModel):
 class Azure_Audit_Info:
     credentials: DefaultAzureCredential
     identity: Azure_Identity_Info
-    subscriptions: list[dict]
+    subscriptions: dict
     audited_account: str
 
     def __init__(self, credentials, identity, subscriptions):

--- a/prowler
+++ b/prowler
@@ -229,6 +229,12 @@ if __name__ == "__main__":
         action="store_true",
         help="Display detailed information about findings.",
     )
+    parser.add_argument(
+        "--subscription-ids",
+        nargs="+",
+        default=[],
+        help="Azure subscription ids to be scanned by prowler",
+    )
     # Parse Arguments
     args = parser.parse_args()
 
@@ -244,6 +250,10 @@ if __name__ == "__main__":
     severities = args.severity
     compliance_framework = args.compliance
     output_modes = args.output_modes
+
+    # Azure options
+    subscriptions = args.subscription_ids
+
     # We treat the compliance framework as another output format
     if compliance_framework:
         output_modes.extend(compliance_framework)
@@ -362,7 +372,7 @@ if __name__ == "__main__":
             args.organizations_role,
         )
     elif provider == "azure":
-        audit_info = azure_provider_set_session()
+        audit_info = azure_provider_set_session(subscriptions)
 
     # Check if custom output filename was input, if not, set the default
     if not output_filename:


### PR DESCRIPTION
### Context 

Adds the option to pass a subscription to be scanned for Azure provider, right now scans all the regions by default


### Description

Adds the option to pass a subscription to be scanned for Azure provider, right now scans all the regions by default


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
