### PR TITLE
fix(): IAM status messages switched fail and pass text and some grammar

### DIFF
--- a/prowler/providers/aws/services/iam/iam_disable_30_days_credentials/iam_disable_30_days_credentials.py
+++ b/prowler/providers/aws/services/iam/iam_disable_30_days_credentials/iam_disable_30_days_credentials.py
@@ -25,14 +25,14 @@ class iam_disable_30_days_credentials(Check):
                 )
                 if time_since_insertion.days > maximum_expiration_days:
                     report.status = "FAIL"
-                    report.status_extended = f"User {user.name} has not logged into the console in the past 30 days."
+                    report.status_extended = f"User {user.name} has not logged in to the console in the past 30 days."
                 else:
                     report.status = "PASS"
-                    report.status_extended = f"User {user.name} has logged into the console in the past 30 days."
+                    report.status_extended = f"User {user.name} has logged in to the console in the past 30 days."
             else:
                 report.status = "PASS"
                 report.status_extended = (
-                    f"User {user.name} has not a console password or is unused."
+                    f"User {user.name} does not have a console password or is unused."
                 )
 
             # Append report

--- a/prowler/providers/aws/services/iam/iam_disable_45_days_credentials/iam_disable_45_days_credentials.py
+++ b/prowler/providers/aws/services/iam/iam_disable_45_days_credentials/iam_disable_45_days_credentials.py
@@ -25,14 +25,14 @@ class iam_disable_45_days_credentials(Check):
                 )
                 if time_since_insertion.days > maximum_expiration_days:
                     report.status = "FAIL"
-                    report.status_extended = f"User {user.name} has not logged into the console in the past 45 days."
+                    report.status_extended = f"User {user.name} has not logged in to the console in the past 45 days."
                 else:
                     report.status = "PASS"
-                    report.status_extended = f"User {user.name} has logged into the console in the past 45 days."
+                    report.status_extended = f"User {user.name} has logged in to the console in the past 45 days."
             else:
                 report.status = "PASS"
                 report.status_extended = (
-                    f"User {user.name} has not a console password or is unused."
+                    f"User {user.name} does not have a console password or is unused."
                 )
 
             # Append report

--- a/prowler/providers/aws/services/iam/iam_disable_90_days_credentials/iam_disable_90_days_credentials.py
+++ b/prowler/providers/aws/services/iam/iam_disable_90_days_credentials/iam_disable_90_days_credentials.py
@@ -25,15 +25,15 @@ class iam_disable_90_days_credentials(Check):
                 )
                 if time_since_insertion.days > maximum_expiration_days:
                     report.status = "FAIL"
-                    report.status_extended = f"User {user.name} has not logged into the console in the past 90 days."
+                    report.status_extended = f"User {user.name} has not logged in to the console in the past 90 days."
                 else:
                     report.status = "PASS"
-                    report.status_extended = f"User {user.name} has logged into the console in the past 90 days."
+                    report.status_extended = f"User {user.name} has logged in to the console in the past 90 days."
             else:
                 report.status = "PASS"
 
                 report.status_extended = (
-                    f"User {user.name} has not a console password or is unused."
+                    f"User {user.name} does not have a console password or is unused."
                 )
             # Append report
             findings.append(report)

--- a/prowler/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key.py
+++ b/prowler/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key.py
@@ -18,7 +18,7 @@ class iam_no_root_access_key(Check):
                     and user["access_key_2_active"] == "false"
                 ):
                     report.status = "PASS"
-                    report.status_extended = f"User {user['user']} has not access keys."
+                    report.status_extended = f"User {user['user']} does not have access keys."
                 elif (
                     user["access_key_1_active"] == "true"
                     and user["access_key_2_active"] == "true"

--- a/prowler/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key.py
+++ b/prowler/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key.py
@@ -18,7 +18,9 @@ class iam_no_root_access_key(Check):
                     and user["access_key_2_active"] == "false"
                 ):
                     report.status = "PASS"
-                    report.status_extended = f"User {user['user']} does not have access keys."
+                    report.status_extended = (
+                        f"User {user['user']} does not have access keys."
+                    )
                 elif (
                     user["access_key_1_active"] == "true"
                     and user["access_key_2_active"] == "true"

--- a/prowler/providers/aws/services/iam/iam_password_policy_lowercase/iam_password_policy_lowercase.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_lowercase/iam_password_policy_lowercase.py
@@ -13,11 +13,11 @@ class iam_password_policy_lowercase(Check):
             # Check if lowercase flag is set
             if iam_client.password_policy.lowercase:
                 report.status = "PASS"
-                report.status_extended = "IAM password policy does not require at least one lowercase letter."
+                report.status_extended = "IAM password policy requires at least one lowercase letter."
             else:
                 report.status = "FAIL"
                 report.status_extended = (
-                    "IAM password policy require at least one lowercase letter."
+                    "IAM password policy does not require at least one lowercase letter."
                 )
         else:
             report.status = "FAIL"

--- a/prowler/providers/aws/services/iam/iam_password_policy_lowercase/iam_password_policy_lowercase.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_lowercase/iam_password_policy_lowercase.py
@@ -13,12 +13,12 @@ class iam_password_policy_lowercase(Check):
             # Check if lowercase flag is set
             if iam_client.password_policy.lowercase:
                 report.status = "PASS"
-                report.status_extended = "IAM password policy requires at least one lowercase letter."
+                report.status_extended = (
+                    "IAM password policy requires at least one lowercase letter."
+                )
             else:
                 report.status = "FAIL"
-                report.status_extended = (
-                    "IAM password policy does not require at least one lowercase letter."
-                )
+                report.status_extended = "IAM password policy does not require at least one lowercase letter."
         else:
             report.status = "FAIL"
             report.status_extended = "Password policy cannot be found"

--- a/prowler/providers/aws/services/iam/iam_password_policy_minimum_length_14/iam_password_policy_minimum_length_14.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_minimum_length_14/iam_password_policy_minimum_length_14.py
@@ -16,12 +16,12 @@ class iam_password_policy_minimum_length_14(Check):
                 and iam_client.password_policy.length >= 14
             ):
                 report.status = "PASS"
-                report.status_extended = "IAM password policy requires minimum length of 14 characters."
+                report.status_extended = (
+                    "IAM password policy requires minimum length of 14 characters."
+                )
             else:
                 report.status = "FAIL"
-                report.status_extended = (
-                    "IAM password policy does not require minimum length of 14 characters."
-                )
+                report.status_extended = "IAM password policy does not require minimum length of 14 characters."
         else:
             report.status = "FAIL"
             report.status_extended = "Password policy cannot be found"

--- a/prowler/providers/aws/services/iam/iam_password_policy_minimum_length_14/iam_password_policy_minimum_length_14.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_minimum_length_14/iam_password_policy_minimum_length_14.py
@@ -16,11 +16,11 @@ class iam_password_policy_minimum_length_14(Check):
                 and iam_client.password_policy.length >= 14
             ):
                 report.status = "PASS"
-                report.status_extended = "IAM password policy does not requires minimum length of 14 characters."
+                report.status_extended = "IAM password policy requires minimum length of 14 characters."
             else:
                 report.status = "FAIL"
                 report.status_extended = (
-                    "IAM password policy requires minimum length of 14 characters."
+                    "IAM password policy does not require minimum length of 14 characters."
                 )
         else:
             report.status = "FAIL"

--- a/prowler/providers/aws/services/iam/iam_password_policy_number/iam_password_policy_number.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_number/iam_password_policy_number.py
@@ -14,12 +14,12 @@ class iam_password_policy_number(Check):
             if iam_client.password_policy.numbers:
                 report.status = "PASS"
                 report.status_extended = (
-                    "IAM password policy does not require at least one number"
+                    "IAM password policy requires at least one number."
                 )
             else:
                 report.status = "FAIL"
                 report.status_extended = (
-                    "IAM password policy require at least one number."
+                    "IAM password policy does not require at least one number."
                 )
         else:
             report.status = "FAIL"

--- a/prowler/providers/aws/services/iam/iam_password_policy_symbol/iam_password_policy_symbol.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_symbol/iam_password_policy_symbol.py
@@ -14,12 +14,12 @@ class iam_password_policy_symbol(Check):
             if iam_client.password_policy.symbols:
                 report.status = "PASS"
                 report.status_extended = (
-                    "IAM password policy does not require at least one symbol."
+                    "IAM password policy requires at least one symbol."
                 )
             else:
                 report.status = "FAIL"
                 report.status_extended = (
-                    "IAM password policy requires at least one symbol."
+                    "IAM password policy does not require at least one symbol."
                 )
         else:
             report.status = "FAIL"

--- a/prowler/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.py
+++ b/prowler/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.py
@@ -19,10 +19,10 @@ class iam_root_hardware_mfa_enabled(Check):
                     if "root" in mfa["SerialNumber"]:
                         virtual_mfa = True
                         report.status = "FAIL"
-                        report.status_extended = "Root account has a virtual MFA instead of a hardware MFA enabled."
+                        report.status_extended = "Root account has a virtual MFA instead of a hardware MFA device enabled."
                 if not virtual_mfa:
                     report.status = "PASS"
-                    report.status_extended = "Root account has hardware MFA enabled."
+                    report.status_extended = "Root account has a hardware MFA device enabled."
             else:
                 report.status = "FAIL"
                 report.status_extended = "MFA is not enabled for root account."

--- a/prowler/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.py
+++ b/prowler/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.py
@@ -22,7 +22,9 @@ class iam_root_hardware_mfa_enabled(Check):
                         report.status_extended = "Root account has a virtual MFA instead of a hardware MFA device enabled."
                 if not virtual_mfa:
                     report.status = "PASS"
-                    report.status_extended = "Root account has a hardware MFA device enabled."
+                    report.status_extended = (
+                        "Root account has a hardware MFA device enabled."
+                    )
             else:
                 report.status = "FAIL"
                 report.status_extended = "MFA is not enabled for root account."

--- a/prowler/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.py
+++ b/prowler/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.py
@@ -21,7 +21,9 @@ class iam_rotate_access_key_90_days(Check):
                 and user["access_key_2_last_rotated"] == "N/A"
             ):
                 report.status = "PASS"
-                report.status_extended = f"User {user['user']} does not have access keys."
+                report.status_extended = (
+                    f"User {user['user']} does not have access keys."
+                )
             else:
                 old_access_keys = False
                 if user["access_key_1_last_rotated"] != "N/A":
@@ -50,9 +52,7 @@ class iam_rotate_access_key_90_days(Check):
                         report.status_extended = f"User {user['user']} has not rotated access key 2 in over 90 days ({access_key_2_last_rotated.days} days)."
                 if not old_access_keys:
                     report.status = "PASS"
-                    report.status_extended = (
-                        f"User {user['user']} does not have access keys older than 90 days."
-                    )
+                    report.status_extended = f"User {user['user']} does not have access keys older than 90 days."
             findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.py
+++ b/prowler/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.py
@@ -21,7 +21,7 @@ class iam_rotate_access_key_90_days(Check):
                 and user["access_key_2_last_rotated"] == "N/A"
             ):
                 report.status = "PASS"
-                report.status_extended = f"User {user['user']} has not access keys."
+                report.status_extended = f"User {user['user']} does not have access keys."
             else:
                 old_access_keys = False
                 if user["access_key_1_last_rotated"] != "N/A":
@@ -51,7 +51,7 @@ class iam_rotate_access_key_90_days(Check):
                 if not old_access_keys:
                     report.status = "PASS"
                     report.status_extended = (
-                        f"User {user['user']} has access keys not older than 90 days."
+                        f"User {user['user']} does not have access keys older than 90 days."
                     )
             findings.append(report)
 

--- a/prowler/providers/aws/services/iam/iam_user_hardware_mfa_enabled/iam_user_hardware_mfa_enabled.py
+++ b/prowler/providers/aws/services/iam/iam_user_hardware_mfa_enabled/iam_user_hardware_mfa_enabled.py
@@ -18,14 +18,14 @@ class iam_user_hardware_mfa_enabled(Check):
                 for mfa_device in user.mfa_devices:
                     if mfa_device.type == "mfa" or mfa_device.type == "sms-mfa":
                         report.status = "FAIL"
-                        report.status_extended = f"User {user.name} has a virtual MFA instead of a hardware MFA enabled."
+                        report.status_extended = f"User {user.name} has a virtual MFA instead of a hardware MFA device enabled."
                         break
 
                 findings.append(report)
             else:
                 report.status = "FAIL"
                 report.status_extended = (
-                    f"User {user.name} has not any type of MFA enabled."
+                    f"User {user.name} does not have any type of MFA enabled."
                 )
                 findings.append(report)
 

--- a/prowler/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access.py
+++ b/prowler/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access.py
@@ -24,13 +24,13 @@ class iam_user_mfa_enabled_console_access(Check):
                 else:
                     report.status = "PASS"
                     report.status_extended = (
-                        f"User {user['user']} has not Console Password enabled."
+                        f"User {user['user']} does not have Console Password enabled."
                     )
             # root user
             else:
                 report.status = "PASS"
                 report.status_extended = (
-                    f"User {user['user']} has not Console Password enabled."
+                    f"User {user['user']} does not have Console Password enabled."
                 )
             findings.append(report)
 

--- a/prowler/providers/aws/services/iam/iam_user_two_active_access_key/iam_user_two_active_access_key.py
+++ b/prowler/providers/aws/services/iam/iam_user_two_active_access_key/iam_user_two_active_access_key.py
@@ -24,7 +24,7 @@ class iam_user_two_active_access_key(Check):
                 else:
                     report.status = "PASS"
                     report.status_extended = (
-                        f"User {user['user']} has not 2 active access keys."
+                        f"User {user['user']} does not have 2 active access keys."
                     )
                 findings.append(report)
         except Exception as error:

--- a/tests/providers/aws/services/iam/iam_disable_30_days_credentials/iam_disable_30_days_credentials_test.py
+++ b/tests/providers/aws/services/iam/iam_disable_30_days_credentials/iam_disable_30_days_credentials_test.py
@@ -33,7 +33,7 @@ class Test_iam_disable_30_days_credentials_test:
             result = check.execute()
             assert result[0].status == "PASS"
             assert search(
-                f"User {user} has logged into the console in the past 30 days.",
+                f"User {user} has logged in to the console in the past 30 days.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == user
@@ -65,7 +65,7 @@ class Test_iam_disable_30_days_credentials_test:
             result = check.execute()
             assert result[0].status == "FAIL"
             assert search(
-                f"User {user} has not logged into the console in the past 30 days.",
+                f"User {user} has not logged in to the console in the past 30 days.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == user
@@ -96,7 +96,7 @@ class Test_iam_disable_30_days_credentials_test:
             result = check.execute()
             assert result[0].status == "PASS"
             assert search(
-                f"User {user} has not a console password or is unused.",
+                f"User {user} does not have a console password or is unused.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == user

--- a/tests/providers/aws/services/iam/iam_disable_45_days_credentials/iam_disable_45_days_credentials_test.py
+++ b/tests/providers/aws/services/iam/iam_disable_45_days_credentials/iam_disable_45_days_credentials_test.py
@@ -33,7 +33,7 @@ class Test_iam_disable_45_days_credentials_test:
             result = check.execute()
             assert result[0].status == "PASS"
             assert search(
-                f"User {user} has logged into the console in the past 45 days.",
+                f"User {user} has logged in to the console in the past 45 days.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == user
@@ -65,7 +65,7 @@ class Test_iam_disable_45_days_credentials_test:
             result = check.execute()
             assert result[0].status == "FAIL"
             assert search(
-                f"User {user} has not logged into the console in the past 45 days.",
+                f"User {user} has not logged in to the console in the past 45 days.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == user
@@ -95,7 +95,7 @@ class Test_iam_disable_45_days_credentials_test:
             result = check.execute()
             assert result[0].status == "PASS"
             assert search(
-                f"User {user} has not a console password or is unused.",
+                f"User {user} does not have a console password or is unused.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == user

--- a/tests/providers/aws/services/iam/iam_disable_90_days_credentials/iam_disable_90_days_credentials_test.py
+++ b/tests/providers/aws/services/iam/iam_disable_90_days_credentials/iam_disable_90_days_credentials_test.py
@@ -33,7 +33,7 @@ class Test_iam_disable_90_days_credentials_test:
             result = check.execute()
             assert result[0].status == "PASS"
             assert search(
-                f"User {user} has logged into the console in the past 90 days.",
+                f"User {user} has logged in to the console in the past 90 days.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == user
@@ -65,7 +65,7 @@ class Test_iam_disable_90_days_credentials_test:
             result = check.execute()
             assert result[0].status == "FAIL"
             assert search(
-                f"User {user} has not logged into the console in the past 90 days.",
+                f"User {user} has not logged in to the console in the past 90 days.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == user
@@ -96,7 +96,7 @@ class Test_iam_disable_90_days_credentials_test:
             result = check.execute()
             assert result[0].status == "PASS"
             assert search(
-                f"User {user} has not a console password or is unused.",
+                f"User {user} does not have a console password or is unused.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == user

--- a/tests/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key_test.py
+++ b/tests/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key_test.py
@@ -15,6 +15,8 @@ class Test_iam_no_root_access_key_test:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
+
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_no_root_access_key.iam_no_root_access_key.iam_client",
             new=IAM(current_audit_info),
@@ -35,7 +37,7 @@ class Test_iam_no_root_access_key_test:
             # raise Exception
             assert result[0].status == "PASS"
             assert search(
-                "User <root_account> has not access keys.",
+                "User <root_account> does not have access keys.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == "<root_account>"
@@ -52,6 +54,8 @@ class Test_iam_no_root_access_key_test:
 
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
+
+        current_audit_info.audited_partition = "aws"
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_no_root_access_key.iam_no_root_access_key.iam_client",
@@ -91,6 +95,8 @@ class Test_iam_no_root_access_key_test:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
+
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_no_root_access_key.iam_no_root_access_key.iam_client",
             new=IAM(current_audit_info),
@@ -128,6 +134,8 @@ class Test_iam_no_root_access_key_test:
 
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
+
+        current_audit_info.audited_partition = "aws"
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_no_root_access_key.iam_no_root_access_key.iam_client",

--- a/tests/providers/aws/services/iam/iam_password_policy_lowercase/iam_password_policy_lowercase_test.py
+++ b/tests/providers/aws/services/iam/iam_password_policy_lowercase/iam_password_policy_lowercase_test.py
@@ -1,3 +1,4 @@
+from re import search
 from unittest import mock
 
 from boto3 import client
@@ -14,6 +15,8 @@ class Test_iam_password_policy_lowercase:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
+
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_password_policy_lowercase.iam_password_policy_lowercase.iam_client",
             new=IAM(current_audit_info),
@@ -26,6 +29,11 @@ class Test_iam_password_policy_lowercase:
             check = iam_password_policy_lowercase()
             result = check.execute()
             assert result[0].status == "FAIL"
+            assert search(
+                "IAM password policy does not require at least one lowercase letter.",
+                result[0].status_extended,
+            )
+            assert result[0].resource_id == "password_policy"
 
     @mock_iam
     def test_iam_password_policy_lowercase_flag(self):
@@ -35,6 +43,8 @@ class Test_iam_password_policy_lowercase:
 
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
+
+        current_audit_info.audited_partition = "aws"
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_password_policy_lowercase.iam_password_policy_lowercase.iam_client",
@@ -48,3 +58,8 @@ class Test_iam_password_policy_lowercase:
             check = iam_password_policy_lowercase()
             result = check.execute()
             assert result[0].status == "PASS"
+            assert search(
+                "IAM password policy requires at least one lowercase letter.",
+                result[0].status_extended,
+            )
+            assert result[0].resource_id == "password_policy"

--- a/tests/providers/aws/services/iam/iam_password_policy_minimum_length_14/iam_password_policy_minimum_length_14_test.py
+++ b/tests/providers/aws/services/iam/iam_password_policy_minimum_length_14/iam_password_policy_minimum_length_14_test.py
@@ -1,3 +1,4 @@
+from re import search
 from unittest import mock
 
 from boto3 import client
@@ -14,6 +15,8 @@ class Test_iam_password_policy_minimum_length_14:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
+
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_password_policy_minimum_length_14.iam_password_policy_minimum_length_14.iam_client",
             new=IAM(current_audit_info),
@@ -26,6 +29,11 @@ class Test_iam_password_policy_minimum_length_14:
             check = iam_password_policy_minimum_length_14()
             result = check.execute()
             assert result[0].status == "PASS"
+            assert search(
+                "IAM password policy requires minimum length of 14 characters.",
+                result[0].status_extended,
+            )
+            assert result[0].resource_id == "password_policy"
 
     @mock_iam
     def test_iam_password_policy_minimum_length_greater_14(self):
@@ -36,6 +44,8 @@ class Test_iam_password_policy_minimum_length_14:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
+
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_password_policy_minimum_length_14.iam_password_policy_minimum_length_14.iam_client",
             new=IAM(current_audit_info),
@@ -48,6 +58,11 @@ class Test_iam_password_policy_minimum_length_14:
             check = iam_password_policy_minimum_length_14()
             result = check.execute()
             assert result[0].status == "PASS"
+            assert search(
+                "IAM password policy requires minimum length of 14 characters.",
+                result[0].status_extended,
+            )
+            assert result[0].resource_id == "password_policy"
 
     @mock_iam
     def test_iam_password_policy_minimum_length_less_14(self):
@@ -57,6 +72,8 @@ class Test_iam_password_policy_minimum_length_14:
 
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
+
+        current_audit_info.audited_partition = "aws"
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_password_policy_minimum_length_14.iam_password_policy_minimum_length_14.iam_client",
@@ -70,3 +87,8 @@ class Test_iam_password_policy_minimum_length_14:
             check = iam_password_policy_minimum_length_14()
             result = check.execute()
             assert result[0].status == "FAIL"
+            assert search(
+                "IAM password policy does not require minimum length of 14 characters.",
+                result[0].status_extended,
+            )
+            assert result[0].resource_id == "password_policy"

--- a/tests/providers/aws/services/iam/iam_password_policy_number/iam_password_policy_number_test.py
+++ b/tests/providers/aws/services/iam/iam_password_policy_number/iam_password_policy_number_test.py
@@ -1,3 +1,4 @@
+from re import search
 from unittest import mock
 
 from boto3 import client
@@ -14,6 +15,8 @@ class Test_iam_password_policy_number:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
+
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_password_policy_number.iam_password_policy_number.iam_client",
             new=IAM(current_audit_info),
@@ -26,6 +29,11 @@ class Test_iam_password_policy_number:
             check = iam_password_policy_number()
             result = check.execute()
             assert result[0].status == "FAIL"
+            assert search(
+                "IAM password policy does not require at least one number.",
+                result[0].status_extended,
+            )
+            assert result[0].resource_id == "password_policy"
 
     @mock_iam
     def test_iam_password_policy_number_flag(self):
@@ -35,6 +43,8 @@ class Test_iam_password_policy_number:
 
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
+
+        current_audit_info.audited_partition = "aws"
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_password_policy_number.iam_password_policy_number.iam_client",
@@ -48,3 +58,8 @@ class Test_iam_password_policy_number:
             check = iam_password_policy_number()
             result = check.execute()
             assert result[0].status == "PASS"
+            assert search(
+                "IAM password policy requires at least one number.",
+                result[0].status_extended,
+            )
+            assert result[0].resource_id == "password_policy"

--- a/tests/providers/aws/services/iam/iam_password_policy_symbol/iam_password_policy_symbol_test.py
+++ b/tests/providers/aws/services/iam/iam_password_policy_symbol/iam_password_policy_symbol_test.py
@@ -1,3 +1,4 @@
+from re import search
 from unittest import mock
 
 from boto3 import client
@@ -14,6 +15,8 @@ class Test_iam_password_policy_symbol:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
+
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_password_policy_symbol.iam_password_policy_symbol.iam_client",
             new=IAM(current_audit_info),
@@ -26,6 +29,11 @@ class Test_iam_password_policy_symbol:
             check = iam_password_policy_symbol()
             result = check.execute()
             assert result[0].status == "FAIL"
+            assert search(
+                "IAM password policy does not require at least one symbol.",
+                result[0].status_extended,
+            )
+            assert result[0].resource_id == "password_policy"
 
     @mock_iam
     def test_iam_password_policy_symbol_flag(self):
@@ -35,6 +43,8 @@ class Test_iam_password_policy_symbol:
 
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
+
+        current_audit_info.audited_partition = "aws"
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_password_policy_symbol.iam_password_policy_symbol.iam_client",
@@ -48,3 +58,8 @@ class Test_iam_password_policy_symbol:
             check = iam_password_policy_symbol()
             result = check.execute()
             assert result[0].status == "PASS"
+            assert search(
+                "IAM password policy requires at least one symbol.",
+                result[0].status_extended,
+            )
+            assert result[0].resource_id == "password_policy"

--- a/tests/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled_test.py
+++ b/tests/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled_test.py
@@ -14,6 +14,8 @@ class Test_iam_root_hardware_mfa_enabled_test:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
+
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_root_hardware_mfa_enabled.iam_root_hardware_mfa_enabled.iam_client",
             new=IAM(current_audit_info),
@@ -29,7 +31,7 @@ class Test_iam_root_hardware_mfa_enabled_test:
             result = check.execute()
             assert result[0].status == "FAIL"
             assert search(
-                "Root account has a virtual MFA instead of a hardware MFA enabled.",
+                "Root account has a virtual MFA instead of a hardware MFA device enabled.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == "root"
@@ -41,6 +43,8 @@ class Test_iam_root_hardware_mfa_enabled_test:
         iam.create_virtual_mfa_device(VirtualMFADeviceName=mfa_device_name)
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
+
+        current_audit_info.audited_partition = "aws"
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_root_hardware_mfa_enabled.iam_root_hardware_mfa_enabled.iam_client",
@@ -57,7 +61,8 @@ class Test_iam_root_hardware_mfa_enabled_test:
             result = check.execute()
             assert result[0].status == "PASS"
             assert search(
-                "Root account has hardware MFA enabled.", result[0].status_extended
+                "Root account has a hardware MFA device enabled.",
+                result[0].status_extended,
             )
             assert result[0].resource_id == "root"
             assert (

--- a/tests/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days_test.py
+++ b/tests/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days_test.py
@@ -15,6 +15,8 @@ class Test_iam_rotate_access_key_90_days_test:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
+
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_rotate_access_key_90_days.iam_rotate_access_key_90_days.iam_client",
             new=IAM(current_audit_info),
@@ -29,7 +31,9 @@ class Test_iam_rotate_access_key_90_days_test:
             check = iam_rotate_access_key_90_days()
             result = check.execute()
             assert result[0].status == "PASS"
-            assert result[0].status_extended == f"User {user} has not access keys."
+            assert (
+                result[0].status_extended == f"User {user} does not have access keys."
+            )
             assert result[0].resource_id == user
             assert result[0].resource_arn == arn
 
@@ -44,6 +48,8 @@ class Test_iam_rotate_access_key_90_days_test:
 
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
+
+        current_audit_info.audited_partition = "aws"
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_rotate_access_key_90_days.iam_rotate_access_key_90_days.iam_client",
@@ -78,6 +84,8 @@ class Test_iam_rotate_access_key_90_days_test:
 
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
+
+        current_audit_info.audited_partition = "aws"
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_rotate_access_key_90_days.iam_rotate_access_key_90_days.iam_client",

--- a/tests/providers/aws/services/iam/iam_user_hardware_mfa_enabled/iam_user_hardware_mfa_enabled_test.py
+++ b/tests/providers/aws/services/iam/iam_user_hardware_mfa_enabled/iam_user_hardware_mfa_enabled_test.py
@@ -14,6 +14,8 @@ class Test_iam_user_hardware_mfa_enabled_test:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
+
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_user_hardware_mfa_enabled.iam_user_hardware_mfa_enabled.iam_client",
             new=IAM(current_audit_info),
@@ -28,7 +30,7 @@ class Test_iam_user_hardware_mfa_enabled_test:
 
             assert result[0].status == "FAIL"
             assert search(
-                f"User {user} has not any type of MFA enabled.",
+                f"User {user} does not have any type of MFA enabled.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == user
@@ -41,6 +43,8 @@ class Test_iam_user_hardware_mfa_enabled_test:
         arn = iam_client.create_user(UserName=user)["User"]["Arn"]
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM, MFADevice
+
+        current_audit_info.audited_partition = "aws"
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_user_hardware_mfa_enabled.iam_user_hardware_mfa_enabled.iam_client",
@@ -62,7 +66,7 @@ class Test_iam_user_hardware_mfa_enabled_test:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert search(
-                f"User {user} has a virtual MFA instead of a hardware MFA enabled.",
+                f"User {user} has a virtual MFA instead of a hardware MFA device enabled.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == user
@@ -75,6 +79,8 @@ class Test_iam_user_hardware_mfa_enabled_test:
         arn = iam_client.create_user(UserName=user)["User"]["Arn"]
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM, MFADevice
+
+        current_audit_info.audited_partition = "aws"
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_user_hardware_mfa_enabled.iam_user_hardware_mfa_enabled.iam_client",
@@ -96,7 +102,7 @@ class Test_iam_user_hardware_mfa_enabled_test:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert search(
-                f"User {user} has a virtual MFA instead of a hardware MFA enabled.",
+                f"User {user} has a virtual MFA instead of a hardware MFA device enabled.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == user

--- a/tests/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access_test.py
+++ b/tests/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access_test.py
@@ -31,7 +31,7 @@ class Test_iam_user_mfa_enabled_console_access_test:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"User {user} has not Console Password enabled."
+                == f"User {user} does not have Console Password enabled."
             )
             assert result[0].resource_id == user
             assert result[0].resource_arn == arn
@@ -62,7 +62,7 @@ class Test_iam_user_mfa_enabled_console_access_test:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"User {user} has not Console Password enabled."
+                == f"User {user} does not have Console Password enabled."
             )
             assert result[0].resource_id == user
             assert result[0].resource_arn == arn

--- a/tests/providers/aws/services/iam/iam_user_two_active_access_key/iam_user_two_active_access_key_test.py
+++ b/tests/providers/aws/services/iam/iam_user_two_active_access_key/iam_user_two_active_access_key_test.py
@@ -20,6 +20,8 @@ class Test_iam_user_two_active_access_key:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
+
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_user_two_active_access_key.iam_user_two_active_access_key.iam_client",
             new=IAM(current_audit_info),
@@ -52,6 +54,8 @@ class Test_iam_user_two_active_access_key:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
+
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_user_two_active_access_key.iam_user_two_active_access_key.iam_client",
             new=IAM(current_audit_info),
@@ -69,7 +73,8 @@ class Test_iam_user_two_active_access_key:
             assert result[0].resource_id == user
             assert result[0].resource_arn == user_arn
             assert search(
-                f"User {user} has not 2 active access keys.", result[0].status_extended
+                f"User {user} does not have 2 active access keys.",
+                result[0].status_extended,
             )
 
     @mock_iam
@@ -82,6 +87,8 @@ class Test_iam_user_two_active_access_key:
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
 
+        current_audit_info.audited_partition = "aws"
+
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_user_two_active_access_key.iam_user_two_active_access_key.iam_client",
             new=IAM(current_audit_info),
@@ -99,13 +106,16 @@ class Test_iam_user_two_active_access_key:
             assert result[0].resource_id == user
             assert result[0].resource_arn == user_arn
             assert search(
-                f"User {user} has not 2 active access keys.", result[0].status_extended
+                f"User {user} does not have 2 active access keys.",
+                result[0].status_extended,
             )
 
     @mock_iam
     def test_iam_no_users(self):
         from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.iam.iam_service import IAM
+
+        current_audit_info.audited_partition = "aws"
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_user_two_active_access_key.iam_user_two_active_access_key.iam_client",


### PR DESCRIPTION
### Context

The following IAM status messages are swapped for FAIL and PASS text:
* https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/aws/services/iam/iam_password_policy_lowercase/iam_password_policy_lowercase.py
* https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/aws/services/iam/iam_password_policy_minimum_length_14/iam_password_policy_minimum_length_14.py
* https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/aws/services/iam/iam_password_policy_number/iam_password_policy_number.py
* https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/aws/services/iam/iam_password_policy_symbol/iam_password_policy_symbol.py

https://github.com/prowler-cloud/prowler/tree/master/prowler/providers/aws/services/iam

### Description

I fixed the wrong status messages, which was the important part, and fixed some status message grammar in other IAM checks.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
