### PR TITLE
fix(list-groups): Delete option

### DIFF
--- a/prowler
+++ b/prowler
@@ -81,9 +81,6 @@ if __name__ == "__main__":
     # List checks options
     list_group = parser.add_mutually_exclusive_group()
     list_group.add_argument(
-        "-L", "--list-groups", action="store_true", help="List groups"
-    )
-    list_group.add_argument(
         "-l", "--list-checks", action="store_true", help="List checks"
     )
     list_group.add_argument(


### PR DESCRIPTION
### Description

Remove the `-L/--list-groups` because is no longer used.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
