### PR TITLE
fix: deleted test exclusion in name loading checks

### DIFF
--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -233,11 +233,7 @@ def recover_checks_from_provider(provider: str, service: str = None) -> list[tup
             # Format: "prowler.providers.{provider}.services.{service}.{check_name}.{check_name}"
             check_module_name = module_name.name
             # We need to exclude common shared libraries in services
-            if (
-                check_module_name.count(".") == 6
-                and "lib" not in check_module_name
-                and "test" not in check_module_name
-            ):
+            if check_module_name.count(".") == 6 and "lib" not in check_module_name:
                 check_path = module_name.module_finder.path
                 # Check name is the last part of the check_module_name
                 check_name = check_module_name.split(".")[-1]


### PR DESCRIPTION
### Context

In Prowler v3 we were excluding files with test into filename when loading checks to avoid load test files, and that was excluding the checks `ecr_repositories_scan_vulnerabilities_in_latest_image` and `opensearch_service_domains_updated_to_the_latest_service_software_version` to be loaded and executed.

### Description

Delete the condition of not loading filenames with `test` on it


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
