### PR TITLE
feat(allowlist): AWS Lambda function support

### DIFF
--- a/docs/tutorials/allowlist.md
+++ b/docs/tutorials/allowlist.md
@@ -74,3 +74,36 @@ prowler aws -w arn:aws:dynamodb:<region_name>:<account_id>:table/<table_name>
 <img src="../img/allowlist-row.png"/>
 
 > Make sure that the used AWS credentials have `dynamodb:PartiQLSelect` permissions in the table.
+
+### AWS Lambda ARN
+
+Passing an AWS Lambda ARN:
+
+```
+prowler aws -w arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME
+```
+
+Make sure that the credentials that Prowler uses can invoke the Lambda Function:
+
+```
+        - PolicyName: GetAllowList
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Action: 'lambda:InvokeFunction'
+                Effect: Allow
+                Resource: arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME
+```
+
+The Lambda Function can then generate an Allowlist dynamically. Here is the code an example Python Lambda Function that 
+generates an Allowlist
+
+```
+def handler(event, context):
+  checks = {}
+  checks["vpc_flow_logs_enabled"] = { "Regions": [ "*" ], "Resources": [ "" ] }
+
+  al = { "Allowlist": { "Accounts": { "*": { "Checks": allow_list } } } }
+  return al
+```
+

--- a/docs/tutorials/allowlist.md
+++ b/docs/tutorials/allowlist.md
@@ -103,7 +103,7 @@ def handler(event, context):
   checks = {}
   checks["vpc_flow_logs_enabled"] = { "Regions": [ "*" ], "Resources": [ "" ] }
 
-  al = { "Allowlist": { "Accounts": { "*": { "Checks": allow_list } } } }
+  al = { "Allowlist": { "Accounts": { "*": { "Checks": checks } } } }
   return al
 ```
 

--- a/docs/tutorials/allowlist.md
+++ b/docs/tutorials/allowlist.md
@@ -77,7 +77,7 @@ prowler aws -w arn:aws:dynamodb:<region_name>:<account_id>:table/<table_name>
 
 ### AWS Lambda ARN
 
-Passing an AWS Lambda ARN:
+You will need to pass the AWS Lambda Function ARN:
 
 ```
 prowler aws -w arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME
@@ -86,17 +86,17 @@ prowler aws -w arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME
 Make sure that the credentials that Prowler uses can invoke the Lambda Function:
 
 ```
-        - PolicyName: GetAllowList
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Action: 'lambda:InvokeFunction'
-                Effect: Allow
-                Resource: arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME
+- PolicyName: GetAllowList
+  PolicyDocument:
+    Version: '2012-10-17'
+    Statement:
+      - Action: 'lambda:InvokeFunction'
+        Effect: Allow
+        Resource: arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME
 ```
 
-The Lambda Function can then generate an Allowlist dynamically. Here is the code an example Python Lambda Function that 
-generates an Allowlist
+The Lambda Function can then generate an Allowlist dynamically. Here is the code an example Python Lambda Function that
+generates an Allowlist:
 
 ```
 def handler(event, context):
@@ -106,4 +106,3 @@ def handler(event, context):
   al = { "Allowlist": { "Accounts": { "*": { "Checks": checks } } } }
   return al
 ```
-

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -341,7 +341,7 @@ Detailed documentation at https://docs.prowler.cloud
             "--allowlist-file",
             nargs="?",
             default=None,
-            help="Path for allowlist yaml file. See example prowler/config/allowlist.yaml for reference and format. It also accepts AWS DynamoDB Table ARN or S3 URI, see more in https://docs.prowler.cloud/en/latest/tutorials/allowlist/",
+            help="Path for allowlist yaml file. See example prowler/config/allowlist.yaml for reference and format. It also accepts AWS DynamoDB Table or Lambda ARNs or S3 URIs, see more in https://docs.prowler.cloud/en/latest/tutorials/allowlist/",
         )
 
     def __init_azure_parser__(self):

--- a/prowler/providers/aws/lib/allowlist/allowlist.py
+++ b/prowler/providers/aws/lib/allowlist/allowlist.py
@@ -61,13 +61,13 @@ def parse_allowlist_file(audit_info, allowlist_file):
         else:
             with open(allowlist_file) as f:
                 allowlist = yaml.safe_load(f)["Allowlist"]
-                try:
-                    allowlist_schema.validate(allowlist)
-                except Exception as error:
-                    logger.critical(
-                        f"{error.__class__.__name__} -- Allowlist YAML is malformed - {error}[{error.__traceback__.tb_lineno}]"
-                    )
-                    sys.exit()
+        try:
+            allowlist_schema.validate(allowlist)
+        except Exception as error:
+            logger.critical(
+                f"{error.__class__.__name__} -- Allowlist YAML is malformed - {error}[{error.__traceback__.tb_lineno}]"
+            )
+            sys.exit()
         return allowlist
     except Exception as error:
         logger.critical(

--- a/prowler/providers/aws/lib/allowlist/allowlist.py
+++ b/prowler/providers/aws/lib/allowlist/allowlist.py
@@ -25,8 +25,12 @@ def parse_allowlist_file(audit_info, allowlist_file):
         # Check if file is a Lambda Function ARN
         elif re.search("^arn:(\w+):lambda:", allowlist_file):
             lambda_region = allowlist_file.split(":")[3]
-            lambda_client = audit_info.audit_session.client("lambda", region_name=lambda_region)
-            lambda_response = lambda_client.invoke(FunctionName=allowlist_file, InvocationType="RequestResponse")
+            lambda_client = audit_info.audit_session.client(
+                "lambda", region_name=lambda_region
+            )
+            lambda_response = lambda_client.invoke(
+                FunctionName=allowlist_file, InvocationType="RequestResponse"
+            )
             lambda_payload = lambda_response["Payload"].read()
             allowlist = yaml.safe_load(lambda_payload)["Allowlist"]
         # Check if file is a DynamoDB ARN

--- a/prowler/providers/aws/lib/allowlist/allowlist.py
+++ b/prowler/providers/aws/lib/allowlist/allowlist.py
@@ -22,6 +22,13 @@ def parse_allowlist_file(audit_info, allowlist_file):
             allowlist = yaml.safe_load(
                 s3_client.get_object(Bucket=bucket, Key=key)["Body"]
             )["Allowlist"]
+        # Check if file is a Lambda Function ARN
+        elif re.search("^arn:(\w+):lambda:", allowlist_file):
+            lambda_region = allowlist_file.split(":")[3]
+            lambda_client = audit_info.audit_session.client("lambda", region_name=lambda_region)
+            lambda_response = lambda_client.invoke(FunctionName=allowlist_file, InvocationType="RequestResponse")
+            lambda_payload = lambda_response["Payload"].read()
+            allowlist = yaml.safe_load(lambda_payload)["Allowlist"]
         # Check if file is a DynamoDB ARN
         elif re.search(
             r"^arn:aws(-cn|-us-gov)?:dynamodb:[a-z]{2}-[a-z-]+-[1-9]{1}:[0-9]{12}:table\/[a-zA-Z0-9._-]+$",


### PR DESCRIPTION
### Context

While studying how to implement Prowler for our use case, I found some challenges with the current Allowlist options.

Some examples:
 - For the `ec2_instance_public_ip` check, we have instances in AutoScalingGroups that cannot be listed in Resources. Allowlisting all instances with `Resources: [ '' ]` in the Allowlist will make potentially unallowed instances to be Allowed
 - We want to allow some distrubtions for the `cloudfront_distributions_using_waf` check, but due to the dynamic nature of resources in our accounts (stacks get created and destroyed with CloudFormation) we cannot whitelist a set of CloudFront distributions that are allowed to not have WAF.
 - Some of our stacks create a "dormant" Security Group which is seldomly used, but very convenient to have pre-configured. To whitelist those resources in `ec2_securitygroup_not_used`  we cannot know beforehand the security group Ids that are going to be allowed.

### Description

I've added an option for the allowlist parameter to be an AWS Lambda ARN which will be invoked to obtain the Allowlist. The Lambda can then query AWS APIs and generate Allowlist checks for resources following the organizations needs.

I have added some documentation with example code also.

I would like to know if this feature is good for being accepted before continuing to implement prowler depending on this feature (I would prefer to depend on a non-forked version going forward)

Note that this PR builds on #1792, which can be merged separately if this feature is not acceptable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license