### PR TITLE
fix(kms): call GetKeyRotationStatus only for Customer Keys

### DIFF
--- a/prowler/providers/aws/services/kms/kms_service.py
+++ b/prowler/providers/aws/services/kms/kms_service.py
@@ -73,7 +73,7 @@ class KMS:
         logger.info("KMS - Get Key Rotation Status...")
         for key in self.keys:
             try:
-                if "EXTERNAL" not in key.origin:
+                if "EXTERNAL" not in key.origin and "AWS" not in key.manager:
                     regional_client = self.regional_clients[key.region]
                     key.rotation_enabled = regional_client.get_key_rotation_status(
                         KeyId=key.id


### PR DESCRIPTION
### Description

Regarding https://github.com/prowler-cloud/prowler/issues/1838, solve the following error:
````
2023-02-03 15:35:54,753 [File: kms_service.py:75] [Module: kms_service] ERROR: us-west-2 -- ClientError:71 -- An error occurred (AccessDeniedException) when calling the GetKeyRotationStatus operation: User: [redacted] is not authorized to perform: kms:GetKeyRotationStatus on resource: [redacted] because no resource-based policy allows the kms:GetKeyRotationStatus action
````
### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
