### PR TITLE
fix(KeyError): handle service key errors

### DIFF
--- a/prowler/providers/aws/services/awslambda/awslambda_service.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_service.py
@@ -51,9 +51,11 @@ class Lambda:
                             function["FunctionArn"], self.audit_resources
                         )
                     ):
+                        lambda_runtime = None
+                        if "Runtime" in function:
+                            lambda_runtime = function["Runtime"]
                         lambda_name = function["FunctionName"]
                         lambda_arn = function["FunctionArn"]
-                        lambda_runtime = function["Runtime"]
                         self.functions[lambda_name] = Function(
                             name=lambda_name,
                             arn=lambda_arn,

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
@@ -43,11 +43,14 @@ class CloudWatch:
                     if not self.audit_resources or (
                         is_resource_filtered(alarm["AlarmArn"], self.audit_resources)
                     ):
+                        metric_name = None
+                        if "MetricName" in alarm:
+                            metric_name = alarm["MetricName"]
                         self.metric_alarms.append(
                             MetricAlarm(
                                 alarm["AlarmArn"],
                                 alarm["AlarmName"],
-                                alarm["MetricName"],
+                                metric_name,
                                 alarm["Namespace"],
                                 regional_client.region,
                             )

--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -64,6 +64,7 @@ class EC2:
                             http_endpoint = None
                             public_dns = None
                             public_ip = None
+                            private_ip = None
                             instance_profile = None
                             if "MetadataOptions" in instance:
                                 http_tokens = instance["MetadataOptions"]["HttpTokens"]
@@ -76,6 +77,8 @@ class EC2:
                             ):
                                 public_dns = instance["PublicDnsName"]
                                 public_ip = instance["PublicIpAddress"]
+                            if "PrivateIpAddress" in instance:
+                                private_ip = instance["PrivateIpAddress"]
                             if "IamInstanceProfile" in instance:
                                 instance_profile = instance["IamInstanceProfile"]
 
@@ -89,7 +92,7 @@ class EC2:
                                     instance["ImageId"],
                                     instance["LaunchTime"],
                                     instance["PrivateDnsName"],
-                                    instance["PrivateIpAddress"],
+                                    private_ip,
                                     public_dns,
                                     public_ip,
                                     http_tokens,

--- a/prowler/providers/aws/services/emr/emr_service.py
+++ b/prowler/providers/aws/services/emr/emr_service.py
@@ -79,9 +79,14 @@ class EMR:
                     master_node_security_group = cluster_info["Cluster"][
                         "Ec2InstanceAttributes"
                     ]["EmrManagedMasterSecurityGroup"]
-                    master_node_additional_security_groups = cluster_info["Cluster"][
-                        "Ec2InstanceAttributes"
-                    ]["AdditionalMasterSecurityGroups"]
+                    master_node_additional_security_groups = None
+                    if (
+                        "AdditionalMasterSecurityGroups"
+                        in cluster_info["Cluster"]["Ec2InstanceAttributes"]
+                    ):
+                        master_node_additional_security_groups = cluster_info[
+                            "Cluster"
+                        ]["Ec2InstanceAttributes"]["AdditionalMasterSecurityGroups"]
                     self.clusters[cluster.id].master = Node(
                         security_group_id=master_node_security_group,
                         additional_security_groups_id=master_node_additional_security_groups,

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -40,8 +40,8 @@ class S3:
 
     def __list_buckets__(self, audit_info):
         logger.info("S3 - Listing buckets...")
+        buckets = []
         try:
-            buckets = []
             list_buckets = self.client.list_buckets()
             for bucket in list_buckets["Buckets"]:
                 try:
@@ -67,11 +67,11 @@ class S3:
                     logger.error(
                         f"{bucket_region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
-            return buckets
         except Exception as error:
             logger.error(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
+        return buckets
 
     def __get_bucket_versioning__(self, bucket):
         logger.info("S3 - Get buckets versioning...")


### PR DESCRIPTION
### Description

Solve the following Service Key Errors:
```
[
    {
        "@timestamp": "2023-02-02 01:04:00.627",
        "@message": {
            "timestamp": "2023-02-02 01:04:00,626",
            "filename": "ec2_service.py:94",
            "level": "ERROR",
            "module": "ec2_service",
            "message": "ap-southeast-2 -- KeyError[85]: 'PrivateIpAddress'"
        }
    },
    {
        "@timestamp": "2023-02-02 00:50:59.911",
        "@message": {
            "timestamp": "2023-02-02 00:50:59,911",
            "filename": "awslambda_service.py:61",
            "level": "ERROR",
            "module": "awslambda_service",
            "message": "us-east-1 -- KeyError[49]: 'Runtime'"
        }
    },
    {
        "@timestamp": "2023-02-01 16:59:31.077",
        "@message": {
            "timestamp": "2023-02-01 16:59:31,077",
            "filename": "emr_service.py:109",
            "level": "ERROR",
            "module": "emr_service",
            "message": "eu-west-1 -- KeyError[75]: 'AdditionalMasterSecurityGroups'"
        }
    },
    {
        "@timestamp": "2023-02-01 19:13:02.075",
        "@message": {
            "timestamp": "2023-02-01 19:13:02,075",
            "filename": "cloudwatch_service.py:51",
            "level": "ERROR",
            "module": "cloudwatch_service",
            "message": "us-west-1 -- KeyError[45]: 'MetricName'"
        }
    }
]
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
