### PR TITLE
feat(check): New cloudtrail_bucket_requires_mfa_delete

### DIFF
--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete.metadata.json
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete.metadata.json
@@ -1,0 +1,36 @@
+{
+  "Provider": "aws",
+  "CheckID": "cloudtrail_bucket_requires_mfa_delete",
+  "CheckTitle": "Ensure the S3 bucket CloudTrail bucket requires MFA delete",
+  "CheckType": [
+    "Software and Configuration Checks",
+    "Industry and Regulatory Standards",
+    "CIS AWS Foundations Benchmark"
+  ],
+  "ServiceName": "cloudtrail",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
+  "Severity": "medium",
+  "ResourceType": "AwsCloudTrailTrail",
+  "Description": "Ensure the S3 bucket CloudTrail bucket requires MFA",
+  "Risk": "If the S3 bucket CloudTrail bucket does not require MFA, it can be deleted by an attacker.",
+  "RelatedUrl": "",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws s3api put-bucket-versioning --bucket DOC-EXAMPLE-BUCKET1 --versioning-configuration Status=Enabled,MFADelete=Enabled --mfa \"SERIAL 123456\"",
+      "NativeIaC": "",
+      "Other": "",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Configure MFA Delete for the S3 bucket CloudTrail bucket",
+      "Url": "https://docs.aws.amazon.com/AmazonS3/latest/userguide/MultiFactorAuthenticationDelete.html"
+    }
+  },
+  "Categories": [
+    "forensics-ready"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete.py
@@ -18,17 +18,13 @@ class cloudtrail_bucket_requires_mfa_delete(Check):
                 report.resource_arn = trail.arn
                 report.resource_tags = trail.tags
                 report.status = "FAIL"
-                report.status_extended = (
-                    f"Trail {trail.name} bucket ({trail_bucket}) has not MFA delete enabled"
-                )
+                report.status_extended = f"Trail {trail.name} bucket ({trail_bucket}) has not MFA delete enabled"
                 for bucket in s3_client.buckets:
                     if trail_bucket == bucket.name:
                         trail_bucket_is_in_account = True
                         if bucket.mfa_delete:
                             report.status = "PASS"
-                            report.status_extended = (
-                                f"Trail {trail.name} bucket ({trail_bucket}) has MFA delete enabled"
-                            )
+                            report.status_extended = f"Trail {trail.name} bucket ({trail_bucket}) has MFA delete enabled"
                 # check if trail bucket is a cross account bucket
                 if not trail_bucket_is_in_account:
                     report.status = "PASS"

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete.py
@@ -1,0 +1,39 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.cloudtrail.cloudtrail_client import (
+    cloudtrail_client,
+)
+from prowler.providers.aws.services.s3.s3_client import s3_client
+
+
+class cloudtrail_bucket_requires_mfa_delete(Check):
+    def execute(self):
+        findings = []
+        for trail in cloudtrail_client.trails:
+            if trail.is_logging:
+                trail_bucket_is_in_account = False
+                trail_bucket = trail.s3_bucket
+                report = Check_Report_AWS(self.metadata())
+                report.region = trail.region
+                report.resource_id = trail.name
+                report.resource_arn = trail.arn
+                report.resource_tags = trail.tags
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"Trail {trail.name} bucket ({trail_bucket}) has not MFA delete enabled"
+                )
+                for bucket in s3_client.buckets:
+                    if trail_bucket == bucket.name:
+                        trail_bucket_is_in_account = True
+                        if bucket.mfa_delete:
+                            report.status = "PASS"
+                            report.status_extended = (
+                                f"Trail {trail.name} bucket ({trail_bucket}) has MFA delete enabled"
+                            )
+                # check if trail bucket is a cross account bucket
+                if not trail_bucket_is_in_account:
+                    report.status = "PASS"
+                    report.status_extended = f"Trail {trail.name} bucket ({trail_bucket}) is a cross-account bucket in another account out of Prowler's permissions scope, please check it manually"
+
+                findings.append(report)
+
+        return findings

--- a/tests/providers/aws/lib/allowlist/allowlist_test.py
+++ b/tests/providers/aws/lib/allowlist/allowlist_test.py
@@ -11,7 +11,7 @@ from prowler.providers.aws.lib.allowlist.allowlist import (
 )
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 

--- a/tests/providers/aws/services/acm/acm_certificates_expiration_check/acm_certificates_expiration_check_test.py
+++ b/tests/providers/aws/services/acm/acm_certificates_expiration_check/acm_certificates_expiration_check_test.py
@@ -4,7 +4,7 @@ from unittest import mock
 from prowler.providers.aws.services.acm.acm_service import Certificate
 
 AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 DAYS_TO_EXPIRE_THRESHOLD = 7
 
 

--- a/tests/providers/aws/services/acm/acm_certificates_transparency_logs_enabled/acm_certificates_transparency_logs_enabled_test.py
+++ b/tests/providers/aws/services/acm/acm_certificates_transparency_logs_enabled/acm_certificates_transparency_logs_enabled_test.py
@@ -4,7 +4,7 @@ from unittest import mock
 from prowler.providers.aws.services.acm.acm_service import Certificate
 
 AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_acm_certificates_transparency_logs_enabled:

--- a/tests/providers/aws/services/acm/acm_service_test.py
+++ b/tests/providers/aws/services/acm/acm_service_test.py
@@ -12,7 +12,7 @@ from prowler.providers.aws.services.acm.acm_service import ACM
 # from moto import mock_acm
 
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 # Mocking Access Analyzer Calls

--- a/tests/providers/aws/services/apigateway/apigateway_service_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_service_test.py
@@ -4,7 +4,7 @@ from moto import mock_apigateway
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.apigateway.apigateway_service import APIGateway
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 

--- a/tests/providers/aws/services/apigatewayv2/apigatewayv2_service_test.py
+++ b/tests/providers/aws/services/apigatewayv2/apigatewayv2_service_test.py
@@ -8,7 +8,7 @@ from prowler.providers.aws.services.apigatewayv2.apigatewayv2_service import (
     ApiGatewayV2,
 )
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 # Mocking ApiGatewayV2 Calls

--- a/tests/providers/aws/services/autoscaling/autoscaling_service_test.py
+++ b/tests/providers/aws/services/autoscaling/autoscaling_service_test.py
@@ -6,7 +6,7 @@ from moto import mock_autoscaling
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.autoscaling.autoscaling_service import AutoScaling
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
@@ -1,0 +1,164 @@
+from unittest import mock
+from unittest.mock import patch
+
+from boto3 import client, session
+from moto import mock_cloudtrail, mock_s3, mock_iam
+import botocore
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.aws.services.cloudtrail.cloudtrail_service import Cloudtrail
+from prowler.providers.aws.services.s3.s3_service import S3
+
+AWS_ACCOUNT_NUMBER = 123456789012
+
+# Mocking Backup Calls
+make_api_call = botocore.client.BaseClient._make_api_call
+
+class Test_cloudtrail_bucket_requires_mfa_delete:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+        return audit_info
+
+    @mock_cloudtrail
+    def test_no_trails(self):
+        current_audit_info = self.set_mocked_audit_info()
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.cloudtrail_client",
+                new=Cloudtrail(current_audit_info),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete import (
+                    cloudtrail_bucket_requires_mfa_delete,
+                )
+
+                check = cloudtrail_bucket_requires_mfa_delete()
+                result = check.execute()
+                assert len(result) == 0
+
+    @mock_cloudtrail
+    @mock_s3
+    def test_trails_with_no_mfa_bucket(self):
+        current_audit_info = self.set_mocked_audit_info()
+
+        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        trail_name_us = "trail_test_us_with_no_mfa_bucket"
+        bucket_name_us = "bucket_test_us_with_no_mfa"
+        s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
+        trail_us = cloudtrail_client_us_east_1.create_trail(
+            Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=False
+        )
+        cloudtrail_client_us_east_1.start_logging(Name=trail_name_us)
+        cloudtrail_client_us_east_1.get_trail_status(Name=trail_name_us)
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.cloudtrail_client",
+                new=Cloudtrail(current_audit_info),
+            ):
+                with mock.patch(
+                    "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.s3_client",
+                    new=S3(current_audit_info),
+                ):
+                    # Test Check
+                    from prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete import (
+                        cloudtrail_bucket_requires_mfa_delete,
+                    )
+
+                    check = cloudtrail_bucket_requires_mfa_delete()
+                    result = check.execute()
+                    assert len(result) == 1
+                    assert result[0].status == "FAIL"
+                    assert (
+                        result[0].status_extended
+                        == f"Trail {trail_name_us} bucket ({bucket_name_us}) has not MFA delete enabled"
+                    )
+                    assert result[0].resource_id == trail_name_us
+                    assert result[0].region == "us-east-1"
+                    assert result[0].resource_arn == trail_us["TrailARN"]
+
+    # Create an MFA device is not supported for moto, so we mock the call:
+    def mock_make_api_call_getbucketversioning_mfadelete_enabled(self, operation_name, kwarg):
+        """
+        Mock unsoportted AWS API call
+        """
+        if operation_name == "GetBucketVersioning":
+            return {
+                'MFADelete': 'Enabled',
+                'Status': 'Enabled'
+            }
+        return make_api_call(self, operation_name, kwarg)
+
+    @mock_cloudtrail
+    @mock_s3
+    @mock_iam
+    # Patch with mock_make_api_call_getbucketversioning_mfadelete_enabled:
+    @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call_getbucketversioning_mfadelete_enabled)
+    def test_trails_with_mfa_bucket(self):
+        current_audit_info = self.set_mocked_audit_info()
+
+        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        trail_name_us = "trail_test_us_with_mfa_bucket"
+        bucket_name_us = "bucket_test_us_with_mfa"
+        s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
+        trail_us = cloudtrail_client_us_east_1.create_trail(
+            Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=False
+        )
+        cloudtrail_client_us_east_1.start_logging(Name=trail_name_us)
+        cloudtrail_client_us_east_1.get_trail_status(Name=trail_name_us)
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.cloudtrail_client",
+                new=Cloudtrail(current_audit_info),
+            ):
+                with mock.patch(
+                    "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.s3_client",
+                    new=S3(current_audit_info),
+                ):
+                    # Test Check
+                    from prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete import (
+                        cloudtrail_bucket_requires_mfa_delete,
+                    )
+
+                    check = cloudtrail_bucket_requires_mfa_delete()
+                    result = check.execute()
+                    assert len(result) == 1
+                    assert result[0].status == "PASS"
+                    assert (
+                        result[0].status_extended
+                        == f"Trail {trail_name_us} bucket ({bucket_name_us}) has MFA delete enabled"
+                    )
+                    assert result[0].resource_id == trail_name_us
+                    assert result[0].region == "us-east-1"
+                    assert result[0].resource_arn == trail_us["TrailARN"]

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
@@ -10,6 +10,7 @@ from prowler.providers.aws.services.cloudtrail.cloudtrail_service import Cloudtr
 from prowler.providers.aws.services.s3.s3_service import S3
 
 AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER_2 = 123456789013
 
 # Mocking Backup Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -25,6 +26,28 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
                 botocore_session=None,
             ),
             audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+        return audit_info
+
+    def set_mocked_audit_info_cross(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER_2,
             audited_user_id=None,
             audited_partition="aws",
             audited_identity_arn=None,
@@ -161,6 +184,109 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
                     assert (
                         result[0].status_extended
                         == f"Trail {trail_name_us} bucket ({bucket_name_us}) has MFA delete enabled"
+                    )
+                    assert result[0].resource_id == trail_name_us
+                    assert result[0].region == "us-east-1"
+                    assert result[0].resource_arn == trail_us["TrailARN"]
+
+    @mock_cloudtrail
+    @mock_s3
+    def test_trails_with_no_mfa_bucket_cross(self):
+        current_audit_info = self.set_mocked_audit_info()
+
+        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        trail_name_us = "trail_test_us_with_no_mfa_bucket"
+        bucket_name_us = "bucket_test_us_with_no_mfa"
+        s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
+        trail_us = cloudtrail_client_us_east_1.create_trail(
+            Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=False
+        )
+        cloudtrail_client_us_east_1.start_logging(Name=trail_name_us)
+        cloudtrail_client_us_east_1.get_trail_status(Name=trail_name_us)
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.cloudtrail_client",
+                new=Cloudtrail(current_audit_info),
+            ):
+                with mock.patch(
+                    "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.s3_client",
+                    new=S3(current_audit_info),
+                ) as s3_client:
+                    # Test Check
+                    from prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete import (
+                        cloudtrail_bucket_requires_mfa_delete,
+                    )
+
+                    # Empty s3 buckets to simulate the bucket is in another account
+                    s3_client.buckets = []
+
+                    check = cloudtrail_bucket_requires_mfa_delete()
+                    result = check.execute()
+                    assert len(result) == 1
+                    assert result[0].status == "PASS"
+                    assert (
+                        result[0].status_extended
+                        == f"Trail {trail_name_us} bucket ({bucket_name_us}) is a cross-account bucket in another account out of Prowler's permissions scope, please check it manually"
+                    )
+                    assert result[0].resource_id == trail_name_us
+                    assert result[0].region == "us-east-1"
+                    assert result[0].resource_arn == trail_us["TrailARN"]
+
+
+    @mock_cloudtrail
+    @mock_s3
+    @mock_iam
+    # Patch with mock_make_api_call_getbucketversioning_mfadelete_enabled:
+    @patch(
+        "botocore.client.BaseClient._make_api_call",
+        new=mock_make_api_call_getbucketversioning_mfadelete_enabled,
+    )
+    def test_trails_with_mfa_bucket_cross(self):
+        current_audit_info = self.set_mocked_audit_info()
+
+        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        trail_name_us = "trail_test_us_with_mfa_bucket"
+        bucket_name_us = "bucket_test_us_with_mfa"
+        s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
+        trail_us = cloudtrail_client_us_east_1.create_trail(
+            Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=False
+        )
+        cloudtrail_client_us_east_1.start_logging(Name=trail_name_us)
+        cloudtrail_client_us_east_1.get_trail_status(Name=trail_name_us)
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.cloudtrail_client",
+                new=Cloudtrail(current_audit_info),
+            ):
+                with mock.patch(
+                    "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.s3_client",
+                    new=S3(current_audit_info),
+                ) as s3_client:
+                    # Test Check
+                    from prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete import (
+                        cloudtrail_bucket_requires_mfa_delete,
+                    )
+
+                    # Empty s3 buckets to simulate the bucket is in another account
+                    s3_client.buckets = []
+
+                    check = cloudtrail_bucket_requires_mfa_delete()
+                    result = check.execute()
+                    assert len(result) == 1
+                    assert result[0].status == "PASS"
+                    assert (
+                        result[0].status_extended
+                        == f"Trail {trail_name_us} bucket ({bucket_name_us}) is a cross-account bucket in another account out of Prowler's permissions scope, please check it manually"
                     )
                     assert result[0].resource_id == trail_name_us
                     assert result[0].region == "us-east-1"

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
@@ -10,7 +10,6 @@ from prowler.providers.aws.services.cloudtrail.cloudtrail_service import Cloudtr
 from prowler.providers.aws.services.s3.s3_service import S3
 
 AWS_ACCOUNT_NUMBER = 123456789012
-AWS_ACCOUNT_NUMBER_2 = 123456789013
 
 # Mocking Backup Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -26,28 +25,6 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
                 botocore_session=None,
             ),
             audited_account=AWS_ACCOUNT_NUMBER,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-        )
-        return audit_info
-
-    def set_mocked_audit_info_cross(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER_2,
             audited_user_id=None,
             audited_partition="aws",
             audited_identity_arn=None,

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
@@ -237,7 +237,6 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
                     assert result[0].region == "us-east-1"
                     assert result[0].resource_arn == trail_us["TrailARN"]
 
-
     @mock_cloudtrail
     @mock_s3
     @mock_iam

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
@@ -9,7 +9,7 @@ from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.cloudtrail.cloudtrail_service import Cloudtrail
 from prowler.providers.aws.services.s3.s3_service import S3
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 # Mocking Backup Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -45,19 +45,18 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.cloudtrail_client",
+            new=Cloudtrail(current_audit_info),
         ):
-            with mock.patch(
-                "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.cloudtrail_client",
-                new=Cloudtrail(current_audit_info),
-            ):
-                # Test Check
-                from prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete import (
-                    cloudtrail_bucket_requires_mfa_delete,
-                )
+            # Test Check
+            from prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete import (
+                cloudtrail_bucket_requires_mfa_delete,
+            )
 
-                check = cloudtrail_bucket_requires_mfa_delete()
-                result = check.execute()
-                assert len(result) == 0
+            check = cloudtrail_bucket_requires_mfa_delete()
+            result = check.execute()
+            assert len(result) == 0
 
     @mock_cloudtrail
     @mock_s3
@@ -78,31 +77,29 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.cloudtrail_client",
+            new=Cloudtrail(current_audit_info),
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.s3_client",
+            new=S3(current_audit_info),
         ):
-            with mock.patch(
-                "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.cloudtrail_client",
-                new=Cloudtrail(current_audit_info),
-            ):
-                with mock.patch(
-                    "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.s3_client",
-                    new=S3(current_audit_info),
-                ):
-                    # Test Check
-                    from prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete import (
-                        cloudtrail_bucket_requires_mfa_delete,
-                    )
+            # Test Check
+            from prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete import (
+                cloudtrail_bucket_requires_mfa_delete,
+            )
 
-                    check = cloudtrail_bucket_requires_mfa_delete()
-                    result = check.execute()
-                    assert len(result) == 1
-                    assert result[0].status == "FAIL"
-                    assert (
-                        result[0].status_extended
-                        == f"Trail {trail_name_us} bucket ({bucket_name_us}) has not MFA delete enabled"
-                    )
-                    assert result[0].resource_id == trail_name_us
-                    assert result[0].region == "us-east-1"
-                    assert result[0].resource_arn == trail_us["TrailARN"]
+            check = cloudtrail_bucket_requires_mfa_delete()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Trail {trail_name_us} bucket ({bucket_name_us}) has not MFA delete enabled"
+            )
+            assert result[0].resource_id == trail_name_us
+            assert result[0].region == "us-east-1"
+            assert result[0].resource_arn == trail_us["TrailARN"]
 
     # Create an MFA device is not supported for moto, so we mock the call:
     def mock_make_api_call_getbucketversioning_mfadelete_enabled(
@@ -140,31 +137,29 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.cloudtrail_client",
+            new=Cloudtrail(current_audit_info),
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.s3_client",
+            new=S3(current_audit_info),
         ):
-            with mock.patch(
-                "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.cloudtrail_client",
-                new=Cloudtrail(current_audit_info),
-            ):
-                with mock.patch(
-                    "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.s3_client",
-                    new=S3(current_audit_info),
-                ):
-                    # Test Check
-                    from prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete import (
-                        cloudtrail_bucket_requires_mfa_delete,
-                    )
+            # Test Check
+            from prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete import (
+                cloudtrail_bucket_requires_mfa_delete,
+            )
 
-                    check = cloudtrail_bucket_requires_mfa_delete()
-                    result = check.execute()
-                    assert len(result) == 1
-                    assert result[0].status == "PASS"
-                    assert (
-                        result[0].status_extended
-                        == f"Trail {trail_name_us} bucket ({bucket_name_us}) has MFA delete enabled"
-                    )
-                    assert result[0].resource_id == trail_name_us
-                    assert result[0].region == "us-east-1"
-                    assert result[0].resource_arn == trail_us["TrailARN"]
+            check = cloudtrail_bucket_requires_mfa_delete()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Trail {trail_name_us} bucket ({bucket_name_us}) has MFA delete enabled"
+            )
+            assert result[0].resource_id == trail_name_us
+            assert result[0].region == "us-east-1"
+            assert result[0].resource_arn == trail_us["TrailARN"]
 
     @mock_cloudtrail
     @mock_s3
@@ -185,34 +180,32 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
-        ):
-            with mock.patch(
-                "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.cloudtrail_client",
-                new=Cloudtrail(current_audit_info),
-            ):
-                with mock.patch(
-                    "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.s3_client",
-                    new=S3(current_audit_info),
-                ) as s3_client:
-                    # Test Check
-                    from prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete import (
-                        cloudtrail_bucket_requires_mfa_delete,
-                    )
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.cloudtrail_client",
+            new=Cloudtrail(current_audit_info),
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.s3_client",
+            new=S3(current_audit_info),
+        ) as s3_client:
+            # Test Check
+            from prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete import (
+                cloudtrail_bucket_requires_mfa_delete,
+            )
 
-                    # Empty s3 buckets to simulate the bucket is in another account
-                    s3_client.buckets = []
+            # Empty s3 buckets to simulate the bucket is in another account
+            s3_client.buckets = []
 
-                    check = cloudtrail_bucket_requires_mfa_delete()
-                    result = check.execute()
-                    assert len(result) == 1
-                    assert result[0].status == "PASS"
-                    assert (
-                        result[0].status_extended
-                        == f"Trail {trail_name_us} bucket ({bucket_name_us}) is a cross-account bucket in another account out of Prowler's permissions scope, please check it manually"
-                    )
-                    assert result[0].resource_id == trail_name_us
-                    assert result[0].region == "us-east-1"
-                    assert result[0].resource_arn == trail_us["TrailARN"]
+            check = cloudtrail_bucket_requires_mfa_delete()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Trail {trail_name_us} bucket ({bucket_name_us}) is a cross-account bucket in another account out of Prowler's permissions scope, please check it manually"
+            )
+            assert result[0].resource_id == trail_name_us
+            assert result[0].region == "us-east-1"
+            assert result[0].resource_arn == trail_us["TrailARN"]
 
     @mock_cloudtrail
     @mock_s3
@@ -239,31 +232,29 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
-        ):
-            with mock.patch(
-                "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.cloudtrail_client",
-                new=Cloudtrail(current_audit_info),
-            ):
-                with mock.patch(
-                    "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.s3_client",
-                    new=S3(current_audit_info),
-                ) as s3_client:
-                    # Test Check
-                    from prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete import (
-                        cloudtrail_bucket_requires_mfa_delete,
-                    )
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.cloudtrail_client",
+            new=Cloudtrail(current_audit_info),
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete.s3_client",
+            new=S3(current_audit_info),
+        ) as s3_client:
+            # Test Check
+            from prowler.providers.aws.services.cloudtrail.cloudtrail_bucket_requires_mfa_delete.cloudtrail_bucket_requires_mfa_delete import (
+                cloudtrail_bucket_requires_mfa_delete,
+            )
 
-                    # Empty s3 buckets to simulate the bucket is in another account
-                    s3_client.buckets = []
+            # Empty s3 buckets to simulate the bucket is in another account
+            s3_client.buckets = []
 
-                    check = cloudtrail_bucket_requires_mfa_delete()
-                    result = check.execute()
-                    assert len(result) == 1
-                    assert result[0].status == "PASS"
-                    assert (
-                        result[0].status_extended
-                        == f"Trail {trail_name_us} bucket ({bucket_name_us}) is a cross-account bucket in another account out of Prowler's permissions scope, please check it manually"
-                    )
-                    assert result[0].resource_id == trail_name_us
-                    assert result[0].region == "us-east-1"
-                    assert result[0].resource_arn == trail_us["TrailARN"]
+            check = cloudtrail_bucket_requires_mfa_delete()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Trail {trail_name_us} bucket ({bucket_name_us}) is a cross-account bucket in another account out of Prowler's permissions scope, please check it manually"
+            )
+            assert result[0].resource_id == trail_name_us
+            assert result[0].region == "us-east-1"
+            assert result[0].resource_arn == trail_us["TrailARN"]

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_insights_exist/cloudtrail_insights_exist_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_insights_exist/cloudtrail_insights_exist_test.py
@@ -6,7 +6,7 @@ from moto import mock_cloudtrail, mock_s3
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.cloudtrail.cloudtrail_service import Cloudtrail
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_cloudtrail_insights_exist:

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_kms_encryption_enabled/cloudtrail_kms_encryption_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_kms_encryption_enabled/cloudtrail_kms_encryption_enabled_test.py
@@ -1,11 +1,37 @@
 from re import search
 from unittest import mock
 
-from boto3 import client
+from boto3 import client, session
 from moto import mock_cloudtrail, mock_kms, mock_s3
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_cloudtrail_kms_encryption_enabled:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+        return audit_info
+
     @mock_cloudtrail
     @mock_s3
     def test_trail_no_kms(self):
@@ -18,16 +44,16 @@ class Test_cloudtrail_kms_encryption_enabled:
             Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=False
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
             Cloudtrail,
         )
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_kms_encryption_enabled.cloudtrail_kms_encryption_enabled.cloudtrail_client",
-            new=Cloudtrail(current_audit_info),
+            new=Cloudtrail(self.set_mocked_audit_info()),
         ):
             # Test Check
             from prowler.providers.aws.services.cloudtrail.cloudtrail_kms_encryption_enabled.cloudtrail_kms_encryption_enabled import (
@@ -64,16 +90,16 @@ class Test_cloudtrail_kms_encryption_enabled:
             KmsKeyId=key_arn,
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
             Cloudtrail,
         )
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_kms_encryption_enabled.cloudtrail_kms_encryption_enabled.cloudtrail_client",
-            new=Cloudtrail(current_audit_info),
+            new=Cloudtrail(self.set_mocked_audit_info()),
         ):
             # Test Check
             from prowler.providers.aws.services.cloudtrail.cloudtrail_kms_encryption_enabled.cloudtrail_kms_encryption_enabled import (

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_test.py
@@ -56,7 +56,7 @@ class Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible:
             "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_client",
             new=Cloudtrail(self.set_mocked_audit_info()),
         ), mock.patch(
-            "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_logs_s3_bucket_access_logging_enabled.s3_client",
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.s3_client",
             new=S3(self.set_mocked_audit_info()),
         ):
             # Test Check

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_test.py
@@ -1,11 +1,37 @@
 from re import search
 from unittest import mock
 
-from boto3 import client
+from boto3 import client, session
 from moto import mock_cloudtrail, mock_s3
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+        return audit_info
+
     @mock_cloudtrail
     @mock_s3
     def test_trail_bucket_no_acl(self):
@@ -17,38 +43,39 @@ class Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible:
         trail_us = cloudtrail_client.create_trail(
             Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=False
         )
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
+
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
             Cloudtrail,
         )
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_client",
-            new=Cloudtrail(current_audit_info),
+            new=Cloudtrail(self.set_mocked_audit_info()),
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_logs_s3_bucket_access_logging_enabled.s3_client",
+            new=S3(self.set_mocked_audit_info()),
         ):
-            with mock.patch(
-                "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_logs_s3_bucket_access_logging_enabled.s3_client",
-                new=S3(current_audit_info),
-            ):
-                # Test Check
-                from prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible import (
-                    cloudtrail_logs_s3_bucket_is_not_publicly_accessible,
-                )
+            # Test Check
+            from prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible import (
+                cloudtrail_logs_s3_bucket_is_not_publicly_accessible,
+            )
 
-                check = cloudtrail_logs_s3_bucket_is_not_publicly_accessible()
-                result = check.execute()
+            check = cloudtrail_logs_s3_bucket_is_not_publicly_accessible()
+            result = check.execute()
 
-                assert len(result) == 1
-                assert result[0].status == "PASS"
-                assert result[0].resource_id == trail_name_us
-                assert result[0].resource_arn == trail_us["TrailARN"]
-                assert search(
-                    result[0].status_extended,
-                    f"S3 Bucket {bucket_name_us} from single region trail {trail_name_us} is not publicly accessible",
-                )
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].resource_id == trail_name_us
+
+            assert result[0].resource_arn == trail_us["TrailARN"]
+            assert search(
+                result[0].status_extended,
+                f"S3 Bucket {bucket_name_us} from single region trail {trail_name_us} is not publicly accessible",
+            )
 
     @mock_cloudtrail
     @mock_s3
@@ -81,38 +108,37 @@ class Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible:
             Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=False
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
             Cloudtrail,
         )
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_client",
-            new=Cloudtrail(current_audit_info),
+            new=Cloudtrail(self.set_mocked_audit_info()),
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.s3_client",
+            new=S3(self.set_mocked_audit_info()),
         ):
-            with mock.patch(
-                "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.s3_client",
-                new=S3(current_audit_info),
-            ):
-                # Test Check
-                from prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible import (
-                    cloudtrail_logs_s3_bucket_is_not_publicly_accessible,
-                )
+            # Test Check
+            from prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible import (
+                cloudtrail_logs_s3_bucket_is_not_publicly_accessible,
+            )
 
-                check = cloudtrail_logs_s3_bucket_is_not_publicly_accessible()
-                result = check.execute()
+            check = cloudtrail_logs_s3_bucket_is_not_publicly_accessible()
+            result = check.execute()
 
-                assert len(result) == 1
-                assert result[0].status == "FAIL"
-                assert result[0].resource_id == trail_name_us
-                assert result[0].resource_arn == trail_us["TrailARN"]
-                assert search(
-                    result[0].status_extended,
-                    f"S3 Bucket {bucket_name_us} from single region trail {trail_name_us} is publicly accessible",
-                )
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_id == trail_name_us
+            assert result[0].resource_arn == trail_us["TrailARN"]
+            assert search(
+                result[0].status_extended,
+                f"S3 Bucket {bucket_name_us} from single region trail {trail_name_us} is publicly accessible",
+            )
 
     @mock_cloudtrail
     @mock_s3
@@ -144,38 +170,37 @@ class Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible:
             },
             Bucket=bucket_name_us,
         )
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
             Cloudtrail,
         )
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_client",
-            new=Cloudtrail(current_audit_info),
+            new=Cloudtrail(self.set_mocked_audit_info()),
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.s3_client",
+            new=S3(self.set_mocked_audit_info()),
         ):
-            with mock.patch(
-                "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.s3_client",
-                new=S3(current_audit_info),
-            ):
-                # Test Check
-                from prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible import (
-                    cloudtrail_logs_s3_bucket_is_not_publicly_accessible,
-                )
+            # Test Check
+            from prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible import (
+                cloudtrail_logs_s3_bucket_is_not_publicly_accessible,
+            )
 
-                check = cloudtrail_logs_s3_bucket_is_not_publicly_accessible()
-                result = check.execute()
+            check = cloudtrail_logs_s3_bucket_is_not_publicly_accessible()
+            result = check.execute()
 
-                assert len(result) == 1
-                assert result[0].status == "PASS"
-                assert result[0].resource_id == trail_name_us
-                assert result[0].resource_arn == trail_us["TrailARN"]
-                assert search(
-                    result[0].status_extended,
-                    f"S3 Bucket {bucket_name_us} from single region trail {trail_name_us} is not publicly accessible",
-                )
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].resource_id == trail_name_us
+            assert result[0].resource_arn == trail_us["TrailARN"]
+            assert search(
+                result[0].status_extended,
+                f"S3 Bucket {bucket_name_us} from single region trail {trail_name_us} is not publicly accessible",
+            )
 
     @mock_cloudtrail
     @mock_s3
@@ -189,38 +214,37 @@ class Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible:
             Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=False
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
             Cloudtrail,
         )
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_client",
-            new=Cloudtrail(current_audit_info),
-        ):
-            with mock.patch(
-                "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.s3_client",
-                new=S3(current_audit_info),
-            ) as s3_client:
-                # Test Check
-                from prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible import (
-                    cloudtrail_logs_s3_bucket_is_not_publicly_accessible,
-                )
+            new=Cloudtrail(self.set_mocked_audit_info()),
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.s3_client",
+            new=S3(self.set_mocked_audit_info()),
+        ) as s3_client:
+            # Test Check
+            from prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible import (
+                cloudtrail_logs_s3_bucket_is_not_publicly_accessible,
+            )
 
-                # Empty s3 buckets to simulate the bucket is in another account
-                s3_client.buckets = []
+            # Empty s3 buckets to simulate the bucket is in another account
+            s3_client.buckets = []
 
-                check = cloudtrail_logs_s3_bucket_is_not_publicly_accessible()
-                result = check.execute()
+            check = cloudtrail_logs_s3_bucket_is_not_publicly_accessible()
+            result = check.execute()
 
-                assert len(result) == 1
-                assert result[0].status == "PASS"
-                assert result[0].resource_id == trail_name_us
-                assert result[0].resource_arn == trail_us["TrailARN"]
-                assert search(
-                    "is a cross-account bucket in another account out of Prowler's permissions scope",
-                    result[0].status_extended,
-                )
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].resource_id == trail_name_us
+            assert result[0].resource_arn == trail_us["TrailARN"]
+            assert search(
+                "is a cross-account bucket in another account out of Prowler's permissions scope",
+                result[0].status_extended,
+            )

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_test.py
@@ -7,7 +7,7 @@ from moto import mock_cloudtrail, mock_s3
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.cloudtrail.cloudtrail_service import Trail
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_cloudtrail_multi_region_enabled:

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_read_enabled/cloudtrail_s3_dataevents_read_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_read_enabled/cloudtrail_s3_dataevents_read_enabled_test.py
@@ -6,7 +6,7 @@ from moto import mock_cloudtrail, mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_cloudtrail_s3_dataevents_read_enabled:

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_write_enabled/cloudtrail_s3_dataevents_write_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_write_enabled/cloudtrail_s3_dataevents_write_enabled_test.py
@@ -6,7 +6,7 @@ from moto import mock_cloudtrail, mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_cloudtrail_s3_dataevents_write_enabled:

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_service_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_service_test.py
@@ -5,7 +5,7 @@ from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.cloudwatch.cloudwatch_service import CloudWatch
 from prowler.providers.common.models import Audit_Metadata
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 

--- a/tests/providers/aws/services/codebuild/codebuild_service_test.py
+++ b/tests/providers/aws/services/codebuild/codebuild_service_test.py
@@ -10,7 +10,7 @@ from prowler.providers.aws.services.codebuild.codebuild_service import Codebuild
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 # last time invoked time
 last_invoked_time = datetime.now() - timedelta(days=2)

--- a/tests/providers/aws/services/config/config_service_test.py
+++ b/tests/providers/aws/services/config/config_service_test.py
@@ -4,7 +4,7 @@ from moto import mock_config
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.config.config_service import Config
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 

--- a/tests/providers/aws/services/dynamodb/dynamodb_service_test.py
+++ b/tests/providers/aws/services/dynamodb/dynamodb_service_test.py
@@ -4,7 +4,7 @@ from moto import mock_dax, mock_dynamodb
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.dynamodb.dynamodb_service import DAX, DynamoDB
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 

--- a/tests/providers/aws/services/ec2/ec2_service_test.py
+++ b/tests/providers/aws/services/ec2/ec2_service_test.py
@@ -11,7 +11,7 @@ from moto import mock_ec2
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 EXAMPLE_AMI_ID = "ami-12c6146b"
 MOCK_DATETIME = datetime(2023, 1, 4, 7, 27, 30, tzinfo=tzutc())

--- a/tests/providers/aws/services/ecr/ecr_service_test.py
+++ b/tests/providers/aws/services/ecr/ecr_service_test.py
@@ -7,7 +7,7 @@ from moto import mock_ecr
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.ecr.ecr_service import ECR
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
 
 repo_arn = f"arn:aws:ecr:eu-west-1:{AWS_ACCOUNT_NUMBER}:repository/test-repo"

--- a/tests/providers/aws/services/ecs/ecs_service_test.py
+++ b/tests/providers/aws/services/ecs/ecs_service_test.py
@@ -6,7 +6,7 @@ from moto import mock_ecs
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.ecs.ecs_service import ECS
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
 
 

--- a/tests/providers/aws/services/eks/eks_service_test.py
+++ b/tests/providers/aws/services/eks/eks_service_test.py
@@ -6,7 +6,7 @@ from moto import mock_ec2, mock_eks
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.eks.eks_service import EKS
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
 
 cluster_name = "test"

--- a/tests/providers/aws/services/elb/elb_service_test.py
+++ b/tests/providers/aws/services/elb/elb_service_test.py
@@ -4,7 +4,7 @@ from moto import mock_ec2, mock_elb
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.elb.elb_service import ELB
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 

--- a/tests/providers/aws/services/elbv2/elbv2_service_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_service_test.py
@@ -4,7 +4,7 @@ from moto import mock_ec2, mock_elbv2
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 

--- a/tests/providers/aws/services/glue/glue_service_test.py
+++ b/tests/providers/aws/services/glue/glue_service_test.py
@@ -7,7 +7,7 @@ from moto import mock_glue
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.glue.glue_service import Glue
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 # Mocking Access Analyzer Calls

--- a/tests/providers/aws/services/guardduty/guardduty_service_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_service_test.py
@@ -7,7 +7,7 @@ from moto import mock_guardduty
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.guardduty.guardduty_service import GuardDuty
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
 
 make_api_call = botocore.client.BaseClient._make_api_call

--- a/tests/providers/aws/services/iam/iam_service_test.py
+++ b/tests/providers/aws/services/iam/iam_service_test.py
@@ -7,7 +7,7 @@ from moto import mock_iam
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.iam.iam_service import IAM, is_service_role
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 TEST_DATETIME = "2023-01-01T12:01:01+00:00"
 
 

--- a/tests/providers/aws/services/kms/kms_service_test.py
+++ b/tests/providers/aws/services/kms/kms_service_test.py
@@ -6,7 +6,7 @@ from moto import mock_kms
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.kms.kms_service import KMS
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 

--- a/tests/providers/aws/services/opensearch/opensearch_service_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_test.py
@@ -9,7 +9,7 @@ from prowler.providers.aws.services.opensearch.opensearch_service import (
     OpenSearchService,
 )
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
 
 test_domain_name = "test"

--- a/tests/providers/aws/services/rds/rds_service_test.py
+++ b/tests/providers/aws/services/rds/rds_service_test.py
@@ -4,7 +4,7 @@ from moto import mock_rds
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.rds.rds_service import RDS
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 

--- a/tests/providers/aws/services/redshift/redshift_service_test.py
+++ b/tests/providers/aws/services/redshift/redshift_service_test.py
@@ -8,7 +8,7 @@ from moto import mock_redshift
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.redshift.redshift_service import Redshift
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
 
 topic_name = "test-topic"

--- a/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
@@ -7,7 +7,7 @@ from boto3 import session
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.sagemaker.sagemaker_service import SageMaker
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
 
 test_notebook_instance = "test-notebook-instance"

--- a/tests/providers/aws/services/sns/sns_service_test.py
+++ b/tests/providers/aws/services/sns/sns_service_test.py
@@ -9,7 +9,7 @@ from moto import mock_sns
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.sns.sns_service import SNS
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
 
 topic_name = "test-topic"

--- a/tests/providers/aws/services/sqs/sqs_service_test.py
+++ b/tests/providers/aws/services/sqs/sqs_service_test.py
@@ -9,7 +9,7 @@ from moto import mock_sqs
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.sqs.sqs_service import SQS
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
 
 test_queue = "test-queue"

--- a/tests/providers/aws/services/trustedadvisor/trustedadvisor_service_test.py
+++ b/tests/providers/aws/services/trustedadvisor/trustedadvisor_service_test.py
@@ -9,7 +9,7 @@ from prowler.providers.aws.services.trustedadvisor.trustedadvisor_service import
     TrustedAdvisor,
 )
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 make_api_call = botocore.client.BaseClient._make_api_call

--- a/tests/providers/aws/services/vpc/vpc_service_test.py
+++ b/tests/providers/aws/services/vpc/vpc_service_test.py
@@ -6,7 +6,7 @@ from moto import mock_ec2, mock_elbv2
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC, Route
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 

--- a/tests/providers/aws/services/waf/waf_service_test.py
+++ b/tests/providers/aws/services/waf/waf_service_test.py
@@ -6,7 +6,7 @@ from boto3 import session
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.waf.waf_service import WAF
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 # Mocking WAF-Regional Calls

--- a/tests/providers/aws/services/wafv2/wafv2_service_test.py
+++ b/tests/providers/aws/services/wafv2/wafv2_service_test.py
@@ -4,7 +4,7 @@ from moto import mock_ec2, mock_elbv2, mock_wafv2
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 

--- a/tests/providers/aws/services/workspaces/workspaces_service_test.py
+++ b/tests/providers/aws/services/workspaces/workspaces_service_test.py
@@ -7,7 +7,7 @@ from boto3 import session
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.workspaces.workspaces_service import WorkSpaces
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
 
 


### PR DESCRIPTION
### Context

New CloudTrail Check: `cloudtrail_bucket_requires_mfa_delete`

If the S3 bucket CloudTrail bucket does not require MFA, it can be deleted by an attacker.


Fixed the following failures in test:
- `AWS_ACCOUNT` must be a string.
- `Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible.test_trail_bucket_no_acl` was importing a bad S3 client from another test.
- Mock the `current_audit_info` object in all CloudTrail tests.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
