### PR TITLE
chore(security hub): add --skip-sh-update

### DIFF
--- a/docs/tutorials/aws/securityhub.md
+++ b/docs/tutorials/aws/securityhub.md
@@ -36,3 +36,12 @@ or for only one filtered region like eu-west-1:
 Once you run findings for first time you will be able to see Prowler findings in Findings section:
 
 ![Screenshot 2020-10-29 at 10 29 05 PM](https://user-images.githubusercontent.com/3985464/97634676-66c9f600-1a36-11eb-9341-70feb06f6331.png)
+
+## Skip sending updates of findings to Security Hub
+
+By default, Prowler archives all its findings in Security Hub that have not appeared in the last scan.
+You can skip this logic by using the option `--skip-sh-update` so Prowler will not archive older findings:
+
+```sh
+./prowler -S --skip-sh-update
+```

--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -203,7 +203,7 @@ def prowler():
                 )
 
     # Resolve previous fails of Security Hub
-    if provider == "aws" and args.security_hub:
+    if provider == "aws" and args.security_hub and not args.skip_sh_update:
         resolve_security_hub_previous_findings(args.output_directory, audit_info)
 
     # Display summary table

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -316,6 +316,11 @@ Detailed documentation at https://docs.prowler.cloud
             action="store_true",
             help="Send check output to AWS Security Hub",
         )
+        aws_security_hub_subparser.add_argument(
+            "--skip-sh-update",
+            action="store_true",
+            help="Skip updating previous findings of Prowler in Security Hub",
+        )
         # AWS Quick Inventory
         aws_quick_inventory_subparser = aws_parser.add_argument_group("Quick Inventory")
         aws_quick_inventory_subparser.add_argument(

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -738,6 +738,12 @@ class Test_Parser:
         parsed = self.parser.parse(command)
         assert parsed.security_hub
 
+    def test_aws_parser_skip_sh_update(self):
+        argument = "--skip-sh-update"
+        command = [prowler_command, argument]
+        parsed = self.parser.parse(command)
+        assert parsed.skip_sh_update
+
     def test_aws_parser_quick_inventory_short(self):
         argument = "-i"
         command = [prowler_command, argument]


### PR DESCRIPTION
### Description

Regarding https://github.com/prowler-cloud/prowler/issues/1867, allow users to skip updates of previous Security Hub findings of Prowler.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
