### PR TITLE
fix(pypi): Set base branch when updating release version

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           token: ${{ secrets.PROWLER_ACCESS_TOKEN }}
           commit-message: "chore(release): update Prowler Version to ${{ env.RELEASE_TAG }}."
+          base: master
           branch: release-${{ env.RELEASE_TAG }}
           labels: "status/waiting-for-revision, severity/low"
           title: "chore(release): update Prowler Version to ${{ env.RELEASE_TAG }}"


### PR DESCRIPTION
### Description

Set base branch when updating release version.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
