### PR TITLE
fix(test): Mock audit info API Gateway

### DIFF
--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -26,7 +26,7 @@ from prowler.providers.aws.aws_provider import (
 )
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
-AWS_ACCOUNT_NUMBER = 123456789012
+AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
 
 expected_packages = [

--- a/tests/providers/aws/services/apigateway/apigateway_authorizers_enabled/apigateway_authorizers_enabled_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_authorizers_enabled/apigateway_authorizers_enabled_test.py
@@ -1,23 +1,51 @@
 from unittest import mock
 
-from boto3 import client
+from boto3 import client, session
 from moto import mock_apigateway, mock_iam, mock_lambda
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+
 AWS_REGION = "us-east-1"
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_apigateway_authorizers_enabled:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_apigateway
     def test_apigateway_no_rest_apis(self):
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigateway.apigateway_authorizers_enabled.apigateway_authorizers_enabled.apigateway_client",
             new=APIGateway(current_audit_info),
         ):
@@ -62,14 +90,16 @@ class Test_apigateway_authorizers_enabled:
             type="TOKEN",
             authorizerUri=f"arn:aws:apigateway:{apigateway_client.meta.region_name}:lambda:path/2015-03-31/functions/arn:aws:lambda:{apigateway_client.meta.region_name}:{ACCOUNT_ID}:function:{authorizer['FunctionName']}/invocations",
         )
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigateway.apigateway_authorizers_enabled.apigateway_authorizers_enabled.apigateway_client",
             new=APIGateway(current_audit_info),
         ):
@@ -101,14 +131,16 @@ class Test_apigateway_authorizers_enabled:
         rest_api = apigateway_client.create_rest_api(
             name="test-rest-api",
         )
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigateway.apigateway_authorizers_enabled.apigateway_authorizers_enabled.apigateway_client",
             new=APIGateway(current_audit_info),
         ):

--- a/tests/providers/aws/services/apigateway/apigateway_client_certificate_enabled/apigateway_client_certificate_enabled_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_client_certificate_enabled/apigateway_client_certificate_enabled_test.py
@@ -1,14 +1,39 @@
 from unittest import mock
 
-from boto3 import client
+from boto3 import client, session
 from moto import mock_apigateway
 
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.apigateway.apigateway_service import Stage
 
 AWS_REGION = "us-east-1"
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_apigateway_client_certificate_enabled:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_apigateway
     def test_apigateway_no_stages(self):
         # Create APIGateway Mocked Resources
@@ -17,14 +42,16 @@ class Test_apigateway_client_certificate_enabled:
         apigateway_client.create_rest_api(
             name="test-rest-api",
         )
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigateway.apigateway_client_certificate_enabled.apigateway_client_certificate_enabled.apigateway_client",
             new=APIGateway(current_audit_info),
         ):
@@ -73,14 +100,16 @@ class Test_apigateway_client_certificate_enabled:
             restApiId=rest_api["id"],
             stageName="test",
         )
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigateway.apigateway_client_certificate_enabled.apigateway_client_certificate_enabled.apigateway_client",
             new=APIGateway(current_audit_info),
         ):
@@ -112,14 +141,16 @@ class Test_apigateway_client_certificate_enabled:
         rest_api = apigateway_client.create_rest_api(
             name="test-rest-api",
         )
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigateway.apigateway_client_certificate_enabled.apigateway_client_certificate_enabled.apigateway_client",
             new=APIGateway(current_audit_info),
         ) as service_client:

--- a/tests/providers/aws/services/apigateway/apigateway_endpoint_public/apigateway_endpoint_public_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_endpoint_public/apigateway_endpoint_public_test.py
@@ -1,22 +1,50 @@
 from unittest import mock
 
-from boto3 import client
+from boto3 import client, session
 from moto import mock_apigateway
 
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+
 AWS_REGION = "us-east-1"
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_apigateway_endpoint_public:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_apigateway
     def test_apigateway_no_rest_apis(self):
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigateway.apigateway_endpoint_public.apigateway_endpoint_public.apigateway_client",
             new=APIGateway(current_audit_info),
         ):
@@ -43,14 +71,16 @@ class Test_apigateway_endpoint_public:
                 ]
             },
         )
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigateway.apigateway_endpoint_public.apigateway_endpoint_public.apigateway_client",
             new=APIGateway(current_audit_info),
         ):
@@ -87,14 +117,16 @@ class Test_apigateway_endpoint_public:
                 ]
             },
         )
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigateway.apigateway_endpoint_public.apigateway_endpoint_public.apigateway_client",
             new=APIGateway(current_audit_info),
         ):

--- a/tests/providers/aws/services/apigateway/apigateway_logging_enabled/apigateway_logging_enabled_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_logging_enabled/apigateway_logging_enabled_test.py
@@ -1,22 +1,50 @@
 from unittest import mock
 
-from boto3 import client
+from boto3 import client, session
 from moto import mock_apigateway
 
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+
 AWS_REGION = "us-east-1"
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_apigateway_logging_enabled:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_apigateway
     def test_apigateway_no_rest_apis(self):
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigateway.apigateway_logging_enabled.apigateway_logging_enabled.apigateway_client",
             new=APIGateway(current_audit_info),
         ):
@@ -75,14 +103,16 @@ class Test_apigateway_logging_enabled:
                 },
             ],
         )
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigateway.apigateway_logging_enabled.apigateway_logging_enabled.apigateway_client",
             new=APIGateway(current_audit_info),
         ):
@@ -142,14 +172,16 @@ class Test_apigateway_logging_enabled:
             stageName="test",
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigateway.apigateway_logging_enabled.apigateway_logging_enabled.apigateway_client",
             new=APIGateway(current_audit_info),
         ):

--- a/tests/providers/aws/services/apigateway/apigateway_waf_acl_attached/apigateway_waf_acl_attached_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_waf_acl_attached/apigateway_waf_acl_attached_test.py
@@ -1,22 +1,50 @@
 from unittest import mock
 
-from boto3 import client
+from boto3 import client, session
 from moto import mock_apigateway, mock_wafv2
 
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+
 AWS_REGION = "us-east-1"
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_apigateway_waf_acl_attached:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_apigateway
     def test_apigateway_no_rest_apis(self):
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigateway.apigateway_waf_acl_attached.apigateway_waf_acl_attached.apigateway_client",
             new=APIGateway(current_audit_info),
         ):
@@ -81,14 +109,16 @@ class Test_apigateway_waf_acl_attached:
             ResourceArn=f"arn:aws:apigateway:{apigateway_client.meta.region_name}::/restapis/{rest_api['id']}/stages/test",
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigateway.apigateway_waf_acl_attached.apigateway_waf_acl_attached.apigateway_client",
             new=APIGateway(current_audit_info),
         ):
@@ -148,14 +178,16 @@ class Test_apigateway_waf_acl_attached:
             stageName="test",
         )
 
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigateway.apigateway_waf_acl_attached.apigateway_waf_acl_attached.apigateway_client",
             new=APIGateway(current_audit_info),
         ):

--- a/tests/providers/aws/services/apigatewayv2/apigatewayv2_authorizers_enabled/apigatewayv2_authorizers_enabled_test.py
+++ b/tests/providers/aws/services/apigatewayv2/apigatewayv2_authorizers_enabled/apigatewayv2_authorizers_enabled_test.py
@@ -1,11 +1,14 @@
 from unittest import mock
 
 import botocore
-from boto3 import client
+from boto3 import client, session
 from mock import patch
 from moto import mock_apigatewayv2
 
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+
 AWS_REGION = "us-east-1"
+AWS_ACCOUNT_NUMBER = "123456789012"
 
 # Mocking ApiGatewayV2 Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -36,16 +39,41 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_apigatewayv2_authorizers_enabled:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     @mock_apigatewayv2
     def test_apigateway_no_apis(self):
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigatewayv2.apigatewayv2_service import (
             ApiGatewayV2,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigatewayv2.apigatewayv2_authorizers_enabled.apigatewayv2_authorizers_enabled.apigatewayv2_client",
             new=ApiGatewayV2(current_audit_info),
         ):
@@ -72,14 +100,16 @@ class Test_apigatewayv2_authorizers_enabled:
             Name="auth1",
             AuthorizerPayloadFormatVersion="2.0",
         )
-        from prowler.providers.aws.lib.audit_info.audit_info import current_audit_info
         from prowler.providers.aws.services.apigatewayv2.apigatewayv2_service import (
             ApiGatewayV2,
         )
 
-        current_audit_info.audited_partition = "aws"
+        current_audit_info = self.set_mocked_audit_info()
 
         with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
             "prowler.providers.aws.services.apigatewayv2.apigatewayv2_authorizers_enabled.apigatewayv2_authorizers_enabled.apigatewayv2_client",
             new=ApiGatewayV2(current_audit_info),
         ):


### PR DESCRIPTION
### Description

Mock `current_audit_info` in API Gateway test.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
