### PR TITLE
fix(checks): added validation for non-existing VPC endpoint policy

### DIFF
--- a/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
+++ b/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
@@ -10,7 +10,11 @@ class vpc_endpoint_connections_trust_boundaries(Check):
         trusted_account_ids = get_config_var("trusted_account_ids")
         for endpoint in vpc_client.vpc_endpoints:
             # Check VPC endpoint policy
-            for statement in endpoint.policy_document["Statement"]:
+            policy_statements = []
+            if endpoint.policy_document is not None:
+                policy_statements = endpoint.policy_document["Statement"]
+
+            for statement in policy_statements:
                 if "*" == statement["Principal"]:
                     report = Check_Report_AWS(self.metadata())
                     report.region = endpoint.region

--- a/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
+++ b/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
@@ -10,45 +10,42 @@ class vpc_endpoint_connections_trust_boundaries(Check):
         trusted_account_ids = get_config_var("trusted_account_ids")
         for endpoint in vpc_client.vpc_endpoints:
             # Check VPC endpoint policy
-            policy_statements = []
-            if endpoint.policy_document is not None:
-                policy_statements = endpoint.policy_document["Statement"]
-
-            for statement in policy_statements:
-                if "*" == statement["Principal"]:
-                    report = Check_Report_AWS(self.metadata())
-                    report.region = endpoint.region
-                    report.status = "FAIL"
-                    report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} has full access."
-                    report.resource_id = endpoint.id
-                    findings.append(report)
-                    break
-
-                else:
-                    if type(statement["Principal"]["AWS"]) == str:
-                        principals = [statement["Principal"]["AWS"]]
-                    else:
-                        principals = statement["Principal"]["AWS"]
-                    for principal_arn in principals:
+            if endpoint.policy_document:
+                for statement in endpoint.policy_document["Statement"]:
+                    if "*" == statement["Principal"]:
                         report = Check_Report_AWS(self.metadata())
                         report.region = endpoint.region
-                        if principal_arn == "*":
-                            report.status = "FAIL"
-                            report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} has full access."
-                            report.resource_id = endpoint.id
+                        report.status = "FAIL"
+                        report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} has full access."
+                        report.resource_id = endpoint.id
+                        findings.append(report)
+                        break
+
+                    else:
+                        if type(statement["Principal"]["AWS"]) == str:
+                            principals = [statement["Principal"]["AWS"]]
                         else:
-                            account_id = principal_arn.split(":")[4]
-                            if (
-                                account_id in trusted_account_ids
-                                or account_id in vpc_client.audited_account
-                            ):
-                                report.status = "PASS"
-                                report.status_extended = f"Found trusted account {account_id} in VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id}."
+                            principals = statement["Principal"]["AWS"]
+                        for principal_arn in principals:
+                            report = Check_Report_AWS(self.metadata())
+                            report.region = endpoint.region
+                            if principal_arn == "*":
+                                report.status = "FAIL"
+                                report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} has full access."
                                 report.resource_id = endpoint.id
                             else:
-                                report.status = "FAIL"
-                                report.status_extended = f"Found untrusted account {account_id} in VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id}."
-                                report.resource_id = endpoint.id
-                        findings.append(report)
+                                account_id = principal_arn.split(":")[4]
+                                if (
+                                    account_id in trusted_account_ids
+                                    or account_id in vpc_client.audited_account
+                                ):
+                                    report.status = "PASS"
+                                    report.status_extended = f"Found trusted account {account_id} in VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id}."
+                                    report.resource_id = endpoint.id
+                                else:
+                                    report.status = "FAIL"
+                                    report.status_extended = f"Found untrusted account {account_id} in VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id}."
+                                    report.resource_id = endpoint.id
+                            findings.append(report)
 
         return findings


### PR DESCRIPTION
### Context

I have just noticed the following error for one of the VPC endpoint-related checks:
```
2023-02-07 18:36:25,881 [File: check.py:307] 	[Module: check]	 ERROR: vpc_endpoint_connections_trust_boundaries -- TypeError[13]: 'NoneType' object is not subscriptable
```
I added some debug info (please see `Policy Document is equal to None, skipping the test` in the output below) and found out that some VPC endpoints do not have any policies attached to them, e.g. (some data is masked):

```
VpcEndpoint(id='vpce-034bxxxxxxx', vpc_id='vpc-xxxxxxxx', state='available', policy_document=None, owner_id='xxxxxxxxxx', region='cn-northwest-1')
Policy Document is equal to None, skipping the test
VpcEndpoint(id='vpce-0a12exxxxxx', vpc_id='vpc-xxxxxxxx', state='available', policy_document=None, owner_id='xxxxxxxxxx', region='cn-northwest-1')
Policy Document is equal to None, skipping the test
VpcEndpoint(id='vpce-0290xxxxxxxx', vpc_id='vpc-xxxxxxxx', state='available', policy_document=None, owner_id='xxxxxxxxxx', region='cn-northwest-1')
Policy Document is equal to None, skipping the test
VpcEndpoint(id='vpce-00cxxxxxxx', vpc_id='vpc-xxxxxxxx', state='available', policy_document={'Version': '2008-10-17', 'Statement': [{'Effect': 'Allow', 'Principal': '*', 'Action': '*', 'Resource': '*'}]}, owner_id='xxxxxxxxxx', region='cn-northwest-1')
```
As you can see most of the endpoints have `policy_document` set to `None` and there are no conditions for filtering out these resources.

After adding this condition, I'm able to run `./prowler.py aws -M html -c vpc_endpoint_connections_trust_boundaries --log-level ERROR` and check is able to pass for all endpoints that have policies attached and skips all others which do not have them not failing the full check.

P.S. I do not know if it's true for Non-Chinese regions and unfortunately I'm not able to check it now (I mean the structure of the object that is returned by AWS API for VPC endpoint), but I believe other regions will have the same problem so it should fix all of the regions at once.

### Description

Added condition to check if VPC Endpoint resource has any policy attached to it.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
