### PR TITLE
fix(elbv2): handle service for GWLB resources

### DIFF
--- a/prowler/providers/aws/services/elbv2/elbv2_service.py
+++ b/prowler/providers/aws/services/elbv2/elbv2_service.py
@@ -54,8 +54,9 @@ class ELBv2:
                             type=elbv2["Type"],
                             listeners=[],
                         )
-                        if elbv2["Type"] != "gateway":
+                        if "DNSName" in elbv2:
                             lb.dns = elbv2["DNSName"]
+                        if "Scheme" in elbv2:
                             lb.scheme = elbv2["Scheme"]
                         self.loadbalancersv2.append(lb)
         except Exception as error:


### PR DESCRIPTION
### Context

I noticed that prowler returns errors while processing Gateway LB:
```
2023-02-07 22:28:12,378 [File: elbv2_service.py:62]     [Module: elbv2_service]  ERROR: cn-northwest-1 -- KeyError[53]: 'DNSName'
```
It turned out that the GWLB API object does not have the `DNSName` and `Scheme` fields so I made them optional and added some conditions.

Also, GWLB listener does not have the `Protocol` field.

For some reason, `boto3` throws a `ListenerNotFound` exception while trying to get a list of listener rules for GWLB. I have raised an issue for `boto3` repo about that: https://github.com/boto/boto3/issues/3591

P.S. I'm not very experienced in writing Python tests so please feel free to add all required things to this PR.

### Description

Issues during the GWLB describe operations.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
