### PR TITLE
chore(actions): Use GHA cache

### DIFF
--- a/.github/workflows/build-lint-push-containers.yml
+++ b/.github/workflows/build-lint-push-containers.yml
@@ -77,7 +77,9 @@ jobs:
           tags: |
             ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}
             ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}
-          file: ${{ env.DOCKERFILE_PATH }}
+          file: ${{ env.DOCKERFILE_PATH }}          
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build container image (release)
         if: github.event_name == 'release'
@@ -93,6 +95,8 @@ jobs:
             ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
             ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.STABLE_TAG }}
           file: ${{ env.DOCKERFILE_PATH }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   dispatch-action:
     needs: container-build-push

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,15 +17,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Install poetry
+        run: |
+         python -m pip install --upgrade pip
+         pipx install poetry
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'poetry'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install poetry
           poetry install
           poetry run pip list
           VERSION=$(curl --silent "https://api.github.com/repos/hadolint/hadolint/releases/latest" | \

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -19,15 +19,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ env.GITHUB_BRANCH }}
+      - name: Install dependencies
+        run: |
+          pipx install poetry
+          pipx inject poetry poetry-bumpversion
       - name: setup python
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
           cache: 'poetry'
-      - name: Install dependencies
-        run: |
-          pipx install poetry
-          pipx inject poetry poetry-bumpversion
       - name: Change version and Build package
         run: |
           poetry version ${{ env.RELEASE_TAG }}

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -20,9 +20,10 @@ jobs:
         with:
           ref: ${{ env.GITHUB_BRANCH }}
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9 #install the python needed
+          python-version: 3.9
+          cache: 'poetry'
       - name: Install dependencies
         run: |
           pipx install poetry


### PR DESCRIPTION
### Description

Start using the Github Actions cache when building docker images.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
