### PR TITLE
fix(test): call cloudtrail_s3_dataevents_write_enabled check

### DIFF
--- a/tests/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_write_enabled/cloudtrail_s3_dataevents_write_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_write_enabled/cloudtrail_s3_dataevents_write_enabled_test.py
@@ -54,7 +54,6 @@ class Test_cloudtrail_s3_dataevents_write_enabled:
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
         ):
-
             with mock.patch(
                 "prowler.providers.aws.services.cloudtrail.cloudtrail_s3_dataevents_write_enabled.cloudtrail_s3_dataevents_write_enabled.cloudtrail_client",
                 new=Cloudtrail(current_audit_info),
@@ -109,7 +108,6 @@ class Test_cloudtrail_s3_dataevents_write_enabled:
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
         ):
-
             with mock.patch(
                 "prowler.providers.aws.services.cloudtrail.cloudtrail_s3_dataevents_write_enabled.cloudtrail_s3_dataevents_write_enabled.cloudtrail_client",
                 new=Cloudtrail(current_audit_info),
@@ -165,7 +163,6 @@ class Test_cloudtrail_s3_dataevents_write_enabled:
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
         ):
-
             with mock.patch(
                 "prowler.providers.aws.services.cloudtrail.cloudtrail_s3_dataevents_write_enabled.cloudtrail_s3_dataevents_write_enabled.cloudtrail_client",
                 new=Cloudtrail(current_audit_info),
@@ -220,17 +217,16 @@ class Test_cloudtrail_s3_dataevents_write_enabled:
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
         ):
-
             with mock.patch(
-                "prowler.providers.aws.services.cloudtrail.cloudtrail_s3_dataevents_read_enabled.cloudtrail_s3_dataevents_read_enabled.cloudtrail_client",
+                "prowler.providers.aws.services.cloudtrail.cloudtrail_s3_dataevents_write_enabled.cloudtrail_s3_dataevents_write_enabled.cloudtrail_client",
                 new=Cloudtrail(current_audit_info),
             ):
                 # Test Check
-                from prowler.providers.aws.services.cloudtrail.cloudtrail_s3_dataevents_read_enabled.cloudtrail_s3_dataevents_read_enabled import (
-                    cloudtrail_s3_dataevents_read_enabled,
+                from prowler.providers.aws.services.cloudtrail.cloudtrail_s3_dataevents_write_enabled.cloudtrail_s3_dataevents_write_enabled import (
+                    cloudtrail_s3_dataevents_write_enabled,
                 )
 
-                check = cloudtrail_s3_dataevents_read_enabled()
+                check = cloudtrail_s3_dataevents_write_enabled()
                 result = check.execute()
 
                 assert len(result) == 1


### PR DESCRIPTION
### Description

Fix the test `Test_cloudtrail_s3_dataevents_write_enabled.test_trail_with_s3_advanced_data_events` because it was calling the wrong check instead of `cloudtrail_s3_dataevents_write_enabled`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
