### PR TITLE
fix(checks): solve different errors in EFS, S3 and VPC

### DIFF
--- a/prowler/providers/aws/services/efs/efs_service.py
+++ b/prowler/providers/aws/services/efs/efs_service.py
@@ -1,3 +1,4 @@
+import json
 import threading
 from dataclasses import dataclass
 
@@ -74,7 +75,7 @@ class EFS:
                                 FileSystemId=filesystem.id
                             )
                             if "Policy" in fs_policy:
-                                filesystem.policy = fs_policy["Policy"]
+                                filesystem.policy = json.loads(fs_policy["Policy"])
                         except ClientError as e:
                             if e.response["Error"]["Code"] == "PolicyNotFound":
                                 filesystem.policy = {}

--- a/prowler/providers/aws/services/s3/s3_bucket_public_access/s3_bucket_public_access.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_public_access/s3_bucket_public_access.py
@@ -53,7 +53,8 @@ class s3_bucket_public_access(Check):
                                 report.status_extended = f"S3 Bucket {bucket.name} has public access due to bucket policy."
                             else:
                                 if (
-                                    "AWS" in statement["Principal"]
+                                    "Principal" in statement
+                                    and "AWS" in statement["Principal"]
                                     and statement["Effect"] == "Allow"
                                 ):
                                     if type(statement["Principal"]["AWS"]) == str:

--- a/tests/providers/aws/services/efs/efs_service_test.py
+++ b/tests/providers/aws/services/efs/efs_service_test.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 import botocore
@@ -34,7 +35,7 @@ filesystem_policy = {
 
 def mock_make_api_call(self, operation_name, kwarg):
     if operation_name == "DescribeFileSystemPolicy":
-        return {"FileSystemId": file_system_id, "Policy": filesystem_policy}
+        return {"FileSystemId": file_system_id, "Policy": json.dumps(filesystem_policy)}
     if operation_name == "DescribeBackupPolicy":
         return {"BackupPolicy": {"Status": backup_policy_status}}
     return make_api_call(self, operation_name, kwarg)


### PR DESCRIPTION
### Description

Solve the following errors:
```
Executing 3 checks, please wait...

Something went wrong in efs_not_publicly_accessible, please use --log-level ERROR
2023-02-03 15:23:23,143 [File: check.py:307] 	[Module: check]	 ERROR: efs_not_publicly_accessible -- TypeError[21]: string indices must be integers
Something went wrong in s3_bucket_public_access, please use --log-level ERROR
2023-02-03 15:23:42,923 [File: check.py:307] 	[Module: check]	 ERROR: s3_bucket_public_access -- KeyError[56]: 'Principal'
Something went wrong in vpc_endpoint_connections_trust_boundaries, please use --log-level ERROR
2023-02-03 15:23:51,619 [File: check.py:307] 	[Module: check]	 ERROR: vpc_endpoint_connections_trust_boundaries -- IndexError[29]: list index out of range
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
