### PR TITLE
fix(ecs_task_definitions_no_environment_secrets): dump_env_vars is reintialised

### DIFF
--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
@@ -20,8 +20,8 @@ class ecs_task_definitions_no_environment_secrets(Check):
             report.status = "PASS"
             report.status_extended = f"No secrets found in variables of ECS task definition {task_definition.name} with revision {task_definition.revision}"
             if task_definition.environment_variables:
+                dump_env_vars = {}
                 for env_var in task_definition.environment_variables:
-                    dump_env_vars = {}
                     dump_env_vars.update({env_var.name: env_var.value})
 
                 temp_env_data_file = tempfile.NamedTemporaryFile(delete=False)


### PR DESCRIPTION
Fixed a bug on how the environment variables were being stored in dump_env_vars before the they written to disk


### Context

Fixed a bug in the ecs_task_definitions_no_environment_secrets check


### Description

Confirmed through debugging that the dump_env_vars dict was being reintialised each time it went through the for loop, so the check would only run detect_secrets against the last env_var


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
