### PR TITLE
fix(trustedadvisor): avoid not_available checks

### DIFF
--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_errors_and_warnings/trustedadvisor_errors_and_warnings.py
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_errors_and_warnings/trustedadvisor_errors_and_warnings.py
@@ -15,7 +15,7 @@ class trustedadvisor_errors_and_warnings(Check):
                     report.resource_id = check.id
                     report.status = "FAIL"
                     report.status_extended = f"Trusted Advisor check {check.name} is in state {check.status}."
-                    if check.status == "ok":
+                    if check.status == "ok" or check.status == "not_available":
                         report.status = "PASS"
                     findings.append(report)
         else:

--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_errors_and_warnings/trustedadvisor_errors_and_warnings.py
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_errors_and_warnings/trustedadvisor_errors_and_warnings.py
@@ -10,14 +10,17 @@ class trustedadvisor_errors_and_warnings(Check):
         if trustedadvisor_client.enabled:
             if trustedadvisor_client.checks:
                 for check in trustedadvisor_client.checks:
-                    report = Check_Report_AWS(self.metadata())
-                    report.region = check.region
-                    report.resource_id = check.id
-                    report.status = "FAIL"
-                    report.status_extended = f"Trusted Advisor check {check.name} is in state {check.status}."
-                    if check.status == "ok" or check.status == "not_available":
-                        report.status = "PASS"
-                    findings.append(report)
+                    if (
+                        check.status != "not_available"
+                    ):  # avoid not_available checks since there are no resources that apply
+                        report = Check_Report_AWS(self.metadata())
+                        report.region = check.region
+                        report.resource_id = check.id
+                        report.status = "FAIL"
+                        report.status_extended = f"Trusted Advisor check {check.name} is in state {check.status}."
+                        if check.status == "ok":
+                            report.status = "PASS"
+                        findings.append(report)
         else:
             report = Check_Report_AWS(self.metadata())
             report.status = "INFO"

--- a/tests/providers/aws/services/trustedadvisor/trustedadvisor_errors_and_warnings/trustedadvisor_errors_and_warnings_test.py
+++ b/tests/providers/aws/services/trustedadvisor/trustedadvisor_errors_and_warnings/trustedadvisor_errors_and_warnings_test.py
@@ -86,3 +86,27 @@ class Test_trustedadvisor_errors_and_warnings:
             assert result[0].status == "FAIL"
             assert search("error", result[0].status_extended)
             assert result[0].resource_id == "check1"
+
+    def test_trustedadvisor_not_available_check(self):
+        trustedadvisor_client = mock.MagicMock
+        trustedadvisor_client.checks = []
+        trustedadvisor_client.enabled = True
+        trustedadvisor_client.checks.append(
+            Check(
+                id="check1",
+                name="check1",
+                region=AWS_REGION,
+                status="not_available",
+            )
+        )
+        with mock.patch(
+            "prowler.providers.aws.services.trustedadvisor.trustedadvisor_service.TrustedAdvisor",
+            trustedadvisor_client,
+        ):
+            from prowler.providers.aws.services.trustedadvisor.trustedadvisor_errors_and_warnings.trustedadvisor_errors_and_warnings import (
+                trustedadvisor_errors_and_warnings,
+            )
+
+            check = trustedadvisor_errors_and_warnings()
+            result = check.execute()
+            assert len(result) == 0


### PR DESCRIPTION
### Description

Avoid `not_available` checks since there are no resources that apply.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
