### PR TITLE
fix(): password enabled issues in iam_user_mfa_enabled_console_access

### DIFF
--- a/prowler/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access.py
+++ b/prowler/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access.py
@@ -11,13 +11,22 @@ class iam_user_mfa_enabled_console_access(Check):
             report.resource_id = user["user"]
             report.resource_arn = user["arn"]
             report.region = iam_client.region
+            # all the users but root (which by default does not support console password)
             if user["password_enabled"] != "not_supported":
-                if user["mfa_active"] == "false":
-                    report.status = "FAIL"
-                    report.status_extended = f"User {user['user']} has Console Password enabled but MFA disabled."
+                # check if the user has password enabled
+                if user["password_enabled"] == "true":
+                    if user["mfa_active"] == "false":
+                        report.status = "FAIL"
+                        report.status_extended = f"User {user['user']} has Console Password enabled but MFA disabled."
+                    else:
+                        report.status = "PASS"
+                        report.status_extended = f"User {user['user']} has Console Password enabled and MFA enabled."
                 else:
                     report.status = "PASS"
-                    report.status_extended = f"User {user['user']} has Console Password enabled and MFA enabled."
+                    report.status_extended = (
+                        f"User {user['user']} has not Console Password enabled."
+                    )
+            # root user
             else:
                 report.status = "PASS"
                 report.status_extended = (

--- a/tests/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access_test.py
+++ b/tests/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access_test.py
@@ -6,7 +6,7 @@ from moto import mock_iam
 
 class Test_iam_user_mfa_enabled_console_access_test:
     @mock_iam
-    def test_user_not_password_console_enabled(self):
+    def test_root_user_not_password_console_enabled(self):
         iam_client = client("iam")
         user = "test-user"
         arn = iam_client.create_user(UserName=user)["User"]["Arn"]
@@ -14,6 +14,7 @@ class Test_iam_user_mfa_enabled_console_access_test:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_user_mfa_enabled_console_access.iam_user_mfa_enabled_console_access.iam_client",
             new=IAM(current_audit_info),
@@ -36,6 +37,37 @@ class Test_iam_user_mfa_enabled_console_access_test:
             assert result[0].resource_arn == arn
 
     @mock_iam
+    def test_user_not_password_console_enabled(self):
+        iam_client = client("iam")
+        user = "test-user"
+        arn = iam_client.create_user(UserName=user)["User"]["Arn"]
+
+        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        current_audit_info.audited_partition = "aws"
+        with mock.patch(
+            "prowler.providers.aws.services.iam.iam_user_mfa_enabled_console_access.iam_user_mfa_enabled_console_access.iam_client",
+            new=IAM(current_audit_info),
+        ) as service_client:
+            from prowler.providers.aws.services.iam.iam_user_mfa_enabled_console_access.iam_user_mfa_enabled_console_access import (
+                iam_user_mfa_enabled_console_access,
+            )
+
+            service_client.credential_report[0]["password_enabled"] = "false"
+
+            check = iam_user_mfa_enabled_console_access()
+            result = check.execute()
+
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"User {user} has not Console Password enabled."
+            )
+            assert result[0].resource_id == user
+            assert result[0].resource_arn == arn
+
+    @mock_iam
     def test_user_password_console_and_mfa_enabled(self):
         iam_client = client("iam")
         user = "test-user"
@@ -44,6 +76,7 @@ class Test_iam_user_mfa_enabled_console_access_test:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_user_mfa_enabled_console_access.iam_user_mfa_enabled_console_access.iam_client",
             new=IAM(current_audit_info),
@@ -75,6 +108,7 @@ class Test_iam_user_mfa_enabled_console_access_test:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_user_mfa_enabled_console_access.iam_user_mfa_enabled_console_access.iam_client",
             new=IAM(current_audit_info),


### PR DESCRIPTION

### Context

Comes from https://github.com/prowler-cloud/prowler/issues/1605.



### Description

The issue reported is that a regular user with no console enabled is generating a fail. It comes from the check logic, which only filters if the user is root, and then assume that all the other users has console enabled. That logic has been modified


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
