### PR TITLE
fix(extra7131): exclude DocumentDB since AutoMinorVersionUpgrade is only for relational databases

### DIFF
--- a/checks/check_extra7131
+++ b/checks/check_extra7131
@@ -18,15 +18,15 @@ CHECK_SEVERITY_extra7131="Low"
 CHECK_ASFF_RESOURCE_TYPE_extra7131="AwsRdsDbInstance"
 CHECK_ALTERNATE_check7131="extra7131"
 CHECK_SERVICENAME_extra7131="rds"
-CHECK_RISK_extra7131='Auto Minor Version Upgrade is a feature that you can enable to have your database automatically upgraded when a new minor database engine version is available. Minor version upgrades often patch security vulnerabilities and fix bugs; and therefor should be applied.'
-CHECK_REMEDIATION_extra7131='Enable auto minor version upgrade for all databases and environments.'
+CHECK_RISK_extra7131='Auto Minor Version Upgrade is a feature that you can enable to have your relational database automatically upgraded when a new minor database engine version is available. Minor version upgrades often patch security vulnerabilities and fix bugs; and therefor should be applied.'
+CHECK_REMEDIATION_extra7131='Enable auto minor version upgrade for all relational databases and environments.'
 CHECK_DOC_extra7131='https://aws.amazon.com/blogs/database/best-practices-for-upgrading-amazon-rds-to-major-and-minor-versions-of-postgresql/'
 CHECK_CAF_EPIC_extra7131='Infrastructure Security'
 
 extra7131(){
   for regx in $REGIONS; do
     # LIST_OF_RDS_PUBLIC_INSTANCES=$($AWSCLI rds describe-db-instances $PROFILE_OPT --region $regx --query 'DBInstances[?PubliclyAccessible==`true` && DBInstanceStatus==`"available"`].[DBInstanceIdentifier,Endpoint.Address]' --output text)
-    LIST_OF_RDS_INSTANCES=$($AWSCLI rds describe-db-instances $PROFILE_OPT --region $regx --query 'DBInstances[*].[DBInstanceIdentifier,AutoMinorVersionUpgrade]'  --output text 2>&1)
+    LIST_OF_RDS_INSTANCES=$($AWSCLI rds describe-db-instances $PROFILE_OPT --region $regx --query "DBInstances[?Engine != 'docdb'].[DBInstanceIdentifier,AutoMinorVersionUpgrade]"  --output text 2>&1)
     if [[ $(echo "$LIST_OF_RDS_INSTANCES" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
         textInfo "$regx: Access Denied trying to describe DB instances" "$regx"
         continue


### PR DESCRIPTION
### Context

Prowler `check_extra7131` returns false positives for DocumentDB instances.

### Description

As written in AWS's [documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-docdb-dbinstance.html#cfn-docdb-dbinstance-autominorversionupgrade), the parameter `AutoMinorVersionUpgrade` does not apply to Amazon DocumentDB.  Neither [CDK](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_docdb.DatabaseCluster.html) or AWS Web-GUI allow to set `AutoMinorVersionUpgrade` for DocumentDB's.
The AWS CLI command that `check_extra7131` is using returns `"AutoMinorVersionUpgrade": false` for DocumentDB instances which let's the check fail.
Therefore, prowler `check_extra7131` needs to exclude DocumentDB instances to avoid false positives. 

Btw. the same has been done correctly already in:

- check_extra7113
- check_extra7132
- check_extra7133

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
