### PR TITLE
fix(actions): fixed dispatch commit message

### DIFF
--- a/.github/workflows/build-lint-push-containers.yml
+++ b/.github/workflows/build-lint-push-containers.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Get latest commit info
         if: github.event_name == 'push'
         run: |
-          LATEST_COMMIT_HASH=$(echo ${{ github.event.head }} | cut -b -6)
+          LATEST_COMMIT_HASH=$(echo ${{ github.event.after }} | cut -b -6)
           echo "LATEST_COMMIT_HASH=${LATEST_COMMIT_HASH}" >> $GITHUB_ENV
       - name: Dispatch event for latest
         if: github.event_name == 'push'


### PR DESCRIPTION
### Context

Action was not sending the latest commit to remote dispatch


### Description

Change `LATEST_COMMIT_HASH` to use `github.event.after` instead of `github.event.head`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
