### PR TITLE
fix(logging): add default resource id when no resources

### DIFF
--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_audit_configuration_changes_enabled/logging_log_metric_filter_and_alert_for_audit_configuration_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_audit_configuration_changes_enabled/logging_log_metric_filter_and_alert_for_audit_configuration_changes_enabled.py
@@ -12,7 +12,7 @@ class logging_log_metric_filter_and_alert_for_audit_configuration_changes_enable
         findings = []
         report = Check_Report_GCP(self.metadata())
         report.project_id = logging_client.project_id
-        report.resource_id = ""
+        report.resource_id = logging_client.project_id
         report.resource_name = ""
         report.location = logging_client.region
         report.status = "FAIL"

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled/logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled/logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled.py
@@ -10,7 +10,7 @@ class logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled(
         findings = []
         report = Check_Report_GCP(self.metadata())
         report.project_id = logging_client.project_id
-        report.resource_id = ""
+        report.resource_id = logging_client.project_id
         report.resource_name = ""
         report.location = logging_client.region
         report.status = "FAIL"

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_custom_role_changes_enabled/logging_log_metric_filter_and_alert_for_custom_role_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_custom_role_changes_enabled/logging_log_metric_filter_and_alert_for_custom_role_changes_enabled.py
@@ -10,7 +10,7 @@ class logging_log_metric_filter_and_alert_for_custom_role_changes_enabled(Check)
         findings = []
         report = Check_Report_GCP(self.metadata())
         report.project_id = logging_client.project_id
-        report.resource_id = ""
+        report.resource_id = logging_client.project_id
         report.resource_name = ""
         report.location = logging_client.region
         report.status = "FAIL"

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled/logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled/logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.py
@@ -10,7 +10,7 @@ class logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled(
         findings = []
         report = Check_Report_GCP(self.metadata())
         report.project_id = logging_client.project_id
-        report.resource_id = ""
+        report.resource_id = logging_client.project_id
         report.resource_name = ""
         report.location = logging_client.region
         report.status = "FAIL"

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_sql_instance_configuration_changes_enabled/logging_log_metric_filter_and_alert_for_sql_instance_configuration_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_sql_instance_configuration_changes_enabled/logging_log_metric_filter_and_alert_for_sql_instance_configuration_changes_enabled.py
@@ -12,7 +12,7 @@ class logging_log_metric_filter_and_alert_for_sql_instance_configuration_changes
         findings = []
         report = Check_Report_GCP(self.metadata())
         report.project_id = logging_client.project_id
-        report.resource_id = ""
+        report.resource_id = logging_client.project_id
         report.resource_name = ""
         report.location = logging_client.region
         report.status = "FAIL"

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_vpc_firewall_rule_changes_enabled/logging_log_metric_filter_and_alert_for_vpc_firewall_rule_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_vpc_firewall_rule_changes_enabled/logging_log_metric_filter_and_alert_for_vpc_firewall_rule_changes_enabled.py
@@ -10,7 +10,7 @@ class logging_log_metric_filter_and_alert_for_vpc_firewall_rule_changes_enabled(
         findings = []
         report = Check_Report_GCP(self.metadata())
         report.project_id = logging_client.project_id
-        report.resource_id = ""
+        report.resource_id = logging_client.project_id
         report.resource_name = ""
         report.location = logging_client.region
         report.status = "FAIL"

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_vpc_network_changes_enabled/logging_log_metric_filter_and_alert_for_vpc_network_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_vpc_network_changes_enabled/logging_log_metric_filter_and_alert_for_vpc_network_changes_enabled.py
@@ -10,7 +10,7 @@ class logging_log_metric_filter_and_alert_for_vpc_network_changes_enabled(Check)
         findings = []
         report = Check_Report_GCP(self.metadata())
         report.project_id = logging_client.project_id
-        report.resource_id = ""
+        report.resource_id = logging_client.project_id
         report.resource_name = ""
         report.location = logging_client.region
         report.status = "FAIL"

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_vpc_network_route_changes_enabled/logging_log_metric_filter_and_alert_for_vpc_network_route_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_vpc_network_route_changes_enabled/logging_log_metric_filter_and_alert_for_vpc_network_route_changes_enabled.py
@@ -10,7 +10,7 @@ class logging_log_metric_filter_and_alert_for_vpc_network_route_changes_enabled(
         findings = []
         report = Check_Report_GCP(self.metadata())
         report.project_id = logging_client.project_id
-        report.resource_id = ""
+        report.resource_id = logging_client.project_id
         report.resource_name = ""
         report.location = logging_client.region
         report.status = "FAIL"

--- a/prowler/providers/gcp/services/logging/logging_sink_created/logging_sink_created.py
+++ b/prowler/providers/gcp/services/logging/logging_sink_created/logging_sink_created.py
@@ -8,7 +8,7 @@ class logging_sink_created(Check):
         if not logging_client.sinks:
             report = Check_Report_GCP(self.metadata())
             report.project_id = logging_client.project_id
-            report.resource_id = ""
+            report.resource_id = logging_client.project_id
             report.resource_name = ""
             report.location = logging_client.region
             report.status = "FAIL"


### PR DESCRIPTION
### Description

Set Project ID as default Resource ID when there are no resources.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
