### PR TITLE
fix(readme): add GCP provider to README introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 # Description
 
-`Prowler` is an Open Source security tool to perform AWS and Azure security best practices assessments, audits, incident response, continuous monitoring, hardening and forensics readiness.
+`Prowler` is an Open Source security tool to perform AWS, GCP and Azure security best practices assessments, audits, incident response, continuous monitoring, hardening and forensics readiness.
 
 It contains hundreds of controls covering CIS, PCI-DSS, ISO27001, GDPR, HIPAA, FFIEC, SOC2, AWS FTR, ENS and custom security frameworks.
 


### PR DESCRIPTION
### Description

Add GCP provider to README introduction.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
