### PR TITLE
fix(list_checks): arn filtering checks after audit_info set

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -7,10 +7,10 @@ from prowler.lib.banner import print_banner
 from prowler.lib.check.check import (
     bulk_load_checks_metadata,
     bulk_load_compliance_frameworks,
-    exclude_checks_from_input_arn,
     exclude_checks_to_run,
     exclude_services_to_run,
     execute_checks,
+    get_checks_from_input_arn,
     list_categories,
     list_services,
     print_categories,
@@ -136,7 +136,7 @@ def prowler():
 
     # Once the audit_info is set and we have the eventual checks from arn, it is time to exclude the others
     if audit_info.audit_resources:
-        checks_to_execute = exclude_checks_from_input_arn(
+        checks_to_execute = get_checks_from_input_arn(
             audit_info.audit_resources, provider
         )
 

--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -7,6 +7,7 @@ from prowler.lib.banner import print_banner
 from prowler.lib.check.check import (
     bulk_load_checks_metadata,
     bulk_load_compliance_frameworks,
+    exclude_checks_from_input_arn,
     exclude_checks_to_run,
     exclude_services_to_run,
     execute_checks,
@@ -99,9 +100,6 @@ def prowler():
             )
             sys.exit()
 
-    # Set the audit info based on the selected provider
-    audit_info = set_provider_audit_info(provider, args.__dict__)
-
     # Load checks to execute
     checks_to_execute = load_checks_to_execute(
         bulk_checks_metadata,
@@ -113,7 +111,6 @@ def prowler():
         compliance_framework,
         categories,
         provider,
-        audit_info,
     )
 
     # Exclude checks if -e/--excluded-checks
@@ -133,6 +130,14 @@ def prowler():
     if args.list_checks:
         print_checks(provider, checks_to_execute, bulk_checks_metadata)
         sys.exit()
+
+    # Set the audit info based on the selected provider
+    audit_info = set_provider_audit_info(provider, args.__dict__)
+
+    # Once the audit_info is set and we have the eventual checks from arn, it is time to exclude the others
+    checks_to_execute = exclude_checks_from_input_arn(
+        checks_to_execute, audit_info.audit_resources, provider
+    )
 
     # Parse content from Allowlist file and get it, if necessary, from S3
     if provider == "aws" and args.allowlist_file:

--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -135,9 +135,10 @@ def prowler():
     audit_info = set_provider_audit_info(provider, args.__dict__)
 
     # Once the audit_info is set and we have the eventual checks from arn, it is time to exclude the others
-    checks_to_execute = exclude_checks_from_input_arn(
-        checks_to_execute, audit_info.audit_resources, provider
-    )
+    if audit_info.audit_resources:
+        checks_to_execute = exclude_checks_from_input_arn(
+            audit_info.audit_resources, provider
+        )
 
     # Parse content from Allowlist file and get it, if necessary, from S3
     if provider == "aws" and args.allowlist_file:

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -350,7 +350,6 @@ def execute_checks(
 
             # If check does not exists in the provider or is from another provider
             except ModuleNotFoundError:
-
                 logger.critical(
                     f"Check '{check_name}' was not found for the {provider.upper()} provider"
                 )
@@ -460,3 +459,51 @@ def update_audit_metadata(
         logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
+
+
+def recover_checks_from_service(service_list: list, provider: str) -> list:
+    checks = set()
+    for service in service_list:
+        modules = recover_checks_from_provider(provider, service)
+        if not modules:
+            logger.error(f"Service '{service}' does not have checks.")
+
+        else:
+            for check_module in modules:
+                # Recover check name and module name from import path
+                # Format: "providers.{provider}.services.{service}.{check_name}.{check_name}"
+                check_name = check_module[0].split(".")[-1]
+                # If the service is present in the group list passed as parameters
+                # if service_name in group_list: checks_from_arn.add(check_name)
+                checks.add(check_name)
+    return checks
+
+
+def exclude_checks_from_input_arn(
+    checks_to_execute: set, audit_resources: list, provider: str
+) -> set:
+    checks_from_arn = set()
+    # Handle if there are audit resources so only their services are executed
+    if audit_resources:
+        service_list = []
+        for resource in audit_resources:
+            service = resource.split(":")[2]
+            # Parse services when they are different in the ARNs
+            if service == "lambda":
+                service = "awslambda"
+            if service == "elasticloadbalancing":
+                service = "elb"
+            elif service == "logs":
+                service = "cloudwatch"
+            service_list.append(service)
+
+        checks_from_arn = recover_checks_from_service(service_list, provider)
+        # Time to iterate over the general loaded checks to exclude those that don't match the input options
+        # The copy is needed since you cant change the size of the set while iterating over it
+        # Changes will be done on original set
+        for check in checks_to_execute.copy():
+            if check not in checks_from_arn:
+                checks_to_execute.remove(check)
+
+    # Return final checks list
+    return checks_to_execute

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -480,6 +480,7 @@ def recover_checks_from_service(service_list: list, provider: str) -> list:
 
 
 def exclude_checks_from_input_arn(audit_resources: list, provider: str) -> set:
+    """exclude_checks_from_input_arn gets the list of checks from the input arns"""
     checks_from_arn = set()
     # Handle if there are audit resources so only their services are executed
     if audit_resources:

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -479,8 +479,8 @@ def recover_checks_from_service(service_list: list, provider: str) -> list:
     return checks
 
 
-def exclude_checks_from_input_arn(audit_resources: list, provider: str) -> set:
-    """exclude_checks_from_input_arn gets the list of checks from the input arns"""
+def get_checks_from_input_arn(audit_resources: list, provider: str) -> set:
+    """get_checks_from_input_arn gets the list of checks from the input arns"""
     checks_from_arn = set()
     # Handle if there are audit resources so only their services are executed
     if audit_resources:

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -479,9 +479,7 @@ def recover_checks_from_service(service_list: list, provider: str) -> list:
     return checks
 
 
-def exclude_checks_from_input_arn(
-    checks_to_execute: set, audit_resources: list, provider: str
-) -> set:
+def exclude_checks_from_input_arn(audit_resources: list, provider: str) -> set:
     checks_from_arn = set()
     # Handle if there are audit resources so only their services are executed
     if audit_resources:
@@ -498,12 +496,6 @@ def exclude_checks_from_input_arn(
             service_list.append(service)
 
         checks_from_arn = recover_checks_from_service(service_list, provider)
-        # Time to iterate over the general loaded checks to exclude those that don't match the input options
-        # The copy is needed since you cant change the size of the set while iterating over it
-        # Changes will be done on original set
-        for check in checks_to_execute.copy():
-            if check not in checks_from_arn:
-                checks_to_execute.remove(check)
 
     # Return final checks list
-    return checks_to_execute
+    return checks_from_arn

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -6,9 +6,9 @@ from pkgutil import ModuleInfo
 from mock import patch
 
 from prowler.lib.check.check import (
-    exclude_checks_from_input_arn,
     exclude_checks_to_run,
     exclude_services_to_run,
+    get_checks_from_input_arn,
     list_modules,
     list_services,
     parse_checks_from_file,
@@ -285,7 +285,7 @@ class Test_Check:
         "prowler.lib.check.check.recover_checks_from_provider",
         new=mock_recover_checks_from_aws_provider_lambda_service,
     )
-    def test_exclude_checks_from_input_arn(self):
+    def test_get_checks_from_input_arn(self):
         audit_resources = ["arn:aws:lambda:us-east-1:123456789:function:test-lambda"]
         provider = "aws"
         expected_checks = {
@@ -293,7 +293,7 @@ class Test_Check:
             "awslambda_function_invoke_api_operations_cloudtrail_logging_enabled",
             "awslambda_function_no_secrets_in_code",
         }
-        recovered_checks = exclude_checks_from_input_arn(audit_resources, provider)
+        recovered_checks = get_checks_from_input_arn(audit_resources, provider)
         assert recovered_checks == expected_checks
 
     # def test_parse_checks_from_compliance_framework_two(self):

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -286,13 +286,6 @@ class Test_Check:
         new=mock_recover_checks_from_aws_provider_lambda_service,
     )
     def test_exclude_checks_from_input_arn(self):
-        checks_to_execute = {
-            "accessanalyzer_enabled_without_findings",
-            "awslambda_function_url_cors_policy",
-            "ec2_securitygroup_allow_ingress_from_internet_to_any_port",
-            "awslambda_function_invoke_api_operations_cloudtrail_logging_enabled",
-            "awslambda_function_no_secrets_in_code",
-        }
         audit_resources = ["arn:aws:lambda:us-east-1:123456789:function:test-lambda"]
         provider = "aws"
         expected_checks = {
@@ -300,9 +293,7 @@ class Test_Check:
             "awslambda_function_invoke_api_operations_cloudtrail_logging_enabled",
             "awslambda_function_no_secrets_in_code",
         }
-        recovered_checks = exclude_checks_from_input_arn(
-            checks_to_execute, audit_resources, provider
-        )
+        recovered_checks = exclude_checks_from_input_arn(audit_resources, provider)
         assert recovered_checks == expected_checks
 
     # def test_parse_checks_from_compliance_framework_two(self):


### PR DESCRIPTION
### Context

With the inclusion of the input arn resource filtering feature some unauthenticated old features were not working, asking for credentials.

### Description

Exclude checks using arn filtering after `audit_info` has been set


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
