### PR TITLE
feat(python-option): Make it possible to run Prowler from Python as a library

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -39,10 +39,10 @@ from prowler.providers.common.outputs import set_provider_output_options
 from prowler.providers.common.quick_inventory import run_provider_quick_inventory
 
 
-def prowler():
+def prowler(args=None):
     # Parse Arguments
     parser = ProwlerArgumentParser()
-    args = parser.parse()
+    args = parser.parse(args=args)
 
     # Save Arguments
     provider = args.provider
@@ -50,6 +50,7 @@ def prowler():
     excluded_checks = args.excluded_checks
     excluded_services = args.excluded_services
     services = args.services
+    use_python = args.python
     categories = args.categories
     checks_file = args.checks_file
     severities = args.severity
@@ -66,7 +67,10 @@ def prowler():
         print_banner(args)
 
     if args.list_services:
-        print_services(list_services(provider))
+        service_list = list_services(provider)
+        if use_python:
+            return service_list
+        print_services(service_list)
         sys.exit()
 
     # Load checks metadata
@@ -74,7 +78,10 @@ def prowler():
     bulk_checks_metadata = bulk_load_checks_metadata(provider)
 
     if args.list_categories:
-        print_categories(list_categories(provider, bulk_checks_metadata))
+        category_list = list_categories(provider, bulk_checks_metadata)
+        if use_python:
+            return category_list
+        print_categories(category_list)
         sys.exit()
 
     bulk_compliance_frameworks = {}
@@ -87,6 +94,8 @@ def prowler():
         bulk_compliance_frameworks, bulk_checks_metadata
     )
     if args.list_compliance:
+        if use_python:
+            return bulk_compliance_frameworks
         print_compliance_frameworks(bulk_compliance_frameworks)
         sys.exit()
     if args.list_compliance_requirements:
@@ -158,6 +167,8 @@ def prowler():
             "There are no checks to execute. Please, check your input arguments"
         )
 
+    if use_python:
+        return findings
     # Extract findings stats
     stats = extract_findings_statistics(findings)
 

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -112,6 +112,11 @@ Detailed documentation at https://docs.prowler.cloud
             "Outputs"
         )
         common_outputs_parser.add_argument(
+            "--python",
+            action="store_true",
+            help="Use prowler from python",
+        )
+        common_outputs_parser.add_argument(
             "-q",
             "--quiet",
             action="store_true",


### PR DESCRIPTION
The --python option enable prowler to be called by a python program to manipulate findings directly

### Context

Hello, It would be nice to be able to use prowler from python. In this way it's possible to have the type hint of the checks and manipulate them on the fly. Maybe with an additional PR we could also change the code to return the findings with a `yield` keyword and get them in real time.

To run prowler from python:

```
# inside the root directory of the project
pip install .
```

And then with a script:

```py
from prowler import __main__
from prowler.lib.check.models import Check_Report_AWS
from typing import List

arguments = ["aws", "--region", "eu-west-1", "--python", "-c", "account_maintain_current_contact_details"]
findings: List[Check_Report_AWS] = __main__.prowler(args=arguments)
for finding in findings:
    print(finding.status)
    print(finding.check_metadata)
```

### Description

No dependencies are required for this PR. The PR make it possible to run prowler directly from python. Let me know if it's something that you think is useful for your project, or I'll close the PR. A redesign of the __main__.py would be needed to make it a bit cleaner :D 

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
