### PR TITLE
fix(cloudtrail): list tags only in owned trails

### DIFF
--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -138,8 +138,11 @@ class Cloudtrail:
         logger.info("CloudTrail - List Tags...")
         try:
             for trail in self.trails:
-                # Check if trails are in this region
-                if trail.region == trail.home_region:
+                # Check if trails are in this account and region
+                if (
+                    trail.region == trail.home_region
+                    and self.audited_account in trail.arn
+                ):
                     regional_client = self.regional_clients[trail.region]
                     response = regional_client.list_tags(ResourceIdList=[trail.arn])[
                         "ResourceTagList"

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_service_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_service_test.py
@@ -4,7 +4,7 @@ from moto import mock_cloudtrail, mock_s3
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.cloudtrail.cloudtrail_service import Cloudtrail
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_Cloudtrail_Service:


### PR DESCRIPTION
### Description

Check the account of the trail in order to fix the following error when listing trail tags:
`ERROR: CloudTrailARNInvalidException[145]: An error occurred (CloudTrailARNInvalidException) when calling the ListTags operation: AccountID in ARN is wrong, you can only access resources with AccountID <redacted>.`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
