### PR TITLE
fix(client_error): Handle errors

### DIFF
--- a/prowler/providers/aws/services/cloudformation/cloudformation_service.py
+++ b/prowler/providers/aws/services/cloudformation/cloudformation_service.py
@@ -81,7 +81,7 @@ class CloudFormation:
                 stack.is_nested_stack = True if stack.root_nested_stack != "" else False
 
             except ClientError as error:
-                if error.response["Error"]["Code"] != "ValidationError":
+                if error.response["Error"]["Code"] == "ValidationError":
                     logger.warning(
                         f"{stack.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )

--- a/prowler/providers/aws/services/dynamodb/dynamodb_service.py
+++ b/prowler/providers/aws/services/dynamodb/dynamodb_service.py
@@ -177,7 +177,7 @@ class DAX:
                 cluster.tags = response
 
             except ClientError as error:
-                if error.response["Error"]["Code"] != "InvalidARNFault":
+                if error.response["Error"]["Code"] == "InvalidARNFault":
                     logger.warning(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -119,7 +119,7 @@ class IAM:
             credential_list = list(csv_reader)
 
         except ClientError as error:
-            if error.response["Error"]["Code"] != "LimitExceededException":
+            if error.response["Error"]["Code"] == "LimitExceededException":
                 logger.warning(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )

--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -150,7 +150,7 @@ class RDS:
                         if "all" in att["AttributeValues"]:
                             snapshot.public = True
             except ClientError as error:
-                if error.response["Error"]["Code"] != "DBSnapshotNotFound":
+                if error.response["Error"]["Code"] == "DBSnapshotNotFound":
                     logger.warning(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )


### PR DESCRIPTION
### Description

Fix comparison to handle Boto3 `ClientError` exceptions to log it as `warning`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
