### PR TITLE
fix(shub): associate resource_arn as resourceId in Security Hub

### DIFF
--- a/prowler/lib/outputs/json.py
+++ b/prowler/lib/outputs/json.py
@@ -14,12 +14,14 @@ from prowler.lib.utils.utils import hash_sha512, open_file
 
 def fill_json_asff(finding_output, audit_info, finding):
     # Check if there are no resources in the finding
-    if finding.resource_id == "":
-        finding.resource_id = "NONE_PROVIDED"
+    if finding.resource_arn == "":
+        if finding.resource_id == "":
+            finding.resource_id = "NONE_PROVIDED"
+        finding.resource_arn = finding.resource_id
     finding_output.Id = f"prowler-{finding.check_metadata.CheckID}-{audit_info.audited_account}-{finding.region}-{hash_sha512(finding.resource_id)}"
     finding_output.ProductArn = f"arn:{audit_info.audited_partition}:securityhub:{finding.region}::product/prowler/prowler"
     finding_output.ProductFields = ProductFields(
-        ProviderVersion=prowler_version, ProwlerResourceName=finding.resource_id
+        ProviderVersion=prowler_version, ProwlerResourceName=finding.resource_arn
     )
     finding_output.GeneratorId = "prowler-" + finding.check_metadata.CheckID
     finding_output.AwsAccountId = audit_info.audited_account
@@ -32,7 +34,7 @@ def fill_json_asff(finding_output, audit_info, finding):
     finding_output.Description = finding.check_metadata.Description
     finding_output.Resources = [
         Resource(
-            Id=finding.resource_id,
+            Id=finding.resource_arn,
             Type=finding.check_metadata.ResourceType,
             Partition=audit_info.audited_partition,
             Region=finding.region,

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -276,7 +276,7 @@ class Test_Outputs:
         expected.Id = f"prowler-{finding.check_metadata.CheckID}-123456789012-eu-west-1-{hash_sha512('test-resource')}"
         expected.ProductArn = "arn:aws:securityhub:eu-west-1::product/prowler/prowler"
         expected.ProductFields = ProductFields(
-            ProviderVersion=prowler_version, ProwlerResourceName="test-resource"
+            ProviderVersion=prowler_version, ProwlerResourceName="test-arn"
         )
         expected.GeneratorId = "prowler-" + finding.check_metadata.CheckID
         expected.AwsAccountId = AWS_ACCOUNT_ID
@@ -289,7 +289,7 @@ class Test_Outputs:
         expected.Description = finding.check_metadata.Description
         expected.Resources = [
             Resource(
-                Id="test-resource",
+                Id="test-arn",
                 Type=finding.check_metadata.ResourceType,
                 Partition="aws",
                 Region="eu-west-1",


### PR DESCRIPTION
### Description

 Associate resource_arn as the resourceId in Security Hub regarding https://github.com/prowler-cloud/prowler/issues/1661

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
