### PR TITLE
fix(allowlist): validate allowlist for any database format (file, dynamo, s3, etc)

### DIFF
--- a/prowler/providers/aws/lib/allowlist/allowlist.py
+++ b/prowler/providers/aws/lib/allowlist/allowlist.py
@@ -61,13 +61,13 @@ def parse_allowlist_file(audit_info, allowlist_file):
         else:
             with open(allowlist_file) as f:
                 allowlist = yaml.safe_load(f)["Allowlist"]
-                try:
-                    allowlist_schema.validate(allowlist)
-                except Exception as error:
-                    logger.critical(
-                        f"{error.__class__.__name__} -- Allowlist YAML is malformed - {error}[{error.__traceback__.tb_lineno}]"
-                    )
-                    sys.exit()
+        try:
+            allowlist_schema.validate(allowlist)
+        except Exception as error:
+            logger.critical(
+                f"{error.__class__.__name__} -- Allowlist YAML is malformed - {error}[{error.__traceback__.tb_lineno}]"
+            )
+            sys.exit()
         return allowlist
     except Exception as error:
         logger.critical(


### PR DESCRIPTION
### Context

While trying out allowlist functionality, I observed that the (very useful) allowlist validation was only happening when the allowlist is a file.


### Description

This changes puts the allowlist validation at the level of all types of allowlist types

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
