### PR TITLE
fix(cloudfront_distributions_https_enabled): Add default case

### DIFF
--- a/prowler/providers/aws/services/cloudfront/cloudfront_distributions_https_enabled/cloudfront_distributions_https_enabled.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_distributions_https_enabled/cloudfront_distributions_https_enabled.py
@@ -20,13 +20,6 @@ class cloudfront_distributions_https_enabled(Check):
             if (
                 distribution.default_cache_config
                 and distribution.default_cache_config.viewer_protocol_policy
-                == ViewerProtocolPolicy.allow_all
-            ):
-                report.status = "FAIL"
-                report.status_extended = f"CloudFront Distribution {distribution.id} viewers can use HTTP or HTTPS"
-            elif (
-                distribution.default_cache_config
-                and distribution.default_cache_config.viewer_protocol_policy
                 == ViewerProtocolPolicy.redirect_to_https
             ):
                 report.status = "PASS"

--- a/prowler/providers/aws/services/cloudfront/cloudfront_distributions_https_enabled/cloudfront_distributions_https_enabled.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_distributions_https_enabled/cloudfront_distributions_https_enabled.py
@@ -16,6 +16,7 @@ class cloudfront_distributions_https_enabled(Check):
             report.resource_arn = distribution.arn
             report.resource_id = distribution.id
             report.resource_tags = distribution.tags
+
             if (
                 distribution.default_cache_config
                 and distribution.default_cache_config.viewer_protocol_policy
@@ -41,6 +42,10 @@ class cloudfront_distributions_https_enabled(Check):
                 report.status_extended = (
                     f"CloudFront Distribution {distribution.id} has HTTPS only"
                 )
+            else:
+                report.status = "FAIL"
+                report.status_extended = f"CloudFront Distribution {distribution.id} viewers can use HTTP or HTTPS"
+
             findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/cloudfront/cloudfront_service.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_service.py
@@ -83,7 +83,7 @@ class CloudFront:
                 ]["WebACLId"]
 
                 # Default Cache Config
-                default_chache_config = DefaultCacheConfigBehaviour(
+                default_cache_config = DefaultCacheConfigBehaviour(
                     realtime_log_config_arn=distribution_config["DistributionConfig"][
                         "DefaultCacheBehavior"
                     ].get("RealtimeLogConfigArn"),
@@ -96,7 +96,7 @@ class CloudFront:
                 )
                 distributions[
                     distribution_id
-                ].default_cache_config = default_chache_config
+                ].default_cache_config = default_cache_config
 
         except Exception as error:
             logger.error(


### PR DESCRIPTION
### Context

In some AWS accounts this check generates findings without `result` and `result_extended` since the check does not have a default case if the conditions are not matched.

### Description

Include a default condition to raise a `FAIL` finding if no other condition is matched.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
