### PR TITLE
fix(allowlist) - `tags` parameter is a string, not a list

### DIFF
--- a/prowler/providers/aws/lib/allowlist/allowlist.py
+++ b/prowler/providers/aws/lib/allowlist/allowlist.py
@@ -212,13 +212,12 @@ def is_allowlisted_in_tags(check_allowlist, elem, resource, tags):
             all_allowed_tags_in_resource_tags = True
             for allowed_tag in check_allowlist["Tags"]:
                 found_allowed_tag = False
-                for resource_tag in tags:
-                    if re.search(allowed_tag, resource_tag):
-                        found_allowed_tag = True
-                        break
+                if re.search(allowed_tag, tags):
+                    found_allowed_tag = True
 
                 if not found_allowed_tag:
                     all_allowed_tags_in_resource_tags = False
+                    break
 
             return all_allowed_tags_in_resource_tags
         else:

--- a/tests/providers/aws/lib/allowlist/allowlist_test.py
+++ b/tests/providers/aws/lib/allowlist/allowlist_test.py
@@ -165,15 +165,15 @@ class Test_Allowlist:
         }
 
         assert is_allowlisted(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler", []
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler", ""
         )
 
         assert is_allowlisted(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler-test", []
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler-test", ""
         )
 
         assert is_allowlisted(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "test-prowler", []
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "test-prowler", ""
         )
 
         assert is_allowlisted(
@@ -187,7 +187,7 @@ class Test_Allowlist:
 
         assert not (
             is_allowlisted(
-                allowlist, AWS_ACCOUNT_NUMBER, "check_test", "us-east-2", "test", []
+                allowlist, AWS_ACCOUNT_NUMBER, "check_test", "us-east-2", "test", ""
             )
         )
 
@@ -207,20 +207,20 @@ class Test_Allowlist:
         }
 
         assert is_allowlisted(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler", []
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler", ""
         )
 
         assert is_allowlisted(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler-test", []
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler-test", ""
         )
 
         assert is_allowlisted(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "test-prowler", []
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "test-prowler", ""
         )
 
         assert not (
             is_allowlisted(
-                allowlist, AWS_ACCOUNT_NUMBER, "check_test", "us-east-2", "test", []
+                allowlist, AWS_ACCOUNT_NUMBER, "check_test", "us-east-2", "test", ""
             )
         )
 
@@ -240,20 +240,20 @@ class Test_Allowlist:
         }
 
         assert is_allowlisted(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler", []
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler", ""
         )
 
         assert is_allowlisted(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler-test", []
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler-test", ""
         )
 
         assert is_allowlisted(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "test-prowler", []
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "test-prowler", ""
         )
 
         assert not (
             is_allowlisted(
-                allowlist, AWS_ACCOUNT_NUMBER, "check_test", "us-east-2", "test", []
+                allowlist, AWS_ACCOUNT_NUMBER, "check_test", "us-east-2", "test", ""
             )
         )
 
@@ -273,20 +273,20 @@ class Test_Allowlist:
         }
 
         assert is_allowlisted_in_region(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler", []
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler", ""
         )
 
         assert is_allowlisted_in_region(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler-test", []
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler-test", ""
         )
 
         assert is_allowlisted_in_region(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "test-prowler", []
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "test-prowler", ""
         )
 
         assert not (
             is_allowlisted_in_region(
-                allowlist, AWS_ACCOUNT_NUMBER, "check_test", "us-east-2", "test", []
+                allowlist, AWS_ACCOUNT_NUMBER, "check_test", "us-east-2", "test", ""
             )
         )
 
@@ -306,20 +306,20 @@ class Test_Allowlist:
         }
 
         assert is_allowlisted_in_check(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler", []
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler", ""
         )
 
         assert is_allowlisted_in_check(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler-test", []
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler-test", ""
         )
 
         assert is_allowlisted_in_check(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "test-prowler", []
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "test-prowler", ""
         )
 
         assert not (
             is_allowlisted_in_check(
-                allowlist, AWS_ACCOUNT_NUMBER, "check_test", "us-east-2", "test", []
+                allowlist, AWS_ACCOUNT_NUMBER, "check_test", "us-east-2", "test", ""
             )
         )
 
@@ -344,7 +344,7 @@ class Test_Allowlist:
             "s3_bucket_public_access",
             AWS_REGION,
             "prowler",
-            [],
+            "",
         )
 
         assert is_allowlisted_in_check(
@@ -353,7 +353,7 @@ class Test_Allowlist:
             "s3_bucket_public_access",
             AWS_REGION,
             "prowler-test",
-            [],
+            "",
         )
 
         assert is_allowlisted_in_check(
@@ -362,7 +362,7 @@ class Test_Allowlist:
             "s3_bucket_public_access",
             AWS_REGION,
             "test-prowler",
-            [],
+            "",
         )
 
         assert not (
@@ -372,7 +372,7 @@ class Test_Allowlist:
                 "iam_user_hardware_mfa_enabled",
                 AWS_REGION,
                 "test",
-                [],
+                "",
             )
         )
 
@@ -398,7 +398,7 @@ class Test_Allowlist:
             "check_test",
             AWS_REGION,
             "prowler",
-            ["environment=dev"],
+            "environment=dev",
         )
 
         assert is_allowlisted(
@@ -407,7 +407,7 @@ class Test_Allowlist:
             "check_test",
             AWS_REGION,
             "prowler-test",
-            ["environment=dev", "project=prowler"],
+            "environment=dev | project=prowler",
         )
 
         assert not (
@@ -417,7 +417,7 @@ class Test_Allowlist:
                 "check_test",
                 "us-east-2",
                 "test",
-                ["environment=pro"],
+                "environment=pro",
             )
         )
 
@@ -433,14 +433,14 @@ class Test_Allowlist:
             check_allowlist,
             check_allowlist["Resources"][0],
             "prowler",
-            ["environment=dev"],
+            "environment=dev",
         )
 
         assert is_allowlisted_in_tags(
             check_allowlist,
             check_allowlist["Resources"][0],
             "prowler-test",
-            ["environment=dev", "project=prowler"],
+            "environment=dev | project=prowler",
         )
 
         assert not (
@@ -448,7 +448,7 @@ class Test_Allowlist:
                 check_allowlist,
                 check_allowlist["Resources"][0],
                 "test",
-                ["environment=pro"],
+                "environment=pro",
             )
         )
 
@@ -464,19 +464,19 @@ class Test_Allowlist:
             check_allowlist,
             check_allowlist["Resources"][0],
             "prowler-test",
-            ["environment=test", "proj=prowler"],
+            "environment=test | proj=prowler",
         )
 
         assert not is_allowlisted_in_tags(
             check_allowlist,
             check_allowlist["Resources"][0],
             "prowler-test",
-            ["env=prod", "project=prowler"],
+            "env=prod | project=prowler",
         )
 
         assert not is_allowlisted_in_tags(
             check_allowlist,
             check_allowlist["Resources"][0],
             "prowler-test",
-            ["environment=prod", "project=myproj"],
+            "environment=prod | project=myproj",
         )


### PR DESCRIPTION
### Context

As part of #2300 I had attempted to interpret the `tags` parameter as a list and not a string.  I now realize that the `tags` parameter is a pipe separated string generated via `unroll_tags`.  This reverts the logic back to treating the `tags` as a string.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
