### PR TITLE
fix(lambda-runtime): Init value must be empty string

### DIFF
--- a/prowler/providers/aws/services/awslambda/awslambda_function_using_supported_runtimes/awslambda_function_using_supported_runtimes.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_using_supported_runtimes/awslambda_function_using_supported_runtimes.py
@@ -7,18 +7,19 @@ class awslambda_function_using_supported_runtimes(Check):
     def execute(self):
         findings = []
         for function in awslambda_client.functions.values():
-            report = Check_Report_AWS(self.metadata())
-            report.region = function.region
-            report.resource_id = function.name
-            report.resource_arn = function.arn
+            if function.runtime:
+                report = Check_Report_AWS(self.metadata())
+                report.region = function.region
+                report.resource_id = function.name
+                report.resource_arn = function.arn
 
-            if function.runtime in get_config_var("obsolete_lambda_runtimes"):
-                report.status = "FAIL"
-                report.status_extended = f"Lambda function {function.name} is using {function.runtime} which is obsolete"
-            else:
-                report.status = "PASS"
-                report.status_extended = f"Lambda function {function.name} is using {function.runtime} which is supported"
+                if function.runtime in get_config_var("obsolete_lambda_runtimes"):
+                    report.status = "FAIL"
+                    report.status_extended = f"Lambda function {function.name} is using {function.runtime} which is obsolete"
+                else:
+                    report.status = "PASS"
+                    report.status_extended = f"Lambda function {function.name} is using {function.runtime} which is supported"
 
-            findings.append(report)
+                findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/awslambda/awslambda_service.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_service.py
@@ -3,7 +3,7 @@ import json
 import threading
 import zipfile
 from enum import Enum
-from typing import Any
+from typing import Any, Optional
 
 import requests
 from botocore.client import ClientError
@@ -59,17 +59,15 @@ class Lambda:
                             function["FunctionArn"], self.audit_resources
                         )
                     ):
-                        lambda_runtime = None
-                        if "Runtime" in function:
-                            lambda_runtime = function["Runtime"]
                         lambda_name = function["FunctionName"]
                         lambda_arn = function["FunctionArn"]
                         self.functions[lambda_name] = Function(
                             name=lambda_name,
                             arn=lambda_arn,
-                            runtime=lambda_runtime,
                             region=regional_client.region,
                         )
+                        if "Runtime" in function:
+                            self.functions[lambda_name].runtime = function["Runtime"]
                         if "Environment" in function:
                             lambda_environment = function["Environment"]["Variables"]
                             self.functions[lambda_name].environment = lambda_environment
@@ -179,7 +177,7 @@ class URLConfig(BaseModel):
 class Function(BaseModel):
     name: str
     arn: str
-    runtime: str
+    runtime: Optional[str]
     environment: dict = None
     region: str
     policy: dict = None

--- a/tests/providers/aws/services/awslambda/awslambda_function_using_supported_runtimes/awslambda_function_using_supported_runtimes_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_using_supported_runtimes/awslambda_function_using_supported_runtimes_test.py
@@ -124,3 +124,32 @@ class Test_awslambda_function_using_supported_runtimes:
                 result[0].status_extended
                 == f"Lambda function {function_name} is using {function_runtime} which is supported"
             )
+
+    def test_function_no_runtime(self):
+        lambda_client = mock.MagicMock
+        function_name = "test-lambda"
+        function_arn = (
+            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        )
+        lambda_client.functions = {
+            "function_name": Function(
+                name=function_name, arn=function_arn, region=AWS_REGION
+            )
+        }
+
+        with mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            new=lambda_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_using_supported_runtimes.awslambda_function_using_supported_runtimes.get_config_var",
+            new=mock_get_config_var,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.awslambda.awslambda_function_using_supported_runtimes.awslambda_function_using_supported_runtimes import (
+                awslambda_function_using_supported_runtimes,
+            )
+
+            check = awslambda_function_using_supported_runtimes()
+            result = check.execute()
+
+            assert len(result) == 0


### PR DESCRIPTION
### Description

Init value for Lambda Runtime must be an empty string.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
