### PR TITLE
Remove additional `apk update` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.9-alpine
 LABEL maintainer="https://github.com/prowler-cloud/prowler"
 
 # Update system dependencies
-RUN apk --no-cache update && apk --no-cache upgrade
+RUN apk --no-cache upgrade
 
 # Create nonroot user
 RUN mkdir -p /home/prowler && \


### PR DESCRIPTION
### Context

I just happened to see this can be improved as I was passing by.

### Description

`apt upgrade` with `--no-cache` will do the cache update thing before the upgrade, just without leaving cache. Another `apt update` will only spend more time and network bandwidth ;)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
