### PR TITLE
fix(trustedadvisor_errors_and_warnings): add region

### DIFF
--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_errors_and_warnings/trustedadvisor_errors_and_warnings.py
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_errors_and_warnings/trustedadvisor_errors_and_warnings.py
@@ -23,6 +23,7 @@ class trustedadvisor_errors_and_warnings(Check):
             report.status = "INFO"
             report.status_extended = "Amazon Web Services Premium Support Subscription is required to use this service."
             report.resource_id = trustedadvisor_client.account
+            report.region = trustedadvisor_client.region
             findings.append(report)
 
         return findings


### PR DESCRIPTION
### Description

Add missing region in trusted advisor service that makes Security Hub to fail:
`2023-01-05 16:15:15,037 [File: security_hub.py:132]     [Module: security_hub]   ERROR: ValueError -- [84]:Invalid endpoint: https://securityhub..amazonaws.com in region `

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
