### PR TITLE
fix(codeartifact): set Namespace attribute as optional

### DIFF
--- a/prowler/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled.py
@@ -26,10 +26,10 @@ class codeartifact_packages_external_public_publishing_disabled(Check):
                         == RestrictionValues.ALLOW
                     ):
                         report.status = "FAIL"
-                        report.status_extended = f"Internal package {package.namespace} {package.name} is vulnerable to dependency confusion in repository {repository.arn}"
+                        report.status_extended = f"Internal package {package.name} is vulnerable to dependency confusion in repository {repository.arn}"
                     else:
                         report.status = "PASS"
-                        report.status_extended = f"Internal package {package.namespace} {package.name} is not vulnerable to dependency confusion in repository {repository.arn}"
+                        report.status_extended = f"Internal package {package.name} is not vulnerable to dependency confusion in repository {repository.arn}"
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/codeartifact/codeartifact_service.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_service.py
@@ -1,5 +1,6 @@
 import threading
 from enum import Enum
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -79,7 +80,7 @@ class CodeArtifact:
                         for package in page["packages"]:
                             # Package information
                             package_format = package["format"]
-                            package_namespace = package["namespace"]
+                            package_namespace = package.get("namespace")
                             package_name = package["package"]
                             package_origin_configuration_restrictions_publish = package[
                                 "originConfiguration"
@@ -98,9 +99,8 @@ class CodeArtifact:
                                     ].domain_owner,
                                     repository=repository,
                                     format=package_format,
-                                    namespace=package_namespace,
                                     package=package_name,
-                                    short_by="PUBLISHED_TIME",
+                                    sortBy="PUBLISHED_TIME",
                                 )
                             )
                             latest_version = latest_version_information["versions"][0][
@@ -207,7 +207,7 @@ class Package(BaseModel):
     """Details of a package"""
 
     name: str
-    namespace: str
+    namespace: Optional[str]
     format: str
     origin_configuration: OriginConfiguration
     latest_version: LatestPackageVersion

--- a/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_test.py
+++ b/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_test.py
@@ -113,7 +113,7 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Internal package {package_namespace} {package_name} is vulnerable to dependency confusion in repository {repository_arn}"
+                == f"Internal package {package_name} is vulnerable to dependency confusion in repository {repository_arn}"
             )
 
     def test_repository_package_private_publishing_origin_internal(self):
@@ -168,5 +168,5 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Internal package {package_namespace} {package_name} is not vulnerable to dependency confusion in repository {repository_arn}"
+                == f"Internal package {package_name} is not vulnerable to dependency confusion in repository {repository_arn}"
             )


### PR DESCRIPTION
### Description

To avoid Key Errors with packages without namespaces, we need to set the attribute to optional.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
