### PR TITLE
fix(rds): exclude Aurora in rds_instance_transport_encrypted check

### DIFF
--- a/prowler/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted.py
+++ b/prowler/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted.py
@@ -14,8 +14,11 @@ class rds_instance_transport_encrypted(Check):
             report.status_extended = (
                 f"RDS Instance {db_instance.id} connections are not encrypted."
             )
-            # Check only RDS SQL Server or PostgreSQL engines
-            if any(engine in db_instance.engine for engine in supported_engines):
+            # Check only RDS SQL Server or PostgreSQL engines (Aurora not supported)
+            if (
+                any(engine in db_instance.engine for engine in supported_engines)
+                and "aurora" not in db_instance.engine
+            ):
                 for parameter in db_instance.parameters:
                     if (
                         parameter["ParameterName"] == "rds.force_ssl"


### PR DESCRIPTION
### Description

Exclude Aurora Instances in `rds_instance_transport_encrypted` check since `rds.force_ssl` is not supported in the DB Parameter Groups.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
