### PR TITLE
fix(ec2_securitygroup_not_used): ignore default security groups

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used.py
@@ -6,16 +6,17 @@ class ec2_securitygroup_not_used(Check):
     def execute(self):
         findings = []
         for security_group in ec2_client.security_groups:
-            report = Check_Report_AWS(self.metadata())
-            report.region = security_group.region
-            report.resource_id = security_group.id
-            report.resource_arn = security_group.arn
-            report.status = "PASS"
-            report.status_extended = f"Security group {security_group.name} ({security_group.id}) it is being used."
-            if len(security_group.network_interfaces) == 0:
-                report.status = "FAIL"
-                report.status_extended = f"Security group {security_group.name} ({security_group.id}) it is not being used."
+            if security_group.name != "default":
+                report = Check_Report_AWS(self.metadata())
+                report.region = security_group.region
+                report.resource_id = security_group.id
+                report.resource_arn = security_group.arn
+                report.status = "PASS"
+                report.status_extended = f"Security group {security_group.name} ({security_group.id}) it is being used."
+                if len(security_group.network_interfaces) == 0:
+                    report.status = "FAIL"
+                    report.status_extended = f"Security group {security_group.name} ({security_group.id}) it is not being used."
 
-            findings.append(report)
+                findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used.py
@@ -6,6 +6,7 @@ class ec2_securitygroup_not_used(Check):
     def execute(self):
         findings = []
         for security_group in ec2_client.security_groups:
+            # Default security groups can not be deleted, so ignore them
             if security_group.name != "default":
                 report = Check_Report_AWS(self.metadata())
                 report.region = security_group.region


### PR DESCRIPTION
### Description

Regarding https://github.com/prowler-cloud/prowler/issues/1789, ignore default security groups.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
