### PR TITLE
fix: Solve IAM policy Errors

### DIFF
--- a/prowler/providers/aws/services/codebuild/codebuild_service.py
+++ b/prowler/providers/aws/services/codebuild/codebuild_service.py
@@ -58,11 +58,12 @@ class Codebuild:
                     if project.region == region:
                         ids = client.list_builds_for_project(projectName=project.name)
                         if "ids" in ids:
-                            builds = client.batch_get_builds(ids=[ids["ids"][0]])
-                            if "builds" in builds:
-                                project.last_invoked_time = builds["builds"][0][
-                                    "endTime"
-                                ]
+                            if len(ids["ids"]) > 0:
+                                builds = client.batch_get_builds(ids=[ids["ids"][0]])
+                                if "builds" in builds:
+                                    project.last_invoked_time = builds["builds"][0][
+                                        "endTime"
+                                    ]
 
                         projects = client.batch_get_projects(names=[project.name])[
                             "projects"

--- a/prowler/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption.py
+++ b/prowler/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption.py
@@ -19,6 +19,7 @@ class iam_no_custom_policy_permissive_role_assumption(Check):
             for statement in policy_statements:
                 if (
                     statement["Effect"] == "Allow"
+                    and "Action" in statement
                     and (
                         "sts:AssumeRole" in statement["Action"]
                         or "sts:*" in statement["Action"]

--- a/prowler/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption.py
+++ b/prowler/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption.py
@@ -12,10 +12,13 @@ class iam_no_custom_policy_permissive_role_assumption(Check):
             report.resource_id = iam_client.policies[index]["PolicyName"]
             report.status = "PASS"
             report.status_extended = f"Custom Policy {iam_client.policies[index]['PolicyName']} does not allow permissive STS Role assumption"
-            for statement in policy_document["Statement"]:
+            if type(policy_document["Statement"]) != list:
+                policy_statements = [policy_document["Statement"]]
+            else:
+                policy_statements = policy_document["Statement"]
+            for statement in policy_statements:
                 if (
                     statement["Effect"] == "Allow"
-                    and "Action" in statement
                     and (
                         "sts:AssumeRole" in statement["Action"]
                         or "sts:*" in statement["Action"]

--- a/prowler/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation.py
@@ -72,14 +72,17 @@ class iam_policy_allows_privilege_escalation(Check):
             denied_not_actions = set()
 
             # Recover all policy actions
-            for statements in policy["PolicyDocument"]["Statement"]:
+            if type(policy["PolicyDocument"]["Statement"]) != list:
+                policy_statements = [policy["PolicyDocument"]["Statement"]]
+            else:
+                policy_statements = policy["PolicyDocument"]["Statement"]
+            for statements in policy_statements:
                 # Recover allowed actions
                 if statements["Effect"] == "Allow":
-                    if "Action" in statements:
-                        if type(statements["Action"]) is str:
-                            allowed_actions = {statements["Action"]}
-                        if type(statements["Action"]) is list:
-                            allowed_actions = set(statements["Action"])
+                    if type(statements["Action"]) is str:
+                        allowed_actions = {statements["Action"]}
+                    if type(statements["Action"]) is list:
+                        allowed_actions = set(statements["Action"])
 
                 # Recover denied actions
                 if statements["Effect"] == "Deny":

--- a/prowler/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation.py
@@ -79,10 +79,11 @@ class iam_policy_allows_privilege_escalation(Check):
             for statements in policy_statements:
                 # Recover allowed actions
                 if statements["Effect"] == "Allow":
-                    if type(statements["Action"]) is str:
-                        allowed_actions = {statements["Action"]}
-                    if type(statements["Action"]) is list:
-                        allowed_actions = set(statements["Action"])
+                    if "Action" in statements:
+                        if type(statements["Action"]) is str:
+                            allowed_actions = {statements["Action"]}
+                        if type(statements["Action"]) is list:
+                            allowed_actions = set(statements["Action"])
 
                 # Recover denied actions
                 if statements["Effect"] == "Deny":

--- a/prowler/providers/aws/services/iam/iam_policy_no_administrative_privileges/iam_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_policy_no_administrative_privileges/iam_policy_no_administrative_privileges.py
@@ -20,6 +20,7 @@ class iam_policy_no_administrative_privileges(Check):
             for statement in policy_statements:
                 if (
                     statement["Effect"] == "Allow"
+                    and "Action" in statement
                     and "*" in statement["Action"]
                     and "*" in statement["Resource"]
                 ):

--- a/prowler/providers/aws/services/iam/iam_policy_no_administrative_privileges/iam_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_policy_no_administrative_privileges/iam_policy_no_administrative_privileges.py
@@ -13,11 +13,13 @@ class iam_policy_no_administrative_privileges(Check):
             report.status = "PASS"
             report.status_extended = f"Policy {iam_client.policies[index]['PolicyName']} does not allow '*:*' administrative privileges"
             # Check the statements, if one includes *:* stop iterating over the rest
-            print(policy_document)
-            for statement in policy_document["Statement"]:
+            if type(policy_document["Statement"]) != list:
+                policy_statements = [policy_document["Statement"]]
+            else:
+                policy_statements = policy_document["Statement"]
+            for statement in policy_statements:
                 if (
                     statement["Effect"] == "Allow"
-                    and "Action" in statement
                     and "*" in statement["Action"]
                     and "*" in statement["Resource"]
                 ):

--- a/prowler/providers/aws/services/iam/iam_policy_no_administrative_privileges/iam_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_policy_no_administrative_privileges/iam_policy_no_administrative_privileges.py
@@ -13,6 +13,7 @@ class iam_policy_no_administrative_privileges(Check):
             report.status = "PASS"
             report.status_extended = f"Policy {iam_client.policies[index]['PolicyName']} does not allow '*:*' administrative privileges"
             # Check the statements, if one includes *:* stop iterating over the rest
+            print(policy_document)
             for statement in policy_document["Statement"]:
                 if (
                     statement["Effect"] == "Allow"


### PR DESCRIPTION
### Description
Solve the following IAM and codebuild ERRORs:
```
Something went wrong in iam_no_custom_policy_permissive_role_assumption, please use --log-level ERROR
2023-01-12 12:17:28,215 [File: check.py:297]    [Module: check]  ERROR: iam_no_custom_policy_permissive_role_assumption -- TypeError[294]: string indices must be integers
Something went wrong in iam_policy_allows_privilege_escalation, please use --log-level ERROR
2023-01-12 12:17:28,307 [File: check.py:297]    [Module: check]  ERROR: iam_policy_allows_privilege_escalation -- TypeError[294]: string indices must be integers
Something went wrong in iam_policy_no_administrative_privileges, please use --log-level ERROR
2023-01-12 12:17:28,492 [File: check.py:297]    [Module: check]  ERROR: iam_policy_no_administrative_privileges -- TypeError[294]: string indices must be integers

2023-01-12 12:12:55,401 [File: codebuild_service.py:74]         [Module: codebuild_service]      ERROR: IndexError[61]: list index out of range
```
This was done since Statement could be a dict and not a list.
### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
