### PR TITLE
fix(metadata): typo in title for awslambda_function_not_publicly_accessible

### DIFF
--- a/prowler/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "awslambda_function_not_publicly_accessible",
-  "CheckTitle": "heck if Lambda functions have resource-based policy set as Public.",
+  "CheckTitle": "Check if Lambda functions have resource-based policy set as Public.",
   "CheckType": [],
   "ServiceName": "lambda",
   "SubServiceName": "",


### PR DESCRIPTION
### Context

Just noticed this typo and decided to fix it by myself without opening an issue :D


### Description

Typo fix in `awslambda_function_not_publicly_accessible` check title.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
