### PR TITLE
Update AWS provider's default retry mode

### DIFF
--- a/prowler/providers/common/audit_info.py
+++ b/prowler/providers/common/audit_info.py
@@ -137,6 +137,17 @@ Caller Identity ARN: {Fore.YELLOW}[{audit_info.audited_identity_arn}]{Style.RESE
             # Merge the new configuration
             new_boto3_config = current_audit_info.session_config.merge(config)
             current_audit_info.session_config = new_boto3_config
+        else:
+            # Use the standard retry mode, and increase max retries from 3 to 5
+            config = Config(
+                retries={
+                    "max_attempts": 5,
+                    "mode": "standard",
+                }
+            )
+            # Merge the new configuration
+            new_boto3_config = current_audit_info.session_config.merge(config)
+            current_audit_info.session_config = new_boto3_config
 
         # Setting session
         current_audit_info.profile = input_profile


### PR DESCRIPTION


### Context

If the aws_retries_max_attempts argument is not specified, the retry mode would be set to legacy.

The standard retry mode has some improvements to the legacy mode, including handling a wider range of exceptions that should result in a retry being performed.
Further info: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html

This change defaults the retry mode to the standard retry mode, and set the max retries to 5.


### Description

Added an else clause to specify that the standard retry mode with a max retries of 5 is used if the aws_retries_max_attempts argument is not specified.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
