### PR TITLE
fix(cloudtrail): improve cloudtrail_cloudwatch_logging_enabled status extended

### DIFF
--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_cloudwatch_logging_enabled/cloudtrail_cloudwatch_logging_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_cloudwatch_logging_enabled/cloudtrail_cloudwatch_logging_enabled.py
@@ -38,9 +38,9 @@ class cloudtrail_cloudwatch_logging_enabled(Check):
                 else:
                     report.status = "FAIL"
                     if trail.is_multiregion:
-                        report.status_extended = f"Multiregion trail {trail.name} is not configured to deliver logs"
+                        report.status_extended = f"Multiregion trail {trail.name} is not logging in the last 24h or not configured to deliver logs"
                     else:
-                        report.status_extended = f"Single region trail {trail.name} is not configured to deliver logs"
+                        report.status_extended = f"Single region trail {trail.name} is not logging in the last 24h or not configured to deliver logs"
                 findings.append(report)
 
         return findings

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_cloudwatch_logging_enabled/cloudtrail_cloudwatch_logging_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_cloudwatch_logging_enabled/cloudtrail_cloudwatch_logging_enabled_test.py
@@ -220,15 +220,15 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
                     assert report.resource_id == trail_name_us
                     assert report.resource_arn == trail_us["TrailARN"]
                     assert report.status == "PASS"
-                    assert search(
-                        report.status_extended,
-                        f"Single region trail {trail_name_us} has been logging the last 24h",
+                    assert (
+                        report.status_extended
+                        == f"Single region trail {trail_name_us} has been logging the last 24h"
                     )
                 if report.resource_id == trail_name_eu:
                     assert report.resource_id == trail_name_eu
                     assert report.resource_arn == trail_eu["TrailARN"]
                     assert report.status == "FAIL"
-                    assert search(
-                        report.status_extended,
-                        f"Single region trail {trail_name_eu} is not configured to deliver logs",
+                    assert (
+                        report.status_extended
+                        == f"Single region trail {trail_name_eu} is not logging in the last 24h or not configured to deliver logs"
                     )


### PR DESCRIPTION
### Description

Give more information to the user when Trail is not logging for the last 24 hours.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
