### PR TITLE
fix(kms): handle empty principal error

### DIFF
--- a/prowler/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
@@ -20,14 +20,17 @@ class kms_key_not_publicly_accessible(Check):
                 if key.policy and "Statement" in key.policy:
                     for statement in key.policy["Statement"]:
                         if (
-                            "*" == statement["Principal"]
+                            "Principal" in statement
+                            and "*" == statement["Principal"]
                             and "Condition" not in statement
                         ):
                             report.status = "FAIL"
                             report.status_extended = (
                                 f"KMS key {key.id} may be publicly accessible!"
                             )
-                        elif "AWS" in statement["Principal"]:
+                        elif (
+                            "Principal" in statement and "AWS" in statement["Principal"]
+                        ):
                             if type(statement["Principal"]["AWS"]) == str:
                                 principals = [statement["Principal"]["AWS"]]
                             else:

--- a/tests/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible_test.py
@@ -108,3 +108,50 @@ class Test_kms_key_not_publicly_accessible:
             )
             assert result[0].resource_id == key["KeyId"]
             assert result[0].resource_arn == key["Arn"]
+
+    @mock_kms
+    def test_kms_key_empty_principal(self):
+        # Generate KMS Client
+        kms_client = client("kms", region_name=AWS_REGION)
+        # Creaty KMS key with public policy
+        key = kms_client.create_key(
+            Policy=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Id": "key-default-1",
+                    "Statement": [
+                        {
+                            "Sid": "Enable IAM User Permissions",
+                            "Effect": "Allow",
+                            "Action": "kms:*",
+                            "Resource": "*",
+                        }
+                    ],
+                }
+            )
+        )["KeyMetadata"]
+        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
+        from prowler.providers.aws.services.kms.kms_service import KMS
+
+        current_audit_info.audited_partition = "aws"
+
+        with mock.patch(
+            "prowler.providers.aws.services.kms.kms_key_not_publicly_accessible.kms_key_not_publicly_accessible.kms_client",
+            new=KMS(current_audit_info),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.kms.kms_key_not_publicly_accessible.kms_key_not_publicly_accessible import (
+                kms_key_not_publicly_accessible,
+            )
+
+            check = kms_key_not_publicly_accessible()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"KMS key {key['KeyId']} is not exposed to Public."
+            )
+            assert result[0].resource_id == key["KeyId"]
+            assert result[0].resource_arn == key["Arn"]


### PR DESCRIPTION
### Description

Fix the following error:
```
kms_key_not_publicly_accessible -- KeyError[23]: 'Principal'
```
### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
