### PR TITLE
fix(route53): handle empty Records in Zones

### DIFF
--- a/prowler/providers/aws/services/route53/route53_service.py
+++ b/prowler/providers/aws/services/route53/route53_service.py
@@ -74,7 +74,9 @@ class Route53:
                                 type=record["Type"],
                                 records=[
                                     resource_record["Value"]
-                                    for resource_record in record["ResourceRecords"]
+                                    for resource_record in record.get(
+                                        "ResourceRecords", []
+                                    )
                                 ],
                                 is_alias=True if "AliasTarget" in record else False,
                                 hosted_zone_id=zone_id,


### PR DESCRIPTION
### Description

Handle empty Records in Route53 Zones
`KeyError[77]: 'ResourceRecords'`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
