### PR TITLE
feat(orgs checks region): added region to all orgs checks

### DIFF
--- a/prowler/providers/aws/services/organizations/organizations_account_part_of_organizations/organizations_account_part_of_organizations.py
+++ b/prowler/providers/aws/services/organizations/organizations_account_part_of_organizations/organizations_account_part_of_organizations.py
@@ -19,6 +19,7 @@ class organizations_account_part_of_organizations(Check):
                 report.status_extended = (
                     "AWS Organizations is not in-use for this AWS Account"
                 )
+            report.region = organizations_client.region
             report.resource_id = org.id
             report.resource_arn = org.arn
             findings.append(report)

--- a/prowler/providers/aws/services/organizations/organizations_delegated_administrators/organizations_delegated_administrators.py
+++ b/prowler/providers/aws/services/organizations/organizations_delegated_administrators/organizations_delegated_administrators.py
@@ -17,6 +17,7 @@ class organizations_delegated_administrators(Check):
                 report = Check_Report_AWS(self.metadata())
                 report.resource_id = org.id
                 report.resource_arn = org.arn
+                report.region = organizations_client.region
                 if org.delegated_administrators is None:
                     # Access Denied to list_policies
                     continue

--- a/prowler/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions.py
+++ b/prowler/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions.py
@@ -14,6 +14,7 @@ class organizations_scp_check_deny_regions(Check):
             report = Check_Report_AWS(self.metadata())
             report.resource_id = org.id
             report.resource_arn = org.arn
+            report.region = organizations_client.region
             if org.status == "ACTIVE":
                 if org.policies is None:
                     # Access Denied to list_policies

--- a/tests/providers/aws/services/organizations/organizations_account_part_of_organizations/organizations_account_part_of_organizations_test.py
+++ b/tests/providers/aws/services/organizations/organizations_account_part_of_organizations/organizations_account_part_of_organizations_test.py
@@ -13,7 +13,6 @@ AWS_REGION = "us-east-1"
 
 
 class Test_organizations_account_part_of_organizations:
-
     # Mocked Audit Info
     def set_mocked_audit_info(self):
         audit_info = AWS_Audit_Info(
@@ -31,7 +30,7 @@ class Test_organizations_account_part_of_organizations:
             profile_region=None,
             credentials=None,
             assumed_role_info=None,
-            audited_regions=None,
+            audited_regions=[AWS_REGION],
             organizations_metadata=None,
             audit_resources=None,
         )
@@ -39,7 +38,6 @@ class Test_organizations_account_part_of_organizations:
 
     @mock_organizations
     def test_no_organization(self):
-
         audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
@@ -66,10 +64,10 @@ class Test_organizations_account_part_of_organizations:
                 )
                 assert result[0].resource_id == "AWS Organization"
                 assert result[0].resource_arn == ""
+                assert result[0].region == AWS_REGION
 
     @mock_organizations
     def test_organization(self):
-
         audit_info = self.set_mocked_audit_info()
 
         # Create Organization
@@ -100,3 +98,4 @@ class Test_organizations_account_part_of_organizations:
                 )
                 assert result[0].resource_id == response["Organization"]["Id"]
                 assert result[0].resource_arn == response["Organization"]["Arn"]
+                assert result[0].region == AWS_REGION

--- a/tests/providers/aws/services/organizations/organizations_delegated_administrators/organizations_delegated_administrators_test.py
+++ b/tests/providers/aws/services/organizations/organizations_delegated_administrators/organizations_delegated_administrators_test.py
@@ -13,7 +13,6 @@ AWS_REGION = "us-east-1"
 
 
 class Test_organizations_delegated_administrators:
-
     # Mocked Audit Info
     def set_mocked_audit_info(self):
         audit_info = AWS_Audit_Info(
@@ -31,7 +30,7 @@ class Test_organizations_delegated_administrators:
             profile_region=None,
             credentials=None,
             assumed_role_info=None,
-            audited_regions=None,
+            audited_regions=[AWS_REGION],
             organizations_metadata=None,
             audit_resources=None,
         )
@@ -39,7 +38,6 @@ class Test_organizations_delegated_administrators:
 
     @mock_organizations
     def test_no_organization(self):
-
         audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
@@ -62,7 +60,6 @@ class Test_organizations_delegated_administrators:
 
     @mock_organizations
     def test_organization_no_delegations(self):
-
         audit_info = self.set_mocked_audit_info()
 
         # Create Organization
@@ -93,10 +90,10 @@ class Test_organizations_delegated_administrators:
                     "No Delegated Administrators",
                     result[0].status_extended,
                 )
+                assert result[0].region == AWS_REGION
 
     @mock_organizations
     def test_organization_trusted_delegated(self):
-
         audit_info = self.set_mocked_audit_info()
 
         # Create Organization
@@ -141,10 +138,10 @@ class Test_organizations_delegated_administrators:
                         "Trusted Delegated Administrator",
                         result[0].status_extended,
                     )
+                    assert result[0].region == AWS_REGION
 
     @mock_organizations
     def test_organization_untrusted_delegated(self):
-
         audit_info = self.set_mocked_audit_info()
 
         # Create Organization
@@ -185,3 +182,4 @@ class Test_organizations_delegated_administrators:
                     "Untrusted Delegated Administrator",
                     result[0].status_extended,
                 )
+                assert result[0].region == AWS_REGION

--- a/tests/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions_test.py
+++ b/tests/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions_test.py
@@ -17,7 +17,6 @@ def scp_restrict_regions_with_deny():
 
 
 class Test_organizations_scp_check_deny_regions:
-
     # Mocked Audit Info
     def set_mocked_audit_info(self):
         audit_info = AWS_Audit_Info(
@@ -35,7 +34,7 @@ class Test_organizations_scp_check_deny_regions:
             profile_region=None,
             credentials=None,
             assumed_role_info=None,
-            audited_regions=None,
+            audited_regions=[AWS_REGION],
             organizations_metadata=None,
             audit_resources=None,
         )
@@ -43,7 +42,6 @@ class Test_organizations_scp_check_deny_regions:
 
     @mock_organizations
     def test_no_organization(self):
-
         audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
@@ -70,10 +68,10 @@ class Test_organizations_scp_check_deny_regions:
                 )
                 assert result[0].resource_id == "AWS Organization"
                 assert result[0].resource_arn == ""
+                assert result[0].region == AWS_REGION
 
     @mock_organizations
     def test_organization_without_scp_deny_regions(self):
-
         audit_info = self.set_mocked_audit_info()
 
         # Create Organization
@@ -104,10 +102,10 @@ class Test_organizations_scp_check_deny_regions:
                     "level but don't restrict AWS Regions",
                     result[0].status_extended,
                 )
+                assert result[0].region == AWS_REGION
 
     @mock_organizations
     def test_organization_with_scp_deny_regions_valid(self):
-
         audit_info = self.set_mocked_audit_info()
 
         # Create Organization
@@ -149,10 +147,10 @@ class Test_organizations_scp_check_deny_regions:
                         "restricting all configured regions found",
                         result[0].status_extended,
                     )
+                    assert result[0].region == AWS_REGION
 
     @mock_organizations
     def test_organization_with_scp_deny_regions_not_valid(self):
-
         audit_info = self.set_mocked_audit_info()
 
         # Create Organization
@@ -194,3 +192,4 @@ class Test_organizations_scp_check_deny_regions:
                         "restricting some AWS Regions, but not all the configured ones, please check config...",
                         result[0].status_extended,
                     )
+                    assert result[0].region == AWS_REGION


### PR DESCRIPTION
### Context

Organizations checks don't have the region set


### Description

Add the Organizations service general region to the three Organization checks
- `organizations_delegated_administrators`
- `organizations_scp_check_deny_regions`
- `organizations_account_part_of_organizations`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
