### PR TITLE
fix(azure output): change default values of audit identity metadata

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2572,14 +2572,14 @@ files = [
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.8"
+version = "6.0.12.9"
 description = "Typing stubs for PyYAML"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "types-PyYAML-6.0.12.8.tar.gz", hash = "sha256:19304869a89d49af00be681e7b267414df213f4eb89634c4495fa62e8f942b9f"},
-    {file = "types_PyYAML-6.0.12.8-py3-none-any.whl", hash = "sha256:5314a4b2580999b2ea06b2e5f9a7763d860d6e09cdf21c0e9561daa9cbd60178"},
+    {file = "types-PyYAML-6.0.12.9.tar.gz", hash = "sha256:c51b1bd6d99ddf0aa2884a7a328810ebf70a4262c292195d3f4f9a0005f9eeb6"},
+    {file = "types_PyYAML-6.0.12.9-py3-none-any.whl", hash = "sha256:5aed5aa66bd2d2e158f75dda22b059570ede988559f030cf294871d3b647e3e8"},
 ]
 
 [[package]]

--- a/prowler/providers/azure/lib/audit_info/models.py
+++ b/prowler/providers/azure/lib/audit_info/models.py
@@ -6,10 +6,10 @@ from pydantic import BaseModel
 
 
 class Azure_Identity_Info(BaseModel):
-    identity_id: str = None
-    identity_type: str = None
+    identity_id: str = ""
+    identity_type: str = ""
     tenant_ids: list[str] = []
-    domain: str = None
+    domain: str = ""
     subscriptions: dict = {}
 
 


### PR DESCRIPTION
### Context

Azure output files are failing when the tenant domain info can't be retrieved


### Description

Change the default values of the `Azure_Identity_Info` attributes to be compatible with the definition of `Azure_Check_Output_CSV`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
