### PR TITLE
fix(output bucket): solve IsADirectoryError using compliance flag

### DIFF
--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -210,6 +210,8 @@ def send_to_s3_bucket(
             filename = f"{output_filename}{json_asff_file_suffix}"
         elif output_mode == "html":
             filename = f"{output_filename}{html_file_suffix}"
+        else:  # Compliance output mode
+            return
         logger.info(f"Sending outputs to S3 bucket {output_bucket}")
         bucket_remote_dir = output_directory
         while "prowler/" in bucket_remote_dir:  # Check if it is not a custom directory

--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -211,7 +211,7 @@ def send_to_s3_bucket(
         elif output_mode == "html":
             filename = f"{output_filename}{html_file_suffix}"
         else:  # Compliance output mode
-            return
+            filename = f"{output_filename}_{output_mode}{csv_file_suffix}"
         logger.info(f"Sending outputs to S3 bucket {output_bucket}")
         bucket_remote_dir = output_directory
         while "prowler/" in bucket_remote_dir:  # Check if it is not a custom directory


### PR DESCRIPTION
### Description

Solve `IsADirectoryError` when sending outputs to bucket using compliance flag.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
