### PR TITLE
fix(shub): Handle Security Hub InvalidAccessException error

### DIFF
--- a/prowler/providers/aws/services/securityhub/securityhub_service.py
+++ b/prowler/providers/aws/services/securityhub/securityhub_service.py
@@ -63,9 +63,21 @@ class SecurityHub:
                 )
 
         except Exception as error:
-            logger.error(
-                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-            )
+            # Check if Account is subscribed to Security Hub
+            if "InvalidAccessException" in str(error):
+                self.securityhubs.append(
+                    SecurityHubHub(
+                        "",
+                        "Security Hub",
+                        "NOT_AVAILABLE",
+                        "",
+                        regional_client.region,
+                    )
+                )
+            else:
+                logger.error(
+                    f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
 
 
 @dataclass


### PR DESCRIPTION
### Description

Handle Security Hub InvalidAccessException error when it is not enabled.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
