### PR TITLE
feat(checks): New iam_securityaudit_role_created

### DIFF
--- a/prowler/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created.metadata.json
+++ b/prowler/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created.metadata.json
@@ -13,7 +13,7 @@
   "Severity": "low",
   "ResourceType": "AwsIamRole",
   "Description": "Ensure a Security Audit role has been created to conduct security audits",
-  "Risk": "Creating an IAM user with a security audit role provides a clear separation of duties between the security team and other teams within the organization. This helps to ensure that security-related activities are performed by authorized individuals with the appropriate expertise and access permissions.",
+  "Risk": "Creating an IAM role with a security audit policy provides a clear separation of duties between the security team and other teams within the organization. This helps to ensure that security-related activities are performed by authorized individuals with the appropriate expertise and access permissions.",
   "RelatedUrl": "",
   "Remediation": {
     "Code": {

--- a/prowler/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created.metadata.json
+++ b/prowler/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created.metadata.json
@@ -1,0 +1,34 @@
+{
+  "Provider": "aws",
+  "CheckID": "iam_securityaudit_role_created",
+  "CheckTitle": "Ensure a Security Audit role has been created to conduct security audits",
+  "CheckType": [
+    "Software and Configuration Checks",
+    "Industry and Regulatory Standards",
+    "CIS AWS Foundations Benchmark"
+  ],
+  "ServiceName": "iam",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
+  "Severity": "low",
+  "ResourceType": "AwsIamRole",
+  "Description": "Ensure a Security Audit role has been created to conduct security audits",
+  "Risk": "Creating an IAM user with a security audit role provides a clear separation of duties between the security team and other teams within the organization. This helps to ensure that security-related activities are performed by authorized individuals with the appropriate expertise and access permissions.",
+  "RelatedUrl": "",
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Create an IAM role for conduct security audits with AWS.",
+      "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html#jf_security-auditor"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created.py
+++ b/prowler/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created.py
@@ -1,0 +1,19 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.iam.iam_client import iam_client
+
+
+class iam_securityaudit_role_created(Check):
+    def execute(self) -> Check_Report_AWS:
+        findings = []
+        report = Check_Report_AWS(self.metadata())
+        report.region = iam_client.region
+        report.resource_id = "SecurityAudit"
+        report.resource_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+        if iam_client.entities_attached_to_securityaudit_roles:
+            report.status = "PASS"
+            report.status_extended = f"SecurityAudit policy attached to role {iam_client.entities_attached_to_securityaudit_roles[0]['RoleName']}"
+        else:
+            report.status = "FAIL"
+            report.status_extended = "SecurityAudit policy is not attached to any role"
+        findings.append(report)
+        return findings

--- a/prowler/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created.py
+++ b/prowler/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created.py
@@ -9,9 +9,9 @@ class iam_securityaudit_role_created(Check):
         report.region = iam_client.region
         report.resource_id = "SecurityAudit"
         report.resource_arn = "arn:aws:iam::aws:policy/SecurityAudit"
-        if iam_client.entities_attached_to_securityaudit_roles:
+        if iam_client.entities_role_attached_to_securityaudit_policy:
             report.status = "PASS"
-            report.status_extended = f"SecurityAudit policy attached to role {iam_client.entities_attached_to_securityaudit_roles[0]['RoleName']}"
+            report.status_extended = f"SecurityAudit policy attached to role {iam_client.entities_role_attached_to_securityaudit_policy[0]['RoleName']}"
         else:
             report.status = "FAIL"
             report.status_extended = "SecurityAudit policy is not attached to any role"

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -56,6 +56,9 @@ class IAM:
         self.entities_attached_to_support_roles = (
             self.__get_entities_attached_to_support_roles__()
         )
+        self.entities_attached_to_securityaudit_roles = (
+            self.__get_entities_attached_to_securityaudit_roles__()
+        )
         self.policies = self.__list_policies__()
         self.__list_policies_version__(self.policies)
         self.saml_providers = self.__list_saml_providers__()
@@ -352,6 +355,20 @@ class IAM:
             )
         finally:
             return support_roles
+
+    def __get_entities_attached_to_securityaudit_roles__(self):
+        try:
+            securityaudit_roles = []
+            securityaudit_entry_policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+            securityaudit_roles = self.client.list_entities_for_policy(
+                PolicyArn=securityaudit_entry_policy_arn, EntityFilter="Role"
+            )["PolicyRoles"]
+        except Exception as error:
+            logger.error(
+                f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+        finally:
+            return securityaudit_roles
 
     def __list_policies__(self):
         try:

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -53,11 +53,15 @@ class IAM:
         self.__list_inline_user_policies__()
         self.__list_mfa_devices__()
         self.password_policy = self.__get_password_policy__()
-        self.entities_attached_to_support_roles = (
-            self.__get_entities_attached_to_support_roles__()
+        support_policy_arn = (
+            "arn:aws:iam::aws:policy/aws-service-role/AWSSupportServiceRolePolicy"
         )
-        self.entities_attached_to_securityaudit_roles = (
-            self.__get_entities_attached_to_securityaudit_roles__()
+        self.entities_role_attached_to_support_policy = (
+            self.__list_entities_role_for_policy__(support_policy_arn)
+        )
+        securityaudit_policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+        self.entities_role_attached_to_securityaudit_policy = (
+            self.__list_entities_role_for_policy__(securityaudit_policy_arn)
         )
         self.policies = self.__list_policies__()
         self.__list_policies_version__(self.policies)
@@ -340,35 +344,18 @@ class IAM:
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_entities_attached_to_support_roles__(self):
+    def __list_entities_role_for_policy__(self, policy_arn):
         try:
-            support_roles = []
-            support_entry_policy_arn = (
-                "arn:aws:iam::aws:policy/aws-service-role/AWSSupportServiceRolePolicy"
-            )
-            support_roles = self.client.list_entities_for_policy(
-                PolicyArn=support_entry_policy_arn, EntityFilter="Role"
+            roles = []
+            roles = self.client.list_entities_for_policy(
+                PolicyArn=policy_arn, EntityFilter="Role"
             )["PolicyRoles"]
         except Exception as error:
             logger.error(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         finally:
-            return support_roles
-
-    def __get_entities_attached_to_securityaudit_roles__(self):
-        try:
-            securityaudit_roles = []
-            securityaudit_entry_policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
-            securityaudit_roles = self.client.list_entities_for_policy(
-                PolicyArn=securityaudit_entry_policy_arn, EntityFilter="Role"
-            )["PolicyRoles"]
-        except Exception as error:
-            logger.error(
-                f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-            )
-        finally:
-            return securityaudit_roles
+            return roles
 
     def __list_policies__(self):
         try:

--- a/prowler/providers/aws/services/iam/iam_support_role_created/iam_support_role_created.py
+++ b/prowler/providers/aws/services/iam/iam_support_role_created/iam_support_role_created.py
@@ -11,9 +11,9 @@ class iam_support_role_created(Check):
         report.resource_arn = (
             "arn:aws:iam::aws:policy/aws-service-role/AWSSupportServiceRolePolicy"
         )
-        if iam_client.entities_attached_to_support_roles:
+        if iam_client.entities_role_attached_to_support_policy:
             report.status = "PASS"
-            report.status_extended = f"Support policy attached to role {iam_client.entities_attached_to_support_roles[0]['RoleName']}"
+            report.status_extended = f"Support policy attached to role {iam_client.entities_role_attached_to_support_policy[0]['RoleName']}"
         else:
             report.status = "FAIL"
             report.status_extended = "Support policy is not attached to any role"

--- a/tests/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created_test.py
+++ b/tests/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created_test.py
@@ -25,7 +25,7 @@ class Test_iam_securityaudit_role_created:
             audited_partition="aws",
             audited_identity_arn=None,
             profile=None,
-            profile_region=None,
+            profile_region="us-east-1",
             credentials=None,
             assumed_role_info=None,
             audited_regions=None,
@@ -79,6 +79,7 @@ class Test_iam_securityaudit_role_created:
                 )
                 assert result[0].resource_id == "SecurityAudit"
                 assert result[0].resource_arn == "arn:aws:iam::aws:policy/SecurityAudit"
+                assert result[0].region == "us-east-1"
 
     @mock_iam
     def test_no_securityaudit_role_created(self):
@@ -106,3 +107,4 @@ class Test_iam_securityaudit_role_created:
                 )
                 assert result[0].resource_id == "SecurityAudit"
                 assert result[0].resource_arn == "arn:aws:iam::aws:policy/SecurityAudit"
+                assert result[0].region == "us-east-1"

--- a/tests/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created_test.py
+++ b/tests/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created_test.py
@@ -1,0 +1,108 @@
+from json import dumps
+from re import search
+from unittest import mock
+
+from boto3 import client, session
+from moto import mock_iam
+
+from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
+from prowler.providers.aws.services.iam.iam_service import IAM
+
+
+class Test_iam_securityaudit_role_created:
+
+    # Mocked Audit Info
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=None,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=None,
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+        return audit_info
+
+    @mock_iam
+    def test_securityaudit_role_created(self):
+        audit_info = self.set_mocked_audit_info()
+        iam = client("iam")
+        role_name = "test_securityaudit_role_created"
+        assume_role_policy_document = {
+            "Version": "2012-10-17",
+            "Statement": {
+                "Sid": "test",
+                "Effect": "Allow",
+                "Principal": {"AWS": "*"},
+                "Action": "sts:AssumeRole",
+            },
+        }
+        iam.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=dumps(assume_role_policy_document),
+        )
+        iam.attach_role_policy(
+            RoleName=role_name,
+            PolicyArn="arn:aws:iam::aws:policy/SecurityAudit",
+        )
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.iam.iam_securityaudit_role_created.iam_securityaudit_role_created.iam_client",
+                new=IAM(audit_info),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.iam.iam_securityaudit_role_created.iam_securityaudit_role_created import (
+                    iam_securityaudit_role_created,
+                )
+
+                check = iam_securityaudit_role_created()
+                result = check.execute()
+                assert result[0].status == "PASS"
+                assert search(
+                    f"SecurityAudit policy attached to role {role_name}",
+                    result[0].status_extended,
+                )
+                assert result[0].resource_id == "SecurityAudit"
+                assert result[0].resource_arn == "arn:aws:iam::aws:policy/SecurityAudit"
+
+    @mock_iam
+    def test_no_securityaudit_role_created(self):
+        audit_info = self.set_mocked_audit_info()
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.iam.iam_securityaudit_role_created.iam_securityaudit_role_created.iam_client",
+                new=IAM(audit_info),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.iam.iam_securityaudit_role_created.iam_securityaudit_role_created import (
+                    iam_securityaudit_role_created,
+                )
+
+                check = iam_securityaudit_role_created()
+                result = check.execute()
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "SecurityAudit policy is not attached to any role"
+                )
+                assert result[0].resource_id == "SecurityAudit"
+                assert result[0].resource_arn == "arn:aws:iam::aws:policy/SecurityAudit"

--- a/tests/providers/aws/services/iam/iam_service_test.py
+++ b/tests/providers/aws/services/iam/iam_service_test.py
@@ -604,7 +604,10 @@ class Test_IAM_Service:
         audit_info = self.set_mocked_audit_info()
         iam = IAM(audit_info)
         assert len(iam.entities_role_attached_to_securityaudit_policy) == 1
-        assert iam.entities_role_attached_to_securityaudit_policy[0]["RoleName"] == role_name
+        assert (
+            iam.entities_role_attached_to_securityaudit_policy[0]["RoleName"]
+            == role_name
+        )
 
     @mock_iam
     def test___list_policies__(self):

--- a/tests/providers/aws/services/iam/iam_service_test.py
+++ b/tests/providers/aws/services/iam/iam_service_test.py
@@ -563,6 +563,50 @@ class Test_IAM_Service:
         assert iam.entities_attached_to_support_roles[0]["RoleName"] == role_name
 
     @mock_iam
+    def test__get_entities_attached_to_securityaudit_roles__no_roles(self):
+        iam_client = client("iam")
+        _ = iam_client.list_entities_for_policy(
+            PolicyArn="arn:aws:iam::aws:policy/SecurityAudit",
+            EntityFilter="Role",
+        )["PolicyRoles"]
+
+        audit_info = self.set_mocked_audit_info()
+        iam = IAM(audit_info)
+        assert len(iam.entities_attached_to_securityaudit_roles) == 0
+
+    @mock_iam
+    def test__get_entities_attached_to_securityaudit_roles__(self):
+        iam_client = client("iam")
+        role_name = "test_securityaudit"
+        assume_role_policy_document = {
+            "Version": "2012-10-17",
+            "Statement": {
+                "Sid": "test",
+                "Effect": "Allow",
+                "Principal": {"AWS": "*"},
+                "Action": "sts:AssumeRole",
+            },
+        }
+        iam_client.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=dumps(assume_role_policy_document),
+        )
+        iam_client.attach_role_policy(
+            RoleName=role_name,
+            PolicyArn="arn:aws:iam::aws:policy/SecurityAudit",
+        )
+
+        iam_client.list_entities_for_policy(
+            PolicyArn="arn:aws:iam::aws:policy/SecurityAudit",
+            EntityFilter="Role",
+        )["PolicyRoles"]
+
+        audit_info = self.set_mocked_audit_info()
+        iam = IAM(audit_info)
+        assert len(iam.entities_attached_to_securityaudit_roles) == 1
+        assert iam.entities_attached_to_securityaudit_roles[0]["RoleName"] == role_name
+
+    @mock_iam
     def test___list_policies__(self):
         iam_client = client("iam")
         policy_name = "policy1"

--- a/tests/providers/aws/services/iam/iam_service_test.py
+++ b/tests/providers/aws/services/iam/iam_service_test.py
@@ -528,7 +528,7 @@ class Test_IAM_Service:
 
         audit_info = self.set_mocked_audit_info()
         iam = IAM(audit_info)
-        assert len(iam.entities_attached_to_support_roles) == 0
+        assert len(iam.entities_role_attached_to_support_policy) == 0
 
     @mock_iam
     def test__get_entities_attached_to_support_roles__(self):
@@ -559,8 +559,8 @@ class Test_IAM_Service:
 
         audit_info = self.set_mocked_audit_info()
         iam = IAM(audit_info)
-        assert len(iam.entities_attached_to_support_roles) == 1
-        assert iam.entities_attached_to_support_roles[0]["RoleName"] == role_name
+        assert len(iam.entities_role_attached_to_support_policy) == 1
+        assert iam.entities_role_attached_to_support_policy[0]["RoleName"] == role_name
 
     @mock_iam
     def test__get_entities_attached_to_securityaudit_roles__no_roles(self):
@@ -572,7 +572,7 @@ class Test_IAM_Service:
 
         audit_info = self.set_mocked_audit_info()
         iam = IAM(audit_info)
-        assert len(iam.entities_attached_to_securityaudit_roles) == 0
+        assert len(iam.entities_role_attached_to_securityaudit_policy) == 0
 
     @mock_iam
     def test__get_entities_attached_to_securityaudit_roles__(self):
@@ -603,8 +603,8 @@ class Test_IAM_Service:
 
         audit_info = self.set_mocked_audit_info()
         iam = IAM(audit_info)
-        assert len(iam.entities_attached_to_securityaudit_roles) == 1
-        assert iam.entities_attached_to_securityaudit_roles[0]["RoleName"] == role_name
+        assert len(iam.entities_role_attached_to_securityaudit_policy) == 1
+        assert iam.entities_role_attached_to_securityaudit_policy[0]["RoleName"] == role_name
 
     @mock_iam
     def test___list_policies__(self):


### PR DESCRIPTION
### Context

This is a new IAM check: `iam_securityaudit_role_created`
Description: Ensure a Security Audit role has been created to conduct security audits

### Description

Creating an IAM user with a security audit role provides a clear separation of duties between the security team and other teams within the organization. This helps to ensure that security-related activities are performed by authorized individuals with the appropriate expertise and access permissions.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
