### PR TITLE
fix(pypi-release): Push version change to the branch

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -36,6 +36,7 @@ jobs:
           git tag -fa ${{ env.RELEASE_TAG }} -m "chore(release): ${{ env.RELEASE_TAG }}"
           git push -f origin ${{ env.RELEASE_TAG }}
           git checkout -B release-${{ env.RELEASE_TAG }}
+          git push origin release-${{ env.RELEASE_TAG }}
           poetry build
       - name: Publish prowler package to PyPI
         run: |


### PR DESCRIPTION
### Description

Push version change to the branch to automatically create the PR when a new release is cut.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
