### PR TITLE
fix(services): Handle AWS service errors

### DIFF
--- a/prowler/providers/aws/services/awslambda/awslambda_service.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_service.py
@@ -162,9 +162,14 @@ class Lambda:
         logger.info("Lambda - List Tags...")
         try:
             for function in self.functions.values():
-                regional_client = self.regional_clients[function.region]
-                response = regional_client.list_tags(Resource=function.arn)["Tags"]
-                function.tags = [response]
+                try:
+                    regional_client = self.regional_clients[function.region]
+                    response = regional_client.list_tags(Resource=function.arn)["Tags"]
+                    function.tags = [response]
+                except ClientError as e:
+                    if e.response["Error"]["Code"] == "ResourceNotFoundException":
+                        function.tags = []
+
         except Exception as error:
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"

--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -1,5 +1,6 @@
 import threading
 from datetime import datetime
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -172,4 +173,4 @@ class BackupReportPlan(BaseModel):
     region: str
     name: str
     last_attempted_execution_date: datetime
-    last_successful_execution_date: datetime
+    last_successful_execution_date: Optional[datetime]

--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
@@ -47,6 +47,10 @@ class TrustedAdvisor:
         except ClientError as error:
             if error.response["Error"]["Code"] == "SubscriptionRequiredException":
                 self.enabled = False
+            elif error.response["Error"]["Code"] == "InvalidParameterValueException":
+                logger.warning(
+                    f"{self.client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
             else:
                 logger.error(
                     f"{self.client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"


### PR DESCRIPTION
### Description

Handle the following AWS service errors:
- `ResourceNotFoundException: An error occurred (ResourceNotFoundException) when calling the ListTags operation: Function not found` in `Lambda` service.
- `ValidationError: 1 validation error for BackupReportPlan
last_successful_execution_date
  none is not an allowed value (type=type_error.none.not_allowed)` in `Backup` service.
- `ClientError: An error occurred (InvalidParameterValueException) when calling the DescribeTrustedAdvisorCheckResult operation: [UNKNOWN_CHECK_ID_ERROR] Unknown ID` in `TrustedAdvisor` service.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
