### PR TITLE
fix(IAM): add missing permissions for Prowler

### DIFF
--- a/permissions/prowler-additions-policy.json
+++ b/permissions/prowler-additions-policy.json
@@ -3,14 +3,20 @@
   "Statement": [
     {
       "Action": [
-        "ds:ListAuthorizedApplications",
+        "appstream:DescribeFleets",
+        "codeartifact:ListPackage*",
+        "codebuild:BatchGetBuilds",
+        "ds:DescribeEventTopics",
+        "ds:GetSnapshotLimits",
+        "ds:List*",
         "ec2:GetEbsEncryptionByDefault",
         "ecr:Describe*",
         "elasticfilesystem:DescribeBackupPolicy",
         "glue:GetConnections",
-        "glue:GetSecurityConfiguration",
+        "glue:GetSecurityConfiguration*",
         "glue:SearchTables",
-        "lambda:GetFunction",
+        "lambda:GetFunction*",
+        "macie2:GetMacieSession",
         "s3:GetAccountPublicAccessBlock",
         "shield:DescribeProtection",
         "shield:GetSubscriptionState",
@@ -21,6 +27,15 @@
       "Resource": "*",
       "Effect": "Allow",
       "Sid": "AllowMoreReadForProwler"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "apigateway:GET"
+      ],
+      "Resource": [
+        "arn:aws:apigateway:*::/restapis/*"
+      ]
     }
   ]
 }

--- a/permissions/prowler-additions-policy.json
+++ b/permissions/prowler-additions-policy.json
@@ -3,11 +3,11 @@
   "Statement": [
     {
       "Action": [
-        "appstream:DescribeFleets",
-        "codeartifact:ListPackage*",
-        "codebuild:BatchGetBuilds",
-        "ds:DescribeEventTopics",
-        "ds:GetSnapshotLimits",
+        "appstream:Describe*",
+        "codeartifact:List*",
+        "codebuild:BatchGet*",
+        "ds:Describe*",
+        "ds:Get*",
         "ds:List*",
         "ec2:GetEbsEncryptionByDefault",
         "ecr:Describe*",
@@ -18,6 +18,7 @@
         "lambda:GetFunction*",
         "macie2:GetMacieSession",
         "s3:GetAccountPublicAccessBlock",
+        "s3:GetPublicAccessBlock",
         "shield:DescribeProtection",
         "shield:GetSubscriptionState",
         "ssm:GetDocument",


### PR DESCRIPTION
### Description

Add the following missing permissions that are needed for a complete execution of Prowler:
```
        "appstream:DescribeFleets",
        "codeartifact:ListPackage*",
        "codebuild:BatchGetBuilds",
        "ds:DescribeEventTopics",
        "ds:GetSnapshotLimits",
        "ds:List*",
        "glue:GetSecurityConfiguration*",
        "lambda:GetFunction*",
        "macie2:GetMacieSession",
        "apigateway:GET"
```


The following are present in  the Security Audit AWS Policy:
```
s3:GetEncryptionConfiguration
eks:list*
eks:Describe*
securityhub:GetFindings
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
