### PR TITLE
chore(version): check latest version

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -3,6 +3,7 @@
 
 import sys
 
+from prowler.config.config import check_current_version
 from prowler.lib.banner import print_banner
 from prowler.lib.check.check import (
     bulk_load_checks_metadata,
@@ -54,6 +55,9 @@ def prowler():
     checks_file = args.checks_file
     severities = args.severity
     compliance_framework = args.compliance
+
+    if args.version:
+        check_current_version()
 
     # We treat the compliance framework as another output format
     if compliance_framework:

--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -3,7 +3,6 @@
 
 import sys
 
-from prowler.config.config import check_current_version
 from prowler.lib.banner import print_banner
 from prowler.lib.check.check import (
     bulk_load_checks_metadata,
@@ -55,9 +54,6 @@ def prowler():
     checks_file = args.checks_file
     severities = args.severity
     compliance_framework = args.compliance
-
-    if args.version:
-        check_current_version()
 
     # We treat the compliance framework as another output format
     if compliance_framework:

--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -3,6 +3,7 @@ import pathlib
 from datetime import datetime, timezone
 from os import getcwd
 
+import requests
 import yaml
 
 from prowler.lib.logger import logger
@@ -41,6 +42,19 @@ json_file_suffix = ".json"
 json_asff_file_suffix = ".asff.json"
 html_file_suffix = ".html"
 config_yaml = f"{pathlib.Path(os.path.dirname(os.path.realpath(__file__)))}/config.yaml"
+
+
+def check_current_version(prowler_version):
+    try:
+        latest_version = requests.get(
+            "https://api.github.com/repos/prowler-cloud/prowler/tags"
+        ).json()[0]["name"]
+        if latest_version != prowler_version:
+            return f"(latest is {latest_version}, upgrade for the latest features)"
+        else:
+            return "(it is the latest version, yay!)"
+    except Exception:
+        return ""
 
 
 def change_config_var(variable, value):

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -4,6 +4,7 @@ from argparse import RawTextHelpFormatter
 
 from prowler.config.config import (
     available_compliance_frameworks,
+    check_current_version,
     default_output_directory,
     prowler_version,
 )
@@ -36,7 +37,7 @@ Detailed documentation at https://docs.prowler.cloud
             "-v",
             "--version",
             action="version",
-            version=f"Prowler {prowler_version}",
+            version=f"Prowler {prowler_version} {check_current_version(prowler_version)}",
             help="show Prowler version",
         )
         # Common arguments parser

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -1,6 +1,16 @@
+from prowler.config.config import check_current_version, prowler_version
 from prowler.providers.aws.aws_provider import get_aws_available_regions
 
 
 class Test_Config:
     def test_get_aws_available_regions(self):
         assert len(get_aws_available_regions()) == 31
+
+    def test_check_current_version(self):
+        assert (
+            check_current_version(prowler_version) == "(it is the latest version, yay!)"
+        )
+        assert (
+            check_current_version("0.0.0")
+            == f"(latest is {prowler_version}, upgrade for the latest features)"
+        )


### PR DESCRIPTION
### Description

Check latest version of Prowler in `--version` flag:
`Prowler 3.3.0 (it is the latest version, yay!)`
`Prowler 3.2.0 (latest is 3.3.0, upgrade for the latest features)`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
