### PR TITLE
fix(iam-credentials-expiration): IAM password policy expires passwords fix

### DIFF
--- a/prowler/providers/aws/services/iam/iam_password_policy_expires_passwords_within_90_days_or_less/iam_password_policy_expires_passwords_within_90_days_or_less.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_expires_passwords_within_90_days_or_less/iam_password_policy_expires_passwords_within_90_days_or_less.py
@@ -12,7 +12,7 @@ class iam_password_policy_expires_passwords_within_90_days_or_less(Check):
         if iam_client.password_policy:
             # Check if password policy expiration exists
             if iam_client.password_policy.max_age:
-                if iam_client.password_policy.max_age < 90:
+                if iam_client.password_policy.max_age <= 90:
                     report.status = "PASS"
                     report.status_extended = f"Password expiration is set lower than 90 days ({iam_client.password_policy.max_age} days)."
                 else:

--- a/tests/providers/aws/services/iam/iam_password_policy_expires_passwords_within_90_days_or_less/iam_password_policy_expires_passwords_within_90_days_or_less_test.py
+++ b/tests/providers/aws/services/iam/iam_password_policy_expires_passwords_within_90_days_or_less/iam_password_policy_expires_passwords_within_90_days_or_less_test.py
@@ -72,3 +72,37 @@ class Test_iam_password_policy_expires_passwords_within_90_days_or_less:
                 "Password expiration is set greater than 90 days",
                 result[0].status_extended,
             )
+
+    @mock_iam
+    def test_password_expiration_just_90(self):
+        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
+        from prowler.providers.aws.services.iam.iam_service import IAM, PasswordPolicy
+
+        with mock.patch(
+            "prowler.providers.aws.services.iam.iam_password_policy_expires_passwords_within_90_days_or_less.iam_password_policy_expires_passwords_within_90_days_or_less.iam_client",
+            new=IAM(current_audit_info),
+        ) as service_client:
+            from prowler.providers.aws.services.iam.iam_password_policy_expires_passwords_within_90_days_or_less.iam_password_policy_expires_passwords_within_90_days_or_less import (
+                iam_password_policy_expires_passwords_within_90_days_or_less,
+            )
+
+            service_client.password_policy = PasswordPolicy(
+                length=10,
+                symbols=True,
+                numbers=True,
+                uppercase=True,
+                lowercase=True,
+                allow_change=True,
+                expiration=True,
+                max_age=90,
+                reuse_prevention=2,
+                hard_expiry=True,
+            )
+            check = iam_password_policy_expires_passwords_within_90_days_or_less()
+            result = check.execute()
+            assert result[0].status == "PASS"
+            assert result[0].resource_id == "password_policy"
+            assert search(
+                "Password expiration is set lower than 90 days",
+                result[0].status_extended,
+            )


### PR DESCRIPTION
### Context

Currently if a password policy is set to expire after 90 days it will fail this check even though the recommendation Says to set it to 90 or less. `Ensure Password expiration period (in days): is set to 90 or less.` With this change 90 days will pass the check


### Description

Made the check `<= 90` instead of `< 90`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
