### PR TITLE
fix(allowlist): remove re.escape

### DIFF
--- a/prowler/providers/aws/lib/allowlist/allowlist.py
+++ b/prowler/providers/aws/lib/allowlist/allowlist.py
@@ -114,6 +114,9 @@ def is_allowlisted_in_region(allowlist, audited_account, check, region, resource
             for elem in allowlist["Accounts"][audited_account]["Checks"][check][
                 "Resources"
             ]:
+                # Check if it is an *
+                if elem == "*":
+                    elem = ".*"
                 if re.search(elem, resource):
                     return True
         # Check if there is the specific region
@@ -121,6 +124,9 @@ def is_allowlisted_in_region(allowlist, audited_account, check, region, resource
             for elem in allowlist["Accounts"][audited_account]["Checks"][check][
                 "Resources"
             ]:
+                # Check if it is an *
+                if elem == "*":
+                    elem = ".*"
                 if re.search(elem, resource):
                     return True
     except Exception as error:

--- a/prowler/providers/aws/lib/allowlist/allowlist.py
+++ b/prowler/providers/aws/lib/allowlist/allowlist.py
@@ -114,7 +114,7 @@ def is_allowlisted_in_region(allowlist, audited_account, check, region, resource
             for elem in allowlist["Accounts"][audited_account]["Checks"][check][
                 "Resources"
             ]:
-                if re.search(re.escape(elem), resource):
+                if re.search(elem, resource):
                     return True
         # Check if there is the specific region
         if region in allowlist["Accounts"][audited_account]["Checks"][check]["Regions"]:

--- a/tests/providers/aws/lib/allowlist/allowlist_test.py
+++ b/tests/providers/aws/lib/allowlist/allowlist_test.py
@@ -109,7 +109,45 @@ class Test_Allowlist:
                     "Checks": {
                         "check_test": {
                             "Regions": ["us-east-1", "eu-west-1"],
-                            "Resources": ["prowler", "^test"],
+                            "Resources": ["prowler", "^test", "prowler-pro"],
+                        }
+                    }
+                }
+            }
+        }
+
+        assert is_allowlisted(
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler"
+        )
+
+        assert is_allowlisted(
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler-test"
+        )
+
+        assert is_allowlisted(
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "test-prowler"
+        )
+
+        assert is_allowlisted(
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler-pro-test"
+        )
+
+        assert not (
+            is_allowlisted(
+                allowlist, AWS_ACCOUNT_NUMBER, "check_test", "us-east-2", "test"
+            )
+        )
+
+    def test_is_allowlisted_wildcard(self):
+
+        # Allowlist example
+        allowlist = {
+            "Accounts": {
+                "*": {
+                    "Checks": {
+                        "check_test": {
+                            "Regions": ["us-east-1", "eu-west-1"],
+                            "Resources": [".*"],
                         }
                     }
                 }

--- a/tests/providers/aws/lib/allowlist/allowlist_test.py
+++ b/tests/providers/aws/lib/allowlist/allowlist_test.py
@@ -171,3 +171,37 @@ class Test_Allowlist:
                 allowlist, AWS_ACCOUNT_NUMBER, "check_test", "us-east-2", "test"
             )
         )
+
+    def test_is_allowlisted_asterisk(self):
+
+        # Allowlist example
+        allowlist = {
+            "Accounts": {
+                "*": {
+                    "Checks": {
+                        "check_test": {
+                            "Regions": ["us-east-1", "eu-west-1"],
+                            "Resources": ["*"],
+                        }
+                    }
+                }
+            }
+        }
+
+        assert is_allowlisted(
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler"
+        )
+
+        assert is_allowlisted(
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler-test"
+        )
+
+        assert is_allowlisted(
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "test-prowler"
+        )
+
+        assert not (
+            is_allowlisted(
+                allowlist, AWS_ACCOUNT_NUMBER, "check_test", "us-east-2", "test"
+            )
+        )


### PR DESCRIPTION
### Description

Remove re.escape to allow Regex expressions with special characters such as `.*`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
