### PR TITLE
fix(version): execute check current version function only when `-v`

### DIFF
--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -46,19 +46,20 @@ html_file_suffix = ".html"
 config_yaml = f"{pathlib.Path(os.path.dirname(os.path.realpath(__file__)))}/config.yaml"
 
 
-def check_current_version(prowler_version):
+def check_current_version():
     try:
+        prowler_version_string = f"Prowler {prowler_version}"
         release_response = requests.get(
             "https://api.github.com/repos/prowler-cloud/prowler/tags"
         )
         latest_version = release_response.json()[0]["name"]
         if latest_version != prowler_version:
-            return f"(latest is {latest_version}, upgrade for the latest features)"
+            return f"{prowler_version_string} (latest is {latest_version}, upgrade for the latest features)"
         else:
-            return "(it is the latest version, yay!)"
-    except Exception as e:
-        print(e)
-        return ""
+            return f"{prowler_version_string} (it is the latest version, yay!)"
+    except Exception as error:
+        logger.error(f"{error.__class__.__name__}: {error}")
+        return f"{prowler_version_string}"
 
 
 def change_config_var(variable, value):

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -6,7 +6,6 @@ from prowler.config.config import (
     available_compliance_frameworks,
     check_current_version,
     default_output_directory,
-    prowler_version,
 )
 from prowler.providers.aws.aws_provider import get_aws_available_regions
 from prowler.providers.aws.lib.arn.arn import is_valid_arn
@@ -36,8 +35,7 @@ Detailed documentation at https://docs.prowler.cloud
         self.parser.add_argument(
             "-v",
             "--version",
-            action="version",
-            version=f"Prowler {prowler_version} {check_current_version(prowler_version)}",
+            action="store_true",
             help="show Prowler version",
         )
         # Common arguments parser
@@ -67,6 +65,10 @@ Detailed documentation at https://docs.prowler.cloud
         # We can override sys.argv
         if args:
             sys.argv = args
+
+        if len(sys.argv) == 2 and sys.argv[1] in ("-v", "--version"):
+            print(check_current_version())
+            sys.exit()
 
         # Set AWS as the default provider if no provider is supplied
         if len(sys.argv) == 1:

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -68,7 +68,7 @@ Detailed documentation at https://docs.prowler.cloud
 
         if len(sys.argv) == 2 and sys.argv[1] in ("-v", "--version"):
             print(check_current_version())
-            sys.exit()
+            sys.exit(0)
 
         # Set AWS as the default provider if no provider is supplied
         if len(sys.argv) == 1:

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -6,6 +6,7 @@ from prowler.config.config import check_current_version
 from prowler.providers.aws.aws_provider import get_aws_available_regions
 
 MOCK_PROWLER_VERSION = "3.3.0"
+MOCK_OLD_PROWLER_VERSION = "0.0.0"
 
 
 def mock_prowler_get_latest_release(_):
@@ -25,10 +26,16 @@ class Test_Config:
     @mock.patch("prowler.config.config.prowler_version", new=MOCK_PROWLER_VERSION)
     def test_check_current_version_with_latest(self):
         assert (
-            check_current_version(MOCK_PROWLER_VERSION)
-            == "(it is the latest version, yay!)"
+            check_current_version()
+            == f"Prowler {MOCK_PROWLER_VERSION} (it is the latest version, yay!)"
         )
+
+    @mock.patch(
+        "prowler.config.config.requests.get", new=mock_prowler_get_latest_release
+    )
+    @mock.patch("prowler.config.config.prowler_version", new=MOCK_OLD_PROWLER_VERSION)
+    def test_check_current_version_with_old(self):
         assert (
-            check_current_version("0.0.0")
-            == f"(latest is {MOCK_PROWLER_VERSION}, upgrade for the latest features)"
+            check_current_version()
+            == f"Prowler {MOCK_OLD_PROWLER_VERSION} (latest is {MOCK_PROWLER_VERSION}, upgrade for the latest features)"
         )

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -132,12 +132,14 @@ class Test_Parser:
         with pytest.raises(SystemExit) as wrapped_exit:
             _ = self.parser.parse(command)
         assert wrapped_exit.type == SystemExit
+        assert wrapped_exit.value.code == 0
 
     def test_root_parser_version_long(self):
         command = [prowler_command, "--version"]
         with pytest.raises(SystemExit) as wrapped_exit:
             _ = self.parser.parse(command)
         assert wrapped_exit.type == SystemExit
+        assert wrapped_exit.value.code == 0
 
     def test_root_parser_help_short(self):
         command = [prowler_command, "-h"]

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -132,14 +132,12 @@ class Test_Parser:
         with pytest.raises(SystemExit) as wrapped_exit:
             _ = self.parser.parse(command)
         assert wrapped_exit.type == SystemExit
-        assert wrapped_exit.value.code == 0
 
     def test_root_parser_version_long(self):
         command = [prowler_command, "--version"]
         with pytest.raises(SystemExit) as wrapped_exit:
             _ = self.parser.parse(command)
         assert wrapped_exit.type == SystemExit
-        assert wrapped_exit.value.code == 0
 
     def test_root_parser_help_short(self):
         command = [prowler_command, "-h"]


### PR DESCRIPTION
### Description

Execute check current version function only when `-v` is passed, and handle error in the logger.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
