### PR TITLE
fix(accessanalyzer_enabled_without_findings): fixed status findings

### DIFF
--- a/prowler/providers/aws/services/accessanalyzer/accessanalyzer_enabled_without_findings/accessanalyzer_enabled_without_findings.py
+++ b/prowler/providers/aws/services/accessanalyzer/accessanalyzer_enabled_without_findings/accessanalyzer_enabled_without_findings.py
@@ -11,21 +11,28 @@ class accessanalyzer_enabled_without_findings(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = analyzer.region
             if analyzer.status == "ACTIVE":
-                if analyzer.findings_count > 0:
-                    report.status = "FAIL"
-                    report.status_extended = f"IAM Access Analyzer {analyzer.name} has {analyzer.findings_count} active findings"
-                    report.resource_id = analyzer.name
-                    report.resource_arn = analyzer.arn
-                else:
-                    report.status = "PASS"
-                    report.status_extended = (
-                        f"IAM Access Analyzer {analyzer.name} has no active findings"
-                    )
-                    report.resource_id = analyzer.name
-                    report.resource_arn = analyzer.arn
+                report.status = "PASS"
+                report.status_extended = (
+                    f"IAM Access Analyzer {analyzer.name} does not have active findings"
+                )
+                report.resource_id = analyzer.name
+                report.resource_arn = analyzer.arn
+                if len(analyzer.findings) != 0:
+                    active_finding_counter = 0
+                    for finding in analyzer.findings:
+                        if finding.status == "ACTIVE":
+                            active_finding_counter += 1
+
+                    if active_finding_counter > 0:
+                        report.status = "FAIL"
+                        report.status_extended = f"IAM Access Analyzer {analyzer.name} has {active_finding_counter} active findings"
+                        report.resource_id = analyzer.name
+                        report.resource_arn = analyzer.arn
             elif analyzer.status == "NOT_AVAILABLE":
                 report.status = "FAIL"
-                report.status_extended = "IAM Access Analyzer is not enabled"
+                report.status_extended = (
+                    f"IAM Access Analyzer {analyzer.name} is not enabled"
+                )
                 report.resource_id = analyzer.name
             else:
                 report.status = "FAIL"

--- a/tests/providers/aws/services/accessanalyzer/accessanalyzer_enabled_without_findings/accessanalyzer_enabled_without_findings_test.py
+++ b/tests/providers/aws/services/accessanalyzer/accessanalyzer_enabled_without_findings/accessanalyzer_enabled_without_findings_test.py
@@ -50,7 +50,10 @@ class Test_accessanalyzer_enabled_without_findings:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].status_extended == "IAM Access Analyzer is not enabled"
+            assert (
+                result[0].status_extended
+                == "IAM Access Analyzer Test Analyzer is not enabled"
+            )
             assert result[0].resource_id == "Test Analyzer"
 
     def test_two_analyzers(self):

--- a/tests/providers/aws/services/accessanalyzer/accessanalyzer_enabled_without_findings/accessanalyzer_enabled_without_findings_test.py
+++ b/tests/providers/aws/services/accessanalyzer/accessanalyzer_enabled_without_findings/accessanalyzer_enabled_without_findings_test.py
@@ -102,7 +102,10 @@ class Test_accessanalyzer_enabled_without_findings:
 
             assert len(result) == 2
             assert result[0].status == "FAIL"
-            assert result[0].status_extended == "IAM Access Analyzer is not enabled"
+            assert (
+                result[0].status_extended
+                == "IAM Access Analyzer Test Analyzer is not enabled"
+            )
             assert result[0].resource_id == "Test Analyzer"
             assert result[0].region == "eu-west-1"
             assert result[1].status == "FAIL"

--- a/tests/providers/aws/services/accessanalyzer/accessanalyzer_enabled_without_findings/accessanalyzer_enabled_without_findings_test.py
+++ b/tests/providers/aws/services/accessanalyzer/accessanalyzer_enabled_without_findings/accessanalyzer_enabled_without_findings_test.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from prowler.providers.aws.services.accessanalyzer.accessanalyzer_service import (
     Analyzer,
+    Finding,
 )
 
 
@@ -28,13 +29,12 @@ class Test_accessanalyzer_enabled_without_findings:
         accessanalyzer_client = mock.MagicMock
         accessanalyzer_client.analyzers = [
             Analyzer(
-                "",
-                "Test Analyzer",
-                "NOT_AVAILABLE",
-                "",
-                "",
-                "",
-                "eu-west-1",
+                arn="",
+                name="Test Analyzer",
+                status="NOT_AVAILABLE",
+                tags="",
+                type="",
+                region="eu-west-1",
             )
         ]
         with mock.patch(
@@ -57,22 +57,30 @@ class Test_accessanalyzer_enabled_without_findings:
         accessanalyzer_client = mock.MagicMock
         accessanalyzer_client.analyzers = [
             Analyzer(
-                "",
-                "Test Analyzer",
-                "NOT_AVAILABLE",
-                "",
-                "",
-                "",
-                "eu-west-1",
+                arn="",
+                name="Test Analyzer",
+                status="NOT_AVAILABLE",
+                tags="",
+                type="",
+                region="eu-west-1",
             ),
             Analyzer(
-                "",
-                "Test Analyzer",
-                "ACTIVE",
-                10,
-                "",
-                "",
-                "eu-west-1",
+                arn="",
+                name="Test Analyzer",
+                status="ACTIVE",
+                findings=[
+                    Finding(
+                        id="test-finding-1",
+                        status="ACTIVE",
+                    ),
+                    Finding(
+                        id="test-finding-2",
+                        status="ARCHIVED",
+                    ),
+                ],
+                tags="",
+                type="",
+                region="eu-west-2",
             ),
         ]
 
@@ -93,24 +101,25 @@ class Test_accessanalyzer_enabled_without_findings:
             assert result[0].status == "FAIL"
             assert result[0].status_extended == "IAM Access Analyzer is not enabled"
             assert result[0].resource_id == "Test Analyzer"
+            assert result[0].region == "eu-west-1"
             assert result[1].status == "FAIL"
             assert (
                 result[1].status_extended
-                == "IAM Access Analyzer Test Analyzer has 10 active findings"
+                == "IAM Access Analyzer Test Analyzer has 1 active findings"
             )
             assert result[1].resource_id == "Test Analyzer"
+            assert result[1].region == "eu-west-2"
 
     def test_one_active_analyzer_without_findings(self):
         accessanalyzer_client = mock.MagicMock
         accessanalyzer_client.analyzers = [
             Analyzer(
-                "",
-                "Test Analyzer",
-                "ACTIVE",
-                0,
-                "",
-                "",
-                "eu-west-1",
+                arn="",
+                name="Test Analyzer",
+                status="ACTIVE",
+                tags="",
+                type="",
+                region="eu-west-2",
             )
         ]
 
@@ -130,22 +139,22 @@ class Test_accessanalyzer_enabled_without_findings:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == "IAM Access Analyzer Test Analyzer has no active findings"
+                == "IAM Access Analyzer Test Analyzer does not have active findings"
             )
             assert result[0].resource_id == "Test Analyzer"
+            assert result[0].region == "eu-west-2"
 
     def test_one_active_analyzer_not_active(self):
         accessanalyzer_client = mock.MagicMock
         accessanalyzer_client.analyzers = [
             Analyzer(
-                "",
-                "Test Analyzer",
-                "FAILED",
-                0,
-                "",
-                "",
-                "eu-west-1",
-            )
+                arn="",
+                name="Test Analyzer",
+                status="NOT_AVAILABLE",
+                tags="",
+                type="",
+                region="eu-west-1",
+            ),
         ]
         # Patch AccessAnalyzer Client
         with mock.patch(
@@ -164,6 +173,7 @@ class Test_accessanalyzer_enabled_without_findings:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == "IAM Access Analyzer Test Analyzer is not active"
+                == "IAM Access Analyzer Test Analyzer is not enabled"
             )
             assert result[0].resource_id == "Test Analyzer"
+            assert result[0].region == "eu-west-1"

--- a/tests/providers/aws/services/accessanalyzer/accessanalyzer_service_test.py
+++ b/tests/providers/aws/services/accessanalyzer/accessanalyzer_service_test.py
@@ -39,11 +39,20 @@ def mock_make_api_call(self, operation_name, kwarg):
     if operation_name == "ListFindings":
         # If we only want to count the number of findings
         # we return a list of values just to count them
-        return {"findings": [0, 1, 2]}
+        return {
+            "findings": [
+                {
+                    "id": "test_id1",
+                }
+            ]
+        }
+    if operation_name == "GetFinding":
+        # If we only want to count the number of findings
+        # we return a list of values just to count them
+        return {"finding": {"id": "test_id1", "status": "ARCHIVED"}}
     return make_api_call(self, operation_name, kwarg)
 
 
-# Mock generate_regional_clients()
 def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
@@ -92,4 +101,6 @@ class Test_AccessAnalyzer_Service:
         current_audit_info.audited_partition = "aws"
         access_analyzer = AccessAnalyzer(current_audit_info)
         assert len(access_analyzer.analyzers) == 1
-        assert access_analyzer.analyzers[0].findings_count == 3
+        assert len(access_analyzer.analyzers[0].findings) == 1
+        assert access_analyzer.analyzers[0].findings[0].status == "ARCHIVED"
+        assert access_analyzer.analyzers[0].findings[0].id == "test_id1"


### PR DESCRIPTION
### Context

Check `accessanalyzer_enabled_without_findings` did not check the status of the findings, setting as fail access analysers with status != ACTIVE from the issue https://github.com/prowler-cloud/prowler/issues/1796


### Description

Retrieve findings status to check it, if they are not ACTIVE -> PASS

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
