### PR TITLE
fix(pypi): Build from release branch

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -6,7 +6,6 @@ on:
 
 env:
   RELEASE_TAG: ${{ github.event.release.tag_name }}
-  GITHUB_BRANCH: master
 
 jobs:
   release-prowler-job:
@@ -17,8 +16,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ env.GITHUB_BRANCH }}
+
       - name: Install dependencies
         run: |
           pipx install poetry


### PR DESCRIPTION
### Description

Build PyPI package from the release branch instead of `master`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
