### PR TITLE
fix(cloudwatch): solve inexistent filterPattern error

### DIFF
--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
@@ -131,7 +131,7 @@ class Logs:
                             MetricFilter(
                                 name=filter["filterName"],
                                 metric=filter["metricTransformations"][0]["metricName"],
-                                pattern=filter["filterPattern"],
+                                pattern=filter.get("filterPattern", ""),
                                 log_group=filter["logGroupName"],
                                 region=regional_client.region,
                             )


### PR DESCRIPTION
### Description

Solve inexistent filterPattern error: `KeyError[108]: 'filterPattern'`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
