### PR TITLE
fix(permissive role assumption): actions list handling

### DIFF
--- a/prowler/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption.py
+++ b/prowler/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption.py
@@ -20,15 +20,26 @@ class iam_no_custom_policy_permissive_role_assumption(Check):
                 if (
                     statement["Effect"] == "Allow"
                     and "Action" in statement
-                    and (
-                        "sts:AssumeRole" in statement["Action"]
-                        or "sts:*" in statement["Action"]
-                        or "*" in statement["Action"]
-                    )
                     and "*" in statement["Resource"]
                 ):
-                    report.status = "FAIL"
-                    report.status_extended = f"Custom Policy {policy['PolicyName']} allows permissive STS Role assumption"
+                    if type(statement["Action"]) == list:
+                        for action in statement["Action"]:
+                            if (
+                                action == "sts:AssumeRole"
+                                or action == "sts:*"
+                                or action == "*"
+                            ):
+                                report.status = "FAIL"
+                                report.status_extended = f"Custom Policy {policy['PolicyName']} allows permissive STS Role assumption"
+                                break
+                    else:
+                        if (
+                            statement["Action"] == "sts:AssumeRole"
+                            or statement["Action"] == "sts:*"
+                            or statement["Action"] == "*"
+                        ):
+                            report.status = "FAIL"
+                            report.status_extended = f"Custom Policy {policy['PolicyName']} allows permissive STS Role assumption"
                     break
 
             findings.append(report)

--- a/tests/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption_test.py
+++ b/tests/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption_test.py
@@ -165,7 +165,7 @@ class Test_iam_no_custom_policy_permissive_role_assumption:
         policy_document_non_permissive = {
             "Version": "2012-10-17",
             "Statement": [
-                {"Effect": "Allow", "Action": "logs:CreateLogGroup", "Resource": "*"},
+                {"Effect": "Allow", "Action": "logs:*", "Resource": "*"},
             ],
         }
         policy_name_permissive = "policy2"


### PR DESCRIPTION
### Context

Check `iam_no_custom_policy_permissive_role_assumption` was returning false positives when `Action` section of the policy was not a list and included a `*` even if the service was not `sts`, e.g. `s3:*`


### Description

Check explicit occurrences of `*` depending on the type of `Action` statement


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
