### PR TITLE
fix(ec2_elastic_ip_unassgined): Incorrect ResourceType for check ec2_elastic_ip_unassgined

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_elastic_ip_unassgined/ec2_elastic_ip_unassgined.metadata.json
+++ b/prowler/providers/aws/services/ec2/ec2_elastic_ip_unassgined/ec2_elastic_ip_unassgined.metadata.json
@@ -6,10 +6,10 @@
     "Infrastructure Security"
   ],
   "ServiceName": "ec2",
-  "SubServiceName": "AwsElasticIPs",
+  "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
   "Severity": "low",
-  "ResourceType": "AwsEc2SecurityGroup",
+  "ResourceType": "AwsEc2Eip",
   "Description": "Check if there is any unassigned Elastic IP.",
   "Risk": "Unassigned Elastic IPs may result in extra cost.",
   "RelatedUrl": "",


### PR DESCRIPTION
### Context

Check `ec2_elastic_ip_unassgined` incorrect ResourceType

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
