### PR TITLE
fix(apigateway2): correct paginator name

### DIFF
--- a/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
+++ b/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
@@ -37,7 +37,7 @@ class ApiGatewayV2:
         logger.info("APIGatewayv2 - Getting APIs...")
         try:
             get_apis_paginator = regional_client.get_paginator("get_apis")
-            for page in get_rest_apis_paginator.paginate():
+            for page in get_apis_paginator.paginate():
                 for apigw in page["Items"]:
                     if not self.audit_resources or (
                         is_resource_filtered(apigw["ApiId"], self.audit_resources)

--- a/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
+++ b/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
@@ -36,7 +36,7 @@ class ApiGatewayV2:
     def __get_apis__(self, regional_client):
         logger.info("APIGatewayv2 - Getting APIs...")
         try:
-            get_rest_apis_paginator = regional_client.get_paginator("get_apis")
+            get_apis_paginator = regional_client.get_paginator("get_apis")
             for page in get_rest_apis_paginator.paginate():
                 for apigw in page["Items"]:
                     if not self.audit_resources or (


### PR DESCRIPTION
### Description

Correct paginator name to be named `get_apis_paginator` since the rest APIs are not gathered with this function.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
