### PR TITLE
fix(output_bucket): Use full path for -o option with output to S3 bucket

### DIFF
--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -198,8 +198,8 @@ def send_to_s3_bucket(
             filename = f"{output_filename}{html_file_suffix}"
         logger.info(f"Sending outputs to S3 bucket {output_bucket}")
         bucket_remote_dir = output_directory
-        if "prowler/" in output_directory:  # Check if it is not a custom directory
-            bucket_remote_dir = output_directory.partition("prowler/")[-1]
+        while "prowler/" in bucket_remote_dir:  # Check if it is not a custom directory
+            bucket_remote_dir = bucket_remote_dir.partition("prowler/")[-1]
         file_name = output_directory + "/" + filename
         bucket_name = output_bucket
         object_name = bucket_remote_dir + "/" + output_mode + "/" + filename

--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -197,9 +197,12 @@ def send_to_s3_bucket(
         elif output_mode == "html":
             filename = f"{output_filename}{html_file_suffix}"
         logger.info(f"Sending outputs to S3 bucket {output_bucket}")
+        bucket_remote_dir = output_directory
+        if "prowler/" in output_directory:  # Check if it is not a custom directory
+            bucket_remote_dir = output_directory.partition("prowler/")[-1]
         file_name = output_directory + "/" + filename
         bucket_name = output_bucket
-        object_name = output_directory + "/" + output_mode + "/" + filename
+        object_name = bucket_remote_dir + "/" + output_mode + "/" + filename
         s3_client = audit_session.client("s3")
         s3_client.upload_file(file_name, bucket_name, object_name)
 

--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -197,10 +197,9 @@ def send_to_s3_bucket(
         elif output_mode == "html":
             filename = f"{output_filename}{html_file_suffix}"
         logger.info(f"Sending outputs to S3 bucket {output_bucket}")
-        bucket_remote_dir = output_directory.split("/")[-1]
         file_name = output_directory + "/" + filename
         bucket_name = output_bucket
-        object_name = bucket_remote_dir + "/" + output_mode + "/" + filename
+        object_name = output_directory + "/" + output_mode + "/" + filename
         s3_client = audit_session.client("s3")
         s3_client.upload_file(file_name, bucket_name, object_name)
 

--- a/prowler/providers/common/outputs.py
+++ b/prowler/providers/common/outputs.py
@@ -1,7 +1,7 @@
 import importlib
 import sys
 from dataclasses import dataclass
-from os import mkdir
+from os import makedirs
 from os.path import isdir
 
 from prowler.config.config import change_config_var, output_file_timestamp
@@ -52,7 +52,7 @@ class Provider_Output_Options:
         if arguments.output_directory:
             if not isdir(arguments.output_directory):
                 if arguments.output_modes:
-                    mkdir(arguments.output_directory)
+                    makedirs(arguments.output_directory)
 
 
 class Azure_Output_Options(Provider_Output_Options):

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 from os import path, remove
 from unittest import mock
 
@@ -337,9 +336,7 @@ class Test_Outputs:
         client.create_bucket(Bucket=bucket_name)
         # Create mock csv output file
         fixtures_dir = "fixtures"
-        output_directory = (
-            f"{pathlib.Path().absolute()}/tests/lib/outputs/{fixtures_dir}"
-        )
+        output_directory = f"tests/lib/outputs/{fixtures_dir}"
         output_mode = "csv"
         filename = f"prowler-output-{input_audit_info.audited_account}"
         # Send mock csv file to mock S3 Bucket
@@ -354,7 +351,12 @@ class Test_Outputs:
         assert (
             client.get_object(
                 Bucket=bucket_name,
-                Key=fixtures_dir + "/" + output_mode + "/" + filename + csv_file_suffix,
+                Key=output_directory
+                + "/"
+                + output_mode
+                + "/"
+                + filename
+                + csv_file_suffix,
             )["ContentType"]
             == "binary/octet-stream"
         )

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -1,5 +1,5 @@
 import os
-from os import path, remove
+from os import getcwd, path, remove
 from unittest import mock
 
 import boto3
@@ -310,6 +310,55 @@ class Test_Outputs:
 
     @mock_s3
     def test_send_to_s3_bucket(self):
+        # Create mock session
+        session = boto3.session.Session(
+            region_name="us-east-1",
+        )
+        # Create mock audit_info
+        input_audit_info = AWS_Audit_Info(
+            original_session=None,
+            audit_session=session,
+            audited_account=AWS_ACCOUNT_ID,
+            audited_identity_arn="test-arn",
+            audited_user_id="test",
+            audited_partition="aws",
+            profile="default",
+            profile_region="eu-west-1",
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["eu-west-2", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+        # Creat mock bucket
+        bucket_name = "test_bucket"
+        client = boto3.client("s3")
+        client.create_bucket(Bucket=bucket_name)
+        # Create mock csv output file
+        fixtures_dir = "tests/lib/outputs/fixtures"
+        output_directory = getcwd() + "/" + fixtures_dir
+        print(output_directory)
+        output_mode = "csv"
+        filename = f"prowler-output-{input_audit_info.audited_account}"
+        # Send mock csv file to mock S3 Bucket
+        send_to_s3_bucket(
+            filename,
+            output_directory,
+            output_mode,
+            bucket_name,
+            input_audit_info.audit_session,
+        )
+        # Check if the file has been sent by checking its content type
+        assert (
+            client.get_object(
+                Bucket=bucket_name,
+                Key=fixtures_dir + "/" + output_mode + "/" + filename + csv_file_suffix,
+            )["ContentType"]
+            == "binary/octet-stream"
+        )
+
+    @mock_s3
+    def test_send_to_s3_bucket_custom_directory(self):
         # Create mock session
         session = boto3.session.Session(
             region_name="us-east-1",

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -337,7 +337,6 @@ class Test_Outputs:
         # Create mock csv output file
         fixtures_dir = "tests/lib/outputs/fixtures"
         output_directory = getcwd() + "/" + fixtures_dir
-        print(output_directory)
         output_mode = "csv"
         filename = f"prowler-output-{input_audit_info.audited_account}"
         # Send mock csv file to mock S3 Bucket


### PR DESCRIPTION
### Description

Regarding https://github.com/prowler-cloud/prowler/issues/1850, when it comes to file upload to S3, prowler takes only the last directory in the -o option value and uses it as a key for the S3 object.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
