### PR TITLE
fix(backup): Return [] when None AdvancedBackupSettings

### DIFF
--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -102,7 +102,7 @@ class Backup:
                                     "LastExecutionDate"
                                 ),
                                 advanced_settings=configuration.get(
-                                    "AdvancedBackupSettings"
+                                    "AdvancedBackupSettings", []
                                 ),
                             )
                         )


### PR DESCRIPTION
### Context

Forcing `[]` when `AdvancedBackupSettings` is `None`

```
2023-05-03 13:51:34,482 [File: backup_service.py:111]   [Module: backup_service]         ERROR: eu-west-1 -- ValidationError[95]: 1 validation error for BackupPlan
advanced_settings
  none is not an allowed value (type=type_error.none.not_allowed)
````
### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
