### PR TITLE
fix(service errors): solve EMR, VPC and ELBv2 service errors

### DIFF
--- a/prowler/providers/aws/services/elbv2/elbv2_service.py
+++ b/prowler/providers/aws/services/elbv2/elbv2_service.py
@@ -1,6 +1,7 @@
 import threading
 from typing import Optional
 
+from botocore.client import ClientError
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
@@ -137,7 +138,11 @@ class ELBv2:
                                     conditions=rule["Conditions"],
                                 )
                             )
-
+        except ClientError as error:
+            if error.response["Error"]["Code"] == "ListenerNotFound":
+                logger.warning(
+                    f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
         except Exception as error:
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"

--- a/prowler/providers/aws/services/emr/emr_service.py
+++ b/prowler/providers/aws/services/emr/emr_service.py
@@ -79,7 +79,7 @@ class EMR:
                     # Master Node Security Groups
                     master_node_security_group = cluster_info["Cluster"][
                         "Ec2InstanceAttributes"
-                    ]["EmrManagedMasterSecurityGroup"]
+                    ].get("EmrManagedMasterSecurityGroup")
                     master_node_additional_security_groups = None
                     if (
                         "AdditionalMasterSecurityGroups"
@@ -171,7 +171,7 @@ class ClusterStatus(Enum):
 
 
 class Node(BaseModel):
-    security_group_id: str = ""
+    security_group_id: Optional[str] = ""
     additional_security_groups_id: Optional[list[str]] = []
 
 

--- a/prowler/providers/aws/services/vpc/vpc_service.py
+++ b/prowler/providers/aws/services/vpc/vpc_service.py
@@ -249,7 +249,7 @@ class VpcEndpoint(BaseModel):
     id: str
     vpc_id: str
     state: str
-    policy_document: dict
+    policy_document: Optional[dict]
     owner_id: str
     region: str
 


### PR DESCRIPTION
### Description

Solve the following errors:
```
ap-southeast-1 -- ListenerNotFoundException[130]: An error occurred (ListenerNotFound) when calling the DescribeRules operation: One or more listeners not found

us-east-1 -- KeyError[80]: 'EmrManagedMasterSecurityGroup'

eu-west-2 -- ValidationError[167]: 1 validation error for VpcEndpoint
policy_document
  none is not an allowed value (type=type_error.none.not_allowed)
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
