### PR TITLE
fix(check): change cloudformation_outputs_find_secrets name

### DIFF
--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -517,12 +517,8 @@ def get_checks_from_input_arn(audit_resources: list, provider: str) -> set:
         for resource in audit_resources:
             service = resource.split(":")[2]
             sub_service = resource.split(":")[5].split("/")[0].replace("-", "_")
-
-            if (
-                service != "wafv2"
-                and service != "waf"
-                and service != "servicediscovery"
-            ):  # WAF Services does not have checks
+            # WAF Services does not have checks
+            if service != "wafv2" and service != "waf":
                 # Parse services when they are different in the ARNs
                 if service == "lambda":
                     service = "awslambda"
@@ -530,7 +526,14 @@ def get_checks_from_input_arn(audit_resources: list, provider: str) -> set:
                     service = "elb"
                 elif service == "logs":
                     service = "cloudwatch"
-                service_list.add(service)
+                # Check if Prowler has checks in service
+                try:
+                    list_modules(provider, service)
+                except ModuleNotFoundError:
+                    # Service is not supported
+                    pass
+                else:
+                    service_list.add(service)
 
                 # Get subservices to execute only applicable checks
                 if service not in services_without_subservices:

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -519,7 +519,9 @@ def get_checks_from_input_arn(audit_resources: list, provider: str) -> set:
             sub_service = resource.split(":")[5].split("/")[0].replace("-", "_")
 
             if (
-                service != "wafv2" and service != "waf"
+                service != "wafv2"
+                and service != "waf"
+                and service != "servicediscovery"
             ):  # WAF Services does not have checks
                 # Parse services when they are different in the ARNs
                 if service == "lambda":

--- a/prowler/providers/aws/services/cloudformation/cloudformation_stack_outputs_find_secrets/cloudformation_stack_outputs_find_secrets.metadata.json
+++ b/prowler/providers/aws/services/cloudformation/cloudformation_stack_outputs_find_secrets/cloudformation_stack_outputs_find_secrets.metadata.json
@@ -1,6 +1,6 @@
 {
   "Provider": "aws",
-  "CheckID": "cloudformation_outputs_find_secrets",
+  "CheckID": "cloudformation_stack_outputs_find_secrets",
   "CheckTitle": "Find secrets in CloudFormation outputs",
   "CheckType": [],
   "ServiceName": "cloudformation",

--- a/prowler/providers/aws/services/cloudformation/cloudformation_stack_outputs_find_secrets/cloudformation_stack_outputs_find_secrets.py
+++ b/prowler/providers/aws/services/cloudformation/cloudformation_stack_outputs_find_secrets/cloudformation_stack_outputs_find_secrets.py
@@ -10,11 +10,11 @@ from prowler.providers.aws.services.cloudformation.cloudformation_client import 
 )
 
 
-class cloudformation_outputs_find_secrets(Check):
+class cloudformation_stack_outputs_find_secrets(Check):
     """Check if a CloudFormation Stack has secrets in their Outputs"""
 
     def execute(self):
-        """Execute the cloudformation_outputs_find_secrets check"""
+        """Execute the cloudformation_stack_outputs_find_secrets check"""
         findings = []
         for stack in cloudformation_client.stacks:
             report = Check_Report_AWS(self.metadata())

--- a/tests/providers/aws/services/cloudformation/cloudformation_outputs_find_secrets/cloudformation_outputs_find_secrets_test.py
+++ b/tests/providers/aws/services/cloudformation/cloudformation_outputs_find_secrets/cloudformation_outputs_find_secrets_test.py
@@ -6,7 +6,7 @@ from prowler.providers.aws.services.cloudformation.cloudformation_service import
 AWS_REGION = "eu-west-1"
 
 
-class Test_cloudformation_outputs_find_secrets:
+class Test_cloudformation_stack_outputs_find_secrets:
     def test_no_stacks(self):
         cloudformation_client = mock.MagicMock
         cloudformation_client.stacks = []
@@ -15,11 +15,11 @@ class Test_cloudformation_outputs_find_secrets:
             new=cloudformation_client,
         ):
             # Test Check
-            from prowler.providers.aws.services.cloudformation.cloudformation_outputs_find_secrets.cloudformation_outputs_find_secrets import (
-                cloudformation_outputs_find_secrets,
+            from prowler.providers.aws.services.cloudformation.cloudformation_stack_outputs_find_secrets.cloudformation_stack_outputs_find_secrets import (
+                cloudformation_stack_outputs_find_secrets,
             )
 
-            check = cloudformation_outputs_find_secrets()
+            check = cloudformation_stack_outputs_find_secrets()
             result = check.execute()
 
             assert len(result) == 0
@@ -40,11 +40,11 @@ class Test_cloudformation_outputs_find_secrets:
             "prowler.providers.aws.services.cloudformation.cloudformation_service.CloudFormation",
             cloudformation_client,
         ):
-            from prowler.providers.aws.services.cloudformation.cloudformation_outputs_find_secrets.cloudformation_outputs_find_secrets import (
-                cloudformation_outputs_find_secrets,
+            from prowler.providers.aws.services.cloudformation.cloudformation_stack_outputs_find_secrets.cloudformation_stack_outputs_find_secrets import (
+                cloudformation_stack_outputs_find_secrets,
             )
 
-            check = cloudformation_outputs_find_secrets()
+            check = cloudformation_stack_outputs_find_secrets()
             result = check.execute()
 
             assert len(result) == 1
@@ -76,11 +76,11 @@ class Test_cloudformation_outputs_find_secrets:
             "prowler.providers.aws.services.cloudformation.cloudformation_service.CloudFormation",
             cloudformation_client,
         ):
-            from prowler.providers.aws.services.cloudformation.cloudformation_outputs_find_secrets.cloudformation_outputs_find_secrets import (
-                cloudformation_outputs_find_secrets,
+            from prowler.providers.aws.services.cloudformation.cloudformation_stack_outputs_find_secrets.cloudformation_stack_outputs_find_secrets import (
+                cloudformation_stack_outputs_find_secrets,
             )
 
-            check = cloudformation_outputs_find_secrets()
+            check = cloudformation_stack_outputs_find_secrets()
             result = check.execute()
 
             assert len(result) == 1
@@ -112,11 +112,11 @@ class Test_cloudformation_outputs_find_secrets:
             "prowler.providers.aws.services.cloudformation.cloudformation_service.CloudFormation",
             cloudformation_client,
         ):
-            from prowler.providers.aws.services.cloudformation.cloudformation_outputs_find_secrets.cloudformation_outputs_find_secrets import (
-                cloudformation_outputs_find_secrets,
+            from prowler.providers.aws.services.cloudformation.cloudformation_stack_outputs_find_secrets.cloudformation_stack_outputs_find_secrets import (
+                cloudformation_stack_outputs_find_secrets,
             )
 
-            check = cloudformation_outputs_find_secrets()
+            check = cloudformation_stack_outputs_find_secrets()
             result = check.execute()
 
             assert len(result) == 1


### PR DESCRIPTION
### Description

Change `cloudformation_outputs_find_secrets` name to follow pattern `service_subservice`.
Also, avoid not supported services in audit_resources.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
