### PR TITLE
fix(send to s3): fixed send to s3 feature

### DIFF
--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -5,6 +5,7 @@ from colorama import Fore, Style
 
 from prowler.config.config import (
     csv_file_suffix,
+    html_file_suffix,
     json_asff_file_suffix,
     json_file_suffix,
     orange_color,
@@ -180,6 +181,7 @@ def send_to_s3_bucket(
     output_filename, output_directory, output_mode, output_bucket, audit_session
 ):
     try:
+        filename = ""
         # Get only last part of the path
         if output_mode == "csv":
             filename = f"{output_filename}{csv_file_suffix}"
@@ -187,10 +189,13 @@ def send_to_s3_bucket(
             filename = f"{output_filename}{json_file_suffix}"
         elif output_mode == "json-asff":
             filename = f"{output_filename}{json_asff_file_suffix}"
+        elif output_mode == "html":
+            filename = f"{output_filename}{html_file_suffix}"
         logger.info(f"Sending outputs to S3 bucket {output_bucket}")
+        bucket_remote_dir = output_directory.split("/")[-1]
         file_name = output_directory + "/" + filename
         bucket_name = output_bucket
-        object_name = output_directory + "/" + output_mode + "/" + filename
+        object_name = bucket_remote_dir + "/" + output_mode + "/" + filename
         s3_client = audit_session.client("s3")
         s3_client.upload_file(file_name, bucket_name, object_name)
 

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -19,18 +19,15 @@ from prowler.lib.check.models import Check_Report, load_check_metadata
 from prowler.lib.outputs.file_descriptors import fill_file_descriptors
 from prowler.lib.outputs.json import fill_json_asff
 from prowler.lib.outputs.models import (
-    generate_csv_fields,
     Check_Output_CSV,
     Check_Output_JSON_ASFF,
     Compliance,
     ProductFields,
     Resource,
     Severity,
+    generate_csv_fields,
 )
-from prowler.lib.outputs.outputs import (
-    send_to_s3_bucket,
-    set_report_color,
-)
+from prowler.lib.outputs.outputs import send_to_s3_bucket, set_report_color
 from prowler.lib.utils.utils import hash_sha512, open_file
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
@@ -304,7 +301,10 @@ class Test_Outputs:
         client = boto3.client("s3")
         client.create_bucket(Bucket=bucket_name)
         # Create mock csv output file
-        output_directory = f"{os.path.dirname(os.path.realpath(__file__))}/fixtures"
+        fixtures_dir = "fixtures"
+        output_directory = (
+            f"{os.path.dirname(os.path.realpath(__file__))}/{fixtures_dir}"
+        )
         output_mode = "csv"
         filename = f"prowler-output-{input_audit_info.audited_account}"
         # Send mock csv file to mock S3 Bucket
@@ -319,12 +319,7 @@ class Test_Outputs:
         assert (
             client.get_object(
                 Bucket=bucket_name,
-                Key=output_directory
-                + "/"
-                + output_mode
-                + "/"
-                + filename
-                + csv_file_suffix,
+                Key=fixtures_dir + "/" + output_mode + "/" + filename + csv_file_suffix,
             )["ContentType"]
             == "binary/octet-stream"
         )


### PR DESCRIPTION
### Context

There was an issue when sending the output to a remote s3 bucket, due to the html default format.


### Description

Now the results are sent to the bucket in the three formats, by default in a directory called `output`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
