### PR TITLE
fix(iam): change prowler additional policy json due errors in creation

### DIFF
--- a/permissions/prowler-additions-policy.json
+++ b/permissions/prowler-additions-policy.json
@@ -18,7 +18,7 @@
         "lambda:GetFunction*",
         "macie2:GetMacieSession",
         "s3:GetAccountPublicAccessBlock",
-        "s3:GetPublicAccessBlock",
+        "s3:GetBucketPublicAccessBlock",
         "shield:DescribeProtection",
         "shield:GetSubscriptionState",
         "ssm:GetDocument",

--- a/permissions/prowler-additions-policy.json
+++ b/permissions/prowler-additions-policy.json
@@ -18,7 +18,6 @@
         "lambda:GetFunction*",
         "macie2:GetMacieSession",
         "s3:GetAccountPublicAccessBlock",
-        "s3:GetBucketPublicAccessBlock",
         "shield:DescribeProtection",
         "shield:GetSubscriptionState",
         "ssm:GetDocument",


### PR DESCRIPTION
### Context

I found a problem adding this policy to a dedicated user in IAM

### Description

Hi!

I was test driving prowler and added this policy to its dedicated IAM user. When I create the policy in the editor It complained about `s3:GetPublicAccessBlock` not existing. I changed it for the one I think is required, but not sure about it.

https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html

I think the problem is that while the API call is `GetPublicAccessBlock` the permission required according to the doc is `s3:GetBucketPublicAccessBlock`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

