### PR TITLE
fix(docs): check extra_742 name adjusted in the V2 to V3 mapping

### DIFF
--- a/docs/tutorials/aws/v2_to_v3_checks_mapping.md
+++ b/docs/tutorials/aws/v2_to_v3_checks_mapping.md
@@ -31,7 +31,7 @@ checks_v3_to_v2_mapping = {
     "awslambda_function_url_cors_policy": "extra7180",
     "awslambda_function_url_public": "extra7179",
     "awslambda_function_using_supported_runtimes": "extra762",
-    "cloudformation_outputs_find_secrets": "extra742",
+    "cloudformation_stack_outputs_find_secrets": "extra742",
     "cloudformation_stacks_termination_protection_enabled": "extra7154",
     "cloudfront_distributions_field_level_encryption_enabled": "extra767",
     "cloudfront_distributions_geo_restrictions_enabled": "extra732",


### PR DESCRIPTION
### Context

Since the extra check 742 had its name changed from "cloudformation_outputs_find_secrets" to "cloudformation_stack_outputs_find_secrets" in #2027 it is also necessary to update the following file: docs/tutorials/aws/v2_to_v3_checks_mapping.md

### Description

Changed extra742 check name from "cloudformation_outputs_find_secrets" to "cloudformation_stack_outputs_find_secrets" in docs/tutorials/aws/v2_to_v3_checks_mapping.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
