### PR TITLE
docs: Boto3 Standard Retrier

### DIFF
--- a/docs/tutorials/aws/boto3-configuration.md
+++ b/docs/tutorials/aws/boto3-configuration.md
@@ -1,0 +1,31 @@
+# Boto3 Retrier Configuration
+
+Prowler's AWS Provider uses the Boto3 [Standard](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html) retry mode to assist in retrying client calls to AWS services when these kinds of errors or exceptions are experienced. This mode includes the following behaviours:
+- A default value of 3 for maximum retry attempts. This can be override with the `--aws-retries-max-attempts` argument.
+- Retry attempts for an expanded list of errors/exceptions:
+    ```
+    # Transient errors/exceptions
+    RequestTimeout
+    RequestTimeoutException
+    PriorRequestNotComplete
+    ConnectionError
+    HTTPClientError
+
+    # Service-side throttling/limit errors and exceptions
+    Throttling
+    ThrottlingException
+    ThrottledException
+    RequestThrottledException
+    TooManyRequestsException
+    ProvisionedThroughputExceededException
+    TransactionInProgressException
+    RequestLimitExceeded
+    BandwidthLimitExceeded
+    LimitExceededException
+    RequestThrottled
+    SlowDown
+    EC2ThrottledException
+    ```
+- Retry attempts on nondescriptive, transient error codes. Specifically, these HTTP status codes: 500, 502, 503, 504.
+
+- Any retry attempt will include an exponential backoff by a base factor of 2 for a maximum backoff time of 20 seconds.

--- a/docs/tutorials/aws/boto3-configuration.md
+++ b/docs/tutorials/aws/boto3-configuration.md
@@ -1,7 +1,7 @@
 # Boto3 Retrier Configuration
 
 Prowler's AWS Provider uses the Boto3 [Standard](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html) retry mode to assist in retrying client calls to AWS services when these kinds of errors or exceptions are experienced. This mode includes the following behaviours:
-- A default value of 3 for maximum retry attempts. This can be override with the `--aws-retries-max-attempts` argument.
+- A default value of 3 for maximum retry attempts. This can be overwritten with the `--aws-retries-max-attempts 5` argument.
 - Retry attempts for an expanded list of errors/exceptions:
     ```
     # Transient errors/exceptions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,19 +25,19 @@ repo_url: https://github.com/prowler-cloud/prowler/
 repo_name: prowler-cloud/prowler
 
 nav:
-    - Getting Started:
-        - Overview: index.md
-        - Requirements: getting-started/requirements.md
-    - Tutorials:
-        - Miscellaneous: tutorials/misc.md
-        - Reporting: tutorials/reporting.md
-        - Compliance: tutorials/compliance.md
-        - Quick Inventory: tutorials/quick-inventory.md
-        - Configuration File: tutorials/configuration_file.md
-        - Logging: tutorials/logging.md
-        - Allowlist: tutorials/allowlist.md
-        - Pentesting: tutorials/pentesting.md
-        - AWS:
+  - Getting Started:
+      - Overview: index.md
+      - Requirements: getting-started/requirements.md
+  - Tutorials:
+      - Miscellaneous: tutorials/misc.md
+      - Reporting: tutorials/reporting.md
+      - Compliance: tutorials/compliance.md
+      - Quick Inventory: tutorials/quick-inventory.md
+      - Configuration File: tutorials/configuration_file.md
+      - Logging: tutorials/logging.md
+      - Allowlist: tutorials/allowlist.md
+      - Pentesting: tutorials/pentesting.md
+      - AWS:
           - Assume Role: tutorials/aws/role-assumption.md
           - AWS Security Hub: tutorials/aws/securityhub.md
           - AWS Organizations: tutorials/aws/organizations.md
@@ -46,14 +46,15 @@ nav:
           - Checks v2 to v3 Mapping: tutorials/aws/v2_to_v3_checks_mapping.md
           - Tag-based Scan: tutorials/aws/tag-based-scan.md
           - Resource ARNs based Scan: tutorials/aws/resource-arn-based-scan.md
-        - Azure:
+          - Boto3 Configuration: tutorials/aws/boto3-configuration.md
+      - Azure:
           - Authentication: tutorials/azure/authentication.md
           - Subscriptions: tutorials/azure/subscriptions.md
-    - Security: security.md
-    - Contact Us: contact.md
-    - Troubleshooting: troubleshooting.md
-    - About: about.md
-    - ProwlerPro: https://prowler.pro
+  - Security: security.md
+  - Contact Us: contact.md
+  - Troubleshooting: troubleshooting.md
+  - About: about.md
+  - ProwlerPro: https://prowler.pro
 # Customization
 extra:
   consent:


### PR DESCRIPTION
### Description

Document the Boto3 Standard Retrier and the new `--aws-retries-max-attempts` argument.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
