### PR TITLE
chore(release): update Prowler Version to 3.3.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -914,14 +914,14 @@ uritemplate = ">=3.0.1,<5"
 
 [[package]]
 name = "google-auth"
-version = "2.16.3"
+version = "2.17.0"
 description = "Google Authentication Library"
 category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
 files = [
-    {file = "google-auth-2.16.3.tar.gz", hash = "sha256:611779ce33a3aee265b94b74d4bb8c188f33010f5814761250a0ebbde94cc745"},
-    {file = "google_auth-2.16.3-py2.py3-none-any.whl", hash = "sha256:4dfcfd8ecd1cf03ddc97fddfb3b1f2973ea4f3f664aa0d8cfaf582ef9f0c60e7"},
+    {file = "google-auth-2.17.0.tar.gz", hash = "sha256:f51d26ebb3e5d723b9a7dbd310b6c88654ef1ad1fc35750d1fdba48ca4d82f52"},
+    {file = "google_auth-2.17.0-py2.py3-none-any.whl", hash = "sha256:45ba9b4b3e49406de3c5451697820694b2f6ce8a6b75bb187852fdae231dab94"},
 ]
 
 [package.dependencies]

--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -11,7 +11,7 @@ from prowler.lib.logger import logger
 
 timestamp = datetime.today()
 timestamp_utc = datetime.now(timezone.utc).replace(tzinfo=timezone.utc)
-prowler_version = "3.3.0"
+prowler_version = "3.3.1"
 html_logo_url = "https://github.com/prowler-cloud/prowler/"
 html_logo_img = "https://user-images.githubusercontent.com/3985464/113734260-7ba06900-96fb-11eb-82bc-d4f68a1e2710.png"
 

--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -11,7 +11,7 @@ from prowler.lib.logger import logger
 
 timestamp = datetime.today()
 timestamp_utc = datetime.now(timezone.utc).replace(tzinfo=timezone.utc)
-prowler_version = "3.3.1"
+prowler_version = "3.3.2"
 html_logo_url = "https://github.com/prowler-cloud/prowler/"
 html_logo_img = "https://user-images.githubusercontent.com/3985464/113734260-7ba06900-96fb-11eb-82bc-d4f68a1e2710.png"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
   {include = "prowler"}
 ]
 readme = "README.md"
-version = "3.3.1"
+version = "3.3.2"
 
 [tool.poetry.dependencies]
 alive-progress = "3.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
   {include = "prowler"}
 ]
 readme = "README.md"
-version = "3.3.0"
+version = "3.3.1"
 
 [tool.poetry.dependencies]
 alive-progress = "3.1.0"

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from prowler.config.config import check_current_version, prowler_version
+from prowler.config.config import check_current_version
 from prowler.providers.aws.aws_provider import get_aws_available_regions
 
 MOCK_PROWLER_VERSION = "3.3.0"
@@ -21,9 +21,10 @@ class Test_Config:
     @mock.patch("prowler.config.config.prowler_version", new=MOCK_PROWLER_VERSION)
     def test_check_current_version_with_latest(self):
         assert (
-            check_current_version(prowler_version) == "(it is the latest version, yay!)"
+            check_current_version(MOCK_PROWLER_VERSION)
+            == "(it is the latest version, yay!)"
         )
         assert (
             check_current_version("0.0.0")
-            == f"(latest is {prowler_version}, upgrade for the latest features)"
+            == f"(latest is {MOCK_PROWLER_VERSION}, upgrade for the latest features)"
         )


### PR DESCRIPTION
### Description

This PR updates Prowler Version to 3.3.2.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.