### PR TITLE
feat(ssmincidents): Use regional_client region instead of audit_profile region

### DIFF
--- a/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
+++ b/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
@@ -52,10 +52,10 @@ class SSMIncidents:
     def __list_replication_sets__(self):
         logger.info("SSMIncidents - Listing Replication Sets...")
         try:
-            regional_client = self.regional_clients[self.region]
-            list_replication_sets = regional_client.list_replication_sets()[
+            regional_client = self.regional_clients[list(self.regional_clients.keys())[0]]
+            list_replication_sets = regional_client.list_replication_sets().get(
                 "replicationSetArns"
-            ]
+            )
             if list_replication_sets:
                 replication_set = list_replication_sets[0]
                 if not self.audit_resources or (
@@ -74,6 +74,8 @@ class SSMIncidents:
     def __get_replication_set__(self):
         logger.info("SSMIncidents - Getting Replication Sets...")
         try:
+            if not self.replication_set:
+                return
             replication_set = self.replication_set[0]
             for regional_client in self.regional_clients.values():
                 try:

--- a/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
+++ b/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
@@ -52,7 +52,9 @@ class SSMIncidents:
     def __list_replication_sets__(self):
         logger.info("SSMIncidents - Listing Replication Sets...")
         try:
-            regional_client = self.regional_clients[list(self.regional_clients.keys())[0]]
+            regional_client = self.regional_clients[
+                list(self.regional_clients.keys())[0]
+            ]
             list_replication_sets = regional_client.list_replication_sets().get(
                 "replicationSetArns"
             )


### PR DESCRIPTION
### Context

```
[File: ssmincidents_service.py:70]      [Module: ssmincidents_service]   ERROR: KeyError:55 -- 'us-east-1'
[File: ssmincidents_service.py:107]     [Module: ssmincidents_service]   ERROR: IndexError:77 -- list index out of range
```

Trying to fix the above error, I think the problem happens when `audit_info.profile_region` is not the same as `list(self.regional_clients.keys())[0]`. 

So i changed it and i made the `__get_replication_set__` only if `__list_replication_sets__` found the replication set. 


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
