### PR TITLE
fix(error): ecr_repositories_scan_vulnerabilities_in_latest_image report not found

### DIFF
--- a/prowler/providers/aws/services/ecr/ecr_repositories_scan_vulnerabilities_in_latest_image/ecr_repositories_scan_vulnerabilities_in_latest_image.py
+++ b/prowler/providers/aws/services/ecr/ecr_repositories_scan_vulnerabilities_in_latest_image/ecr_repositories_scan_vulnerabilities_in_latest_image.py
@@ -30,6 +30,6 @@ class ecr_repositories_scan_vulnerabilities_in_latest_image(Check):
                         report.status = "FAIL"
                         report.status_extended = f"ECR repository {repository.name} has imageTag {image.latest_tag} scanned with findings: CRITICAL->{image.scan_findings_severity_count.critical}, HIGH->{image.scan_findings_severity_count.high}, MEDIUM->{image.scan_findings_severity_count.medium} "
 
-            findings.append(report)
+                findings.append(report)
 
         return findings

--- a/tests/providers/aws/services/ecr/ecr_repositories_scan_vulnerabilities_in_latest_image/ecr_repositories_scan_vulnerabilities_in_latest_image_test.py
+++ b/tests/providers/aws/services/ecr/ecr_repositories_scan_vulnerabilities_in_latest_image/ecr_repositories_scan_vulnerabilities_in_latest_image_test.py
@@ -28,6 +28,32 @@ repo_policy_public = {
 
 
 class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
+    def test_empty_repository(self):
+        ecr_client = mock.MagicMock
+        ecr_client.repositories = []
+        ecr_client.repositories.append(
+            Repository(
+                name=repository_name,
+                arn=repository_arn,
+                region=AWS_REGION,
+                scan_on_push=True,
+                policy=repo_policy_public,
+                images_details=[],
+                lyfecicle_policy=None,
+            )
+        )
+        with mock.patch(
+            "prowler.providers.aws.services.ecr.ecr_service.ECR",
+            ecr_client,
+        ):
+            from prowler.providers.aws.services.ecr.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_repositories_scan_vulnerabilities_in_latest_image import (
+                ecr_repositories_scan_vulnerabilities_in_latest_image,
+            )
+
+            check = ecr_repositories_scan_vulnerabilities_in_latest_image()
+            result = check.execute()
+            assert len(result) == 0
+
     def test_image_scaned_without_findings(self):
         ecr_client = mock.MagicMock
         ecr_client.repositories = []


### PR DESCRIPTION
### Description

Solve report not found error in `ecr_repositories_scan_vulnerabilities_in_latest_image`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
