### PR TITLE
fix(quickinventory): AttributError when creating inventory table

### DIFF
--- a/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
+++ b/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
@@ -166,7 +166,7 @@ def create_inventory_table(resources: list, resources_in_region: dict) -> dict:
             elif "documentation" in split_parts and "parts" in split_parts:
                 resource_type = "restapis-documentation-parts"
             else:
-                resource_type = resource.split(":")[5].split("/")[1]
+                resource_type = resource["arn"].split(":")[5].split("/")[1]
         else:
             resource_type = resource["arn"].split(":")[5].split("/")[0]
         if service not in resources_type:


### PR DESCRIPTION
### Context

The Quick Inventory was failing with an `AttributeError`. 
```
$ prowler aws -i -p $AWS_PROFILE
                         _
 _ __  _ __ _____      _| | ___ _ __
| '_ \| '__/ _ \ \ /\ / / |/ _ \ '__|
| |_) | | | (_) \ V  V /| |  __/ |
| .__/|_|  \___/ \_/\_/ |_|\___|_|v3.3.0
|_| the handy cloud security tool

Date: 2023-03-22 10:28:08


This report is being generated using credentials below:

AWS-CLI Profile: [auditor] AWS Filter Region: [all]
AWS Account: [123456789012] UserId: [AROAEXAMPLE:user]
Caller Identity ARN: [arn:aws:sts::123456789012:assumed-role/AUDITOR/user]

-> Quick Inventory completed! |▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉| 17/17 [100%] in 1:22.1
2023-03-22 10:29:32,377 [File: quick_inventory.py:19]   [Module: quick_inventory]        CRITICAL: AttributeError[15]: 'dict' object has no attribute 'split'
```
I traced the problem to the [apigateway service parsing](https://github.com/prowler-cloud/prowler/blob/6c3db9646ed89739e243e1681d6622fbbdca1391/prowler/providers/aws/lib/quick_inventory/quick_inventory.py#L169) in `create_inventory_table()`

### Description

Changed the final else block to reference `resource["arn"]` instead of the entire resource dict.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
