### PR TITLE
fix(output_filename): Use custom output filename when set

### DIFF
--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -115,7 +115,6 @@ Detailed documentation at https://docs.prowler.cloud
             "-F",
             "--output-filename",
             nargs="?",
-            default=None,
             help="Custom output report name without the file extension, if not specified will use default output/prowler-output-ACCOUNT_NUM-OUTPUT_DATE.format",
         )
         common_outputs_parser.add_argument(

--- a/prowler/lib/outputs/models.py
+++ b/prowler/lib/outputs/models.py
@@ -183,7 +183,7 @@ class Aws_Check_Output_CSV(Check_Output_CSV):
     Aws_Check_Output_CSV generates a finding's output in CSV format for the AWS provider.
     """
 
-    profile: str
+    profile: Optional[str]
     account_id: int
     account_name: Optional[str]
     account_email: Optional[str]

--- a/prowler/providers/common/outputs.py
+++ b/prowler/providers/common/outputs.py
@@ -60,7 +60,10 @@ class Azure_Output_Options(Provider_Output_Options):
         super().__init__(arguments, allowlist_file, bulk_checks_metadata)
 
         # Check if custom output filename was input, if not, set the default
-        if not hasattr(arguments, "output_filename"):
+        if (
+            not hasattr(arguments, "output_filename")
+            or arguments.output_filename is None
+        ):
             if audit_info.identity.domain:
                 self.output_filename = f"prowler-output-{audit_info.identity.domain}-{output_file_timestamp}"
             else:
@@ -85,7 +88,10 @@ class Aws_Output_Options(Provider_Output_Options):
             change_config_var("shodan_api_key", arguments.shodan)
 
         # Check if custom output filename was input, if not, set the default
-        if not hasattr(arguments, "output_filename"):
+        if (
+            not hasattr(arguments, "output_filename")
+            or arguments.output_filename is None
+        ):
             self.output_filename = (
                 f"prowler-output-{audit_info.audited_account}-{output_file_timestamp}"
             )


### PR DESCRIPTION
### Context

Fix https://github.com/prowler-cloud/prowler/issues/1616

### Description

- Use custom output filename when set
- Set the `profile` field in the `Aws_Check_Output_CSV` model as `Optional[str]`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
