### PR TITLE
feat(exit_code 3): add -z option

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -219,6 +219,10 @@ def prowler():
                 audit_output_options.output_directory,
             )
 
+    # If there are failed findings exit code 3, except if -z is input
+    if not args.ignore_exit_code_3 and stats["total_fail"] > 0:
+        sys.exit(3)
+
 
 if __name__ == "__main__":
     prowler()

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -139,6 +139,12 @@ Detailed documentation at https://docs.prowler.cloud
             help="Display detailed information about findings",
         )
         common_outputs_parser.add_argument(
+            "-z",
+            "--ignore-exit-code-3",
+            action="store_true",
+            help="Failed checks do not trigger exit code 3",
+        )
+        common_outputs_parser.add_argument(
             "-b", "--no-banner", action="store_true", help="Hide Prowler banner"
         )
 

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -146,6 +146,16 @@ class Test_Parser:
         parsed = self.parser.parse(command)
         assert parsed.quiet
 
+    def test_root_parser_exit_code_3_short(self):
+        command = [prowler_command, "-z"]
+        parsed = self.parser.parse(command)
+        assert parsed.ignore_exit_code_3
+
+    def test_root_parser_exit_code_3_long(self):
+        command = [prowler_command, "--ignore-exit-code-3"]
+        parsed = self.parser.parse(command)
+        assert parsed.ignore_exit_code_3
+
     def test_root_parser_default_output_modes(self):
         command = [prowler_command]
         parsed = self.parser.parse(command)


### PR DESCRIPTION
### Description

By default, Prowler will exit with code 3 if there is any fail. If an user input `-z`, this feature will be ignore.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
