### PR TITLE
fix(KeyError): handle service key errors

### DIFF
--- a/prowler/providers/aws/services/opensearch/opensearch_service.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service.py
@@ -94,10 +94,12 @@ class OpenSearchService:
                     DomainName=domain.name
                 )
                 domain.arn = describe_domain["DomainStatus"]["ARN"]
-                if "vpc" in describe_domain["DomainStatus"]["Endpoints"]:
-                    domain.endpoint_vpc = describe_domain["DomainStatus"]["Endpoints"][
-                        "vpc"
-                    ]
+                domain.endpoint_vpc = None
+                if "Endpoints" in describe_domain["DomainStatus"]:
+                    if "vpc" in describe_domain["DomainStatus"]["Endpoints"]:
+                        domain.endpoint_vpc = describe_domain["DomainStatus"][
+                            "Endpoints"
+                        ]["vpc"]
                 domain.vpc_id = describe_domain["DomainStatus"]["VPCOptions"]["VPCId"]
                 domain.cognito_options = describe_domain["DomainStatus"][
                     "CognitoOptions"

--- a/prowler/providers/aws/services/s3/s3_bucket_public_access/s3_bucket_public_access.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_public_access/s3_bucket_public_access.py
@@ -45,7 +45,8 @@ class s3_bucket_public_access(Check):
                     if bucket.policy:
                         for statement in bucket.policy["Statement"]:
                             if (
-                                "*" == statement["Principal"]
+                                "Principal" in statement
+                                and "*" == statement["Principal"]
                                 and statement["Effect"] == "Allow"
                             ):
                                 report.status = "FAIL"


### PR DESCRIPTION
### Description

Solve the following Service Key Errors:
```
[
    {
        "@timestamp": "2023-02-02 12:33:26.934",
        "@message": {
            "timestamp": "2023-02-02 12:33:26,934",
            "filename": "opensearch_service.py:117",
            "level": "ERROR",
            "module": "opensearch_service",
            "message": "ap-south-1 -- KeyError[92]: 'Endpoints'"
        }
    },
    {
        "@timestamp": "2023-02-02 12:44:50.005",
        "@message": {
            "timestamp": "2023-02-02 12:44:50,004",
            "filename": "check.py:305",
            "level": "ERROR",
            "module": "check",
            "message": "s3_bucket_public_access -- KeyError[299]: 'Principal'"
        }
    }
]
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
