### PR TITLE
fix(secretsmanager_automatic_rotation_enabled): Improve description for Secrets Manager secret rotation

### DIFF
--- a/prowler/providers/aws/services/secretsmanager/secretsmanager_automatic_rotation_enabled/secretsmanager_automatic_rotation_enabled.metadata.json
+++ b/prowler/providers/aws/services/secretsmanager/secretsmanager_automatic_rotation_enabled/secretsmanager_automatic_rotation_enabled.metadata.json
@@ -1,15 +1,15 @@
 {
   "Provider": "aws",
   "CheckID": "secretsmanager_automatic_rotation_enabled",
-  "CheckTitle": "Check if Secrets Manager key rotation is enabled.",
+  "CheckTitle": "Check if Secrets Manager secret rotation is enabled.",
   "CheckType": [],
   "ServiceName": "secretsmanager",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:secretsmanager:region:account-id:secret:secret-name",
   "Severity": "medium",
   "ResourceType": "AwsSecretsManagerSecret",
-  "Description": "Check if Secrets Manager key rotation is enabled.",
-  "Risk": "Rotating secrets minimizes exposure to attacks using stolen keys.",
+  "Description": "Check if Secrets Manager secret rotation is enabled.",
+  "Risk": "Rotating secrets minimizes exposure to attacks using stolen secrets.",
   "RelatedUrl": "https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets_strategies.html",
   "Remediation": {
     "Code": {


### PR DESCRIPTION
"key rotation" is misleading in this check, because secrets use kms keys.

Not sure if this is the only place.