### PR TITLE
feat(ecs_task_definitions_no_environment_secrets): Update resource_id

### DIFF
--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
@@ -18,7 +18,7 @@ class ecs_task_definitions_no_environment_secrets(Check):
             report.resource_id = f"{task_definition.name}:{task_definition.revision}"
             report.resource_arn = task_definition.arn
             report.status = "PASS"
-            report.status_extended = f"No secrets found in variables of ECS task definition {task_definition.name} revision {task_definition.revision}"
+            report.status_extended = f"No secrets found in variables of ECS task definition {task_definition.name} with revision {task_definition.revision}"
             if task_definition.environment_variables:
                 for env_var in task_definition.environment_variables:
                     dump_env_vars = {}
@@ -36,7 +36,7 @@ class ecs_task_definitions_no_environment_secrets(Check):
 
                 if secrets.json():
                     report.status = "FAIL"
-                    report.status_extended = f"Potential secret found in variables of ECS task definition {task_definition.name} revision {task_definition.revision}"
+                    report.status_extended = f"Potential secret found in variables of ECS task definition {task_definition.name} with revision {task_definition.revision}"
 
                 os.remove(temp_env_data_file.name)
 

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
@@ -15,7 +15,7 @@ class ecs_task_definitions_no_environment_secrets(Check):
         for task_definition in ecs_client.task_definitions:
             report = Check_Report_AWS(self.metadata())
             report.region = task_definition.region
-            report.resource_id = task_definition.name
+            report.resource_id = f"{task_definition.name} revision {task_definition.revision}" 
             report.resource_arn = task_definition.arn
             report.status = "PASS"
             report.status_extended = f"No secrets found in variables of ECS task definition {task_definition.name} revision {task_definition.revision}"

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
@@ -15,7 +15,7 @@ class ecs_task_definitions_no_environment_secrets(Check):
         for task_definition in ecs_client.task_definitions:
             report = Check_Report_AWS(self.metadata())
             report.region = task_definition.region
-            report.resource_id = f"{task_definition.name} revision {task_definition.revision}" 
+            report.resource_id = f"{task_definition.name} revision {task_definition.revision}"
             report.resource_arn = task_definition.arn
             report.status = "PASS"
             report.status_extended = f"No secrets found in variables of ECS task definition {task_definition.name} revision {task_definition.revision}"

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
@@ -15,7 +15,7 @@ class ecs_task_definitions_no_environment_secrets(Check):
         for task_definition in ecs_client.task_definitions:
             report = Check_Report_AWS(self.metadata())
             report.region = task_definition.region
-            report.resource_id = f"{task_definition.name} revision {task_definition.revision}"
+            report.resource_id = f"{task_definition.name}:{task_definition.revision}"
             report.resource_arn = task_definition.arn
             report.status = "PASS"
             report.status_extended = f"No secrets found in variables of ECS task definition {task_definition.name} revision {task_definition.revision}"


### PR DESCRIPTION
Following on from yesterday's changes to include the revision number in the status_extended message, I would like to update the resource ID to also include the task definition revision number. Im not sure if the resource ID is allowed to have spaces in it


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
