### PR TITLE
fix(security hub): remove region filter when archiving findings

### DIFF
--- a/prowler/providers/aws/lib/security_hub/security_hub.py
+++ b/prowler/providers/aws/lib/security_hub/security_hub.py
@@ -99,7 +99,7 @@ def resolve_security_hub_previous_findings(
                 "AwsAccountId": [
                     {"Value": audit_info.audited_account, "Comparison": "EQUALS"}
                 ],
-                "Region": [{"Value": region, "Comparison": "EQUALS"}],
+                "ResourceRegion": [{"Value": region, "Comparison": "EQUALS"}],
             }
             get_findings_paginator = security_hub_client.get_paginator("get_findings")
             findings_to_archive = []


### PR DESCRIPTION
### Description

Remove region filter when archiving Security Hub findings so when using an aggregated hub, the findings of the different regions are also archived if they are not present in the execution.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
