### PR TITLE
feat(workspaces): New check workspaces_vpc_2private_1public_subnets_nat

### DIFF
--- a/prowler/providers/aws/services/vpc/vpc_service.py
+++ b/prowler/providers/aws/services/vpc/vpc_service.py
@@ -275,12 +275,14 @@ class VPC:
                                     )
                                 )
                             public = False
+                            nat_gateway = False
                             for route in route_tables_for_subnet.get("RouteTables")[
                                 0
                             ].get("Routes"):
                                 if "GatewayId" in route and "igw" in route["GatewayId"]:
                                     public = True
-                                    break
+                                if "NatGatewayId" in route:
+                                    nat_gateway = True
                             # Add it to to list of vpc_subnets and to the VPC object
                             object = VpcSubnet(
                                 id=subnet["SubnetId"],
@@ -290,6 +292,7 @@ class VPC:
                                 region=regional_client.region,
                                 availability_zone=subnet["AvailabilityZone"],
                                 public=public,
+                                nat_gateway=nat_gateway,
                                 tags=subnet.get("Tags"),
                             )
                             self.vpc_subnets[subnet["SubnetId"]] = object
@@ -314,6 +317,7 @@ class VpcSubnet(BaseModel):
     cidr_block: str
     availability_zone: str
     public: bool
+    nat_gateway: bool
     region: str
     tags: Optional[list] = []
 

--- a/prowler/providers/aws/services/workspaces/workspaces_service.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_service.py
@@ -45,13 +45,13 @@ class WorkSpaces:
                         )
                     ):
                         workspace_to_append = WorkSpace(
-                            id=workspace["WorkspaceId"],
+                            id=workspace.get("WorkspaceId"),
                             region=regional_client.region,
-                            subnet_id=workspace["SubnetId"],
+                            subnet_id=workspace.get("SubnetId"),
                         )
                         if (
                             "UserVolumeEncryptionEnabled" in workspace
-                            and workspace["UserVolumeEncryptionEnabled"]
+                            and workspace.get("UserVolumeEncryptionEnabled")
                         ):
                             workspace_to_append.user_volume_encryption_enabled = True
                         if (
@@ -87,5 +87,5 @@ class WorkSpace(BaseModel):
     region: str
     user_volume_encryption_enabled: bool = None
     root_volume_encryption_enabled: bool = None
-    subnet_id: str
+    subnet_id: str = None
     tags: Optional[list] = []

--- a/prowler/providers/aws/services/workspaces/workspaces_service.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_service.py
@@ -45,7 +45,9 @@ class WorkSpaces:
                         )
                     ):
                         workspace_to_append = WorkSpace(
-                            id=workspace["WorkspaceId"], region=regional_client.region, subnet_id=workspace["SubnetId"]
+                            id=workspace["WorkspaceId"],
+                            region=regional_client.region,
+                            subnet_id=workspace["SubnetId"],
                         )
                         if (
                             "UserVolumeEncryptionEnabled" in workspace

--- a/prowler/providers/aws/services/workspaces/workspaces_service.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_service.py
@@ -45,7 +45,7 @@ class WorkSpaces:
                         )
                     ):
                         workspace_to_append = WorkSpace(
-                            id=workspace["WorkspaceId"], region=regional_client.region
+                            id=workspace["WorkspaceId"], region=regional_client.region, subnet_id=workspace["SubnetId"]
                         )
                         if (
                             "UserVolumeEncryptionEnabled" in workspace
@@ -85,4 +85,5 @@ class WorkSpace(BaseModel):
     region: str
     user_volume_encryption_enabled: bool = None
     root_volume_encryption_enabled: bool = None
+    subnet_id: str
     tags: Optional[list] = []

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.metadata.json
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.metadata.json
@@ -1,15 +1,15 @@
 {
   "Provider": "aws",
   "CheckID": "workspaces_vpc_2private_1public_subnets_nat",
-  "CheckTitle": "Ensuere Workspaces VPC are deployed using 2 private networks and 1 public network with NAT best practice",
+  "CheckTitle": "Ensure Workspaces VPC are deployed using 2 private networks and 1 public network with NAT best practice",
   "CheckType": [],
   "ServiceName": "workspaces",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:workspaces:region:account-id:workspace",
-  "Severity": "high",
+  "Severity": "medium",
   "ResourceType": "AwsWorkspaces",
-  "Description": "Ensuere Workspaces VPC are deployed using 2 private networks and 1 public network with NAT best practice",
-  "Risk": "",
+  "Description": "Ensure Workspaces VPC are deployed using 2 private networks and 1 public network with NAT best practice",
+  "Risk": "Proper network segmentation is a key security best practice. Workspaces VPC should be deployed using 2 private networks and 1 public network with NAT best practice",
   "RelatedUrl": "https://docs.aws.amazon.com/workspaces/latest/adminguide/amazon-workspaces-vpc.html",
   "Remediation": {
     "Code": {
@@ -19,8 +19,8 @@
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "",
-      "Url": ""
+      "Text": "Follow the documentation and deploy Workspaces VPC using 2 private networks and 1 public network with NAT best practice",
+      "Url": "https://docs.aws.amazon.com/workspaces/latest/adminguide/amazon-workspaces-vpc.html"
     }
   },
   "Categories": [],

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.metadata.json
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.metadata.json
@@ -8,7 +8,7 @@
   "ResourceIdTemplate": "arn:aws:workspaces:region:account-id:workspace",
   "Severity": "medium",
   "ResourceType": "AwsWorkspaces",
-  "Description": "Ensure Workspaces VPC are deployed following best practice: 2 private networks, 1 public network and using NAT Gateway",
+  "Description": "Ensure that the Workspaces VPC are deployed following the best practices using 1 public subnet and 2 private subnets with a NAT Gateway attached",
   "Risk": "Proper network segmentation is a key security best practice. Workspaces VPC should be deployed using 2 private networks and 1 public network with NAT best practice",
   "RelatedUrl": "https://docs.aws.amazon.com/workspaces/latest/adminguide/amazon-workspaces-vpc.html",
   "Remediation": {

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.metadata.json
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "aws",
+  "CheckID": "workspaces_vpc_2private_1public_subnets_nat",
+  "CheckTitle": "Ensuere Workspaces VPC are deployed using 2 private networks and 1 public network with NAT best practice",
+  "CheckType": [],
+  "ServiceName": "workspaces",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:workspaces:region:account-id:workspace",
+  "Severity": "high",
+  "ResourceType": "AwsWorkspaces",
+  "Description": "Ensuere Workspaces VPC are deployed using 2 private networks and 1 public network with NAT best practice",
+  "Risk": "",
+  "RelatedUrl": "https://docs.aws.amazon.com/workspaces/latest/adminguide/amazon-workspaces-vpc.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "",
+      "Url": ""
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.metadata.json
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "workspaces_vpc_2private_1public_subnets_nat",
-  "CheckTitle": "Ensure Workspaces VPC are deployed following best practice: 2 private networks, 1 public network and using NAT Gateway",
+  "CheckTitle": "Ensure that the Workspaces VPC are deployed following the best practices using 1 public subnet and 2 private subnets with a NAT Gateway attached",
   "CheckType": [],
   "ServiceName": "workspaces",
   "SubServiceName": "",

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.metadata.json
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.metadata.json
@@ -9,7 +9,7 @@
   "Severity": "medium",
   "ResourceType": "AwsWorkspaces",
   "Description": "Ensure that the Workspaces VPC are deployed following the best practices using 1 public subnet and 2 private subnets with a NAT Gateway attached",
-  "Risk": "Proper network segmentation is a key security best practice. Workspaces VPC should be deployed using 2 private networks and 1 public network with NAT best practice",
+  "Risk": "Proper network segmentation is a key security best practice. Workspaces VPC should be deployed using 1 public subnet and 2 private subnets with a NAT Gateway attached",
   "RelatedUrl": "https://docs.aws.amazon.com/workspaces/latest/adminguide/amazon-workspaces-vpc.html",
   "Remediation": {
     "Code": {

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.metadata.json
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.metadata.json
@@ -1,14 +1,14 @@
 {
   "Provider": "aws",
   "CheckID": "workspaces_vpc_2private_1public_subnets_nat",
-  "CheckTitle": "Ensure Workspaces VPC are deployed using 2 private networks and 1 public network with NAT best practice",
+  "CheckTitle": "Ensure Workspaces VPC are deployed following best practice: 2 private networks, 1 public network and using NAT Gateway",
   "CheckType": [],
   "ServiceName": "workspaces",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:workspaces:region:account-id:workspace",
   "Severity": "medium",
   "ResourceType": "AwsWorkspaces",
-  "Description": "Ensure Workspaces VPC are deployed using 2 private networks and 1 public network with NAT best practice",
+  "Description": "Ensure Workspaces VPC are deployed following best practice: 2 private networks, 1 public network and using NAT Gateway",
   "Risk": "Proper network segmentation is a key security best practice. Workspaces VPC should be deployed using 2 private networks and 1 public network with NAT best practice",
   "RelatedUrl": "https://docs.aws.amazon.com/workspaces/latest/adminguide/amazon-workspaces-vpc.html",
   "Remediation": {

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.metadata.json
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.metadata.json
@@ -19,7 +19,7 @@
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "Follow the documentation and deploy Workspaces VPC using 2 private networks and 1 public network with NAT best practice",
+      "Text": "Follow the documentation and deploy Workspaces VPC using 1 public subnet and 2 private subnets with a NAT Gateway attached",
       "Url": "https://docs.aws.amazon.com/workspaces/latest/adminguide/amazon-workspaces-vpc.html"
     }
   },

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
@@ -17,10 +17,11 @@ class workspaces_vpc_2private_1public_subnets_nat(Check):
             report.status = "PASS"
             report.status_extended = f"Workspace {workspace.id} is in a VPC which has 1 public subnet 2 private subnets with a NAT Gateway attached"
             vpc_object = None
-            if vpc_client.vpcs[vpc_client.vpc_subnets[workspace.subnet_id].vpc_id]:
-                vpc_object = vpc_client.vpcs[
-                    vpc_client.vpc_subnets[workspace.subnet_id].vpc_id
-                ]
+            if workspace.subnet_id:
+                if vpc_client.vpcs[vpc_client.vpc_subnets[workspace.subnet_id].vpc_id]:
+                    vpc_object = vpc_client.vpcs[
+                        vpc_client.vpc_subnets[workspace.subnet_id].vpc_id
+                    ]
             public_subnets = 0
             private_subnets = 0
             nat_gateway = False

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
@@ -1,0 +1,51 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.workspaces.workspaces_client import (
+    workspaces_client,
+)
+from prowler.providers.aws.services.vpc.vpc_client import (
+    vpc_client,
+)
+
+
+class workspaces_vpc_2private_1public_subnets_nat(Check):
+    def execute(self):
+        findings = []
+        for workspace in workspaces_client.workspaces:
+            report = Check_Report_AWS(self.metadata())
+            report.region = workspace.region
+            report.resource_id = workspace.id
+            report.resource_arn = workspace.arn
+            report.resource_tags = workspace.tags
+            report.status = "PASS"
+            report.status_extended = f"Worspace {workspace.id} it's in a VPC wich has 1 public with nat gateway and 2 private subnets"
+            # Find the vpc id for the subnet in the vpc_client
+            vpc_id = False
+            for subnet in vpc_client.vpc_subnets:
+                if subnet.id == workspace.subnet_id:
+                    vpc_id = subnet.vpc_id
+                    break
+            # Get the vpc object from the vpc_client
+            vpc_object = False
+            for vpc in vpc_client.vpcs:
+                if vpc.id == vpc_id:
+                    vpc_object = vpc
+                    break
+            # Analyze VPC subnets
+            public_subnets = 0
+            private_subnets = 0
+            public_subnet_nat_gateway = False
+            if vpc_object:
+                for vpc_subnet in vpc_object.subnets:
+                    if vpc_subnet.public:
+                        public_subnets += 1
+                        if vpc_subnet.nat_gateway:
+                            public_subnet_nat_gateway = True
+                        # Check NAT Gateway here
+                    if not vpc_subnet.public:
+                        private_subnets += 1
+            if public_subnets < 1 or private_subnets < 2 or not public_subnet_nat_gateway:
+                report.status = "FAIL"
+                report.status_extended = f"Worspaces VPC has not 1 public with nat gateaway and 2 private subnets"
+
+            findings.append(report)
+        return findings

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
@@ -47,7 +47,7 @@ class workspaces_vpc_2private_1public_subnets_nat(Check):
                 or not public_subnet_nat_gateway
             ):
                 report.status = "FAIL"
-                report.status_extended = "Worspaces VPC has not 1 public with nat gateaway and 2 private subnets"
+                report.status_extended = "Workspaces {workspace.id} VPC has not 1 public subnet with NAT gateway and 2 private subnets"
 
             findings.append(report)
         return findings

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
@@ -43,7 +43,7 @@ class workspaces_vpc_2private_1public_subnets_nat(Check):
                         # Check NAT Gateway here
             if public_subnets < 1 or private_subnets < 2 or not nat_gateway:
                 report.status = "FAIL"
-                report.status_extended = f"Workspaces {workspace.id} VPC has not 1 public subnet with NAT gateway and 2 private subnets"
+                report.status_extended = f"Workspace {workspace.id} VPC has not 1 public subnet and 2 private subnets with a NAT Gateway attached"
 
             findings.append(report)
         return findings

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
@@ -16,19 +16,11 @@ class workspaces_vpc_2private_1public_subnets_nat(Check):
             report.resource_tags = workspace.tags
             report.status = "PASS"
             report.status_extended = f"Workspace {workspace.id} is in a VPC which has 1 public subnet 2 private subnets with a NAT Gateway attached"
-            # Find the vpc id for the subnet in the vpc_client
-            vpc_id = False
-            for subnet in vpc_client.vpc_subnets:
-                if subnet.id == workspace.subnet_id:
-                    vpc_id = subnet.vpc_id
-                    break
-            # Get the vpc object from the vpc_client
-            vpc_object = False
-            for vpc in vpc_client.vpcs:
-                if vpc.id == vpc_id:
-                    vpc_object = vpc
-                    break
-            # Analyze VPC subnets
+            vpc_object = None
+            if vpc_client.vpcs[vpc_client.vpc_subnets[workspace.subnet_id].vpc_id]:
+                vpc_object = vpc_client.vpcs[
+                    vpc_client.vpc_subnets[workspace.subnet_id].vpc_id
+                ]
             public_subnets = 0
             private_subnets = 0
             nat_gateway = False

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
@@ -15,7 +15,7 @@ class workspaces_vpc_2private_1public_subnets_nat(Check):
             report.resource_arn = workspace.arn
             report.resource_tags = workspace.tags
             report.status = "PASS"
-            report.status_extended = f"Workspace {workspace.id} is in a VPC which has 1 public subnet with nat gateway and 2 private subnets"
+            report.status_extended = f"Workspace {workspace.id} is in a VPC which has 1 public subnet 2 private subnets with a NAT Gateway attached"
             # Find the vpc id for the subnet in the vpc_client
             vpc_id = False
             for subnet in vpc_client.vpc_subnets:

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
@@ -47,7 +47,7 @@ class workspaces_vpc_2private_1public_subnets_nat(Check):
                 or not public_subnet_nat_gateway
             ):
                 report.status = "FAIL"
-                report.status_extended = "Workspaces {workspace.id} VPC has not 1 public subnet with NAT gateway and 2 private subnets"
+                report.status_extended = f"Workspaces {workspace.id} VPC has not 1 public subnet with NAT gateway and 2 private subnets"
 
             findings.append(report)
         return findings

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
@@ -15,7 +15,7 @@ class workspaces_vpc_2private_1public_subnets_nat(Check):
             report.resource_arn = workspace.arn
             report.resource_tags = workspace.tags
             report.status = "PASS"
-            report.status_extended = f"Worspace {workspace.id} it's in a VPC wich has 1 public with nat gateway and 2 private subnets"
+            report.status_extended = f"Workspace {workspace.id} is in a VPC which has 1 public subnet with nat gateway and 2 private subnets"
             # Find the vpc id for the subnet in the vpc_client
             vpc_id = False
             for subnet in vpc_client.vpc_subnets:

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
@@ -1,9 +1,7 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.vpc.vpc_client import vpc_client
 from prowler.providers.aws.services.workspaces.workspaces_client import (
     workspaces_client,
-)
-from prowler.providers.aws.services.vpc.vpc_client import (
-    vpc_client,
 )
 
 
@@ -43,9 +41,13 @@ class workspaces_vpc_2private_1public_subnets_nat(Check):
                         # Check NAT Gateway here
                     if not vpc_subnet.public:
                         private_subnets += 1
-            if public_subnets < 1 or private_subnets < 2 or not public_subnet_nat_gateway:
+            if (
+                public_subnets < 1
+                or private_subnets < 2
+                or not public_subnet_nat_gateway
+            ):
                 report.status = "FAIL"
-                report.status_extended = f"Worspaces VPC has not 1 public with nat gateaway and 2 private subnets"
+                report.status_extended = "Worspaces VPC has not 1 public with nat gateaway and 2 private subnets"
 
             findings.append(report)
         return findings

--- a/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat.py
@@ -31,21 +31,17 @@ class workspaces_vpc_2private_1public_subnets_nat(Check):
             # Analyze VPC subnets
             public_subnets = 0
             private_subnets = 0
-            public_subnet_nat_gateway = False
+            nat_gateway = False
             if vpc_object:
                 for vpc_subnet in vpc_object.subnets:
                     if vpc_subnet.public:
                         public_subnets += 1
-                        if vpc_subnet.nat_gateway:
-                            public_subnet_nat_gateway = True
-                        # Check NAT Gateway here
                     if not vpc_subnet.public:
                         private_subnets += 1
-            if (
-                public_subnets < 1
-                or private_subnets < 2
-                or not public_subnet_nat_gateway
-            ):
+                        if vpc_subnet.nat_gateway:
+                            nat_gateway = True
+                        # Check NAT Gateway here
+            if public_subnets < 1 or private_subnets < 2 or not nat_gateway:
                 report.status = "FAIL"
                 report.status_extended = f"Workspaces {workspace.id} VPC has not 1 public subnet with NAT gateway and 2 private subnets"
 

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc_test.py
@@ -70,6 +70,7 @@ class Test_networkfirewall_in_all_vpc:
                         cidr_block="192.168.0.0/24",
                         availability_zone="us-east-1a",
                         public=False,
+                        nat_gateway=False,
                         region=AWS_REGION,
                         tags=[],
                     )
@@ -125,6 +126,7 @@ class Test_networkfirewall_in_all_vpc:
                         cidr_block="192.168.0.0/24",
                         availability_zone="us-east-1a",
                         public=False,
+                        nat_gateway=False,
                         region=AWS_REGION,
                         tags=[],
                     )
@@ -190,6 +192,7 @@ class Test_networkfirewall_in_all_vpc:
                         cidr_block="192.168.0.0/24",
                         availability_zone="us-east-1a",
                         public=False,
+                        nat_gateway=False,
                         region=AWS_REGION,
                         tags=[],
                     )
@@ -210,6 +213,7 @@ class Test_networkfirewall_in_all_vpc:
                         cidr_block="192.168.0.0/24",
                         availability_zone="us-east-1a",
                         public=False,
+                        nat_gateway=False,
                         region=AWS_REGION,
                         tags=[],
                     )

--- a/tests/providers/aws/services/vpc/vpc_service_test.py
+++ b/tests/providers/aws/services/vpc/vpc_service_test.py
@@ -311,5 +311,6 @@ class Test_VPC_Service:
                 assert vpc.subnets[0].cidr_block == "172.28.7.192/26"
                 assert vpc.subnets[0].availability_zone == f"{AWS_REGION}a"
                 assert vpc.subnets[0].public is False
+                assert vpc.subnets[0].nat_gateway is False
                 assert vpc.subnets[0].region == AWS_REGION
                 assert vpc.subnets[0].tags is None

--- a/tests/providers/aws/services/workspaces/workspaces_service_test.py
+++ b/tests/providers/aws/services/workspaces/workspaces_service_test.py
@@ -24,6 +24,7 @@ def mock_make_api_call(self, operation_name, kwarg):
                     "WorkspaceId": workspace_id,
                     "UserVolumeEncryptionEnabled": True,
                     "RootVolumeEncryptionEnabled": True,
+                    "SubnetId": "subnet-1234567890",
                 },
             ],
         }

--- a/tests/providers/aws/services/workspaces/workspaces_volume_encryption_enabled/workspaces_volume_encryption_enabled_test.py
+++ b/tests/providers/aws/services/workspaces/workspaces_volume_encryption_enabled/workspaces_volume_encryption_enabled_test.py
@@ -35,6 +35,7 @@ class Test_workspaces_volume_encryption_enabled:
                 region=AWS_REGION,
                 user_volume_encryption_enabled=True,
                 root_volume_encryption_enabled=True,
+                subnet_id="subnet-12345678",
             )
         )
         with mock.patch(
@@ -64,6 +65,7 @@ class Test_workspaces_volume_encryption_enabled:
                 region=AWS_REGION,
                 user_volume_encryption_enabled=False,
                 root_volume_encryption_enabled=True,
+                subnet_id="subnet-12345678",
             )
         )
         with mock.patch(
@@ -91,6 +93,7 @@ class Test_workspaces_volume_encryption_enabled:
                 region=AWS_REGION,
                 user_volume_encryption_enabled=True,
                 root_volume_encryption_enabled=False,
+                subnet_id="subnet-12345678",
             )
         )
         with mock.patch(
@@ -118,6 +121,7 @@ class Test_workspaces_volume_encryption_enabled:
                 region=AWS_REGION,
                 user_volume_encryption_enabled=False,
                 root_volume_encryption_enabled=False,
+                subnet_id="subnet-12345678",
             )
         )
         with mock.patch(

--- a/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
+++ b/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
@@ -119,7 +119,7 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                     assert result[0].status == "FAIL"
                     assert (
                         result[0].status_extended
-                        == "Worspaces VPC has not 1 public with nat gateaway and 2 private subnets"
+                        == f"Workspaces {workspace_id} VPC has not 1 public subnet with NAT gateway and 2 private subnets"
                     )
                     assert result[0].resource_id == workspace_id
                     assert result[0].resource_arn == ""
@@ -202,7 +202,7 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                     assert result[0].status == "FAIL"
                     assert (
                         result[0].status_extended
-                        == "Worspaces VPC has not 1 public with nat gateaway and 2 private subnets"
+                        == f"Workspaces {workspace_id} VPC has not 1 public subnet with NAT gateway and 2 private subnets"
                     )
                     assert result[0].resource_id == workspace_id
                     assert result[0].resource_arn == ""
@@ -304,7 +304,7 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                     assert result[0].status == "FAIL"
                     assert (
                         result[0].status_extended
-                        == "Worspaces VPC has not 1 public with nat gateaway and 2 private subnets"
+                        == f"Workspaces {workspace_id} VPC has not 1 public subnet with NAT gateway and 2 private subnets"
                     )
                     assert result[0].resource_id == workspace_id
                     assert result[0].resource_arn == ""
@@ -414,7 +414,7 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                     assert result[0].status == "PASS"
                     assert (
                         result[0].status_extended
-                        == f"Worspace {workspace_id} it's in a VPC wich has 1 public with nat gateway and 2 private subnets"
+                        == f"Workspace {workspace_id} is in a VPC which has 1 public subnet with nat gateway and 2 private subnets"
                     )
                     assert result[0].resource_id == workspace_id
                     assert result[0].resource_arn == ""

--- a/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
+++ b/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
@@ -119,7 +119,7 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                     assert result[0].status == "FAIL"
                     assert (
                         result[0].status_extended
-                        == f"Workspaces {workspace_id} VPC has not 1 public subnet with NAT gateway and 2 private subnets"
+                        == f"Workspace {workspace_id} VPC has not 1 public subnet and 2 private subnets with a NAT Gateway attached"
                     )
                     assert result[0].resource_id == workspace_id
                     assert result[0].resource_arn == ""
@@ -202,7 +202,7 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                     assert result[0].status == "FAIL"
                     assert (
                         result[0].status_extended
-                        == f"Workspaces {workspace_id} VPC has not 1 public subnet with NAT gateway and 2 private subnets"
+                        == f"Workspace {workspace_id} VPC has not 1 public subnet and 2 private subnets with a NAT Gateway attached"
                     )
                     assert result[0].resource_id == workspace_id
                     assert result[0].resource_arn == ""
@@ -304,7 +304,7 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                     assert result[0].status == "FAIL"
                     assert (
                         result[0].status_extended
-                        == f"Workspaces {workspace_id} VPC has not 1 public subnet with NAT gateway and 2 private subnets"
+                        == f"Workspace {workspace_id} VPC has not 1 public subnet and 2 private subnets with a NAT Gateway attached"
                     )
                     assert result[0].resource_id == workspace_id
                     assert result[0].resource_arn == ""
@@ -414,7 +414,7 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                     assert result[0].status == "PASS"
                     assert (
                         result[0].status_extended
-                        == f"Workspace {workspace_id} is in a VPC which has 1 public subnet with nat gateway and 2 private subnets"
+                        == f"Workspace {workspace_id} is in a VPC which has 1 public subnet 2 private subnets with a NAT Gateway attached"
                     )
                     assert result[0].resource_id == workspace_id
                     assert result[0].resource_arn == ""

--- a/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
+++ b/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
@@ -95,7 +95,7 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                     assert result[0].status == "FAIL"
                     assert (
                         result[0].status_extended
-                        == f"Workspace {workspace_id} VPC has not 1 public subnet and 2 private subnets with a NAT Gateway attached"
+                        == f"Workspace {workspace_id} is not in a private subnet or its VPC has not 1 public subnet and 2 private subnets with a NAT Gateway attached"
                     )
                     assert result[0].resource_id == workspace_id
                     assert result[0].resource_arn == ""
@@ -161,7 +161,7 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                     assert result[0].status == "FAIL"
                     assert (
                         result[0].status_extended
-                        == f"Workspace {workspace_id} VPC has not 1 public subnet and 2 private subnets with a NAT Gateway attached"
+                        == f"Workspace {workspace_id} is not in a private subnet or its VPC has not 1 public subnet and 2 private subnets with a NAT Gateway attached"
                     )
                     assert result[0].resource_id == workspace_id
                     assert result[0].resource_arn == ""
@@ -244,7 +244,7 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                     assert result[0].status == "FAIL"
                     assert (
                         result[0].status_extended
-                        == f"Workspace {workspace_id} VPC has not 1 public subnet and 2 private subnets with a NAT Gateway attached"
+                        == f"Workspace {workspace_id} is not in a private subnet or its VPC has not 1 public subnet and 2 private subnets with a NAT Gateway attached"
                     )
                     assert result[0].resource_id == workspace_id
                     assert result[0].resource_arn == ""
@@ -346,7 +346,7 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                     assert result[0].status == "FAIL"
                     assert (
                         result[0].status_extended
-                        == f"Workspace {workspace_id} VPC has not 1 public subnet and 2 private subnets with a NAT Gateway attached"
+                        == f"Workspace {workspace_id} is not in a private subnet or its VPC has not 1 public subnet and 2 private subnets with a NAT Gateway attached"
                     )
                     assert result[0].resource_id == workspace_id
                     assert result[0].resource_arn == ""
@@ -456,7 +456,7 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                     assert result[0].status == "PASS"
                     assert (
                         result[0].status_extended
-                        == f"Workspace {workspace_id} is in a VPC which has 1 public subnet 2 private subnets with a NAT Gateway attached"
+                        == f"Workspace {workspace_id} is in a private subnet within a VPC which has 1 public subnet 2 private subnets with a NAT Gateway attached"
                     )
                     assert result[0].resource_id == workspace_id
                     assert result[0].resource_arn == ""

--- a/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
+++ b/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
@@ -350,6 +350,14 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
             RouteTableId=route_table_private_2["RouteTable"]["RouteTableId"],
             SubnetId=subnet_private_2["Subnet"]["SubnetId"],
         )
+        # Nat Gateway
+        nat_gw = ec2_client.create_nat_gateway(
+            SubnetId=subnet_private_2["Subnet"]["SubnetId"],
+        )
+        ec2_client.create_route(
+            NatGatewayId=nat_gw["NatGateway"]["NatGatewayId"],
+            RouteTableId=route_table_private_2["RouteTable"]["RouteTableId"],
+        )
         # VPC Public
         subnet_public = ec2_client.create_subnet(
             VpcId=vpc["Vpc"]["VpcId"],
@@ -358,14 +366,6 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
         )
         route_table_public = ec2_client.create_route_table(
             VpcId=vpc["Vpc"]["VpcId"],
-        )
-
-        nat_gw = ec2_client.create_nat_gateway(
-            SubnetId=subnet_public["Subnet"]["SubnetId"],
-        )
-        ec2_client.create_route(
-            NatGatewayId=nat_gw["NatGateway"]["NatGatewayId"],
-            RouteTableId=route_table_public["RouteTable"]["RouteTableId"],
         )
         igw = ec2_client.create_internet_gateway()
         ec2_client.create_route(

--- a/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
+++ b/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
@@ -1,0 +1,67 @@
+from unittest import mock
+from moto import mock_ec2
+from uuid import uuid4
+
+from prowler.providers.aws.services.workspaces.workspaces_service import WorkSpace
+
+AWS_REGION = "eu-west-1"
+AWS_ACCOUNT_NUMBER = "123456789012"
+workspace_id = str(uuid4())
+SUBNET_PUBLIC_ID = "subnet-1234567890"
+SUBNET_PRIVATE_1_ID = "subnet-1234567891"
+SUBNET_PRIVATE_2_ID = "subnet-1234567891"
+
+
+class Test_workspaces_vpc_2private_1public_subnets_nat:
+    def test_no_workspaces(self):
+        workspaces_client = mock.MagicMock
+        workspaces_client.workspaces = []
+        vpc_client = mock.MagicMock
+        vpc_client.vpcs = []
+        with mock.patch(
+            "prowler.providers.aws.services.workspaces.workspaces_service.WorkSpaces",
+            workspaces_client,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.vpc.vpc_service.VPC",
+                vpc_client,
+            ):
+                from prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat import (
+                    workspaces_vpc_2private_1public_subnets_nat,
+                )
+
+                check = workspaces_vpc_2private_1public_subnets_nat()
+                result = check.execute()
+                assert len(result) == 0
+
+    @mock_ec2
+    def test_workspaces_vpc_single_private_subnet(self):
+        workspaces_client = mock.MagicMock
+        workspaces_client.workspaces = []
+        workspaces_client.workspaces.append(
+            WorkSpace(
+                id=workspace_id,
+                region=AWS_REGION,
+                user_volume_encryption_enabled=True,
+                root_volume_encryption_enabled=True,
+                subnet_id=SUBNET_PUBLIC_ID,
+            )
+        )
+        vpc_client = mock.MagicMock
+        vpc_client.vpcs = []
+        vpc_client.vpc_subnets = []
+        with mock.patch(
+            "prowler.providers.aws.services.workspaces.workspaces_service.WorkSpaces",
+            workspaces_client,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.vpc.vpc_service.VPC",
+                vpc_client,
+            ):
+                from prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat import (
+                    workspaces_vpc_2private_1public_subnets_nat,
+                )
+
+                check = workspaces_vpc_2private_1public_subnets_nat()
+                result = check.execute()
+                assert len(result) == 1

--- a/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
+++ b/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
@@ -1,18 +1,42 @@
 from unittest import mock
-from moto import mock_ec2
 from uuid import uuid4
 
+from boto3 import client, session
+from moto import mock_ec2
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.aws.services.vpc.vpc_service import VPC
 from prowler.providers.aws.services.workspaces.workspaces_service import WorkSpace
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 workspace_id = str(uuid4())
-SUBNET_PUBLIC_ID = "subnet-1234567890"
-SUBNET_PRIVATE_1_ID = "subnet-1234567891"
-SUBNET_PRIVATE_2_ID = "subnet-1234567891"
 
 
 class Test_workspaces_vpc_2private_1public_subnets_nat:
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_user_id=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=["us-east-1", "eu-west-1"],
+            organizations_metadata=None,
+            audit_resources=None,
+        )
+
+        return audit_info
+
     def test_no_workspaces(self):
         workspaces_client = mock.MagicMock
         workspaces_client.workspaces = []
@@ -35,7 +59,30 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                 assert len(result) == 0
 
     @mock_ec2
-    def test_workspaces_vpc_single_private_subnet(self):
+    def test_workspaces_vpc_one_private_subnet(self):
+        # EC2 Client
+        ec2_client = client("ec2", region_name=AWS_REGION)
+        vpc = ec2_client.create_vpc(
+            CidrBlock="172.28.7.0/24", InstanceTenancy="default"
+        )
+        # VPC Private
+        subnet_private = ec2_client.create_subnet(
+            VpcId=vpc["Vpc"]["VpcId"],
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=f"{AWS_REGION}a",
+        )
+        route_table_private = ec2_client.create_route_table(
+            VpcId=vpc["Vpc"]["VpcId"],
+        )
+        ec2_client.create_route(
+            DestinationCidrBlock="10.10.10.0",
+            RouteTableId=route_table_private["RouteTable"]["RouteTableId"],
+        )
+        ec2_client.associate_route_table(
+            RouteTableId=route_table_private["RouteTable"]["RouteTableId"],
+            SubnetId=subnet_private["Subnet"]["SubnetId"],
+        )
+        # Workspace Mock
         workspaces_client = mock.MagicMock
         workspaces_client.workspaces = []
         workspaces_client.workspaces.append(
@@ -44,24 +91,330 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                 region=AWS_REGION,
                 user_volume_encryption_enabled=True,
                 root_volume_encryption_enabled=True,
-                subnet_id=SUBNET_PUBLIC_ID,
+                subnet_id=subnet_private["Subnet"]["SubnetId"],
             )
         )
-        vpc_client = mock.MagicMock
-        vpc_client.vpcs = []
-        vpc_client.vpc_subnets = []
+
+        current_audit_info = self.set_mocked_audit_info()
+
         with mock.patch(
-            "prowler.providers.aws.services.workspaces.workspaces_service.WorkSpaces",
-            workspaces_client,
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
         ):
             with mock.patch(
-                "prowler.providers.aws.services.vpc.vpc_service.VPC",
-                vpc_client,
+                "prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat.vpc_client",
+                new=VPC(current_audit_info),
             ):
-                from prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat import (
-                    workspaces_vpc_2private_1public_subnets_nat,
-                )
+                with mock.patch(
+                    "prowler.providers.aws.services.workspaces.workspaces_service.WorkSpaces",
+                    workspaces_client,
+                ):
+                    from prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat import (
+                        workspaces_vpc_2private_1public_subnets_nat,
+                    )
 
-                check = workspaces_vpc_2private_1public_subnets_nat()
-                result = check.execute()
-                assert len(result) == 1
+                    check = workspaces_vpc_2private_1public_subnets_nat()
+                    result = check.execute()
+                    assert len(result) == 1
+                    assert result[0].status == "FAIL"
+                    assert (
+                        result[0].status_extended
+                        == "Worspaces VPC has not 1 public with nat gateaway and 2 private subnets"
+                    )
+                    assert result[0].resource_id == workspace_id
+                    assert result[0].resource_arn == ""
+
+    @mock_ec2
+    def test_workspaces_vpc_two_private_subnet(self):
+        # EC2 Client
+        ec2_client = client("ec2", region_name=AWS_REGION)
+        vpc = ec2_client.create_vpc(
+            CidrBlock="172.28.7.0/24", InstanceTenancy="default"
+        )
+        # VPC Private
+        subnet_private = ec2_client.create_subnet(
+            VpcId=vpc["Vpc"]["VpcId"],
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=f"{AWS_REGION}a",
+        )
+        route_table_private = ec2_client.create_route_table(
+            VpcId=vpc["Vpc"]["VpcId"],
+        )
+        ec2_client.create_route(
+            DestinationCidrBlock="10.10.10.0",
+            RouteTableId=route_table_private["RouteTable"]["RouteTableId"],
+        )
+        ec2_client.associate_route_table(
+            RouteTableId=route_table_private["RouteTable"]["RouteTableId"],
+            SubnetId=subnet_private["Subnet"]["SubnetId"],
+        )
+        # VPC Private 2
+        subnet_private_2 = ec2_client.create_subnet(
+            VpcId=vpc["Vpc"]["VpcId"],
+            CidrBlock="172.28.7.64/26",
+            AvailabilityZone=f"{AWS_REGION}a",
+        )
+        route_table_private_2 = ec2_client.create_route_table(
+            VpcId=vpc["Vpc"]["VpcId"],
+        )
+        ec2_client.create_route(
+            DestinationCidrBlock="10.10.10.0",
+            RouteTableId=route_table_private_2["RouteTable"]["RouteTableId"],
+        )
+        ec2_client.associate_route_table(
+            RouteTableId=route_table_private_2["RouteTable"]["RouteTableId"],
+            SubnetId=subnet_private_2["Subnet"]["SubnetId"],
+        )
+        # Workspace Mock
+        workspaces_client = mock.MagicMock
+        workspaces_client.workspaces = []
+        workspaces_client.workspaces.append(
+            WorkSpace(
+                id=workspace_id,
+                region=AWS_REGION,
+                user_volume_encryption_enabled=True,
+                root_volume_encryption_enabled=True,
+                subnet_id=subnet_private["Subnet"]["SubnetId"],
+            )
+        )
+
+        current_audit_info = self.set_mocked_audit_info()
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat.vpc_client",
+                new=VPC(current_audit_info),
+            ):
+                with mock.patch(
+                    "prowler.providers.aws.services.workspaces.workspaces_service.WorkSpaces",
+                    workspaces_client,
+                ):
+                    from prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat import (
+                        workspaces_vpc_2private_1public_subnets_nat,
+                    )
+
+                    check = workspaces_vpc_2private_1public_subnets_nat()
+                    result = check.execute()
+                    assert len(result) == 1
+                    assert result[0].status == "FAIL"
+                    assert (
+                        result[0].status_extended
+                        == "Worspaces VPC has not 1 public with nat gateaway and 2 private subnets"
+                    )
+                    assert result[0].resource_id == workspace_id
+                    assert result[0].resource_arn == ""
+
+    @mock_ec2
+    def test_workspaces_vpc_two_private_subnet_one_public(self):
+        # EC2 Client
+        ec2_client = client("ec2", region_name=AWS_REGION)
+        vpc = ec2_client.create_vpc(
+            CidrBlock="172.28.7.0/24", InstanceTenancy="default"
+        )
+        # VPC Private
+        subnet_private = ec2_client.create_subnet(
+            VpcId=vpc["Vpc"]["VpcId"],
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=f"{AWS_REGION}a",
+        )
+        route_table_private = ec2_client.create_route_table(
+            VpcId=vpc["Vpc"]["VpcId"],
+        )
+        ec2_client.create_route(
+            DestinationCidrBlock="10.10.10.0",
+            RouteTableId=route_table_private["RouteTable"]["RouteTableId"],
+        )
+        ec2_client.associate_route_table(
+            RouteTableId=route_table_private["RouteTable"]["RouteTableId"],
+            SubnetId=subnet_private["Subnet"]["SubnetId"],
+        )
+        # VPC Private 2
+        subnet_private_2 = ec2_client.create_subnet(
+            VpcId=vpc["Vpc"]["VpcId"],
+            CidrBlock="172.28.7.64/26",
+            AvailabilityZone=f"{AWS_REGION}a",
+        )
+        route_table_private_2 = ec2_client.create_route_table(
+            VpcId=vpc["Vpc"]["VpcId"],
+        )
+        ec2_client.create_route(
+            DestinationCidrBlock="10.10.10.0",
+            RouteTableId=route_table_private_2["RouteTable"]["RouteTableId"],
+        )
+        ec2_client.associate_route_table(
+            RouteTableId=route_table_private_2["RouteTable"]["RouteTableId"],
+            SubnetId=subnet_private_2["Subnet"]["SubnetId"],
+        )
+        # VPC Public
+        subnet_public = ec2_client.create_subnet(
+            VpcId=vpc["Vpc"]["VpcId"],
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=f"{AWS_REGION}a",
+        )
+        route_table_public = ec2_client.create_route_table(
+            VpcId=vpc["Vpc"]["VpcId"],
+        )
+        igw = ec2_client.create_internet_gateway()
+        ec2_client.create_route(
+            DestinationCidrBlock="0.0.0.0",
+            RouteTableId=route_table_public["RouteTable"]["RouteTableId"],
+            GatewayId=igw["InternetGateway"]["InternetGatewayId"],
+        )
+        ec2_client.associate_route_table(
+            RouteTableId=route_table_public["RouteTable"]["RouteTableId"],
+            SubnetId=subnet_public["Subnet"]["SubnetId"],
+        )
+        # Workspace Mock
+        workspaces_client = mock.MagicMock
+        workspaces_client.workspaces = []
+        workspaces_client.workspaces.append(
+            WorkSpace(
+                id=workspace_id,
+                region=AWS_REGION,
+                user_volume_encryption_enabled=True,
+                root_volume_encryption_enabled=True,
+                subnet_id=subnet_private["Subnet"]["SubnetId"],
+            )
+        )
+
+        current_audit_info = self.set_mocked_audit_info()
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat.vpc_client",
+                new=VPC(current_audit_info),
+            ):
+                with mock.patch(
+                    "prowler.providers.aws.services.workspaces.workspaces_service.WorkSpaces",
+                    workspaces_client,
+                ):
+                    from prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat import (
+                        workspaces_vpc_2private_1public_subnets_nat,
+                    )
+
+                    check = workspaces_vpc_2private_1public_subnets_nat()
+                    result = check.execute()
+                    assert len(result) == 1
+                    assert result[0].status == "FAIL"
+                    assert (
+                        result[0].status_extended
+                        == "Worspaces VPC has not 1 public with nat gateaway and 2 private subnets"
+                    )
+                    assert result[0].resource_id == workspace_id
+                    assert result[0].resource_arn == ""
+
+    @mock_ec2
+    def test_workspaces_vpc_two_private_subnet_one_public_and_nat(self):
+        # EC2 Client
+        ec2_client = client("ec2", region_name=AWS_REGION)
+        vpc = ec2_client.create_vpc(
+            CidrBlock="172.28.7.0/24", InstanceTenancy="default"
+        )
+        # VPC Private
+        subnet_private = ec2_client.create_subnet(
+            VpcId=vpc["Vpc"]["VpcId"],
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=f"{AWS_REGION}a",
+        )
+        route_table_private = ec2_client.create_route_table(
+            VpcId=vpc["Vpc"]["VpcId"],
+        )
+        ec2_client.create_route(
+            DestinationCidrBlock="10.10.10.0",
+            RouteTableId=route_table_private["RouteTable"]["RouteTableId"],
+        )
+        ec2_client.associate_route_table(
+            RouteTableId=route_table_private["RouteTable"]["RouteTableId"],
+            SubnetId=subnet_private["Subnet"]["SubnetId"],
+        )
+        # VPC Private 2
+        subnet_private_2 = ec2_client.create_subnet(
+            VpcId=vpc["Vpc"]["VpcId"],
+            CidrBlock="172.28.7.64/26",
+            AvailabilityZone=f"{AWS_REGION}a",
+        )
+        route_table_private_2 = ec2_client.create_route_table(
+            VpcId=vpc["Vpc"]["VpcId"],
+        )
+        ec2_client.create_route(
+            DestinationCidrBlock="10.10.10.0",
+            RouteTableId=route_table_private_2["RouteTable"]["RouteTableId"],
+        )
+        ec2_client.associate_route_table(
+            RouteTableId=route_table_private_2["RouteTable"]["RouteTableId"],
+            SubnetId=subnet_private_2["Subnet"]["SubnetId"],
+        )
+        # VPC Public
+        subnet_public = ec2_client.create_subnet(
+            VpcId=vpc["Vpc"]["VpcId"],
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=f"{AWS_REGION}a",
+        )
+        route_table_public = ec2_client.create_route_table(
+            VpcId=vpc["Vpc"]["VpcId"],
+        )
+
+        nat_gw = ec2_client.create_nat_gateway(
+            SubnetId=subnet_public["Subnet"]["SubnetId"],
+        )
+        ec2_client.create_route(
+            NatGatewayId=nat_gw["NatGateway"]["NatGatewayId"],
+            RouteTableId=route_table_public["RouteTable"]["RouteTableId"],
+        )
+        igw = ec2_client.create_internet_gateway()
+        ec2_client.create_route(
+            DestinationCidrBlock="0.0.0.0",
+            RouteTableId=route_table_public["RouteTable"]["RouteTableId"],
+            GatewayId=igw["InternetGateway"]["InternetGatewayId"],
+        )
+        ec2_client.associate_route_table(
+            RouteTableId=route_table_public["RouteTable"]["RouteTableId"],
+            SubnetId=subnet_public["Subnet"]["SubnetId"],
+        )
+        # Workspace Mock
+        workspaces_client = mock.MagicMock
+        workspaces_client.workspaces = []
+        workspaces_client.workspaces.append(
+            WorkSpace(
+                id=workspace_id,
+                region=AWS_REGION,
+                user_volume_encryption_enabled=True,
+                root_volume_encryption_enabled=True,
+                subnet_id=subnet_private["Subnet"]["SubnetId"],
+            )
+        )
+
+        current_audit_info = self.set_mocked_audit_info()
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat.vpc_client",
+                new=VPC(current_audit_info),
+            ):
+                with mock.patch(
+                    "prowler.providers.aws.services.workspaces.workspaces_service.WorkSpaces",
+                    workspaces_client,
+                ):
+                    from prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat import (
+                        workspaces_vpc_2private_1public_subnets_nat,
+                    )
+
+                    check = workspaces_vpc_2private_1public_subnets_nat()
+                    result = check.execute()
+                    assert len(result) == 1
+                    assert result[0].status == "PASS"
+                    assert (
+                        result[0].status_extended
+                        == f"Worspace {workspace_id} it's in a VPC wich has 1 public with nat gateway and 2 private subnets"
+                    )
+                    assert result[0].resource_id == workspace_id
+                    assert result[0].resource_arn == ""

--- a/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
+++ b/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
@@ -106,8 +106,8 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                 new=VPC(current_audit_info),
             ):
                 with mock.patch(
-                    "prowler.providers.aws.services.workspaces.workspaces_service.WorkSpaces",
-                    workspaces_client,
+                    "prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat.workspaces_client",
+                    new=workspaces_client,
                 ):
                     from prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat import (
                         workspaces_vpc_2private_1public_subnets_nat,
@@ -189,8 +189,8 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                 new=VPC(current_audit_info),
             ):
                 with mock.patch(
-                    "prowler.providers.aws.services.workspaces.workspaces_service.WorkSpaces",
-                    workspaces_client,
+                    "prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat.workspaces_client",
+                    new=workspaces_client,
                 ):
                     from prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat import (
                         workspaces_vpc_2private_1public_subnets_nat,
@@ -291,8 +291,8 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                 new=VPC(current_audit_info),
             ):
                 with mock.patch(
-                    "prowler.providers.aws.services.workspaces.workspaces_service.WorkSpaces",
-                    workspaces_client,
+                    "prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat.workspaces_client",
+                    new=workspaces_client,
                 ):
                     from prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat import (
                         workspaces_vpc_2private_1public_subnets_nat,
@@ -401,8 +401,8 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                 new=VPC(current_audit_info),
             ):
                 with mock.patch(
-                    "prowler.providers.aws.services.workspaces.workspaces_service.WorkSpaces",
-                    workspaces_client,
+                    "prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat.workspaces_client",
+                    new=workspaces_client,
                 ):
                     from prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat import (
                         workspaces_vpc_2private_1public_subnets_nat,

--- a/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
+++ b/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
@@ -58,6 +58,48 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
                 result = check.execute()
                 assert len(result) == 0
 
+    def test_workspaces_no_subnet(self):
+        workspaces_client = mock.MagicMock
+        workspaces_client = mock.MagicMock
+        workspaces_client.workspaces = []
+        workspaces_client.workspaces.append(
+            WorkSpace(
+                id=workspace_id,
+                region=AWS_REGION,
+                user_volume_encryption_enabled=True,
+                root_volume_encryption_enabled=True,
+            )
+        )
+
+        current_audit_info = self.set_mocked_audit_info()
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat.vpc_client",
+                new=VPC(current_audit_info),
+            ):
+                with mock.patch(
+                    "prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat.workspaces_client",
+                    new=workspaces_client,
+                ):
+                    from prowler.providers.aws.services.workspaces.workspaces_vpc_2private_1public_subnets_nat.workspaces_vpc_2private_1public_subnets_nat import (
+                        workspaces_vpc_2private_1public_subnets_nat,
+                    )
+
+                    check = workspaces_vpc_2private_1public_subnets_nat()
+                    result = check.execute()
+                    assert len(result) == 1
+                    assert result[0].status == "FAIL"
+                    assert (
+                        result[0].status_extended
+                        == f"Workspace {workspace_id} VPC has not 1 public subnet and 2 private subnets with a NAT Gateway attached"
+                    )
+                    assert result[0].resource_id == workspace_id
+                    assert result[0].resource_arn == ""
+
     @mock_ec2
     def test_workspaces_vpc_one_private_subnet(self):
         # EC2 Client


### PR DESCRIPTION
### Context

New check for service `workspaces`: `workspaces_vpc_2private_1public_subnets_nat`

Ensure Workspaces VPC is deployed using 2 private networks and 1 public network with NAT best practice.

We are checking this best practice: https://docs.aws.amazon.com/workspaces/latest/adminguide/amazon-workspaces-vpc.html

To be able to perform this check, I improved the `VPCSubnet` class and added to it a `nat_gateway` bool field so we now know if a subnet is public and if it's attached to a nat_gateway. 

I also improved the class `Workspace,` and I added to it the field `subnet_id`.

With this information, I first iterate workspaces, for each workspace, based on the `subnet_id` i use the `vpc_client` to find the vpc and I check the subnets that belong to it. 


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
