### PR TITLE
fix(docs): Include a new comma in the Basic Usage paragraph #HSFDPMUW

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -172,7 +172,7 @@ prowler <provider>
 ![Prowler Execution](img/short-display.png)
 > Running the `prowler` command without options will use your environment variable credentials, see [Requirements](getting-started/requirements/) section to review the credentials settings.
 
-If you miss the former output you can use `--verbose` but Prowler v3 is smoking fast so you won't see much ;)
+If you miss the former output you can use `--verbose` but Prowler v3 is smoking fast, so you won't see much ;)
 
 By default, Prowler will generate a CSV, JSON and HTML reports, however you can generate a JSON-ASFF (used by AWS Security Hub) report with `-M` or `--output-modes`:
 


### PR DESCRIPTION
### Context

Added a new comma for better readability


### Description

Added a comma after the word 'fast' in the Basic Usage paragraph

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
