### PR TITLE
fix(assume-role): Refresh credentials when assuming role

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -8,7 +8,7 @@ from botocore.session import get_session
 from prowler.config.config import aws_services_json_file
 from prowler.lib.logger import logger
 from prowler.lib.utils.utils import open_file, parse_json_file
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.aws.lib.audit_info.models import AWS_Assume_Role, AWS_Audit_Info
 
 
 ################## AWS PROVIDER
@@ -43,7 +43,6 @@ class AWS_Provider:
                 assumed_botocore_session.set_config_variable(
                     "region", audit_info.profile_region
                 )
-
                 return session.Session(
                     profile_name=audit_info.profile,
                     botocore_session=assumed_botocore_session,
@@ -62,7 +61,7 @@ class AWS_Provider:
     def refresh(self):
         logger.info("Refreshing assumed credentials...")
 
-        response = assume_role(self.role_info)
+        response = assume_role(self.aws_session, self.role_info)
         refreshed_credentials = dict(
             # Keys of the dict has to be the same as those that are being searched in the parent class
             # https://github.com/boto/botocore/blob/098cc255f81a25b852e1ecdeb7adebd94c7b1b73/botocore/credentials.py#L609
@@ -76,24 +75,24 @@ class AWS_Provider:
         return refreshed_credentials
 
 
-def assume_role(audit_info: AWS_Audit_Info) -> dict:
+def assume_role(session: session.Session, assumed_role_info: AWS_Assume_Role) -> dict:
     try:
         # set the info to assume the role from the partition, account and role name
-        sts_client = audit_info.original_session.client("sts")
+        sts_client = session.client("sts")
         # If external id, set it to the assume role api call
-        if audit_info.assumed_role_info.external_id:
+        if assumed_role_info.external_id:
             assumed_credentials = sts_client.assume_role(
-                RoleArn=audit_info.assumed_role_info.role_arn,
+                RoleArn=assumed_role_info.role_arn,
                 RoleSessionName="ProwlerProAsessmentSession",
-                DurationSeconds=audit_info.assumed_role_info.session_duration,
-                ExternalId=audit_info.assumed_role_info.external_id,
+                DurationSeconds=assumed_role_info.session_duration,
+                ExternalId=assumed_role_info.external_id,
             )
         # else assume the role without the external id
         else:
             assumed_credentials = sts_client.assume_role(
-                RoleArn=audit_info.assumed_role_info.role_arn,
+                RoleArn=assumed_role_info.role_arn,
                 RoleSessionName="ProwlerProAsessmentSession",
-                DurationSeconds=audit_info.assumed_role_info.session_duration,
+                DurationSeconds=assumed_role_info.session_duration,
             )
     except Exception as error:
         logger.critical(f"{error.__class__.__name__} -- {error}")

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -2,7 +2,11 @@ import boto3
 import sure  # noqa
 from moto import mock_iam, mock_sts
 
-from prowler.providers.aws.aws_provider import assume_role, generate_regional_clients
+from prowler.providers.aws.aws_provider import (
+    AWS_Provider,
+    assume_role,
+    generate_regional_clients,
+)
 from prowler.providers.aws.lib.audit_info.models import AWS_Assume_Role, AWS_Audit_Info
 
 ACCOUNT_ID = 123456789012
@@ -55,7 +59,10 @@ class Test_AWS_Provider:
         )
 
         # Call assume_role
-        assume_role_response = assume_role(audit_info)
+        aws_provider = AWS_Provider(audit_info)
+        assume_role_response = assume_role(
+            aws_provider.aws_session, aws_provider.role_info
+        )
         # Recover credentials for the assume role operation
         credentials = assume_role_response["Credentials"]
         # Test the response


### PR DESCRIPTION
### Context

Prowler did not refresh aws credentials properly when it is executed assuming a role and those credentials expire.


### Description

Reformat `assume_role` input arguments and audit session set

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
