### PR TITLE
fix(ec2): handle false positive in `ec2_securitygroup_allow_ingress_from_internet_to_any_port`

### DIFF
--- a/prowler/providers/aws/services/ec2/lib/security_groups.py
+++ b/prowler/providers/aws/services/ec2/lib/security_groups.py
@@ -70,6 +70,9 @@ def check_security_group(
                             and ingress_rule["IpProtocol"] == protocol
                         ):
                             return True
+                # If no input ports check if all ports are open
+                if len(set(ingress_port_range)) == 65536:
+                    return True
 
         # IPv6
         for ip_ingress_rule in ingress_rule["Ipv6Ranges"]:
@@ -82,6 +85,9 @@ def check_security_group(
                             and ingress_rule["IpProtocol"] == protocol
                         ):
                             return True
+                # If no input ports check if all ports are open
+                if len(set(ingress_port_range)) == 65536:
+                    return True
 
     return False
 

--- a/prowler/providers/aws/services/ec2/lib/security_groups.py
+++ b/prowler/providers/aws/services/ec2/lib/security_groups.py
@@ -70,8 +70,6 @@ def check_security_group(
                             and ingress_rule["IpProtocol"] == protocol
                         ):
                             return True
-                else:
-                    return True
 
         # IPv6
         for ip_ingress_rule in ingress_rule["Ipv6Ranges"]:
@@ -84,8 +82,6 @@ def check_security_group(
                             and ingress_rule["IpProtocol"] == protocol
                         ):
                             return True
-                else:
-                    return True
 
     return False
 

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port_test.py
@@ -167,3 +167,60 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
                         sg.resource_arn
                         == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
+
+    @mock_ec2
+    def test_ec2_compliant_default_sg_only_open_to_one_port(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+        default_sg_id = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "FromPort": 80,
+                    "IpProtocol": "tcp",
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                    "Ipv6Ranges": [],
+                    "PrefixListIds": [],
+                    "ToPort": 80,
+                    "UserIdGroupPairs": [],
+                }
+            ],
+        )
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        current_audit_info = self.set_mocked_audit_info()
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_client",
+            new=EC2(current_audit_info),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port import (
+                ec2_securitygroup_allow_ingress_from_internet_to_any_port,
+            )
+
+            check = ec2_securitygroup_allow_ingress_from_internet_to_any_port()
+            result = check.execute()
+
+            # One default sg per region
+            assert len(result) == 3
+            # Search changed sg
+            for sg in result:
+                if sg.resource_id == default_sg_id:
+                    assert sg.status == "PASS"
+                    assert search(
+                        "has not all ports open to the Internet",
+                        sg.status_extended,
+                    )
+                    assert (
+                        sg.resource_arn
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                    )


### PR DESCRIPTION
### Description

In check `ec2_securitygroup_allow_ingress_from_internet_to_any_port`, flag FAIL only if the Security Group is open to all ports.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
