### PR TITLE
fix(emr): KeyError EmrManagedSlaveSecurityGroup

### DIFF
--- a/prowler/providers/aws/services/emr/emr_service.py
+++ b/prowler/providers/aws/services/emr/emr_service.py
@@ -96,7 +96,7 @@ class EMR:
                     # Slave Node Security Groups
                     slave_node_security_group = cluster_info["Cluster"][
                         "Ec2InstanceAttributes"
-                    ]["EmrManagedSlaveSecurityGroup"]
+                    ].get("EmrManagedSlaveSecurityGroup")
                     slave_node_additional_security_groups = []
                     if (
                         "AdditionalSlaveSecurityGroups"


### PR DESCRIPTION
### Description

Fix the following error in the EMR service: `KeyError[97]: 'EmrManagedSlaveSecurityGroup'`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
