### PR TITLE
chore(iam): add new permissions

### DIFF
--- a/permissions/prowler-additions-policy.json
+++ b/permissions/prowler-additions-policy.json
@@ -6,28 +6,33 @@
         "account:Get*",
         "appstream:Describe*",
         "appstream:List*",
+        "backup:List*",
+        "cloudtrail:GetInsightSelectors",
         "codeartifact:List*",
         "codebuild:BatchGet*",
-        "ds:Describe*",
+        "drs:Describe*",
         "ds:Get*",
+        "ds:Describe*",
         "ds:List*",
         "ec2:GetEbsEncryptionByDefault",
         "ecr:Describe*",
+        "ecr:GetRegistryScanningConfiguration",
         "elasticfilesystem:DescribeBackupPolicy",
         "glue:GetConnections",
         "glue:GetSecurityConfiguration*",
         "glue:SearchTables",
         "lambda:GetFunction*",
+        "logs:FilterLogEvents",
         "macie2:GetMacieSession",
         "s3:GetAccountPublicAccessBlock",
         "shield:DescribeProtection",
         "shield:GetSubscriptionState",
+        "securityhub:BatchImportFindings",
+        "securityhub:GetFindings",
         "ssm:GetDocument",
+        "ssm-incidents:List*",
         "support:Describe*",
-        "tag:GetTagKeys",
-        "organizations:DescribeOrganization",
-        "organizations:ListPolicies*",
-        "organizations:DescribePolicy"
+        "tag:GetTagKeys"
       ],
       "Resource": "*",
       "Effect": "Allow",
@@ -39,7 +44,8 @@
         "apigateway:GET"
       ],
       "Resource": [
-        "arn:aws:apigateway:*::/restapis/*"
+        "arn:aws:apigateway:*::/restapis/*", 
+        "arn:aws:apigateway:*::/apis/*"
       ]
     }
   ]


### PR DESCRIPTION
### Description

Add IAM missing permissions of Prowler because of the new checks

- cloudtrail:GetInsightSelectors
- backup:ListBackupPlans
- backup:ListReportPlans
- logs:FilterLogEvents
- drs:DescribeJobs
- ecr:GetRegistryScanningConfiguration
- ssm-incidents:ListReplicationSets
- ssm-incidents:ListResponsePlans

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
