### PR TITLE
feat(ec2): Add ResourceArn

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_ami_public/ec2_ami_public.metadata.json
+++ b/prowler/providers/aws/services/ec2/ec2_ami_public/ec2_ami_public.metadata.json
@@ -9,7 +9,7 @@
   "SubServiceName": "ami",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
   "Severity": "critical",
-  "ResourceType": "AwsEc2SecurityGroup",
+  "ResourceType": "Other",
   "Description": "Ensure there are no EC2 AMIs set as Public.",
   "Risk": "A shared AMI is an AMI that a developer created and made available for other developers to use. If AMIs have embebed information about the environment could pose a security risk. You use a shared AMI at your own risk. Amazon can not vouch for the integrity or security of AMIs shared by Amazon EC2 users.",
   "RelatedUrl": "",

--- a/prowler/providers/aws/services/ec2/ec2_ami_public/ec2_ami_public.py
+++ b/prowler/providers/aws/services/ec2/ec2_ami_public/ec2_ami_public.py
@@ -9,6 +9,7 @@ class ec2_ami_public(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = image.region
             report.resource_id = image.id
+            report.resource_arn = image.arn
             report.status = "PASS"
             report.status_extended = f"EC2 AMI {image.id} is not public."
             if image.public:

--- a/prowler/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot.py
@@ -8,6 +8,7 @@ class ec2_ebs_public_snapshot(Check):
         for snapshot in ec2_client.snapshots:
             report = Check_Report_AWS(self.metadata())
             report.region = snapshot.region
+            report.resource_arn = snapshot.arn
             if not snapshot.public:
                 report.status = "PASS"
                 report.status_extended = f"EBS Snapshot {snapshot.id} is not Public."

--- a/prowler/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted.py
@@ -8,6 +8,7 @@ class ec2_ebs_snapshots_encrypted(Check):
         for snapshot in ec2_client.snapshots:
             report = Check_Report_AWS(self.metadata())
             report.region = snapshot.region
+            report.resource_arn = snapshot.arn
             if snapshot.encrypted:
                 report.status = "PASS"
                 report.status_extended = f"EBS Snapshot {snapshot.id} is encrypted."

--- a/prowler/providers/aws/services/ec2/ec2_ebs_volume_encryption/ec2_ebs_volume_encryption.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_volume_encryption/ec2_ebs_volume_encryption.py
@@ -9,6 +9,7 @@ class ec2_ebs_volume_encryption(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = volume.region
             report.resource_id = volume.id
+            report.resource_arn = volume.arn
             if volume.encrypted:
                 report.status = "PASS"
                 report.status_extended = f"EBS Snapshot {volume.id} is encrypted."

--- a/prowler/providers/aws/services/ec2/ec2_elastic_ip_shodan/ec2_elastic_ip_shodan.py
+++ b/prowler/providers/aws/services/ec2/ec2_elastic_ip_shodan/ec2_elastic_ip_shodan.py
@@ -15,6 +15,7 @@ class ec2_elastic_ip_shodan(Check):
             for eip in ec2_client.elastic_ips:
                 report = Check_Report_AWS(self.metadata())
                 report.region = eip.region
+                report.resource_arn = eip.arn
                 if eip.public_ip:
                     try:
                         shodan_info = api.host(eip.public_ip)

--- a/prowler/providers/aws/services/ec2/ec2_elastic_ip_unassgined/ec2_elastic_ip_unassgined.py
+++ b/prowler/providers/aws/services/ec2/ec2_elastic_ip_unassgined/ec2_elastic_ip_unassgined.py
@@ -10,6 +10,7 @@ class ec2_elastic_ip_unassgined(Check):
             report.region = eip.region
             if eip.public_ip:
                 report.resource_id = eip.public_ip
+                report.resource_arn = eip.arn
                 report.status = "FAIL"
                 report.status_extended = f"Elastic IP {eip.public_ip} is not associated with an instance or network interface."
                 if eip.association_id:

--- a/prowler/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled.py
@@ -9,6 +9,7 @@ class ec2_instance_imdsv2_enabled(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = instance.region
             report.resource_id = instance.id
+            report.resource_arn = instance.arn
             report.status = "FAIL"
             report.status_extended = (
                 f"EC2 Instance {instance.id} has IMDSv2 disabled or not required."

--- a/prowler/providers/aws/services/ec2/ec2_instance_internet_facing_with_instance_profile/ec2_instance_internet_facing_with_instance_profile.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_internet_facing_with_instance_profile/ec2_instance_internet_facing_with_instance_profile.py
@@ -9,6 +9,7 @@ class ec2_instance_internet_facing_with_instance_profile(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = instance.region
             report.resource_id = instance.id
+            report.resource_arn = instance.arn
             report.status = "PASS"
             report.status_extended = f"EC2 Instance {instance.id} is not internet facing with an instance profile."
             if instance.public_ip and instance.instance_profile:

--- a/prowler/providers/aws/services/ec2/ec2_instance_managed_by_ssm/ec2_instance_managed_by_ssm.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_managed_by_ssm/ec2_instance_managed_by_ssm.py
@@ -9,6 +9,7 @@ class ec2_instance_managed_by_ssm(Check):
         for instance in ec2_client.instances:
             report = Check_Report_AWS(self.metadata())
             report.region = instance.region
+            report.resource_arn = instance.arn
             if not ssm_client.managed_instances.get(instance.id):
                 report.status = "FAIL"
                 report.status_extended = (

--- a/prowler/providers/aws/services/ec2/ec2_instance_older_than_specific_days/ec2_instance_older_than_specific_days.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_older_than_specific_days/ec2_instance_older_than_specific_days.py
@@ -13,6 +13,7 @@ class ec2_instance_older_than_specific_days(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = instance.region
             report.resource_id = instance.id
+            report.resource_arn = instance.arn
             report.status = "PASS"
             report.status_extended = f"EC2 Instance {instance.id} is not running."
             if instance.state == "running":

--- a/prowler/providers/aws/services/ec2/ec2_instance_profile_attached/ec2_instance_profile_attached.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_profile_attached/ec2_instance_profile_attached.py
@@ -9,6 +9,7 @@ class ec2_instance_profile_attached(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = instance.region
             report.resource_id = instance.id
+            report.resource_arn = instance.arn
             report.status = "FAIL"
             report.status_extended = f"EC2 Instance {instance.id} not associated with an Instance Profile Role."
             if instance.instance_profile:

--- a/prowler/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip.py
@@ -8,6 +8,7 @@ class ec2_instance_public_ip(Check):
         for instance in ec2_client.instances:
             report = Check_Report_AWS(self.metadata())
             report.region = instance.region
+            report.resource_arn = instance.arn
             if instance.public_ip:
                 report.status = "FAIL"
                 report.status_extended = f"EC2 Instance {instance.id} has a Public IP: {instance.public_ip} ({instance.public_dns})."

--- a/prowler/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data.py
@@ -16,6 +16,7 @@ class ec2_instance_secrets_user_data(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = instance.region
             report.resource_id = instance.id
+            report.resource_arn = instance.arn
 
             if instance.user_data:
                 temp_user_data_file = tempfile.NamedTemporaryFile(delete=False)

--- a/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_any_port/ec2_networkacl_allow_ingress_any_port.py
+++ b/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_any_port/ec2_networkacl_allow_ingress_any_port.py
@@ -12,6 +12,7 @@ class ec2_networkacl_allow_ingress_any_port(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = network_acl.region
             report.resource_id = network_acl.id
+            report.resource_arn = network_acl.arn
             # If some entry allows it, that ACL is not securely configured
             if not check_network_acl(network_acl.entries, tcp_protocol, check_port):
                 report.status = "PASS"

--- a/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22.py
+++ b/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22.py
@@ -11,6 +11,7 @@ class ec2_networkacl_allow_ingress_tcp_port_22(Check):
         for network_acl in ec2_client.network_acls:
             report = Check_Report_AWS(self.metadata())
             report.region = network_acl.region
+            report.resource_arn = network_acl.arn
             # If some entry allows it, that ACL is not securely configured
             if not check_network_acl(network_acl.entries, tcp_protocol, check_port):
                 report.status = "PASS"

--- a/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389.py
+++ b/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389.py
@@ -11,6 +11,7 @@ class ec2_networkacl_allow_ingress_tcp_port_3389(Check):
         for network_acl in ec2_client.network_acls:
             report = Check_Report_AWS(self.metadata())
             report.region = network_acl.region
+            report.resource_arn = network_acl.arn
             # If some entry allows it, that ACL is not securely configured
             if not check_network_acl(network_acl.entries, tcp_protocol, check_port):
                 report.status = "PASS"

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port.py
@@ -12,6 +12,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_any_port(Check):
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not all ports open to the Internet."
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             # Loop through every security group's ingress rule and check it
             for ingress_rule in security_group.ingress_rules:
                 if check_security_group(ingress_rule, "-1", any_address=True):

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018.py
@@ -11,6 +11,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018(
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not MongoDB ports 27017 and 27018 open to the Internet."
             # Loop through every security group's ingress rule and check it

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21.py
@@ -13,6 +13,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21(Check)
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not FTP ports 20 and 21 open to the Internet."
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             # Loop through every security group's ingress rule and check it
             for ingress_rule in security_group.ingress_rules:
                 if check_security_group(

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.py
@@ -13,6 +13,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22(Check):
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not SSH port 22 open to the Internet."
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             # Loop through every security group's ingress rule and check it
             for ingress_rule in security_group.ingress_rules:
                 if check_security_group(

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.py
@@ -13,6 +13,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389(Check):
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not Microsoft RDP port 3389 open to the Internet."
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             # Loop through every security group's ingress rule and check it
             for ingress_rule in security_group.ingress_rules:
                 if check_security_group(

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888.py
@@ -13,6 +13,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not Casandra ports 7199, 8888 and 9160 open to the Internet."
             # Loop through every security group's ingress rule and check it

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601.py
@@ -13,6 +13,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_ki
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not Elasticsearch/Kibana ports 9200, 9300 and 5601 open to the Internet."
             # Loop through every security group's ingress rule and check it

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092.py
@@ -11,6 +11,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092(Check
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not Kafka port 9092 open to the Internet."
             # Loop through every security group's ingress rule and check it

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211.py
@@ -11,6 +11,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211(
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not Memcached port 11211 open to the Internet."
             # Loop through every security group's ingress rule and check it

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306.py
@@ -11,6 +11,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306(Check
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not MySQL port 3306 open to the Internet."
             # Loop through every security group's ingress rule and check it

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483.py
@@ -11,6 +11,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not Oracle ports 1521 and 2483 open to the Internet."
             # Loop through every security group's ingress rule and check it

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432.py
@@ -11,6 +11,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432(Ch
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not Postgres port 5432 open to the Internet."
             # Loop through every security group's ingress rule and check it

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379.py
@@ -11,6 +11,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379(Check
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not Redis port 6379 open to the Internet."
             # Loop through every security group's ingress rule and check it

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434.py
@@ -13,6 +13,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not Microsoft SQL Server ports 1433 and 1434 open to the Internet."
             # Loop through every security group's ingress rule and check it

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23.py
@@ -11,6 +11,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23(Check)
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has not Telnet port 23 open to the Internet."
             # Loop through every security group's ingress rule and check it

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_wide_open_public_ipv4/ec2_securitygroup_allow_wide_open_public_ipv4.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_wide_open_public_ipv4/ec2_securitygroup_allow_wide_open_public_ipv4.py
@@ -12,6 +12,7 @@ class ec2_securitygroup_allow_wide_open_public_ipv4(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has no potential wide-open non-RFC1918 address."
             # Loop through every security group's ingress rule and check it

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_default_restrict_traffic/ec2_securitygroup_default_restrict_traffic.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_default_restrict_traffic/ec2_securitygroup_default_restrict_traffic.py
@@ -10,6 +10,7 @@ class ec2_securitygroup_default_restrict_traffic(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             # Find default security group
             if security_group.name == "default":
                 report.status = "PASS"

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_from_launch_wizard/ec2_securitygroup_from_launch_wizard.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_from_launch_wizard/ec2_securitygroup_from_launch_wizard.py
@@ -9,6 +9,7 @@ class ec2_securitygroup_from_launch_wizard(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) was not created using the EC2 Launch Wizard."
             if "launch-wizard" in security_group.name:

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_in_use_without_ingress_filtering/ec2_securitygroup_in_use_without_ingress_filtering.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_in_use_without_ingress_filtering/ec2_securitygroup_in_use_without_ingress_filtering.py
@@ -10,6 +10,7 @@ class ec2_securitygroup_in_use_without_ingress_filtering(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has ingress filtering."
             for ingress_rule in security_group.ingress_rules:

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used.py
@@ -9,6 +9,7 @@ class ec2_securitygroup_not_used(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) it is being used."
             if len(security_group.network_interfaces) == 0:

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_with_many_ingress_egress_rules/ec2_securitygroup_with_many_ingress_egress_rules.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_with_many_ingress_egress_rules/ec2_securitygroup_with_many_ingress_egress_rules.py
@@ -11,6 +11,7 @@ class ec2_securitygroup_with_many_ingress_egress_rules(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = security_group.region
             report.resource_id = security_group.id
+            report.resource_arn = security_group.arn
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has {len(security_group.ingress_rules)} inbound rules and {len(security_group.egress_rules)} outbound rules"
             if (

--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -155,7 +155,10 @@ class EC2:
                         encrypted = True
                     self.snapshots.append(
                         Snapshot(
-                            snapshot["SnapshotId"], arn, regional_client.region, encrypted
+                            snapshot["SnapshotId"],
+                            arn,
+                            regional_client.region,
+                            encrypted,
                         )
                     )
         except Exception as error:
@@ -232,7 +235,11 @@ class EC2:
                     public = True
                 self.images.append(
                     Image(
-                        image["ImageId"], arn, image["Name"], public, regional_client.region
+                        image["ImageId"],
+                        arn,
+                        image["Name"],
+                        public,
+                        regional_client.region,
                     )
                 )
         except Exception as error:

--- a/tests/providers/aws/services/ec2/ec2_ami_public/ec2_ami_public_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ami_public/ec2_ami_public_test.py
@@ -65,6 +65,10 @@ class Test_ec2_ami_public:
             assert result[0].status == "PASS"
             assert result[0].status_extended == f"EC2 AMI {image_id} is not public."
             assert result[0].resource_id == image_id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:image/{image_id}"
+            )
 
     @mock_ec2
     def test_one_public_ami(self):
@@ -111,3 +115,7 @@ class Test_ec2_ami_public:
                 result[0].status_extended == f"EC2 AMI {image_id} is currently public."
             )
             assert result[0].resource_id == image_id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:image/{image_id}"
+            )

--- a/tests/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot_test.py
@@ -72,6 +72,10 @@ class Test_ec2_ebs_public_snapshot:
                         snap.status_extended
                         == f"EBS Snapshot {snapshot.id} is currently Public."
                     )
+                    assert (
+                        snap.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:snapshot/{snapshot.id}"
+                    )
 
     @mock_ec2
     def test_ec2_private_snapshot(self):
@@ -108,4 +112,8 @@ class Test_ec2_ebs_public_snapshot:
                     assert (
                         snap.status_extended
                         == f"EBS Snapshot {snapshot.id} is not Public."
+                    )
+                    assert (
+                        snap.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:snapshot/{snapshot.id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted_test.py
@@ -66,6 +66,10 @@ class Test_ec2_ebs_snapshots_encrypted:
                         snap.status_extended
                         == f"EBS Snapshot {snapshot.id} is unencrypted."
                     )
+                    assert (
+                        snap.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:snapshot/{snapshot.id}"
+                    )
 
     @mock_ec2
     def test_ec2_encrypted_snapshot(self):
@@ -102,4 +106,8 @@ class Test_ec2_ebs_snapshots_encrypted:
                     assert (
                         snap.status_extended
                         == f"EBS Snapshot {snapshot.id} is encrypted."
+                    )
+                    assert (
+                        snap.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:snapshot/{snapshot.id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_ebs_volume_encryption/ec2_ebs_volume_encryption_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ebs_volume_encryption/ec2_ebs_volume_encryption_test.py
@@ -60,6 +60,10 @@ class Test_ec2_ebs_volume_encryption:
             assert (
                 result[0].status_extended == f"EBS Snapshot {volume.id} is unencrypted."
             )
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:volume/{volume.id}"
+            )
 
     @mock_ec2
     def test_ec2_encrypted_volume(self):
@@ -92,4 +96,8 @@ class Test_ec2_ebs_volume_encryption:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended == f"EBS Snapshot {volume.id} is encrypted."
+            )
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:volume/{volume.id}"
             )

--- a/tests/providers/aws/services/ec2/ec2_elastic_ip_unassgined/ec2_elastic_ip_unassgined_test.py
+++ b/tests/providers/aws/services/ec2/ec2_elastic_ip_unassgined/ec2_elastic_ip_unassgined_test.py
@@ -36,7 +36,9 @@ class Test_ec2_elastic_ip_unassgined:
     def test_eip_unassociated(self):
         # Create EC2 Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION)
-        ec2_client.allocate_address(Domain="vpc", Address="127.38.43.222")
+        allocation_id = ec2_client.allocate_address(
+            Domain="vpc", Address="127.38.43.222"
+        )["AllocationId"]
 
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.ec2.ec2_service import EC2
@@ -61,6 +63,10 @@ class Test_ec2_elastic_ip_unassgined:
             assert search(
                 "is not associated",
                 results[0].status_extended,
+            )
+            assert (
+                results[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:eip-allocation/{allocation_id}"
             )
 
     @mock_ec2
@@ -105,4 +111,8 @@ class Test_ec2_elastic_ip_unassgined:
             assert search(
                 "is associated",
                 results[0].status_extended,
+            )
+            assert (
+                results[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:eip-allocation/{eip.allocation_id}"
             )

--- a/tests/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled_test.py
@@ -73,6 +73,10 @@ class Test_ec2_instance_imdsv2_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+            )
 
     @mock_ec2
     def test_one_uncompliant_ec2(self):
@@ -115,3 +119,7 @@ class Test_ec2_instance_imdsv2_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+            )

--- a/tests/providers/aws/services/ec2/ec2_instance_internet_facing_with_instance_profile/ec2_instance_internet_facing_with_instance_profile_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_internet_facing_with_instance_profile/ec2_instance_internet_facing_with_instance_profile_test.py
@@ -81,6 +81,10 @@ class Test_ec2_instance_internet_facing_with_instance_profile:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+            )
 
     @mock_iam
     @mock_ec2
@@ -130,3 +134,7 @@ class Test_ec2_instance_internet_facing_with_instance_profile:
                 "is internet-facing with Instance Profile", result[0].status_extended
             )
             assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+            )

--- a/tests/providers/aws/services/ec2/ec2_instance_older_than_specific_days/ec2_instance_older_than_specific_days_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_older_than_specific_days/ec2_instance_older_than_specific_days_test.py
@@ -68,6 +68,10 @@ class Test_ec2_instance_older_than_specific_days:
                 f"EC2 Instance {instance.id} is not older", result[0].status_extended
             )
             assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+            )
 
     @mock_ec2
     def test_one_old_ec2(self):
@@ -107,3 +111,7 @@ class Test_ec2_instance_older_than_specific_days:
                 f"EC2 Instance {instance.id} is older", result[0].status_extended
             )
             assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+            )

--- a/tests/providers/aws/services/ec2/ec2_instance_profile_attached/ec2_instance_profile_attached_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_profile_attached/ec2_instance_profile_attached_test.py
@@ -81,6 +81,10 @@ class Test_ec2_instance_profile_attached:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+            )
 
     @mock_ec2
     def test_one_non_compliant_ec2(self):
@@ -123,3 +127,7 @@ class Test_ec2_instance_profile_attached:
                 "not associated with an Instance Profile", result[0].status_extended
             )
             assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+            )

--- a/tests/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip_test.py
@@ -75,6 +75,10 @@ class Test_ec2_instance_public_ip:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+            )
 
     @mock_ec2
     def test_one_ec2_with_public_ip(self):
@@ -118,3 +122,7 @@ class Test_ec2_instance_public_ip:
                 f"EC2 Instance {instance.id} has a Public IP", result[0].status_extended
             )
             assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+            )

--- a/tests/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data_test.py
@@ -102,6 +102,10 @@ class Test_ec2_instance_secrets_user_data:
                 == f"Potential secret found in EC2 instance {instance.id} User Data."
             )
             assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+            )
 
     @mock_ec2
     def test_one_ec2_file_with_secrets(self):
@@ -140,6 +144,10 @@ class Test_ec2_instance_secrets_user_data:
                 == f"Potential secret found in EC2 instance {instance.id} User Data."
             )
             assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+            )
 
     @mock_ec2
     def test_one_launch_configurations_without_user_data(self):
@@ -173,3 +181,7 @@ class Test_ec2_instance_secrets_user_data:
                 == f"No secrets found in EC2 instance {instance.id} since User Data is empty."
             )
             assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+            )

--- a/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_any_port/ec2_networkacl_allow_ingress_any_port_test.py
+++ b/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_any_port/ec2_networkacl_allow_ingress_any_port_test.py
@@ -107,6 +107,10 @@ class ec2_networkacl_allow_ingress_any_port:
                         nacl.status_extended
                         == f"Network ACL {nacl_id} has every port open to the Internet."
                     )
+                    assert (
+                        nacl.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_nacl(self):
@@ -152,4 +156,8 @@ class ec2_networkacl_allow_ingress_any_port:
                     assert (
                         nacl.status_extended
                         == f"Network ACL {nacl_id} has not every port open to the Internet."
+                    )
+                    assert (
+                        nacl.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22_test.py
+++ b/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22_test.py
@@ -108,6 +108,10 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
                         nacl.status_extended
                         == f"Network ACL {nacl_id} has SSH port 22 open to the Internet."
                     )
+                    assert (
+                        nacl.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_nacl(self):
@@ -154,4 +158,8 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
                     assert (
                         nacl.status_extended
                         == f"Network ACL {nacl_id} has not SSH port 22 open to the Internet."
+                    )
+                    assert (
+                        nacl.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389_test.py
+++ b/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389_test.py
@@ -108,6 +108,10 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
                         nacl.status_extended
                         == f"Network ACL {nacl_id} has Microsoft RDP port 3389 open to the Internet."
                     )
+                    assert (
+                        nacl.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_nacl(self):
@@ -154,4 +158,8 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
                     assert (
                         nacl.status_extended
                         == f"Network ACL {nacl_id} has not Microsoft RDP port 3389 open to the Internet."
+                    )
+                    assert (
+                        nacl.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port_test.py
@@ -83,6 +83,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
                         "has all ports open to the Internet",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -129,4 +133,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
                     assert search(
                         "has not all ports open to the Internet",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018_test.py
@@ -89,6 +89,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_2
                         "has MongoDB ports 27017 and 27018 open to the Internet",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -139,4 +143,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_2
                     assert search(
                         "has not MongoDB ports 27017 and 27018 open to the Internet",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21_test.py
@@ -89,6 +89,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21:
                         "has FTP ports 20 and 21 open to the Internet",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -139,4 +143,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21:
                     assert search(
                         "has not FTP ports 20 and 21 open to the Internet",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22_test.py
@@ -85,6 +85,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
                         "has SSH port 22 open to the Internet",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -133,4 +137,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
                     assert search(
                         "has not SSH port 22 open to the Internet",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389_test.py
@@ -85,6 +85,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
                         "has Microsoft RDP port 3389 open to the Internet",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -133,4 +137,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
                     assert search(
                         "has not Microsoft RDP port 3389 open to the Internet",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888_test.py
@@ -89,6 +89,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7
                         "has Casandra ports 7199, 8888 and 9160 open to the Internet",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -139,4 +143,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7
                     assert search(
                         "has not Casandra ports 7199, 8888 and 9160 open to the Internet",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601_test.py
@@ -89,6 +89,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsear
                         "has Elasticsearch/Kibana ports 9200, 9300 and 5601 open to the Internet",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -139,4 +143,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsear
                     assert search(
                         "has not Elasticsearch/Kibana ports 9200, 9300 and 5601 open to the Internet",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092_test.py
@@ -88,6 +88,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092:
                     assert search(
                         "has Kafka port 9092 open to the Internet", sg.status_extended
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -138,4 +142,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092:
                     assert search(
                         "has not Kafka port 9092 open to the Internet",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211_test.py
@@ -89,6 +89,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_1
                         "has Memcached port 11211 open to the Internet",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -139,4 +143,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_1
                     assert search(
                         "has not Memcached port 11211 open to the Internet",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306_test.py
@@ -89,6 +89,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306:
                         "has MySQL port 3306 open to the Internet",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -139,4 +143,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306:
                     assert search(
                         "has not MySQL port 3306 open to the Internet",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483_test.py
@@ -89,6 +89,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521
                         "has Oracle ports 1521 and 2483 open to the Internet",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -139,4 +143,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521
                     assert search(
                         "has not Oracle ports 1521 and 2483 open to the Internet",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432_test.py
@@ -89,6 +89,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_54
                         "has Postgres port 5432 open to the Internet",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -139,4 +143,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_54
                     assert search(
                         "has not Postgres port 5432 open to the Internet",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379_test.py
@@ -88,6 +88,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
                     assert search(
                         "has Redis port 6379 open to the Internet", sg.status_extended
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -138,4 +142,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
                     assert search(
                         "has not Redis port 6379 open to the Internet",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434_test.py
@@ -89,6 +89,10 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_
                         "has Microsoft SQL Server ports 1433 and 1434 open to the Internet",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -139,4 +143,8 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_
                     assert search(
                         "has not Microsoft SQL Server ports 1433 and 1434 open to the Internet",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23_test.py
@@ -88,6 +88,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23:
                     assert search(
                         "has Telnet port 23 open to the Internet", sg.status_extended
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -138,4 +142,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23:
                     assert search(
                         "has not Telnet port 23 open to the Internet",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_wide_open_public_ipv4/ec2_securitygroup_allow_wide_open_public_ipv4_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_wide_open_public_ipv4/ec2_securitygroup_allow_wide_open_public_ipv4_test.py
@@ -83,6 +83,10 @@ class Test_ec2_securitygroup_allow_wide_open_public_ipv4:
                         "has no potential wide-open non-RFC1918 address",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_default_sg_with_non_RFC1918_address(self):
@@ -129,4 +133,8 @@ class Test_ec2_securitygroup_allow_wide_open_public_ipv4:
                     assert search(
                         "has potential wide-open non-RFC1918 address",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_default_restrict_traffic/ec2_securitygroup_default_restrict_traffic_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_default_restrict_traffic/ec2_securitygroup_default_restrict_traffic_test.py
@@ -77,6 +77,10 @@ class Test_ec2_securitygroup_default_restrict_traffic:
                         sg.status_extended
                         == f"Default Security Group ({default_sg_id}) is open to the Internet."
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -120,4 +124,8 @@ class Test_ec2_securitygroup_default_restrict_traffic:
                     assert (
                         sg.status_extended
                         == f"Default Security Group ({default_sg_id}) is not open to the Internet."
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_from_launch_wizard/ec2_securitygroup_from_launch_wizard_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_from_launch_wizard/ec2_securitygroup_from_launch_wizard_test.py
@@ -75,6 +75,10 @@ class Test_ec2_securitygroup_from_launch_wizard:
                         "was created using the EC2 Launch Wizard",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -121,4 +125,8 @@ class Test_ec2_securitygroup_from_launch_wizard:
                     assert search(
                         "was not created using the EC2 Launch Wizard",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_in_use_without_ingress_filtering/ec2_securitygroup_in_use_without_ingress_filtering_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_in_use_without_ingress_filtering/ec2_securitygroup_in_use_without_ingress_filtering_test.py
@@ -84,6 +84,10 @@ class Test_ec2_securitygroup_in_use_without_ingress_filtering:
                         "has no ingress filtering and it is not being used",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_used_public_default_sg(self):
@@ -139,6 +143,10 @@ class Test_ec2_securitygroup_in_use_without_ingress_filtering:
                         "has no ingress filtering and it is being used",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_private_default_sg(self):
@@ -176,4 +184,8 @@ class Test_ec2_securitygroup_in_use_without_ingress_filtering:
                     assert search(
                         "has ingress filtering",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used_test.py
@@ -75,6 +75,10 @@ class Test_ec2_securitygroup_not_used:
                         "it is not being used",
                         sg.status_extended,
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_used_default_sg(self):
@@ -121,4 +125,8 @@ class Test_ec2_securitygroup_not_used:
                     assert search(
                         "it is being used",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_with_many_ingress_egress_rules/ec2_securitygroup_with_many_ingress_egress_rules_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_with_many_ingress_egress_rules/ec2_securitygroup_with_many_ingress_egress_rules_test.py
@@ -85,6 +85,10 @@ class Test_ec2_securitygroup_with_many_ingress_egress_rules:
                     assert search(
                         "has 60 inbound rules and 1 outbound rules", sg.status_extended
                     )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
@@ -133,4 +137,8 @@ class Test_ec2_securitygroup_with_many_ingress_egress_rules:
                     assert search(
                         "has 1 inbound rules and 1 outbound rules",
                         sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )


### PR DESCRIPTION
### Description

AWS EC2 is not reporting resources ARN. I constructed the ARNs for all available Resources Types and added them to each check report. ARN needs to be constructed manually as they are not provided in describe AWS API CALLs (Thanks Aws! :().

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
