### PR TITLE
fix(iam_rotate_access_key_90_days): check only active access keys

### DIFF
--- a/prowler/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.py
+++ b/prowler/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.py
@@ -26,7 +26,7 @@ class iam_rotate_access_key_90_days(Check):
                 )
             else:
                 old_access_keys = False
-                if user["access_key_1_last_rotated"] != "N/A":
+                if user["access_key_1_last_rotated"] != "N/A" and user["access_key_1_active"] == "true":
                     access_key_1_last_rotated = (
                         datetime.datetime.now()
                         - datetime.datetime.strptime(
@@ -38,7 +38,7 @@ class iam_rotate_access_key_90_days(Check):
                         old_access_keys = True
                         report.status = "FAIL"
                         report.status_extended = f"User {user['user']} has not rotated access key 1 in over 90 days ({access_key_1_last_rotated.days} days)."
-                if user["access_key_2_last_rotated"] != "N/A":
+                if user["access_key_2_last_rotated"] != "N/A" and user["access_key_2_active"] == "true":
                     access_key_2_last_rotated = (
                         datetime.datetime.now()
                         - datetime.datetime.strptime(

--- a/prowler/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.py
+++ b/prowler/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days.py
@@ -26,7 +26,10 @@ class iam_rotate_access_key_90_days(Check):
                 )
             else:
                 old_access_keys = False
-                if user["access_key_1_last_rotated"] != "N/A" and user["access_key_1_active"] == "true":
+                if (
+                    user["access_key_1_last_rotated"] != "N/A"
+                    and user["access_key_1_active"] == "true"
+                ):
                     access_key_1_last_rotated = (
                         datetime.datetime.now()
                         - datetime.datetime.strptime(
@@ -38,7 +41,10 @@ class iam_rotate_access_key_90_days(Check):
                         old_access_keys = True
                         report.status = "FAIL"
                         report.status_extended = f"User {user['user']} has not rotated access key 1 in over 90 days ({access_key_1_last_rotated.days} days)."
-                if user["access_key_2_last_rotated"] != "N/A" and user["access_key_2_active"] == "true":
+                if (
+                    user["access_key_2_last_rotated"] != "N/A"
+                    and user["access_key_2_active"] == "true"
+                ):
                     access_key_2_last_rotated = (
                         datetime.datetime.now()
                         - datetime.datetime.strptime(

--- a/tests/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days_test.py
+++ b/tests/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days_test.py
@@ -59,6 +59,7 @@ class Test_iam_rotate_access_key_90_days_test:
                 iam_rotate_access_key_90_days,
             )
 
+            service_client.credential_report[0]["access_key_1_active"] = "true"
             service_client.credential_report[0][
                 "access_key_1_last_rotated"
             ] = credentials_last_rotated
@@ -95,6 +96,7 @@ class Test_iam_rotate_access_key_90_days_test:
                 iam_rotate_access_key_90_days,
             )
 
+            service_client.credential_report[0]["access_key_2_active"] = "true"
             service_client.credential_report[0][
                 "access_key_2_last_rotated"
             ] = credentials_last_rotated


### PR DESCRIPTION
Updated the check to only report on access keys that haven't been rotated and are active

### Context

I was confused as to why the check for if the root user has access keys had passed, but the check for rotating the access key had failed for the root user. Turns out the rotation check doesn't check that the key is active before reporting on it. Not sure if the check should or shouldn't report on rotating inactive keys, but to minimize false-positives I thought I would make this update.

The other checks for rotations after different amounts of days should also change depending on if this is accepted.

### Description

Included an and statement to check if the key is active
Example values for `access_key_1_active`:
- `'access_key_1_active': 'true'` 
- `'access_key_1_active': 'false'`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
