### PR TITLE
feat(): add ECS task revision number

### DIFF
--- a/prowler/providers/aws/services/ecs/ecs_service.py
+++ b/prowler/providers/aws/services/ecs/ecs_service.py
@@ -41,6 +41,7 @@ class ECS:
                             # we want the family name without the revision
                             name=sub(":.*", "", task_definition.split("/")[1]),
                             arn=task_definition,
+                            revision=task_definition.split(":")[-1],
                             region=regional_client.region,
                             environment_variables=[],
                         )
@@ -80,5 +81,6 @@ class ContainerEnvVariable(BaseModel):
 class TaskDefinition(BaseModel):
     name: str
     arn: str
+    revision: str
     region: str
     environment_variables: list[ContainerEnvVariable]

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
@@ -18,7 +18,7 @@ class ecs_task_definitions_no_environment_secrets(Check):
             report.resource_id = task_definition.name
             report.resource_arn = task_definition.arn
             report.status = "PASS"
-            report.status_extended = f"No secrets found in ECS task definition {task_definition.name} variables"
+            report.status_extended = f"No secrets found in variables of ECS task definition {task_definition.name} revision {task_definition.revision}"
             if task_definition.environment_variables:
                 for env_var in task_definition.environment_variables:
                     dump_env_vars = {}
@@ -36,7 +36,7 @@ class ecs_task_definitions_no_environment_secrets(Check):
 
                 if secrets.json():
                     report.status = "FAIL"
-                    report.status_extended = f"Potential secret found in ECS in ECS task definition {task_definition.name} revision {task_definition.arn.split(':')[-1]} variables"
+                    report.status_extended = f"Potential secret found in variables of ECS task definition {task_definition.name} revision {task_definition.revision}"
 
                 os.remove(temp_env_data_file.name)
 

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
@@ -36,7 +36,7 @@ class ecs_task_definitions_no_environment_secrets(Check):
 
                 if secrets.json():
                     report.status = "FAIL"
-                    report.status_extended = f"Potential secret found in ECS in ECS task definition {task_definition.name} variables"
+                    report.status_extended = f"Potential secret found in ECS in ECS task definition {task_definition.name} revision {task_definition.arn.split(':')[-1]} variables"
 
                 os.remove(temp_env_data_file.name)
 

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
@@ -39,6 +39,7 @@ class Test_ecs_task_definitions_no_environment_secrets:
             TaskDefinition(
                 name=task_name,
                 arn=f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:1",
+                revision="1",
                 region=AWS_REGION,
                 environment_variables=[
                     ContainerEnvVariable(
@@ -61,7 +62,8 @@ class Test_ecs_task_definitions_no_environment_secrets:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert search(
-                "No secrets found in ECS task definition", result[0].status_extended
+                "No secrets found in variables of ECS task definition",
+                result[0].status_extended,
             )
             assert result[0].resource_id == task_name
             assert (
@@ -76,6 +78,7 @@ class Test_ecs_task_definitions_no_environment_secrets:
             TaskDefinition(
                 name=task_name,
                 arn=f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:1",
+                revision="1",
                 region=AWS_REGION,
                 environment_variables=[
                     ContainerEnvVariable(
@@ -98,7 +101,7 @@ class Test_ecs_task_definitions_no_environment_secrets:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert search(
-                "Potential secret found in ECS in ECS task definition",
+                "Potential secret found in variables of ECS task definition",
                 result[0].status_extended,
             )
             assert result[0].resource_id == task_name


### PR DESCRIPTION
### Context

The current output doesn't specify which revision of the task definition potentially contains plaintext secrets

This results in multiple findings for the same task definition being created that look identical, as this check will flag on multiple different versions. It also requires you to manually go and check which revisions actually may contain plaintext secrets.

Adding the revision number to the report output will help clarify which exact definitions may contain plaintext secrets for the user to further investigate.

### Description

I have used the arn to get the revision number for the task definition 

A sample revision is: 'arn:aws:ecs:eu-west-1:ACCOUNTNUMBER:task-definition/task-definition-name:4'

`task_definition.arn.split(':')[-1]` will therefore result in the '4' being obtained, and added to the output

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
