### PR TITLE
fix(awslambdacloudtrail): include advanced event and all lambdas in check

### DIFF
--- a/prowler/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled.py
@@ -21,15 +21,27 @@ class awslambda_function_invoke_api_operations_cloudtrail_logging_enabled(Check)
             lambda_recorded_cloudtrail = False
             for trail in cloudtrail_client.trails:
                 for data_event in trail.data_events:
-                    if "DataResources" in data_event.event_selector:
-                        for resource in data_event.event_selector["DataResources"]:
+                    # classic event selectors
+                    if not data_event.is_advanced:
+                        if "DataResources" in data_event.event_selector:
+                            for resource in data_event.event_selector["DataResources"]:
+                                if resource["Type"] == "AWS::Lambda::Function" and (
+                                    function.arn in resource["Values"]
+                                    or "arn:aws:lambda" in resource["Values"]
+                                ):
+                                    lambda_recorded_cloudtrail = True
+                                    break
+                    elif data_event.is_advanced:
+                        for field_selector in data_event.event_selector[
+                            "FieldSelectors"
+                        ]:
                             if (
-                                resource["Type"] == "AWS::Lambda::Function"
-                                and function.arn in resource["Values"]
+                                field_selector["Field"] == "resources.type"
+                                and field_selector["Equals"][0]
+                                == "AWS::Lambda::Function"
                             ):
                                 lambda_recorded_cloudtrail = True
                                 break
-
                     if lambda_recorded_cloudtrail:
                         break
                 if lambda_recorded_cloudtrail:


### PR DESCRIPTION
### Context

From #1973 
Check `awslambda_function_invoke_api_operations_cloudtrail_logging_enabled` was not taking into account if all lambdas are being recorded in cloudtrail. Also it was missing advanced event selectors treatment.

### Description

Include searching of `"arn:aws:lambda"` pattern and event selector treatment when looking for lambda monitoring


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
