### PR TITLE
fix(list services): Solve list services issue

### DIFF
--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -108,10 +108,10 @@ def parse_checks_from_file(input_file: str, provider: str) -> set:
 
 def list_services(provider: str) -> set():
     available_services = set()
-    checks = recover_checks_from_provider(provider)
-    for check_name in checks:
+    checks_tuple = recover_checks_from_provider(provider)
+    for _, check_path in checks_tuple:
         # Format: "providers.{provider}.services.{service}.{check_name}.{check_name}"
-        service_name = check_name[0].split(".")[3]
+        service_name = check_path.split("/")[-2]
         available_services.add(service_name)
     return sorted(available_services)
 

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -110,7 +110,7 @@ def list_services(provider: str) -> set():
     available_services = set()
     checks_tuple = recover_checks_from_provider(provider)
     for _, check_path in checks_tuple:
-        # Format: "providers.{provider}.services.{service}.{check_name}.{check_name}"
+        # Format: /absolute_path/prowler/providers/{provider}/services/{service_name}/{check_name}
         service_name = check_path.split("/")[-2]
         available_services.add(service_name)
     return sorted(available_services)

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -242,8 +242,7 @@ class Test_Check:
     def test_list_modules(self):
         provider = "azure"
         service = "storage"
-        list_modules(provider, service)
-        expected_modules = expected_packages
+        expected_modules = list_modules(provider, service)
         assert expected_modules == expected_packages
 
     # def test_parse_checks_from_compliance_framework_two(self):


### PR DESCRIPTION
### Context

Due to last changes, the list services flag was not working


### Description

Include a workaround to let `--list-services` flag work again


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
