### PR TITLE
fix(windows-path):  --list-services bad split

### DIFF
--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -122,11 +122,10 @@ def list_services(provider: str) -> set():
     checks_tuple = recover_checks_from_provider(provider)
     for _, check_path in checks_tuple:
         # Format: /absolute_path/prowler/providers/{provider}/services/{service_name}/{check_name}
-        if os.name == 'nt':
+        if os.name == "nt":
             service_name = check_path.split("\\")[-2]
         else:
             service_name = check_path.split("/")[-2]
-        
         available_services.add(service_name)
     return sorted(available_services)
 

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -122,7 +122,6 @@ def list_services(provider: str) -> set():
     checks_tuple = recover_checks_from_provider(provider)
     for _, check_path in checks_tuple:
         # Format: /absolute_path/prowler/providers/{provider}/services/{service_name}/{check_name}
-        #print(checks_tuple)
         if os.name == 'nt':
             service_name = check_path.split("\\")[-2]
         else:

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -122,7 +122,12 @@ def list_services(provider: str) -> set():
     checks_tuple = recover_checks_from_provider(provider)
     for _, check_path in checks_tuple:
         # Format: /absolute_path/prowler/providers/{provider}/services/{service_name}/{check_name}
-        service_name = check_path.split("/")[-2]
+        #print(checks_tuple)
+        if os.name == 'nt':
+            service_name = check_path.split("\\")[-2]
+        else:
+            service_name = check_path.split("/")[-2]
+        
         available_services.add(service_name)
     return sorted(available_services)
 


### PR DESCRIPTION
### Context

When executing --list-services when running prowler on a windows machine, the split fails because the file structure on windows uses back slashes as apposed to forward slashes on linux.
On a windows box an error :-
File "C:\Source\3rd-party\prowler\prowler\lib\check\check.py", line 125
    print checks_tuple

This fix resolves this issue when executing on a Windows machine.


### Description

Added os.name if statement to check what os the prowler is being executed on when executing the --list-services command. This is so that the code correctly parses the file path with back slashes as apposed to forward slashes.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
