### PR TITLE
fix(OSError): handle different OSErrors

### DIFF
--- a/prowler/lib/utils/utils.py
+++ b/prowler/lib/utils/utils.py
@@ -17,9 +17,12 @@ def open_file(input_file: str, mode: str = "r") -> TextIOWrapper:
     try:
         f = open(input_file, mode)
     except OSError as ose:
-        logger.critical(
-            f"{input_file}: OSError:{ose.errno}, {ose.strerror}"
-        )
+        if ose.strerror == "Too many open files":
+            logger.critical(
+                "Ooops! You reached your user session maximum open files. To solve this issue, increase the shell session limit by running this command `ulimit -n 4096`. For more info visit https://docs.prowler.cloud/en/latest/troubleshooting/"
+            )
+        else:
+            logger.critical(f"{input_file}: OSError[{ose.errno}] {ose.strerror}")
         sys.exit(1)
     except Exception as e:
         logger.critical(

--- a/prowler/lib/utils/utils.py
+++ b/prowler/lib/utils/utils.py
@@ -16,9 +16,9 @@ from prowler.lib.logger import logger
 def open_file(input_file: str, mode: str = "r") -> TextIOWrapper:
     try:
         f = open(input_file, mode)
-    except OSError:
+    except OSError as ose:
         logger.critical(
-            "Ooops! You reached your user session maximum open files. To solve this issue, increase the shell session limit by running this command `ulimit -n 4096`. For more info visit https://docs.prowler.cloud/en/latest/troubleshooting/"
+            f"{input_file}: OSError:{ose.errno}, {ose.strerror}"
         )
         sys.exit(1)
     except Exception as e:


### PR DESCRIPTION
Not all oserrors would be "too many files open". Met "File name too long" today.

### Context

Spent way to much time today trying to figure out why my ulimits weren't registering. 
When in reality,  my path just got too long.

### Description

  [Module: utils]  CRITICAL: Ooops! You reached your user session maximum open files. To solve this issue, increase the shell session limit by running this command `ulimit -n 4096`. For more info visit https://docs.prowler.cloud/en/latest/troubleshooting/

Is not correct in the case of lets say,  a very long file name is generated - which is easily fixed with the `-F` option.

No bug associated, just a quick fix for clearity. The linked issue could of cause be kept.  And then extended with hints to `-F` option on OSError:[36] File name too long.    - But stateing  max open files on every OSError is wrong.
  
### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
