### PR TITLE
feat(): update recommendation of ecs_task_definitions_no_environment_secrets

### DIFF
--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.metadata.json
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.metadata.json
@@ -23,7 +23,7 @@
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "Use Secrets Manager or Parameter Store to securely provide credentials to containers without hardcoding the secrets in code or passing them through environment variables.",
+      "Text": "Use Secrets Manager or Parameter Store to securely provide credentials to containers without hardcoding the secrets in code or passing them through environment variables. It is currently not possible to delete task definition revisions which contain plaintext secrets. AWS is looking into implementing this feature in 2023, and it is therefore recommended that all plaintext secrets are rotated at the same time as moving the secrets to Secrets Manager or Parameter Store.",
       "Url": "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html"
     }
   },


### PR DESCRIPTION
### Context

Added additional recommendation on how to remediate this issue, so that people don't just move the credentials to Secrets Manager or Parameter Store and think that the issue is addressed - whilst the credentials will still exist in the previous task definitions.

### Description

As seen in [this open issue](https://github.com/aws/containers-roadmap/issues/685), the AWS team have finally recognized that they should implement a feature to allow you to delete previous task definition revisions.

If a user has previously stored plaintext secrets in their task definition, and have now decided to address it by moving the credentials to Secrets Manager or Paramater Store, the plaintext secrets will still be accessible in the previous revisions of the task definition.

I therefore wanted to clarify that it should be recommended that these credentials are also rotated, until AWS implements this feature to let you delete previous task definition revisions that contain plaintext secrets.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
