### PR TITLE
fix(Azure_Audit_Info): Added audited_resources field

### DIFF
--- a/prowler/providers/azure/lib/audit_info/audit_info.py
+++ b/prowler/providers/azure/lib/audit_info/audit_info.py
@@ -4,5 +4,8 @@ from prowler.providers.azure.lib.audit_info.models import (
 )
 
 azure_audit_info = Azure_Audit_Info(
-    credentials=None, identity=Azure_Identity_Info(), audit_metadata=None
+    credentials=None,
+    identity=Azure_Identity_Info(),
+    audit_resources=None,
+    audit_metadata=None,
 )

--- a/prowler/providers/azure/lib/audit_info/models.py
+++ b/prowler/providers/azure/lib/audit_info/models.py
@@ -17,9 +17,11 @@ class Azure_Identity_Info(BaseModel):
 class Azure_Audit_Info:
     credentials: DefaultAzureCredential
     identity: Azure_Identity_Info
+    audit_resources: Optional[Any]
     audit_metadata: Optional[Any]
 
-    def __init__(self, credentials, identity, audit_metadata):
+    def __init__(self, credentials, identity, audit_metadata, audit_resources):
         self.credentials = credentials
         self.identity = identity
         self.audit_metadata = audit_metadata
+        self.audit_resources = audit_resources

--- a/tests/providers/common/audit_info_test.py
+++ b/tests/providers/common/audit_info_test.py
@@ -44,7 +44,10 @@ mock_current_audit_info = AWS_Audit_Info(
 )
 
 mock_azure_audit_info = Azure_Audit_Info(
-    credentials=None, identity=Azure_Identity_Info(), audit_metadata=None
+    credentials=None,
+    identity=Azure_Identity_Info(),
+    audit_metadata=None,
+    audit_resources=None,
 )
 
 mock_set_audit_info = Audit_Info()

--- a/tests/providers/common/common_outputs_test.py
+++ b/tests/providers/common/common_outputs_test.py
@@ -31,7 +31,10 @@ class Test_Common_Output_Options:
     # Mocked Azure Audit Info
     def set_mocked_azure_audit_info(self):
         audit_info = Azure_Audit_Info(
-            credentials=None, identity=Azure_Identity_Info(), audit_metadata=None
+            credentials=None,
+            identity=Azure_Identity_Info(),
+            audit_metadata=None,
+            audit_resources=None,
         )
         return audit_info
 


### PR DESCRIPTION
### Context

The inclusion of the field `audit_resources` into the `AWS_Audit_Info` was breaking Azure provider internal working since it was not included into `Azure_Audit_Info` object

### Description

Include the field `audit_resources` into `Azure_Audit_Info` object

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
