### PR TITLE
fix(metadata): typo in appstream_fleet_session_disconnect_timeout.metadata.json

### DIFF
--- a/prowler/providers/aws/services/appstream/appstream_fleet_session_disconnect_timeout/appstream_fleet_session_disconnect_timeout.metadata.json
+++ b/prowler/providers/aws/services/appstream/appstream_fleet_session_disconnect_timeout/appstream_fleet_session_disconnect_timeout.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "appstream_fleet_session_disconnect_timeout",
-  "CheckTitle": "Ensure session disconnect timeout is set to 5 minutes or lesss.",
+  "CheckTitle": "Ensure session disconnect timeout is set to 5 minutes or less.",
   "CheckType": [
     "Software and Configuration Checks",
     "Industry and Regulatory Standards",


### PR DESCRIPTION
### Description

Fix typo in appstream_fleet_session_disconnect_timeout.metadata.json.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
