### PR TITLE
fix(backups): change severity and only check report_plans if plans exists

### DIFF
--- a/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.metadata.json
+++ b/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.metadata.json
@@ -10,7 +10,7 @@
   "ServiceName": "backup",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:backup-plan:backup-plan-id",
-  "Severity": "medium",
+  "Severity": "low",
   "ResourceType": "AwsBackupBackupPlan",
   "Description": "This check ensures that there is at least one backup plan in place.",
   "Risk": "Without a backup plan, an organization may be at risk of losing important data due to accidental deletion, system failures, or natural disasters. This can result in significant financial and reputational damage for the organization.",

--- a/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.py
+++ b/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.py
@@ -13,7 +13,9 @@ class backup_plans_exist(Check):
         report.region = backup_client.region
         if backup_client.backup_plans:
             report.status = "PASS"
-            report.status_extended = f"At least one backup plan exists: {backup_client.backup_plans[0].name}"
+            report.status_extended = (
+                f"At least one backup plan exists: {backup_client.backup_plans[0].name}"
+            )
             report.resource_arn = backup_client.backup_plans[0].arn
             report.resource_id = backup_client.backup_plans[0].name
             report.region = backup_client.backup_plans[0].region

--- a/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.py
+++ b/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.py
@@ -13,7 +13,7 @@ class backup_plans_exist(Check):
         report.region = backup_client.region
         if backup_client.backup_plans:
             report.status = "PASS"
-            report.status_extended = f"At least one backup plan exists: { backup_client.backup_plans[0].name}"
+            report.status_extended = f"At least one backup plan exists: {backup_client.backup_plans[0].name}"
             report.resource_arn = backup_client.backup_plans[0].arn
             report.resource_id = backup_client.backup_plans[0].name
             report.region = backup_client.backup_plans[0].region

--- a/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.py
+++ b/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.py
@@ -9,7 +9,7 @@ class backup_plans_exist(Check):
         report.status = "FAIL"
         report.status_extended = "No Backup Plan Exist"
         report.resource_arn = ""
-        report.resource_id = "No Backups"
+        report.resource_id = "Backups"
         report.region = backup_client.region
         if backup_client.backup_plans:
             report.status = "PASS"

--- a/prowler/providers/aws/services/backup/backup_reportplans_exist/backup_reportplans_exist.py
+++ b/prowler/providers/aws/services/backup/backup_reportplans_exist/backup_reportplans_exist.py
@@ -11,7 +11,7 @@ class backup_reportplans_exist(Check):
             report.status = "FAIL"
             report.status_extended = "No Backup Report Plan Exist"
             report.resource_arn = ""
-            report.resource_id = "No Backups"
+            report.resource_id = "Backups"
             report.region = backup_client.region
             if backup_client.backup_report_plans:
                 report.status = "PASS"

--- a/prowler/providers/aws/services/backup/backup_reportplans_exist/backup_reportplans_exist.py
+++ b/prowler/providers/aws/services/backup/backup_reportplans_exist/backup_reportplans_exist.py
@@ -5,18 +5,20 @@ from prowler.providers.aws.services.backup.backup_client import backup_client
 class backup_reportplans_exist(Check):
     def execute(self):
         findings = []
-        report = Check_Report_AWS(self.metadata())
-        report.status = "FAIL"
-        report.status_extended = "No Backup Report Plan Exist"
-        report.resource_arn = ""
-        report.resource_id = "No Backups"
-        report.region = backup_client.region
-        if backup_client.backup_report_plans:
-            report.status = "PASS"
-            report.status_extended = f"At least one backup report plan exists: { backup_client.backup_report_plans[0].name}"
-            report.resource_arn = backup_client.backup_report_plans[0].arn
-            report.resource_id = backup_client.backup_report_plans[0].name
-            report.region = backup_client.backup_report_plans[0].region
+        # We only check report plans if backup plans exist, reducing noise
+        if backup_client.backup_plans:
+            report = Check_Report_AWS(self.metadata())
+            report.status = "FAIL"
+            report.status_extended = "No Backup Report Plan Exist"
+            report.resource_arn = ""
+            report.resource_id = "No Backups"
+            report.region = backup_client.region
+            if backup_client.backup_report_plans:
+                report.status = "PASS"
+                report.status_extended = f"At least one backup report plan exists: { backup_client.backup_report_plans[0].name}"
+                report.resource_arn = backup_client.backup_report_plans[0].arn
+                report.resource_id = backup_client.backup_report_plans[0].name
+                report.region = backup_client.backup_report_plans[0].region
 
-        findings.append(report)
+            findings.append(report)
         return findings

--- a/prowler/providers/aws/services/backup/backup_vaults_exist/backup_vaults_exist.metadata.json
+++ b/prowler/providers/aws/services/backup/backup_vaults_exist/backup_vaults_exist.metadata.json
@@ -10,7 +10,7 @@
   "ServiceName": "backup",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:backup-vault:backup-vault-id",
-  "Severity": "medium",
+  "Severity": "low",
   "ResourceType": "AwsBackupBackupVault",
   "Description": "This check ensures that AWS Backup vaults exist to provide a secure and durable storage location for backup data.",
   "Risk": "Without an AWS Backup vault, an organization's critical data may be at risk of being lost in the event of an accidental deletion, system failures, or natural disasters.",

--- a/prowler/providers/aws/services/backup/backup_vaults_exist/backup_vaults_exist.py
+++ b/prowler/providers/aws/services/backup/backup_vaults_exist/backup_vaults_exist.py
@@ -9,7 +9,7 @@ class backup_vaults_exist(Check):
         report.status = "FAIL"
         report.status_extended = "No Backup Vault Exist"
         report.resource_arn = ""
-        report.resource_id = "No Backups"
+        report.resource_id = "Backups"
         report.region = backup_client.region
         if backup_client.backup_vaults:
             report.status = "PASS"

--- a/tests/providers/aws/services/backup/backup_plans_exist/backup_plans_exist_test.py
+++ b/tests/providers/aws/services/backup/backup_plans_exist/backup_plans_exist_test.py
@@ -26,7 +26,7 @@ class Test_backup_plans_exist:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].status_extended == "No Backup Plan Exist"
-            assert result[0].resource_id == "No Backups"
+            assert result[0].resource_id == "Backups"
             assert result[0].resource_arn == ""
             assert result[0].region == AWS_REGION
 

--- a/tests/providers/aws/services/backup/backup_reportplans_exist/backup_reportplans_exist_test.py
+++ b/tests/providers/aws/services/backup/backup_reportplans_exist/backup_reportplans_exist_test.py
@@ -1,13 +1,15 @@
 from datetime import datetime
 from unittest import mock
 
-from prowler.providers.aws.services.backup.backup_service import BackupReportPlan, BackupPlan
+from prowler.providers.aws.services.backup.backup_service import (
+    BackupPlan,
+    BackupReportPlan,
+)
 
 AWS_REGION = "eu-west-1"
 
 
 class Test_backup_reportplans_exist:
-
     def test_no_backup_plans(self):
         backup_client = mock.MagicMock
         backup_client.region = AWS_REGION
@@ -25,7 +27,6 @@ class Test_backup_reportplans_exist:
             result = check.execute()
 
             assert len(result) == 0
-
 
     def test_no_backup_report_plans(self):
         backup_client = mock.MagicMock

--- a/tests/providers/aws/services/backup/backup_reportplans_exist/backup_reportplans_exist_test.py
+++ b/tests/providers/aws/services/backup/backup_reportplans_exist/backup_reportplans_exist_test.py
@@ -58,7 +58,7 @@ class Test_backup_reportplans_exist:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].status_extended == "No Backup Report Plan Exist"
-            assert result[0].resource_id == "No Backups"
+            assert result[0].resource_id == "Backups"
             assert result[0].resource_arn == ""
             assert result[0].region == AWS_REGION
 

--- a/tests/providers/aws/services/backup/backup_reportplans_exist/backup_reportplans_exist_test.py
+++ b/tests/providers/aws/services/backup/backup_reportplans_exist/backup_reportplans_exist_test.py
@@ -1,15 +1,46 @@
 from datetime import datetime
 from unittest import mock
 
-from prowler.providers.aws.services.backup.backup_service import BackupReportPlan
+from prowler.providers.aws.services.backup.backup_service import BackupReportPlan, BackupPlan
 
 AWS_REGION = "eu-west-1"
 
 
 class Test_backup_reportplans_exist:
+
+    def test_no_backup_plans(self):
+        backup_client = mock.MagicMock
+        backup_client.region = AWS_REGION
+        backup_client.backup_plans = []
+        with mock.patch(
+            "prowler.providers.aws.services.backup.backup_service.Backup",
+            new=backup_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.backup.backup_reportplans_exist.backup_reportplans_exist import (
+                backup_reportplans_exist,
+            )
+
+            check = backup_reportplans_exist()
+            result = check.execute()
+
+            assert len(result) == 0
+
+
     def test_no_backup_report_plans(self):
         backup_client = mock.MagicMock
         backup_client.region = AWS_REGION
+        backup_client.backup_plans = [
+            BackupPlan(
+                arn="ARN",
+                id="MyBackupPlan",
+                region=AWS_REGION,
+                name="MyBackupPlan",
+                version_id="version_id",
+                last_execution_date=datetime(2015, 1, 1),
+                advanced_settings=[],
+            )
+        ]
         backup_client.backup_report_plans = []
         with mock.patch(
             "prowler.providers.aws.services.backup.backup_service.Backup",
@@ -33,6 +64,17 @@ class Test_backup_reportplans_exist:
     def test_one_backup_report_plan(self):
         backup_client = mock.MagicMock
         backup_client.region = AWS_REGION
+        backup_client.backup_plans = [
+            BackupPlan(
+                arn="ARN",
+                id="MyBackupPlan",
+                region=AWS_REGION,
+                name="MyBackupPlan",
+                version_id="version_id",
+                last_execution_date=datetime(2015, 1, 1),
+                advanced_settings=[],
+            )
+        ]
         backup_client.backup_report_plans = [
             BackupReportPlan(
                 arn="ARN",

--- a/tests/providers/aws/services/backup/backup_vaults_exist/backup_vaults_exist_test.py
+++ b/tests/providers/aws/services/backup/backup_vaults_exist/backup_vaults_exist_test.py
@@ -25,7 +25,7 @@ class Test_backup_vaults_exist:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].status_extended == "No Backup Vault Exist"
-            assert result[0].resource_id == "No Backups"
+            assert result[0].resource_id == "Backups"
             assert result[0].resource_arn == ""
             assert result[0].region == AWS_REGION
 


### PR DESCRIPTION
### Context

Fixes #2276

### Description
I changed the logic of the check `backup_reportplans_exist`, which only makes sense if backup plans exist. 
Without plans, we return the check `backup_reportplans_exist` empty (no resources).
I added the test case as well. 


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
