### PR TITLE
fix(opensearch): Handle invalid JSON policy

### DIFF
--- a/prowler/providers/aws/services/opensearch/opensearch_service.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service.py
@@ -1,5 +1,5 @@
 import threading
-from json import loads
+from json import JSONDecodeError, loads
 from typing import Optional
 
 from pydantic import BaseModel
@@ -79,9 +79,16 @@ class OpenSearchService:
                                 ]["Options"][logging_key]["Enabled"],
                             )
                         )
-                domain.access_policy = loads(
-                    describe_domain["DomainConfig"]["AccessPolicies"]["Options"]
-                )
+                try:
+                    domain.access_policy = loads(
+                        describe_domain["DomainConfig"]["AccessPolicies"]["Options"]
+                    )
+                except JSONDecodeError as error:
+                    logger.error(
+                        f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
+                    continue
+
         except Exception as error:
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"


### PR DESCRIPTION
### Description

Handle invalid JSON policy when calling `describe_domain_config`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
