### PR TITLE
fix(ulimit check): try except when checking ulimit

### DIFF
--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -356,7 +356,7 @@ def execute_checks(
         audit_progress=0,
     )
 
-    if not sys.platform.startswith("win32") or not sys.platform.startswith("cygwin"):
+    if os.name != "nt":
         try:
             from resource import RLIMIT_NOFILE, getrlimit
 
@@ -367,9 +367,7 @@ def execute_checks(
                     f"Your session file descriptors limit ({soft} open files) is below 4096. We recommend to increase it to avoid errors. Solve it running this command `ulimit -n 4096`. For more info visit https://docs.prowler.cloud/en/latest/troubleshooting/"
                 )
         except Exception as error:
-            logger.error(
-                "Unable to retrieve ulimit, probably due to resource library is not available for Microsoft environments"
-            )
+            logger.error("Unable to retrieve ulimit default settings")
             logger.error(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -4,7 +4,6 @@ import os
 import sys
 import traceback
 from pkgutil import walk_packages
-from resource import RLIMIT_NOFILE, getrlimit
 from types import ModuleType
 from typing import Any
 
@@ -357,12 +356,23 @@ def execute_checks(
         audit_progress=0,
     )
 
-    # Check ulimit for the maximum system open files
-    soft, _ = getrlimit(RLIMIT_NOFILE)
-    if soft < 4096:
-        logger.warning(
-            f"Your session file descriptors limit ({soft} open files) is below 4096. We recommend to increase it to avoid errors. Solve it running this command `ulimit -n 4096`. For more info visit https://docs.prowler.cloud/en/latest/troubleshooting/"
-        )
+    if not sys.platform.startswith("win32") or not sys.platform.startswith("cygwin"):
+        try:
+            from resource import RLIMIT_NOFILE, getrlimit
+
+            # Check ulimit for the maximum system open files
+            soft, _ = getrlimit(RLIMIT_NOFILE)
+            if soft < 4096:
+                logger.warning(
+                    f"Your session file descriptors limit ({soft} open files) is below 4096. We recommend to increase it to avoid errors. Solve it running this command `ulimit -n 4096`. For more info visit https://docs.prowler.cloud/en/latest/troubleshooting/"
+                )
+        except Exception as error:
+            logger.error(
+                "Unable to retrieve ulimit, probably due to resource library is not available for Microsoft environments"
+            )
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
 
     # Execution with the --only-logs flag
     if audit_output_options.only_logs:


### PR DESCRIPTION
### Context

Fixes `resource` module import when dealing with `ulimit`


### Description

Adds `try ... except` logic to the ulimit check

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
