### PR TITLE
fix(): solve metadata replace

### DIFF
--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -63,8 +63,9 @@ class Check(ABC, Check_Metadata_Model):
     def __init__(self, **data):
         """Check's init function. Calls the CheckMetadataModel init."""
         # Parse the Check's metadata file
-        metadata_file = os.path.abspath(sys.modules[self.__module__].__file__).replace(
-            ".py", ".metadata.json"
+        metadata_file = (
+            os.path.abspath(sys.modules[self.__module__].__file__)[:-3]
+            + ".metadata.json"
         )
         # Store it to validate them with Pydantic
         data = Check_Metadata_Model.parse_file(metadata_file).dict()


### PR DESCRIPTION
### Context

https://github.com/prowler-cloud/prowler/issues/1752: In our environment we use [pyenv](https://github.com/pyenv/pyenv) and all of our python packages are stored in a ~/.pyenv/ directory. So when that replace happens to get the metadata.json file, it replaces that directory name and tries to look for the file in ~/.metadata.jsonenv/ instead. This could be modified to perhaps only replace the last occurrence of ".py" in the path.

### Description

Replace always the last 3 characters (.py).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
