### PR TITLE
fix(cloudtrail): handle InsightNotEnabledException error

### DIFF
--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -2,6 +2,7 @@ import threading
 from datetime import datetime
 from typing import Optional
 
+from botocore.client import ClientError
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
@@ -158,6 +159,16 @@ class Cloudtrail:
                             insight_selectors = client_insight_selectors.get(
                                 "InsightSelectors"
                             )
+                        except ClientError as error:
+                            if (
+                                error.response["Error"]["Code"]
+                                == "InsightNotEnabledException"
+                            ):
+                                continue
+                            else:
+                                logger.error(
+                                    f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                                )
                         except Exception as error:
                             logger.error(
                                 f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"


### PR DESCRIPTION
### Description

Handle `InsightNotEnabledException` error when a trail does not have Insights enabled.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
