### PR TITLE
fix(metadata): use docs.aws.amazon.com like other aws checks, not docs.amazonaws.cn

### DIFF
--- a/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.metadata.json
@@ -10,7 +10,7 @@
   "ResourceType": "AwsRdsDbInstance",
   "Description": "Ensure there are no Public Accessible RDS instances.",
   "Risk": "Publicly accessible databases could expose sensitive data to bad actors.",
-  "RelatedUrl": "https://docs.amazonaws.cn/en_us/config/latest/developerguide/rds-instance-public-access-check.html",
+  "RelatedUrl": "https://docs.aws.amazon.com/config/latest/developerguide/rds-instance-public-access-check.html",
   "Remediation": {
     "Code": {
       "CLI": "aws rds modify-db-instance --db-instance-identifier <db_instance_id> --no-publicly-accessible --apply-immediately",
@@ -20,7 +20,7 @@
     },
     "Recommendation": {
       "Text": "Using an AWS Config rule check for RDS public instances periodically and check there is a business reason for it.",
-      "Url": "https://docs.amazonaws.cn/en_us/config/latest/developerguide/rds-instance-public-access-check.html"
+      "Url": "https://docs.aws.amazon.com/config/latest/developerguide/rds-instance-public-access-check.html"
     }
   },
   "Categories": [


### PR DESCRIPTION
### Context

Use docs.aws.amazon.com URLs (like in other AWS checks) instead of docs.amazonaws.cn URLs

### Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.

.cn is country-code top-level domain, besides .cn doc url is only used in rds_instance_no_public_access check.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
