### PR TITLE
fix(head): Pass head commit to dispatch action

### DIFF
--- a/.github/workflows/build-lint-push-containers.yml
+++ b/.github/workflows/build-lint-push-containers.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Get latest commit info
         if: github.event_name == 'push'
         run: |
-          LATEST_COMMIT_HASH=$(echo ${{ github.event.before }} | cut -b -6)
+          LATEST_COMMIT_HASH=$(echo ${{ github.event.head }} | cut -b -6)
           echo "LATEST_COMMIT_HASH=${LATEST_COMMIT_HASH}" >> $GITHUB_ENV
       - name: Dispatch event for latest
         if: github.event_name == 'push'


### PR DESCRIPTION
### Context

We need to pass the latest commit id to the dispatch action


### Description

Change `LATEST_COMMIT_HASH` assignation from `github.event.before` to `github.event.head`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
