### PR TITLE
fix(azure): fix empty subscriptions case

### DIFF
--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -168,6 +168,13 @@ class Azure_Provider:
                     )
                     identity.subscriptions.update({subscription.display_name: id})
 
+            # If there are no subscriptions listed -> checks are not going to be run against any resource
+            if not identity.subscriptions:
+                logger.critical(
+                    "It was not possible to retrieve any subscriptions, please check your permission assignments"
+                )
+                sys.exit(1)
+
             tenants = subscriptions_client.tenants.list()
             for tenant in tenants:
                 identity.tenant_ids.append(tenant.tenant_id)


### PR DESCRIPTION
### Context

When no azure subscriptions are passed as argument or retrieved from api call checks are being launched against no resource. 

### Description

Exit with critical error when no subscriptions are passed or retrieved


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
