### PR TITLE
fix(metadata): remove `us-east-1` in remediation

### DIFF
--- a/prowler/providers/aws/services/cloudformation/cloudformation_stacks_termination_protection_enabled/cloudformation_stacks_termination_protection_enabled.metadata.json
+++ b/prowler/providers/aws/services/cloudformation/cloudformation_stacks_termination_protection_enabled/cloudformation_stacks_termination_protection_enabled.metadata.json
@@ -13,7 +13,7 @@
   "RelatedUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-protect-stacks.html",
   "Remediation": {
     "Code": {
-      "CLI": "aws cloudformation update-termination-protection --region us-east-1 --stack-name <STACK_NAME> --enable-termination-protection",
+      "CLI": "aws cloudformation update-termination-protection --region <REGION_NAME> --stack-name <STACK_NAME> --enable-termination-protection",
       "NativeIaC": "",
       "Other": "",
       "Terraform": ""


### PR DESCRIPTION
### Description

Regarding https://github.com/prowler-cloud/prowler/issues/1944,  remove `us-east-1` in remediation.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
