### PR TITLE
fix(services): Handle KeyErrors from AWS

### DIFF
--- a/prowler/providers/aws/services/acm/acm_service.py
+++ b/prowler/providers/aws/services/acm/acm_service.py
@@ -59,9 +59,12 @@ class ACM:
                     CertificateArn=certificate.arn
                 )["Certificate"]
                 certificate.type = response["Type"]
-                certificate.expiration_days = (
-                    response["NotAfter"] - timestamp_utc
-                ).days
+                if "NotAfter" in response:
+                    certificate.expiration_days = (
+                        response["NotAfter"] - timestamp_utc
+                    ).days
+                else:
+                    certificate.expiration_days = 0
                 if (
                     response["Options"]["CertificateTransparencyLoggingPreference"]
                     == "ENABLED"

--- a/prowler/providers/aws/services/codebuild/codebuild_service.py
+++ b/prowler/providers/aws/services/codebuild/codebuild_service.py
@@ -1,6 +1,7 @@
 import datetime
 import threading
 from dataclasses import dataclass
+from typing import Optional
 
 from prowler.lib.logger import logger
 from prowler.providers.aws.aws_provider import generate_regional_clients
@@ -63,12 +64,16 @@ class Codebuild:
                                     "endTime"
                                 ]
 
-                        project.buildspec = client.batch_get_projects(
-                            names=[project.name]
-                        )["projects"][0]["source"]["buildspec"]
+                        projects = client.batch_get_projects(names=[project.name])[
+                            "projects"
+                        ][0]["source"]
+                        if "buildspec" in projects:
+                            project.buildspec = projects["buildspec"]
 
         except Exception as error:
-            logger.error(f"{client.region} -- {error.__class__.__name__}: {error}")
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
 
 
 @dataclass
@@ -76,7 +81,7 @@ class CodebuildProject:
     name: str
     region: str
     last_invoked_time: datetime
-    buildspec: str
+    buildspec: Optional[str]
 
     def __init__(self, name, region, last_invoked_time, buildspec):
         self.name = name

--- a/prowler/providers/aws/services/efs/efs_service.py
+++ b/prowler/providers/aws/services/efs/efs_service.py
@@ -62,7 +62,7 @@ class EFS:
                                 FileSystemId=filesystem.id
                             )["BackupPolicy"]["Status"]
                         except ClientError as e:
-                            if e.response["ErrorCode"] == "PolicyNotFound":
+                            if e.response["Error"]["Code"] == "PolicyNotFound":
                                 filesystem.backup_policy = "DISABLED"
                         try:
                             fs_policy = client.describe_file_system_policy(
@@ -71,7 +71,7 @@ class EFS:
                             if "Policy" in fs_policy:
                                 filesystem.policy = fs_policy["Policy"]
                         except ClientError as e:
-                            if e.response["ErrorCode"] == "PolicyNotFound":
+                            if e.response["Error"]["Code"] == "PolicyNotFound":
                                 filesystem.policy = {}
         except Exception as error:
             logger.error(

--- a/prowler/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption.py
+++ b/prowler/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption.py
@@ -15,6 +15,7 @@ class iam_no_custom_policy_permissive_role_assumption(Check):
             for statement in policy_document["Statement"]:
                 if (
                     statement["Effect"] == "Allow"
+                    and "Action" in statement
                     and (
                         "sts:AssumeRole" in statement["Action"]
                         or "sts:*" in statement["Action"]

--- a/prowler/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation.py
@@ -75,10 +75,11 @@ class iam_policy_allows_privilege_escalation(Check):
             for statements in policy["PolicyDocument"]["Statement"]:
                 # Recover allowed actions
                 if statements["Effect"] == "Allow":
-                    if type(statements["Action"]) is str:
-                        allowed_actions = {statements["Action"]}
-                    if type(statements["Action"]) is list:
-                        allowed_actions = set(statements["Action"])
+                    if "Action" in statements:
+                        if type(statements["Action"]) is str:
+                            allowed_actions = {statements["Action"]}
+                        if type(statements["Action"]) is list:
+                            allowed_actions = set(statements["Action"])
 
                 # Recover denied actions
                 if statements["Effect"] == "Deny":

--- a/prowler/providers/aws/services/iam/iam_policy_no_administrative_privileges/iam_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_policy_no_administrative_privileges/iam_policy_no_administrative_privileges.py
@@ -16,6 +16,7 @@ class iam_policy_no_administrative_privileges(Check):
             for statement in policy_document["Statement"]:
                 if (
                     statement["Effect"] == "Allow"
+                    and "Action" in statement
                     and "*" in statement["Action"]
                     and "*" in statement["Resource"]
                 ):


### PR DESCRIPTION
### Description

Solve the following errors:
```
2023-01-11 17:59:25,265 [File: acm_service.py:71]       [Module: acm_service]    ERROR: us-east-1 -- KeyError[63]: 'NotAfter'
2023-01-11 17:59:25,269 [File: check.py:297]    [Module: check]  ERROR: acm_certificates_expiration_check -- AttributeError[294]: 'Certificate' object has no attribute 'expiration_days'

2023-01-11 18:06:13,381 [File: codebuild_service.py:71]         [Module: codebuild_service]      ERROR: ap-south-1 -- KeyError: 'buildspec'

2023-01-11 18:10:10,866 [File: efs_service.py:77]       [Module: efs_service]    ERROR: us-east-1 -- KeyError[74]: 'ErrorCode'

2023-01-11 18:10:29,952 [File: check.py:297]    [Module: check]  ERROR: iam_no_custom_policy_permissive_role_assumption -- KeyError[294]: 'Action'
2023-01-11 18:10:30,037 [File: check.py:297]    [Module: check]  ERROR: iam_policy_allows_privilege_escalation -- KeyError[294]: 'Action'
2023-01-11 18:10:30,216 [File: check.py:297]    [Module: check]  ERROR: iam_policy_no_administrative_privileges -- KeyError[294]: 'Action'
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
