### PR TITLE
feat(docs): added AWS CloudShell and rename FAQ to Troubleshooting

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,7 +1,0 @@
-# FAQ
-- <strong>I am getting `OSError` related with `Too many open files`, what can I do?</strong>
-
-In case of a bad connection, high API response times can be given, so they will generate problems because of having several simultaneous connections, to solve this problem in your system, use the command ulimit to increase the simultaneous open files:
-```
-ulimit -n 1000
-```

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,8 @@ pip install prowler-cloud
 prowler -v
 ```
 
+If you want to execute Prowler from AWS CloudShell see [here](tutorials/aws/cloudshell.md).
+
 ## Prowler container versions
 
 The available versions of Prowler are the following:
@@ -49,6 +51,11 @@ The container images are available here:
 
 - [DockerHub](https://hub.docker.com/r/toniblyx/prowler/tags)
 - [AWS Public ECR](https://gallery.ecr.aws/o4g1s5r6/prowler)
+
+To run it using Docker:
+```
+docker run -ti --rm --name prowler --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN toniblyx/prowler:latest
+```
 
 ## High level architecture
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,8 @@
+# Troubleshooting
+
+- Running `prowler` I get `[File: utils.py:15] [Module: utils]	CRITICAL: path/redacted: OSError[13]`: 
+
+    That is an error related to file descriptors or opened files allowed by your operating system, with `ulimit -n 1000` you solve the issue. We have seen this issue in some macOS Ventura. 
+
+
+See section [Logging](/tutorials/logging/) for further information or [conctact us](/contact/).

--- a/docs/tutorials/aws/cloudshell.md
+++ b/docs/tutorials/aws/cloudshell.md
@@ -1,0 +1,26 @@
+# AWS CloudShell
+
+Prowler can be easely executed in AWS CloudShell but it has some prerequsites to be able to to so. AWS CloudShell is a container running with `Amazon Linux release 2 (Karoo)` that comes with Python 3.7, since Prowler requires Python >= 3.9 we need to first install a newer version of Python. Follow the steps below to successfully execute Prowler v3 in AWS CloudShell:
+
+- First install all dependences and then Python, in this case we need to compile it because there is not a package available at the time this document is written:
+```
+sudo yum -y install gcc openssl-devel bzip2-devel libffi-devel
+wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz
+tar zxf Python-3.9.16.tgz
+cd Python-3.9.16/
+./configure --enable-optimizations
+sudo make altinstall
+python3.9 --version
+cd 
+```
+- Once Python 3.9 is available we can install Prowler from pip:
+```
+pip3.9 install prowler-cloud
+```
+- Now enjoy Prowler:
+```
+prowler -v
+prowler 
+```
+
+- To download the results from AWS CloudShell, select Actions -> Download File and add the full path of each file. For the CSV file it will be something like `/home/cloudshell-user/output/prowler-output-123456789012-20221220191331.csv`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,11 +42,12 @@ nav:
           - AWS Security Hub: tutorials/aws/securityhub.md
           - AWS Organizations: tutorials/aws/organizations.md
           - Scan Multiple AWS Accounts: tutorials/aws/multiaccount.md
+          - AWS CloudShell: tutorials/aws/cloudshell.md
         - Azure:
           - Authentication: tutorials/azure/authentication.md
           - Subscriptions: tutorials/azure/subscriptions.md
     - Contact Us: contact.md
-    - FAQ: faq.md
+    - Troubleshooting: troubleshooting.md
     - About: about.md
     - ProwlerPro: https://prowler.pro
 # Customization


### PR DESCRIPTION
### Context 

To allow users an easier way to use Prowler, we added AWS CloudShell section. FAQ also has been renamed to Troubleshooting because it contains a way to fix a known issue in macOS Ventura with file descriptors. index.md was also changed to include link to AWS CloudShell section and a sample command to run Prowler with a Docker container.

### Description

CloudShell documentation for Prowler and Python 3.9. FAQ section renamed to Troubleshooting.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
