### PR TITLE
fix(action): solve pypi-release action creating the release branch

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -35,6 +35,7 @@ jobs:
           git commit -m "chore(release): ${{ env.RELEASE_TAG }}" --no-verify
           git tag -fa ${{ env.RELEASE_TAG }} -m "chore(release): ${{ env.RELEASE_TAG }}"
           git push -f origin ${{ env.RELEASE_TAG }}
+          git checkout -B release-${{ env.RELEASE_TAG }}
           poetry build
       - name: Publish prowler package to PyPI
         run: |


### PR DESCRIPTION
### Description

Solve `pypi-release` workflow including `git branch -B release-${{ env.RELEASE_TAG }}` to let the action create the PR and upload the `prowler-cloud` PyPI package.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
