### PR TITLE
fix(cloudtrail_multi_region_enabled): reformat check

### DIFF
--- a/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_cloudtrail, mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.aws.services.cloudtrail.cloudtrail_service import Trail
 
 AWS_ACCOUNT_NUMBER = 123456789012
 
@@ -44,7 +45,6 @@ class Test_cloudtrail_multi_region_enabled:
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
         ):
-
             with mock.patch(
                 "prowler.providers.aws.services.cloudtrail.cloudtrail_multi_region_enabled.cloudtrail_multi_region_enabled.cloudtrail_client",
                 new=Cloudtrail(current_audit_info),
@@ -99,7 +99,6 @@ class Test_cloudtrail_multi_region_enabled:
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
         ):
-
             with mock.patch(
                 "prowler.providers.aws.services.cloudtrail.cloudtrail_multi_region_enabled.cloudtrail_multi_region_enabled.cloudtrail_client",
                 new=Cloudtrail(current_audit_info),
@@ -185,3 +184,98 @@ class Test_cloudtrail_multi_region_enabled:
                         )
                         assert report.resource_id == "No trails"
                         assert report.resource_arn == "No trails"
+
+    @mock_cloudtrail
+    @mock_s3
+    def test_trail_multiregion_logging_and_single_region_not_login(self):
+        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        cloudtrail_client_eu_west_1 = client("cloudtrail", region_name="eu-west-1")
+        s3_client_eu_west_1 = client("s3", region_name="eu-west-1")
+        trail_name_us = "trail_test_us"
+        bucket_name_us = "bucket_test_us"
+        trail_name_eu = "aaaaa"
+        bucket_name_eu = "bucket_test_eu"
+        s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
+        s3_client_eu_west_1.create_bucket(
+            Bucket=bucket_name_eu,
+            CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+        )
+        trail_us = cloudtrail_client_us_east_1.create_trail(
+            Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=True
+        )
+        cloudtrail_client_eu_west_1.create_trail(
+            Name=trail_name_eu, S3BucketName=bucket_name_eu, IsMultiRegionTrail=False
+        )
+        _ = cloudtrail_client_us_east_1.start_logging(Name=trail_name_us)
+        _ = cloudtrail_client_us_east_1.get_trail_status(Name=trail_name_us)
+
+        from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
+            Cloudtrail,
+        )
+
+        current_audit_info = self.set_mocked_audit_info()
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.cloudtrail.cloudtrail_multi_region_enabled.cloudtrail_multi_region_enabled.cloudtrail_client",
+                new=Cloudtrail(current_audit_info),
+            ) as cloudtrail_client:
+                # Test Check
+                from prowler.providers.aws.services.cloudtrail.cloudtrail_multi_region_enabled.cloudtrail_multi_region_enabled import (
+                    cloudtrail_multi_region_enabled,
+                )
+
+                ##############################################################################################################
+                # Only until moto issue is solved (Right now is not getting shadow us-east-1 trail status in eu-west-1 region)
+                cloudtrail_client.trails = [
+                    Trail(
+                        name=trail_name_us,
+                        is_multiregion=True,
+                        home_region="us-east-1",
+                        arn=trail_us["TrailARN"],
+                        region="us-east-1",
+                        is_logging=True,
+                    ),
+                    Trail(
+                        name=trail_name_eu,
+                        is_multiregion=False,
+                        home_region="eu-west-1",
+                        arn="",
+                        region="eu-west-1",
+                        is_logging=False,
+                    ),
+                    Trail(
+                        name=trail_name_us,
+                        is_multiregion=True,
+                        home_region="us-east-1",
+                        arn=trail_us["TrailARN"],
+                        region="eu-west-1",
+                        is_logging=True,
+                    ),
+                ]
+                ##############################################################################################################
+
+                check = cloudtrail_multi_region_enabled()
+                result = check.execute()
+                assert len(result) == len(current_audit_info.audited_regions)
+                for report in result:
+                    if report.region == "us-east-1":
+                        assert report.status == "PASS"
+                        assert search(
+                            f"Trail {trail_name_us} is multiregion and it is logging",
+                            report.status_extended,
+                        )
+                        assert report.resource_id == trail_name_us
+                        assert report.resource_arn == trail_us["TrailARN"]
+                    elif report.region == "eu-west-1":
+                        assert report.status == "PASS"
+                        assert search(
+                            f"Trail {trail_name_us} is multiregion and it is logging",
+                            report.status_extended,
+                        )
+                        assert report.resource_id == trail_name_us
+                        assert report.resource_arn == trail_us["TrailARN"]


### PR DESCRIPTION
### Context

Check `cloudtrail_multi_region_enabled` was generating a false negative under certain circunstancies ( multiregion trail created in one region logging, non-logging single region trail in another region with name alphabetically earlier than multiregion trail's name)


### Description

Reformat check code to take into account all the cases


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
