### PR TITLE
fix(README): add references to tenant-id when browser auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ export AZURE_CLIENT_SECRET="XXXXXXX"
 If you try to execute Prowler with the `--sp-env-auth` flag and those variables are empty or not exported, the execution is going to fail.
 ### AZ CLI / Browser / Managed Identity authentication
 
-The other three cases do not need additional configuration, `--az-cli-auth` and `--managed-identity-auth` are automated options, `--browser-auth` needs the user to authenticate using the default browser to start the scan.
+The other three cases do not need additional configuration, `--az-cli-auth` and `--managed-identity-auth` are automated options, `--browser-auth` needs the user to authenticate using the default browser to start the scan. Also `--browser-auth` needs the tenant id to be specified with `--tenant-id`.
 
 ### Permissions
 

--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -52,7 +52,7 @@ export AZURE_CLIENT_SECRET="XXXXXXX"
 If you try to execute Prowler with the `--sp-env-auth` flag and those variables are empty or not exported, the execution is going to fail.
 ### AZ CLI / Browser / Managed Identity authentication
 
-The other three cases does not need additional configuration, `--az-cli-auth` and `--managed-identity-auth` are automated options, `--browser-auth` needs the user to authenticate using the default browser to start the scan.
+The other three cases does not need additional configuration, `--az-cli-auth` and `--managed-identity-auth` are automated options. To use `--browser-auth`  the user needs to authenticate against Azure using the default browser to start the scan, also `tenant-id` is required.
 
 ### Permissions
 

--- a/docs/tutorials/azure/authentication.md
+++ b/docs/tutorials/azure/authentication.md
@@ -18,7 +18,7 @@ prowler azure --sp-env-auth
 prowler azure --az-cli-auth
 
 # To use browser authentication
-prowler azure --browser-auth
+prowler azure --browser-auth --tenant-id "XXXXXXXX"
 
 # To use managed identity auth
 prowler azure --managed-identity-auth


### PR DESCRIPTION
### Context

Internal working of azure provider has been changed, browser auth needs tenant id parameter


### Description

Include tenant id requirement into README file and docs


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
