### PR TITLE
fix(redshift): correct description in redshift_cluster_automatic_upgrades

### DIFF
--- a/prowler/providers/aws/services/redshift/redshift_cluster_automatic_upgrades/redshift_cluster_automatic_upgrades.metadata.json
+++ b/prowler/providers/aws/services/redshift/redshift_cluster_automatic_upgrades/redshift_cluster_automatic_upgrades.metadata.json
@@ -1,14 +1,14 @@
 {
   "Provider": "aws",
   "CheckID": "redshift_cluster_automatic_upgrades",
-  "CheckTitle": "Check for Publicly Accessible Redshift Clusters",
+  "CheckTitle": "Check for Redshift Automatic Version Upgrade",
   "CheckType": [],
   "ServiceName": "redshift",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:redshift:region:account-id:cluster:cluster-name",
   "Severity": "high",
   "ResourceType": "AwsRedshiftCluster",
-  "Description": "Check for Publicly Accessible Redshift Clusters",
+  "Description": "Check for Redshift Automatic Version Upgrade",
   "Risk": "Without automatic version upgrade enabled; a critical Redshift Cluster version can become severly out of date",
   "RelatedUrl": "https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-operations.html",
   "Remediation": {


### PR DESCRIPTION
### Context

The description seems to be copied and is not relevant

### Description

The description was "Check for Publicly Accessible Redshift Clusters" which was probably copied from that check

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
