### PR TITLE
fix(quick_inventory): handle ApiGateway resources

### DIFF
--- a/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
+++ b/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
@@ -143,6 +143,14 @@ def create_inventory_table(resources: list) -> dict:
             resource_type = "topic"
         elif service == "sqs":
             resource_type = "queue"
+        elif service == "apigateway":
+            split_parts = resource.split(":")[5].split("/")
+            if "integration" in split_parts and "responses" in split_parts: 
+                resource_type = "restapis-resources-methods-integration-response"
+            elif "documentation" in split_parts and "parts" in split_parts:
+                resource_type = "restapis-documentation-parts"
+            else:
+                resource_type = resource.split(":")[5].split("/")[1]
         else:
             resource_type = resource.split(":")[5].split("/")[0]
         if service not in resources_type:

--- a/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
+++ b/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
@@ -50,7 +50,6 @@ def quick_inventory(audit_info: AWS_Audit_Info, output_directory: str):
                     or region == "us-gov-west-1"
                     or region == "cn-north-1"
                 ):
-
                     get_roles_paginator = iam_client.get_paginator("list_roles")
                     for page in get_roles_paginator.paginate():
                         for role in page["Roles"]:
@@ -117,7 +116,6 @@ def quick_inventory(audit_info: AWS_Audit_Info, output_directory: str):
 
 
 def create_inventory_table(resources: list) -> dict:
-
     services = {}
     # { "S3":
     #       123,
@@ -145,7 +143,7 @@ def create_inventory_table(resources: list) -> dict:
             resource_type = "queue"
         elif service == "apigateway":
             split_parts = resource.split(":")[5].split("/")
-            if "integration" in split_parts and "responses" in split_parts: 
+            if "integration" in split_parts and "responses" in split_parts:
                 resource_type = "restapis-resources-methods-integration-response"
             elif "documentation" in split_parts and "parts" in split_parts:
                 resource_type = "restapis-documentation-parts"
@@ -179,7 +177,6 @@ def create_inventory_table(resources: list) -> dict:
 
 
 def create_output(resources: list, audit_info: AWS_Audit_Info, output_directory: str):
-
     json_output = []
     output_file = f"{output_directory}/prowler-inventory-{audit_info.audited_account}-{output_file_timestamp}"
 


### PR DESCRIPTION
### Context

Fixed the resource type for apigateway

### Description

Annoyingly, the ARNs for API gateway don't conform to the same standard of every other ARN. They do not follow the last colon, and come before the first slash.
IE
-  `arn:${Partition}:apigateway:${Region}::/restapis`
-  `arn:${Partition}:apigateway:${Region}::/restapis/${RestApiId}/stages/${StageName}` 

Here is the [docs](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonapigatewaymanagement.html), look under "Resource types defined by Amazon API Gateway Management"

The way that I have done it is that it takes every 2nd part of the arn after it is split using '/', and constructs the resource type from that. 
- `arn:${Partition}:apigateway:${Region}::/restapis/${RestApiId}/stages/${StageName}`  -> `restapis-stages`
- `arn:${Partition}:apigateway:${Region}::/restapis` -> `restapis`
- `arn:${Partition}:apigateway:${Region}::/domainnames/${DomainName}/basepathmappings/${BasePath}`  -> `domainnames-basepathmappings`
 
 I don't really see a better way of doing it besides creating a mapping just for apigateway to get the correct resource type.
 
 It worked fine in the environment I currently have access to, but when I was double checking the ARNs defined in the above docs I realised there are these two anomalies that weren't in my current environmen:
 -  `arn:${Partition}:apigateway:${Region}::/restapis/${RestApiId}/documentation/parts/${DocumentationPartId} `
 The resource type would come out as `restapis-documentation-[DocumentationPartId] `
-  `arn:${Partition}:apigateway:${Region}::/restapis/${RestApiId}/resources/${ResourceId}/methods/${HttpMethodType}/integration/responses/${StatusCode}`
The resource type would come out as `restapis-resources-methods-integration-[StatusCode]`

So I added two `if` statements to handle these two cases.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
