### PR TITLE
fix(cloudtrail_multi_region_enabled.py): fixed region when no trails

### DIFF
--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled.py
@@ -45,7 +45,6 @@ class cloudtrail_multi_region_enabled(Check):
                 )
                 report.resource_arn = "No trails"
                 report.resource_id = "No trails"
-                report.region = cloudtrail_client.region
                 findings.append(report)
 
         return findings


### PR DESCRIPTION
### Context

Fixes the issue with check `cloudtrail_multi_region_enabled` that was assigning wrong region in the results (assigned default client profile region )


### Description

Changes the default client profile region in the check by the region that should include the trail 


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
