### PR TITLE
fix(inventory): update resource type for SQS and SNS

### DIFF
--- a/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
+++ b/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
@@ -139,6 +139,10 @@ def create_inventory_table(resources: list) -> dict:
 
         if service == "s3":
             resource_type = "bucket"
+        elif service == "sns":
+            resource_type = "topic"
+        elif service == "sqs":
+            resource_type = "queue"
         else:
             resource_type = resource.split(":")[5].split("/")[0]
         if service not in resources_type:


### PR DESCRIPTION
SQS and SNS currently display the name of resource instead of the type of resource. This update will reflect the type instead.

### Context

Current summary output for AWS Inventory contains the name of resource instead of the type of resource for SQS and SNS. A similar would happen for S3 if it wasn't handled specifically. This patch updates the inventory output summary such that SQS is listed as queues and SNS is listed as topics. 

### Description

Changes include 2 if statements to check for service and override resource type value. No other dependencies. 

Current output
```
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ lambda               │       8 │ function 8                                 │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ logs                 │       8 │ log-group 8                                │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ route53              │       2 │ hostedzone 2                               │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ s3                   │      11 │ bucket 11                                  │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ secretsmanager       │       2 │ secret 2                                   │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ sns                  │       4 │ splunk-forwarder-1 1                       │
│                      │         │ splunk-forwarder-2 1                       │
│                      │         │ splunk-forwarder-3 1                       │
│                      │         │ splunk-forwarder-4 1                       │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ sqs                  │       4 │ splunk-forwarder-1-queue 1                 │
│                      │         │ splunk-forwarder-2-queue 1                 │
│                      │         │ splunk-forwarder-3-queue 1                 │
│                      │         │ splunk-forwarder-4-queue 1                 │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ ssm                  │       3 │ parameter 3                                │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
```

Proposed:
```
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ lambda               │       8 │ function 8                                 │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ logs                 │       8 │ log-group 8                                │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ route53              │       2 │ hostedzone 2                               │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ s3                   │      11 │ bucket 11                                  │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ secretsmanager       │       2 │ secret 2                                   │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ sns                  │       4 │ topics 4                                   │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ sqs                  │       4 │ queues 4                                   │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
│ ssm                  │       3 │ parameter 3                                │
├──────────────────────┼─────────┼────────────────────────────────────────────┤
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
