### PR TITLE
docs: Corrected spelling mistake in multiacount

### DIFF
--- a/docs/tutorials/aws/multiaccount.md
+++ b/docs/tutorials/aws/multiaccount.md
@@ -1,6 +1,6 @@
 # Scan Multiple AWS Accounts
 
-Prowler can scan multiple accounts when it is ejecuted from one account that can assume a role in those given accounts to scan using [Assume Role feature](role-assumption.md) and [AWS Organizations integration feature](organizations.md).
+Prowler can scan multiple accounts when it is executed from one account that can assume a role in those given accounts to scan using [Assume Role feature](role-assumption.md) and [AWS Organizations integration feature](organizations.md).
 
 
 ## Scan multiple specific accounts sequentially


### PR DESCRIPTION
### Context
prowler/docs/tutorials/aws/multiaccount.md had a mispelled word.


### Description

Corrected spelling mistake


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
