### PR TITLE
fix(elb-test): Use a mocked current audit info

### DIFF
--- a/tests/providers/aws/services/elb/elb_insecure_ssl_ciphers/elb_insecure_ssl_ciphers_test.py
+++ b/tests/providers/aws/services/elb/elb_insecure_ssl_ciphers/elb_insecure_ssl_ciphers_test.py
@@ -1,25 +1,49 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource
+from boto3 import client, resource, session
 from moto import mock_ec2, mock_elb
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_elb_insecure_ssl_ciphers:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_elb
     def test_elb_no_balancers(self):
-
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elb.elb_service import ELB
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elb.elb_insecure_ssl_ciphers.elb_insecure_ssl_ciphers.elb_client",
-            new=ELB(current_audit_info),
+            new=ELB(self.set_mocked_audit_info()),
         ):
             # Test Check
             from prowler.providers.aws.services.elb.elb_insecure_ssl_ciphers.elb_insecure_ssl_ciphers import (
@@ -59,14 +83,14 @@ class Test_elb_insecure_ssl_ciphers:
         )
         elb.describe_load_balancer_policies(LoadBalancerName="my-lb")
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elb.elb_service import ELB
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elb.elb_insecure_ssl_ciphers.elb_insecure_ssl_ciphers.elb_client",
-            new=ELB(current_audit_info),
+            new=ELB(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elb.elb_insecure_ssl_ciphers.elb_insecure_ssl_ciphers import (
                 elb_insecure_ssl_ciphers,
@@ -104,14 +128,14 @@ class Test_elb_insecure_ssl_ciphers:
             SecurityGroups=[security_group.id],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elb.elb_service import ELB
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elb.elb_insecure_ssl_ciphers.elb_insecure_ssl_ciphers.elb_client",
-            new=ELB(current_audit_info),
+            new=ELB(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elb.elb_insecure_ssl_ciphers.elb_insecure_ssl_ciphers import (
                 elb_insecure_ssl_ciphers,

--- a/tests/providers/aws/services/elb/elb_internet_facing/elb_internet_facing_test.py
+++ b/tests/providers/aws/services/elb/elb_internet_facing/elb_internet_facing_test.py
@@ -1,25 +1,49 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource
+from boto3 import client, resource, session
 from moto import mock_ec2, mock_elb
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_elb_request_smugling:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_elb
     def test_elb_no_balancers(self):
-
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elb.elb_service import ELB
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elb.elb_internet_facing.elb_internet_facing.elb_client",
-            new=ELB(current_audit_info),
+            new=ELB(self.set_mocked_audit_info()),
         ):
             # Test Check
             from prowler.providers.aws.services.elb.elb_internet_facing.elb_internet_facing import (
@@ -52,14 +76,14 @@ class Test_elb_request_smugling:
             SecurityGroups=[security_group.id],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elb.elb_service import ELB
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elb.elb_internet_facing.elb_internet_facing.elb_client",
-            new=ELB(current_audit_info),
+            new=ELB(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elb.elb_internet_facing.elb_internet_facing import (
                 elb_internet_facing,
@@ -97,14 +121,14 @@ class Test_elb_request_smugling:
             SecurityGroups=[security_group.id],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elb.elb_service import ELB
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elb.elb_internet_facing.elb_internet_facing.elb_client",
-            new=ELB(current_audit_info),
+            new=ELB(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elb.elb_internet_facing.elb_internet_facing import (
                 elb_internet_facing,

--- a/tests/providers/aws/services/elb/elb_logging_enabled/elb_logging_enabled_test.py
+++ b/tests/providers/aws/services/elb/elb_logging_enabled/elb_logging_enabled_test.py
@@ -1,25 +1,49 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource
+from boto3 import client, resource, session
 from moto import mock_ec2, mock_elb
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_elb_logging_enabled:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_elb
     def test_elb_no_balancers(self):
-
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elb.elb_service import ELB
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elb.elb_logging_enabled.elb_logging_enabled.elb_client",
-            new=ELB(current_audit_info),
+            new=ELB(self.set_mocked_audit_info()),
         ):
             # Test Check
             from prowler.providers.aws.services.elb.elb_logging_enabled.elb_logging_enabled import (
@@ -52,14 +76,14 @@ class Test_elb_logging_enabled:
             SecurityGroups=[security_group.id],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elb.elb_service import ELB
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elb.elb_logging_enabled.elb_logging_enabled.elb_client",
-            new=ELB(current_audit_info),
+            new=ELB(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elb.elb_logging_enabled.elb_logging_enabled import (
                 elb_logging_enabled,
@@ -109,14 +133,14 @@ class Test_elb_logging_enabled:
             },
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elb.elb_service import ELB
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elb.elb_logging_enabled.elb_logging_enabled.elb_client",
-            new=ELB(current_audit_info),
+            new=ELB(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elb.elb_logging_enabled.elb_logging_enabled import (
                 elb_logging_enabled,

--- a/tests/providers/aws/services/elb/elb_ssl_listeners/elb_ssl_listeners_test.py
+++ b/tests/providers/aws/services/elb/elb_ssl_listeners/elb_ssl_listeners_test.py
@@ -1,25 +1,46 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource
+from boto3 import client, resource, session
 from moto import mock_ec2, mock_elb
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_elb_ssl_listeners:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_elb
     def test_elb_no_balancers(self):
-
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elb.elb_service import ELB
-
-        current_audit_info.audited_partition = "aws"
 
         with mock.patch(
             "prowler.providers.aws.services.elb.elb_ssl_listeners.elb_ssl_listeners.elb_client",
-            new=ELB(current_audit_info),
+            new=ELB(self.set_mocked_audit_info()),
         ):
             # Test Check
             from prowler.providers.aws.services.elb.elb_ssl_listeners.elb_ssl_listeners import (
@@ -52,14 +73,14 @@ class Test_elb_ssl_listeners:
             SecurityGroups=[security_group.id],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elb.elb_service import ELB
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elb.elb_ssl_listeners.elb_ssl_listeners.elb_client",
-            new=ELB(current_audit_info),
+            new=ELB(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elb.elb_ssl_listeners.elb_ssl_listeners import (
                 elb_ssl_listeners,
@@ -95,14 +116,14 @@ class Test_elb_ssl_listeners:
             Scheme="internal",
             SecurityGroups=[security_group.id],
         )
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elb.elb_service import ELB
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elb.elb_ssl_listeners.elb_ssl_listeners.elb_client",
-            new=ELB(current_audit_info),
+            new=ELB(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elb.elb_ssl_listeners.elb_ssl_listeners import (
                 elb_ssl_listeners,

--- a/tests/providers/aws/services/elbv2/elbv2_deletion_protection/elbv2_deletion_protection_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_deletion_protection/elbv2_deletion_protection_test.py
@@ -1,25 +1,49 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource
+from boto3 import client, resource, session
 from moto import mock_ec2, mock_elbv2
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_elbv2_deletion_protection:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_elbv2
     def test_elb_no_balancers(self):
-
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_deletion_protection.elbv2_deletion_protection.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_deletion_protection.elbv2_deletion_protection import (
@@ -63,14 +87,14 @@ class Test_elbv2_deletion_protection:
             ],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_deletion_protection.elbv2_deletion_protection.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_deletion_protection.elbv2_deletion_protection import (
                 elbv2_deletion_protection,
@@ -119,14 +143,14 @@ class Test_elbv2_deletion_protection:
             ],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_deletion_protection.elbv2_deletion_protection.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_deletion_protection.elbv2_deletion_protection import (
                 elbv2_deletion_protection,

--- a/tests/providers/aws/services/elbv2/elbv2_desync_mitigation_mode/elbv2_desync_mitigation_mode_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_desync_mitigation_mode/elbv2_desync_mitigation_mode_test.py
@@ -1,24 +1,46 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource
+from boto3 import client, resource, session
 from moto import mock_ec2, mock_elbv2
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_elbv2_desync_mitigation_mode:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_elbv2
     def test_elb_no_balancers(self):
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
-
-        current_audit_info.audited_partition = "aws"
 
         with mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode import (
@@ -66,14 +88,14 @@ class Test_elbv2_desync_mitigation_mode:
             ],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode import (
                 elbv2_desync_mitigation_mode,
@@ -127,14 +149,14 @@ class Test_elbv2_desync_mitigation_mode:
             ],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode import (
                 elbv2_desync_mitigation_mode,
@@ -183,14 +205,14 @@ class Test_elbv2_desync_mitigation_mode:
             ],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode import (
                 elbv2_desync_mitigation_mode,

--- a/tests/providers/aws/services/elbv2/elbv2_insecure_ssl_ciphers/elbv2_insecure_ssl_ciphers_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_insecure_ssl_ciphers/elbv2_insecure_ssl_ciphers_test.py
@@ -1,25 +1,49 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource
+from boto3 import client, resource, session
 from moto import mock_ec2, mock_elbv2
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_elbv2_insecure_ssl_ciphers:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_elbv2
     def test_elb_no_balancers(self):
-
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_insecure_ssl_ciphers.elbv2_insecure_ssl_ciphers.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_insecure_ssl_ciphers.elbv2_insecure_ssl_ciphers import (
@@ -80,14 +104,14 @@ class Test_elbv2_insecure_ssl_ciphers:
             DefaultActions=[{"Type": "forward", "TargetGroupArn": target_group_arn}],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_insecure_ssl_ciphers.elbv2_insecure_ssl_ciphers.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_insecure_ssl_ciphers.elbv2_insecure_ssl_ciphers import (
                 elbv2_insecure_ssl_ciphers,
@@ -152,14 +176,14 @@ class Test_elbv2_insecure_ssl_ciphers:
             DefaultActions=[{"Type": "forward", "TargetGroupArn": target_group_arn}],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_insecure_ssl_ciphers.elbv2_insecure_ssl_ciphers.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_insecure_ssl_ciphers.elbv2_insecure_ssl_ciphers import (
                 elbv2_insecure_ssl_ciphers,

--- a/tests/providers/aws/services/elbv2/elbv2_internet_facing/elbv2_internet_facing_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_internet_facing/elbv2_internet_facing_test.py
@@ -1,24 +1,49 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource
+from boto3 import client, resource, session
 from moto import mock_ec2, mock_elbv2
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_elbv2_internet_facing:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_elbv2
     def test_elb_no_balancers(self):
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_internet_facing.elbv2_internet_facing.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_internet_facing.elbv2_internet_facing import (
@@ -55,14 +80,14 @@ class Test_elbv2_internet_facing:
             Type="application",
         )["LoadBalancers"][0]
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_internet_facing.elbv2_internet_facing.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_internet_facing.elbv2_internet_facing import (
                 elbv2_internet_facing,
@@ -104,14 +129,14 @@ class Test_elbv2_internet_facing:
             Scheme="internet-facing",
         )["LoadBalancers"][0]
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_internet_facing.elbv2_internet_facing.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_internet_facing.elbv2_internet_facing import (
                 elbv2_internet_facing,

--- a/tests/providers/aws/services/elbv2/elbv2_listeners_underneath/elbv2_listeners_underneath_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_listeners_underneath/elbv2_listeners_underneath_test.py
@@ -1,25 +1,49 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource
+from boto3 import client, resource, session
 from moto import mock_ec2, mock_elbv2
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_elbv2_listeners_underneath:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_elbv2
     def test_elb_no_balancers(self):
-
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_listeners_underneath.elbv2_listeners_underneath.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_listeners_underneath.elbv2_listeners_underneath import (
@@ -56,14 +80,14 @@ class Test_elbv2_listeners_underneath:
             Type="application",
         )["LoadBalancers"][0]
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_listeners_underneath.elbv2_listeners_underneath.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_listeners_underneath.elbv2_listeners_underneath import (
                 elbv2_listeners_underneath,
@@ -127,14 +151,14 @@ class Test_elbv2_listeners_underneath:
             DefaultActions=[{"Type": "forward", "TargetGroupArn": target_group_arn}],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_listeners_underneath.elbv2_listeners_underneath.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_listeners_underneath.elbv2_listeners_underneath import (
                 elbv2_listeners_underneath,

--- a/tests/providers/aws/services/elbv2/elbv2_logging_enabled/elbv2_logging_enabled_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_logging_enabled/elbv2_logging_enabled_test.py
@@ -1,25 +1,49 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource
+from boto3 import client, resource, session
 from moto import mock_ec2, mock_elbv2
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_elbv2_logging_enabled:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_elbv2
     def test_elb_no_balancers(self):
-
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_logging_enabled.elbv2_logging_enabled.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_logging_enabled.elbv2_logging_enabled import (
@@ -66,14 +90,14 @@ class Test_elbv2_logging_enabled:
             ],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_logging_enabled.elbv2_logging_enabled.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_logging_enabled.elbv2_logging_enabled import (
                 elbv2_logging_enabled,
@@ -125,14 +149,14 @@ class Test_elbv2_logging_enabled:
             ],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_logging_enabled.elbv2_logging_enabled.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_logging_enabled.elbv2_logging_enabled import (
                 elbv2_logging_enabled,

--- a/tests/providers/aws/services/elbv2/elbv2_ssl_listeners/elbv2_ssl_listeners_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_ssl_listeners/elbv2_ssl_listeners_test.py
@@ -1,25 +1,49 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource
+from boto3 import client, resource, session
 from moto import mock_ec2, mock_elbv2
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_elbv2_ssl_listeners:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_elbv2
     def test_elb_no_balancers(self):
-
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners import (
@@ -78,14 +102,14 @@ class Test_elbv2_ssl_listeners:
             DefaultActions=[{"Type": "forward", "TargetGroupArn": target_group_arn}],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners import (
                 elbv2_ssl_listeners,
@@ -149,14 +173,14 @@ class Test_elbv2_ssl_listeners:
             DefaultActions=[{"Type": "forward", "TargetGroupArn": target_group_arn}],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners import (
                 elbv2_ssl_listeners,
@@ -213,14 +237,14 @@ class Test_elbv2_ssl_listeners:
             ],
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
-        current_audit_info.audited_partition = "aws"
-
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=self.set_mocked_audit_info(),
+        ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners.elbv2_client",
-            new=ELBv2(current_audit_info),
+            new=ELBv2(self.set_mocked_audit_info()),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners import (
                 elbv2_ssl_listeners,


### PR DESCRIPTION
### Description

Fix ELB and ELBv2 test to use a mocked `current_audit_info` object instead of the global one which is causing to some test to fail due to race conditions.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
