### PR TITLE
fix(cloudfront): handle empty objects in checks

### DIFF
--- a/prowler/providers/aws/services/cloudfront/cloudfront_distributions_field_level_encryption_enabled/cloudfront_distributions_field_level_encryption_enabled.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_distributions_field_level_encryption_enabled/cloudfront_distributions_field_level_encryption_enabled.py
@@ -12,7 +12,10 @@ class cloudfront_distributions_field_level_encryption_enabled(Check):
             report.region = distribution.region
             report.resource_arn = distribution.arn
             report.resource_id = distribution.id
-            if distribution.default_cache_config.field_level_encryption_id:
+            if (
+                distribution.default_cache_config
+                and distribution.default_cache_config.field_level_encryption_id
+            ):
                 report.status = "PASS"
                 report.status_extended = f"CloudFront Distribution {distribution.id} has Field Level Encryption enabled"
             else:

--- a/prowler/providers/aws/services/cloudfront/cloudfront_distributions_https_enabled/cloudfront_distributions_https_enabled.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_distributions_https_enabled/cloudfront_distributions_https_enabled.py
@@ -16,13 +16,15 @@ class cloudfront_distributions_https_enabled(Check):
             report.resource_arn = distribution.arn
             report.resource_id = distribution.id
             if (
-                distribution.default_cache_config.viewer_protocol_policy
+                distribution.default_cache_config
+                and distribution.default_cache_config.viewer_protocol_policy
                 == ViewerProtocolPolicy.allow_all
             ):
                 report.status = "FAIL"
                 report.status_extended = f"CloudFront Distribution {distribution.id} viewers can use HTTP or HTTPS"
             elif (
-                distribution.default_cache_config.viewer_protocol_policy
+                distribution.default_cache_config
+                and distribution.default_cache_config.viewer_protocol_policy
                 == ViewerProtocolPolicy.redirect_to_https
             ):
                 report.status = "PASS"
@@ -30,7 +32,8 @@ class cloudfront_distributions_https_enabled(Check):
                     f"CloudFront Distribution {distribution.id} has redirect to HTTPS"
                 )
             elif (
-                distribution.default_cache_config.viewer_protocol_policy
+                distribution.default_cache_config
+                and distribution.default_cache_config.viewer_protocol_policy
                 == ViewerProtocolPolicy.https_only
             ):
                 report.status = "PASS"

--- a/prowler/providers/aws/services/cloudfront/cloudfront_distributions_logging_enabled/cloudfront_distributions_logging_enabled.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_distributions_logging_enabled/cloudfront_distributions_logging_enabled.py
@@ -12,9 +12,9 @@ class cloudfront_distributions_logging_enabled(Check):
             report.region = distribution.region
             report.resource_arn = distribution.arn
             report.resource_id = distribution.id
-            if (
-                distribution.logging_enabled
-                or distribution.default_cache_config.realtime_log_config_arn
+            if distribution.logging_enabled or (
+                distribution.default_cache_config
+                and distribution.default_cache_config.realtime_log_config_arn
             ):
                 report.status = "PASS"
                 report.status_extended = (


### PR DESCRIPTION
### Context

There exists various errors in cloudfront checks when there are no permissions to perform `GetDistributionConfig` api call 


### Description

Check the existence of intermediate attributes in the following cloudfront checks:
- `cloudfront_distributions_logging_enabled`
- `cloudfront_distributions_https_enabled`
- `cloudfront_distributions_field_level_encryption_enabled`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
