### PR TITLE
fix(check_report): Init status field and fix stats output

### DIFF
--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -91,6 +91,7 @@ class Check_Report:
     resource_tags: list
 
     def __init__(self, metadata):
+        self.status = ""
         self.check_metadata = Check_Metadata_Model.parse_raw(metadata)
         self.status_extended = ""
         self.resource_details = ""

--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -221,12 +221,12 @@ def extract_findings_statistics(findings: list) -> dict:
     for finding in findings:
         # Save the resource_id
         resources.add(finding.resource_id)
-        # Increment findings
-        findings_count += 1
         if finding.status == "PASS":
             total_pass += 1
+            findings_count += 1
         if finding.status == "FAIL":
             total_fail += 1
+            findings_count += 1
 
     stats["total_pass"] = total_pass
     stats["total_fail"] = total_fail

--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -202,6 +202,16 @@ def send_to_s3_bucket(
 
 
 def extract_findings_statistics(findings: list) -> dict:
+    """
+    extract_findings_statistics takes a list of findings and returns the following dict with the aggregated statistics
+    {
+        "total_pass": 0,
+        "total_fail": 0,
+        "resources_count": 0,
+        "findings_count": 0,
+    }
+    """
+    logger.info("Extracting audit statistics...")
     stats = {}
     total_pass = 0
     total_fail = 0

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -361,6 +361,21 @@ class Test_Outputs:
         assert stats["resources_count"] == 1
         assert stats["findings_count"] == 2
 
+    def test_extract_findings_statistics_info_resources(self):
+        finding_1 = mock.MagicMock()
+        finding_1.status = "INFO"
+        finding_1.resource_id = "test_resource_1"
+        finding_2 = mock.MagicMock()
+        finding_2.status = "PASS"
+        finding_2.resource_id = "test_resource_1"
+        findings = [finding_1, finding_2]
+
+        stats = extract_findings_statistics(findings)
+        assert stats["total_pass"] == 1
+        assert stats["total_fail"] == 0
+        assert stats["resources_count"] == 1
+        assert stats["findings_count"] == 1
+
     def test_extract_findings_statistics_no_findings(self):
         findings = []
 

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -1,5 +1,6 @@
 import os
 from os import path, remove
+from unittest import mock
 
 import boto3
 import pytest
@@ -19,15 +20,16 @@ from prowler.lib.check.models import Check_Report, load_check_metadata
 from prowler.lib.outputs.file_descriptors import fill_file_descriptors
 from prowler.lib.outputs.json import fill_json_asff
 from prowler.lib.outputs.models import (
-    generate_csv_fields,
     Check_Output_CSV,
     Check_Output_JSON_ASFF,
     Compliance,
     ProductFields,
     Resource,
     Severity,
+    generate_csv_fields,
 )
 from prowler.lib.outputs.outputs import (
+    extract_findings_statistics,
     send_to_s3_bucket,
     set_report_color,
 )
@@ -328,3 +330,42 @@ class Test_Outputs:
             )["ContentType"]
             == "binary/octet-stream"
         )
+
+    def test_extract_findings_statistics_different_resources(self):
+        finding_1 = mock.MagicMock()
+        finding_1.status = "PASS"
+        finding_1.resource_id = "test_resource_1"
+        finding_2 = mock.MagicMock()
+        finding_2.status = "FAIL"
+        finding_2.resource_id = "test_resource_2"
+        findings = [finding_1, finding_2]
+
+        stats = extract_findings_statistics(findings)
+        assert stats["total_pass"] == 1
+        assert stats["total_fail"] == 1
+        assert stats["resources_count"] == 2
+        assert stats["findings_count"] == 2
+
+    def test_extract_findings_statistics_same_resources(self):
+        finding_1 = mock.MagicMock()
+        finding_1.status = "PASS"
+        finding_1.resource_id = "test_resource_1"
+        finding_2 = mock.MagicMock()
+        finding_2.status = "PASS"
+        finding_2.resource_id = "test_resource_1"
+        findings = [finding_1, finding_2]
+
+        stats = extract_findings_statistics(findings)
+        assert stats["total_pass"] == 2
+        assert stats["total_fail"] == 0
+        assert stats["resources_count"] == 1
+        assert stats["findings_count"] == 2
+
+    def test_extract_findings_statistics_no_findings(self):
+        findings = []
+
+        stats = extract_findings_statistics(findings)
+        assert stats["total_pass"] == 0
+        assert stats["total_fail"] == 0
+        assert stats["resources_count"] == 0
+        assert stats["findings_count"] == 0


### PR DESCRIPTION
### Context

Fix https://github.com/prowler-cloud/prowler/issues/1575

### Description

- Always init the `status` field
- Handle `INFO` results in the `extract_findings_statistics`
- `extract_findings_statistics` test

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
