### PR TITLE
docs: Placed a comma in the Service Principal authentication paragraph #HSFDPMUW

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Those credentials must be associated to a user or role with proper permissions t
 
 ### Service Principal authentication
 
-To allow Prowler assume the service principal identity to start the scan it is needed to configure the following environment variables:
+To allow Prowler assume the service principal identity to start the scan, it is needed to configure the following environment variables:
 
 ```console
 export AZURE_CLIENT_ID="XXXXXXXXX"


### PR DESCRIPTION
### Context

Placed a missing comma for better readability of the sentence


### Description

Placed a new comma on line 126 after the word 'scan', in the README.md file


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
