### PR TITLE
feat(threading): Improve threading with some general functions

### DIFF
--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -356,15 +356,15 @@ def execute_checks(
         audit_progress=0,
     )
 
-    # if not sys.platform.startswith("win32") or not sys.platform.startswith("cygwin"):
-    #     from resource import RLIMIT_NOFILE, getrlimit
+    if not sys.platform.startswith("win32") or not sys.platform.startswith("cygwin"):
+        from resource import RLIMIT_NOFILE, getrlimit
 
-    #     # Check ulimit for the maximum system open files
-    #     soft, _ = getrlimit(RLIMIT_NOFILE)
-    #     if soft < 4096:
-    #         logger.warning(
-    #             f"Your session file descriptors limit ({soft} open files) is below 4096. We recommend to increase it to avoid errors. Solve it running this command `ulimit -n 4096`. For more info visit https://docs.prowler.cloud/en/latest/troubleshooting/"
-    #         )
+        # Check ulimit for the maximum system open files
+        soft, _ = getrlimit(RLIMIT_NOFILE)
+        if soft < 4096:
+            logger.warning(
+                f"Your session file descriptors limit ({soft} open files) is below 4096. We recommend to increase it to avoid errors. Solve it running this command `ulimit -n 4096`. For more info visit https://docs.prowler.cloud/en/latest/troubleshooting/"
+            )
 
     # Execution with the --only-logs flag
     if audit_output_options.only_logs:

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -356,15 +356,15 @@ def execute_checks(
         audit_progress=0,
     )
 
-    if not sys.platform.startswith("win32") or not sys.platform.startswith("cygwin"):
-        from resource import RLIMIT_NOFILE, getrlimit
+    # if not sys.platform.startswith("win32") or not sys.platform.startswith("cygwin"):
+    #     from resource import RLIMIT_NOFILE, getrlimit
 
-        # Check ulimit for the maximum system open files
-        soft, _ = getrlimit(RLIMIT_NOFILE)
-        if soft < 4096:
-            logger.warning(
-                f"Your session file descriptors limit ({soft} open files) is below 4096. We recommend to increase it to avoid errors. Solve it running this command `ulimit -n 4096`. For more info visit https://docs.prowler.cloud/en/latest/troubleshooting/"
-            )
+    #     # Check ulimit for the maximum system open files
+    #     soft, _ = getrlimit(RLIMIT_NOFILE)
+    #     if soft < 4096:
+    #         logger.warning(
+    #             f"Your session file descriptors limit ({soft} open files) is below 4096. We recommend to increase it to avoid errors. Solve it running this command `ulimit -n 4096`. For more info visit https://docs.prowler.cloud/en/latest/troubleshooting/"
+    #         )
 
     # Execution with the --only-logs flag
     if audit_output_options.only_logs:

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -10,14 +10,26 @@ from prowler.config.config import aws_services_json_file
 from prowler.lib.logger import logger
 from prowler.lib.utils.utils import open_file, parse_json_file
 from prowler.providers.aws.lib.audit_info.models import AWS_Assume_Role, AWS_Audit_Info
-
+import logging
 
 ################## AWS PROVIDER
 class AWS_Provider:
-    def __init__(self, audit_info):
+    def __init__(self, audit_info, thread_provider=False):
+        if thread_provider:
+            logger.disabled = True
+            original_boto3_level = logging.getLogger('boto3').getEffectiveLevel()
+            original_botocore_level = logging.getLogger('botocore').getEffectiveLevel()
+            logging.getLogger('boto3').setLevel(logging.WARNING)
+            logging.getLogger('botocore').setLevel(logging.WARNING)
+        
         logger.info("Instantiating aws provider ...")
         self.aws_session = self.set_session(audit_info)
         self.role_info = audit_info.assumed_role_info
+        
+        if thread_provider:
+            logger.disabled = False
+            logging.getLogger('boto3').setLevel(original_boto3_level)
+            logging.getLogger('botocore').setLevel(original_botocore_level)
 
     def get_session(self):
         return self.aws_session

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -15,21 +15,9 @@ import logging
 ################## AWS PROVIDER
 class AWS_Provider:
     def __init__(self, audit_info, thread_provider=False):
-        if thread_provider:
-            logger.disabled = True
-            original_boto3_level = logging.getLogger('boto3').getEffectiveLevel()
-            original_botocore_level = logging.getLogger('botocore').getEffectiveLevel()
-            logging.getLogger('boto3').setLevel(logging.WARNING)
-            logging.getLogger('botocore').setLevel(logging.WARNING)
-        
         logger.info("Instantiating aws provider ...")
         self.aws_session = self.set_session(audit_info)
         self.role_info = audit_info.assumed_role_info
-        
-        if thread_provider:
-            logger.disabled = False
-            logging.getLogger('boto3').setLevel(original_boto3_level)
-            logging.getLogger('botocore').setLevel(original_botocore_level)
 
     def get_session(self):
         return self.aws_session

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -13,7 +13,7 @@ from prowler.providers.aws.lib.audit_info.models import AWS_Assume_Role, AWS_Aud
 
 ################## AWS PROVIDER
 class AWS_Provider:
-    def __init__(self, audit_info, thread_provider=False):
+    def __init__(self, audit_info):
         logger.info("Instantiating aws provider ...")
         self.aws_session = self.set_session(audit_info)
         self.role_info = audit_info.assumed_role_info

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -10,7 +10,6 @@ from prowler.config.config import aws_services_json_file
 from prowler.lib.logger import logger
 from prowler.lib.utils.utils import open_file, parse_json_file
 from prowler.providers.aws.lib.audit_info.models import AWS_Assume_Role, AWS_Audit_Info
-import logging
 
 ################## AWS PROVIDER
 class AWS_Provider:
@@ -141,7 +140,7 @@ def generate_regional_clients(
         )
 
 
-def gen_regions_for_service(
+def generate_regions_for_service(
     service: str, audit_info: AWS_Audit_Info, global_service: bool = False
 ) -> list:
     try:

--- a/prowler/providers/aws/lib/classes.py
+++ b/prowler/providers/aws/lib/classes.py
@@ -4,12 +4,8 @@ import multiprocessing
 from concurrent.futures import ThreadPoolExecutor
 from threading import current_thread, local
 
-def regional_worker_init():
-    session = 1
-    pass
-
 def regional_worker_intializer_function(audit_info,regions,service,local_context):
-    aws_provider = AWS_Provider(audit_info)
+    aws_provider = AWS_Provider(audit_info,thread_provider=True)
     session = aws_provider.aws_session
 
     thread = current_thread()
@@ -19,7 +15,7 @@ def regional_worker_intializer_function(audit_info,regions,service,local_context
     local_context.regional_client.region = region
 
 def global_worker_intializer_function(audit_info,regions,service,local_context):
-    aws_provider = AWS_Provider(audit_info)
+    aws_provider = AWS_Provider(audit_info,thread_provider=True)
     session = aws_provider.aws_session
     regional_clients = {}
     for region in regions:
@@ -43,11 +39,10 @@ class Service():
                                 initargs=(audit_info,self.regions,self.service,self.local_context)
                                 )
         self.global_pool = ThreadPoolExecutor(
-                                max_workers=len(self.regions),
+                                #max_workers defaults to (# of processors)x5
                                 initializer=global_worker_intializer_function, 
                                 initargs=(audit_info,self.regions,self.service,self.local_context)
                                 )
-        # self.global_pool = multiprocessing.pool.ThreadPool(processes=4)
 
     @property
     def regional_client(self):

--- a/prowler/providers/aws/lib/classes.py
+++ b/prowler/providers/aws/lib/classes.py
@@ -4,53 +4,39 @@ import multiprocessing
 from concurrent.futures import ThreadPoolExecutor
 from threading import current_thread, local
 
-def regional_worker_intializer_function(audit_info,regions,service,local_context):
-    aws_provider = AWS_Provider(audit_info,thread_provider=True)
-    session = aws_provider.aws_session
-
+def regional_worker_intializer_function(regions,regional_clients,local_context):
+    # 1 thread per region. This function intializes the regional_client for each thread 
     thread = current_thread()
     thread_index = int(thread.name.split('_')[-1])
-    region = regions[thread_index]
-    local_context.regional_client = session.client(service_name=service,region_name=region)
-    local_context.regional_client.region = region
+    current_region = regions[thread_index]
+    local_context.regional_client = next(regional_client for region,regional_client in regional_clients.items() if region==current_region)
+    local_context.regional_client.region = current_region
 
-def global_worker_intializer_function(audit_info,regions,service,local_context):
-    aws_provider = AWS_Provider(audit_info,thread_provider=True)
-    session = aws_provider.aws_session
-    regional_clients = {}
-    for region in regions:
-        regional_client = session.client(
-            service, region_name=region, config=audit_info.session_config
-        )
-        regional_client.region = region
-        regional_clients[region] = regional_client
-    local_context.regional_clients = regional_clients
 
 class Service():
     def __init__(self, service, audit_info):
         self.service = service
         self.regions = gen_regions_for_service(self.service, audit_info)
         self.audit_info = audit_info
+        self.regional_clients = generate_regional_clients(self.service, audit_info)
         print(f"Creating regional pool with {len(self.regions)} workers")
         self.local_context = local()
         self.regional_pool = ThreadPoolExecutor(
                                 max_workers=len(self.regions),
                                 initializer=regional_worker_intializer_function, 
-                                initargs=(audit_info,self.regions,self.service,self.local_context)
+                                initargs=(self.regions,self.regional_clients,self.local_context)
                                 )
         self.global_pool = ThreadPoolExecutor(
                                 #max_workers defaults to (# of processors)x5
-                                initializer=global_worker_intializer_function, 
-                                initargs=(audit_info,self.regions,self.service,self.local_context)
                                 )
 
     @property
     def regional_client(self):
         return self.local_context.regional_client
 
-    @property
-    def regional_clients(self):
-        return self.local_context.regional_clients
+    # @property
+    # def regional_clients(self):
+    #     return self.local_context.regional_clients
     
     # @regional_clients.setter
     # def regional_clients(self,x):

--- a/prowler/providers/aws/lib/classes.py
+++ b/prowler/providers/aws/lib/classes.py
@@ -1,7 +1,6 @@
 
-from prowler.providers.aws.aws_provider import generate_regional_clients, gen_regions_for_service, AWS_Provider
-import multiprocessing
-from concurrent.futures import ThreadPoolExecutor
+from prowler.providers.aws.aws_provider import generate_regional_clients, gen_regions_for_service
+from concurrent.futures import ThreadPoolExecutor, wait
 from threading import current_thread, local
 
 def regional_worker_intializer_function(regions,regional_clients,local_context):
@@ -9,6 +8,7 @@ def regional_worker_intializer_function(regions,regional_clients,local_context):
     thread = current_thread()
     thread_index = int(thread.name.split('_')[-1])
     current_region = regions[thread_index]
+    # self.regional_client is mapped to self.local_context.regional_client using a getter in the Service class
     local_context.regional_client = next(regional_client for region,regional_client in regional_clients.items() if region==current_region)
     local_context.regional_client.region = current_region
 
@@ -16,28 +16,28 @@ def regional_worker_intializer_function(regions,regional_clients,local_context):
 class Service():
     def __init__(self, service, audit_info):
         self.service = service
-        self.regions = gen_regions_for_service(self.service, audit_info)
         self.audit_info = audit_info
+        self.session = audit_info.audit_session
+        self.audited_account = audit_info.audited_account
+        self.audited_partition = audit_info.audited_partition
+        self.audit_resources = audit_info.audit_resources
+
+        self.regions = gen_regions_for_service(self.service, audit_info)
         self.regional_clients = generate_regional_clients(self.service, audit_info)
+
         print(f"Creating regional pool with {len(self.regions)} workers")
+        # Local_context is used to store per-thread information. In this case it just stores self.regional_client for each thread. The intializer function sets up each thread so that there is 1 per region
         self.local_context = local()
         self.regional_pool = ThreadPoolExecutor(
                                 max_workers=len(self.regions),
                                 initializer=regional_worker_intializer_function, 
                                 initargs=(self.regions,self.regional_clients,self.local_context)
                                 )
-        self.global_pool = ThreadPoolExecutor(
+        self.general_pool = ThreadPoolExecutor(
                                 #max_workers defaults to (# of processors)x5
                                 )
 
     @property
     def regional_client(self):
         return self.local_context.regional_client
-
-    # @property
-    # def regional_clients(self):
-    #     return self.local_context.regional_clients
     
-    # @regional_clients.setter
-    # def regional_clients(self,x):
-    #     self.__regional_clients = x

--- a/prowler/providers/aws/lib/classes.py
+++ b/prowler/providers/aws/lib/classes.py
@@ -1,6 +1,6 @@
 
 from prowler.providers.aws.aws_provider import generate_regional_clients, generate_regions_for_service
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import ThreadPoolExecutor
 from threading import current_thread, local
 
 def regional_worker_intializer_function(regions,regional_clients,local_context):

--- a/prowler/providers/aws/lib/classes.py
+++ b/prowler/providers/aws/lib/classes.py
@@ -1,0 +1,62 @@
+
+from prowler.providers.aws.aws_provider import generate_regional_clients, gen_regions_for_service, AWS_Provider
+import multiprocessing
+from concurrent.futures import ThreadPoolExecutor
+from threading import current_thread, local
+
+def regional_worker_init():
+    session = 1
+    pass
+
+def regional_worker_intializer_function(audit_info,regions,service,local_context):
+    aws_provider = AWS_Provider(audit_info)
+    session = aws_provider.aws_session
+
+    thread = current_thread()
+    thread_index = int(thread.name.split('_')[-1])
+    region = regions[thread_index]
+    local_context.regional_client = session.client(service_name=service,region_name=region)
+    local_context.regional_client.region = region
+
+def global_worker_intializer_function(audit_info,regions,service,local_context):
+    aws_provider = AWS_Provider(audit_info)
+    session = aws_provider.aws_session
+    regional_clients = {}
+    for region in regions:
+        regional_client = session.client(
+            service, region_name=region, config=audit_info.session_config
+        )
+        regional_client.region = region
+        regional_clients[region] = regional_client
+    local_context.regional_clients = regional_clients
+
+class Service():
+    def __init__(self, service, audit_info):
+        self.service = service
+        self.regions = gen_regions_for_service(self.service, audit_info)
+        self.audit_info = audit_info
+        print(f"Creating regional pool with {len(self.regions)} workers")
+        self.local_context = local()
+        self.regional_pool = ThreadPoolExecutor(
+                                max_workers=len(self.regions),
+                                initializer=regional_worker_intializer_function, 
+                                initargs=(audit_info,self.regions,self.service,self.local_context)
+                                )
+        self.global_pool = ThreadPoolExecutor(
+                                max_workers=len(self.regions),
+                                initializer=global_worker_intializer_function, 
+                                initargs=(audit_info,self.regions,self.service,self.local_context)
+                                )
+        # self.global_pool = multiprocessing.pool.ThreadPool(processes=4)
+
+    @property
+    def regional_client(self):
+        return self.local_context.regional_client
+
+    @property
+    def regional_clients(self):
+        return self.local_context.regional_clients
+    
+    # @regional_clients.setter
+    # def regional_clients(self,x):
+    #     self.__regional_clients = x

--- a/prowler/providers/aws/lib/classes.py
+++ b/prowler/providers/aws/lib/classes.py
@@ -1,5 +1,5 @@
 
-from prowler.providers.aws.aws_provider import generate_regional_clients, gen_regions_for_service
+from prowler.providers.aws.aws_provider import generate_regional_clients, generate_regions_for_service
 from concurrent.futures import ThreadPoolExecutor, wait
 from threading import current_thread, local
 
@@ -22,7 +22,7 @@ class Service():
         self.audited_partition = audit_info.audited_partition
         self.audit_resources = audit_info.audit_resources
 
-        self.regions = gen_regions_for_service(self.service, audit_info)
+        self.regions = generate_regions_for_service(self.service, audit_info)
         self.regional_clients = generate_regional_clients(self.service, audit_info)
 
         print(f"Creating regional pool with {len(self.regions)} workers")

--- a/prowler/providers/aws/lib/decorators/decorators.py
+++ b/prowler/providers/aws/lib/decorators/decorators.py
@@ -1,0 +1,53 @@
+import multiprocessing
+from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
+from prowler.providers.aws.aws_provider import generate_regional_clients, gen_regions_for_service, AWS_Provider
+from concurrent.futures import ThreadPoolExecutor, wait
+from functools import wraps
+import time
+
+
+def threading_regional(function):
+    pass
+    def wrapper(*args,**kwargs):
+        self = args[0]
+        futures = [self.regional_pool.submit(function,self) for region in self.regions]
+        futures, _ = wait(futures)
+        pass
+    return wrapper
+
+
+def threading_global(attribute):
+    def decorate(fn):
+        @wraps(fn)
+        def wrapper(*args,**kwargs):
+            self = args[0]
+            resource_iterable = getattr(self,attribute)
+            futures = [self.global_pool.submit(fn,self,resource) for resource in resource_iterable]
+            futures, _ = wait(futures)
+            pass
+        return wrapper
+    return decorate
+
+
+def timeit(func):
+    @wraps(func)
+    def timeit_wrapper(*args, **kwargs):
+        start_time = time.perf_counter()
+        result = func(*args, **kwargs)
+        end_time = time.perf_counter()
+        total_time = end_time - start_time
+        print(f'Function {func.__name__}{args} {kwargs} Took {total_time:.4f} seconds')
+        return result
+    return timeit_wrapper
+
+# def threading_pool(self,function):
+#     def worker_intializer_function():
+#         aws_provider = AWS_Provider(self.audit_info)
+
+#     def wrapper():
+#         with ThreadPoolExecutor(max_workers=len(self.regions)) as executor:
+#                 futures = [executor.submit(function, self, s3_client, task) for region in self.regions]
+#         pass
+#     return wrapper
+
+

--- a/prowler/providers/aws/lib/decorators/decorators.py
+++ b/prowler/providers/aws/lib/decorators/decorators.py
@@ -1,6 +1,6 @@
 import multiprocessing
 from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
-from prowler.providers.aws.aws_provider import generate_regional_clients, gen_regions_for_service, AWS_Provider
+from prowler.providers.aws.aws_provider import generate_regional_clients, generate_regions_for_service, AWS_Provider
 from concurrent.futures import ThreadPoolExecutor, wait
 from prowler.lib.logger import logger
 from functools import wraps

--- a/prowler/providers/aws/lib/decorators/decorators.py
+++ b/prowler/providers/aws/lib/decorators/decorators.py
@@ -10,7 +10,7 @@ def threading_regional(function):
     pass
     def wrapper(*args,**kwargs):
         self = args[0]
-        futures = [self.regional_pool.submit(function,self) for region in self.regions]
+        futures = [self.regional_pool.submit(function,self) for _ in self.regions]
         futures, _ = wait(futures)
         pass
     return wrapper

--- a/prowler/providers/aws/lib/decorators/decorators.py
+++ b/prowler/providers/aws/lib/decorators/decorators.py
@@ -39,8 +39,7 @@ def thread_per_item(attribute):
 
 def try_catch(function): 
     '''
-    Passes the decorated function 
-    Each thread has intialised the self.regional_client variable, one region per thread. Use this in the logic of the wrapped function
+    Can be used to implement the try-catch strategy used throughout prowler. However, the module and filename fields in the logs then comes up as 'decorators' and 'decorators.py', instead of the actual module the error occured in.
     '''
     def wrapper(*args,**kwargs):
         self = args[0]

--- a/prowler/providers/aws/lib/decorators/decorators.py
+++ b/prowler/providers/aws/lib/decorators/decorators.py
@@ -1,7 +1,4 @@
-import multiprocessing
-from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
-from prowler.providers.aws.aws_provider import generate_regional_clients, generate_regions_for_service, AWS_Provider
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import wait
 from prowler.lib.logger import logger
 from functools import wraps
 import time

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
@@ -154,7 +154,7 @@ class Logs(Service):
 
     @threading_regional
     def __describe_log_groups__(self):
-        logger.info("CloudWatch Logs - Describing log groups...")
+        logger.info(f"CloudWatch Logs - Describing log groups for {self.regional_client.region}...")
         try:
             describe_log_groups_paginator = self.regional_client.get_paginator(
                 "describe_log_groups"
@@ -187,12 +187,6 @@ class Logs(Service):
     @timeit
     @threading_global("log_groups")
     def __get_log_events__(self, log_group):
-        # regional_log_groups = [
-        #     log_group
-        #     for log_group in self.log_groups
-        #     if log_group.region == regional_client.region
-        # ]
-        # total_log_groups = len(regional_log_groups)
         logger.info(
             f"CloudWatch Logs - Retrieving log events for {log_group.name} log group in {log_group.region}..."
         )

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
@@ -6,10 +6,10 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients, gen_regions_for_service
+from prowler.providers.aws.aws_provider import generate_regional_clients
 
 from prowler.providers.aws.lib.classes import Service
-from prowler.providers.aws.lib.decorators.decorators import thread_per_region, thread_per_item, timeit
+from prowler.providers.aws.lib.decorators.decorators import thread_per_region, thread_per_item
 
 
 ################## CloudWatch
@@ -154,7 +154,6 @@ class Logs(Service):
                 f"{self.regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    @timeit
     @thread_per_item("log_groups")
     def __get_log_events__(self, log_group):
         logger.info(


### PR DESCRIPTION
### Context

I have come up with a new strategy for threading. There are 2 options, which have been implemented as decorators.
1. thread_per_region This will use a pool of threads (ThreadPoolExecutor), and initialize each thread to handle 1 region. This is intended to replace the previous __threading_call__ implementation
2. thread_per_item This is a separate pool of threads which is used to thread per item. You specify which list of items you would like to use as the iterator by passing the name of the object's attribute to the decorator. I did this because I could not seem to pass self.some_attribute as a variable to the decorator.

Thread_per_item is the main improvement here. As an example, this used to be the implementation of the `__list_tags_for_resource__` function for the `CloudWatch` class.

```
def __list_tags_for_resource__(self):
        logger.info("CloudWatch - List Tags...")
        try:
            for metric_alarm in self.metric_alarms:
                regional_client = self.regional_clients[metric_alarm.region]
                response = regional_client.list_tags_for_resource(
                    ResourceARN=metric_alarm.arn
                )["Tags"]
                metric_alarm.tags = response
        except Exception as error:
            logger.error(
                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
            )
```

Instead of handling all of the metric_alarms (`for metric_alarm in self.metric_alarms:`), the function now takes in a `metric_alarm` parameter (shown below). `@thread_per_item("metric_alarms")` indicates to the decorator that a thread should be spawned for each item in `self.metric_alarms`, which it will pass in as a parameter to the decorated function. This allows for improved parallel performance, as each API call (`regional_client.list_tags_for_resource`) is now handled in a separate thread in the `ThreadPoolExecutor` pool, rather than 1 thread making all the calls sequentially. I assume this improvement will be more apparent when it comes to other services, such as retrieving the lambda code for each function.
```
@thread_per_item("metric_alarms")
    def __list_tags_for_resource__(self, metric_alarm):
        logger.info(f"CloudWatch - Listing Tags for metric alarm {metric_alarm.name}")
        try:
            regional_client = self.regional_clients[metric_alarm.region]
            response = regional_client.list_tags_for_resource(
                ResourceARN=metric_alarm.arn
            )["Tags"]
            metric_alarm.tags = response
        except Exception as error:
            logger.error(
                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
            )
```

### Description

I have changed the implementation for the cloudwatch_service.py and ec2_service.py files.
To change from the `__threading_call__` to `@thread_per_region`:
- Make the service subclass the `from prowler.providers.aws.lib.classes import Service` class
- Remove the regional_client input parameter, and change instances of `regional_client` within the function to rather be `self.regional_client`

To use `@thread_per_item`:
- Make the service subclass the `from prowler.providers.aws.lib.classes import Service` class
- Remove the handling of the list of items from within the function
- Create the decorator with the name of the object's attribute that will be used to iterate through, and pass an item to the function (ie `self.log_groups`)
- Create another input paramter for the function for the item to be passed in (ie `log_group`)


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
