### PR TITLE
fix(ulimit check): test only when platform is not windows

### DIFF
--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -4,7 +4,6 @@ import os
 import sys
 import traceback
 from pkgutil import walk_packages
-from resource import RLIMIT_NOFILE, getrlimit
 from types import ModuleType
 from typing import Any
 
@@ -357,12 +356,15 @@ def execute_checks(
         audit_progress=0,
     )
 
-    # Check ulimit for the maximum system open files
-    soft, _ = getrlimit(RLIMIT_NOFILE)
-    if soft < 4096:
-        logger.warning(
-            f"Your session file descriptors limit ({soft} open files) is below 4096. We recommend to increase it to avoid errors. Solve it running this command `ulimit -n 4096`. For more info visit https://docs.prowler.cloud/en/latest/troubleshooting/"
-        )
+    if not sys.platform.startswith("win32") or not sys.platform.startswith("cygwin"):
+        from resource import RLIMIT_NOFILE, getrlimit
+
+        # Check ulimit for the maximum system open files
+        soft, _ = getrlimit(RLIMIT_NOFILE)
+        if soft < 4096:
+            logger.warning(
+                f"Your session file descriptors limit ({soft} open files) is below 4096. We recommend to increase it to avoid errors. Solve it running this command `ulimit -n 4096`. For more info visit https://docs.prowler.cloud/en/latest/troubleshooting/"
+            )
 
     # Execution with the --only-logs flag
     if audit_output_options.only_logs:


### PR DESCRIPTION
### Context

Prowler checks the ulimit setting to warn if it is less than 4096


### Description

Don't import the library `resource` to check it unless the platform is not Windows


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
