### PR TITLE
fix(accessanalyzer): no analyzers using pydantic

### DIFF
--- a/prowler/providers/aws/services/accessanalyzer/accessanalyzer_service.py
+++ b/prowler/providers/aws/services/accessanalyzer/accessanalyzer_service.py
@@ -57,12 +57,12 @@ class AccessAnalyzer:
             if analyzer_count == 0:
                 self.analyzers.append(
                     Analyzer(
-                        "",
-                        self.audited_account,
-                        "NOT_AVAILABLE",
-                        "",
-                        "",
-                        regional_client.region,
+                        arn="",
+                        name=self.audited_account,
+                        status="NOT_AVAILABLE",
+                        tags="",
+                        type="",
+                        region=regional_client.region,
                     )
                 )
 


### PR DESCRIPTION
### Context

In Prowler if there are no analyzers in a region, each field needs its name (uses pydantic):


```
if analyzer_count == 0:
                self.analyzers.append(
                    Analyzer(
                        arn="",
                        name=self.audited_account,
                        status="NOT_AVAILABLE",
                        tags="",
                        type="",
                        region=regional_client.region,
                    )
                )
```



### Description

In Prowler if there are no analyzers in a region, each field needs its name (uses pydantic):

```
if analyzer_count == 0:
                self.analyzers.append(
                    Analyzer(
                        arn="",
                        name=self.audited_account,
                        status="NOT_AVAILABLE",
                        tags="",
                        type="",
                        region=regional_client.region,
                    )
                )
```



### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
