### PR TITLE
chore(vpc): add mapPublicIpOnLaunch attribute to VPC subnets

### DIFF
--- a/prowler/providers/aws/services/vpc/vpc_service.py
+++ b/prowler/providers/aws/services/vpc/vpc_service.py
@@ -294,6 +294,7 @@ class VPC:
                                 public=public,
                                 nat_gateway=nat_gateway,
                                 tags=subnet.get("Tags"),
+                                mapPublicIpOnLaunch=subnet["MapPublicIpOnLaunch"],
                             )
                             self.vpc_subnets[subnet["SubnetId"]] = object
                             # Add it to the VPC object
@@ -319,6 +320,7 @@ class VpcSubnet(BaseModel):
     public: bool
     nat_gateway: bool
     region: str
+    mapPublicIpOnLaunch: bool
     tags: Optional[list] = []
 
 

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc_test.py
@@ -108,6 +108,7 @@ class Test_networkfirewall_in_all_vpc:
                         nat_gateway=False,
                         region=AWS_REGION,
                         tags=[],
+                        mapPublicIpOnLaunch=False,
                     )
                 ],
                 tags=[],
@@ -171,6 +172,7 @@ class Test_networkfirewall_in_all_vpc:
                         nat_gateway=False,
                         region=AWS_REGION,
                         tags=[],
+                        mapPublicIpOnLaunch=False,
                     )
                 ],
                 tags=[],
@@ -244,6 +246,7 @@ class Test_networkfirewall_in_all_vpc:
                         nat_gateway=False,
                         region=AWS_REGION,
                         tags=[],
+                        mapPublicIpOnLaunch=False,
                     )
                 ],
                 tags=[],
@@ -265,6 +268,7 @@ class Test_networkfirewall_in_all_vpc:
                         nat_gateway=False,
                         region=AWS_REGION,
                         tags=[],
+                        mapPublicIpOnLaunch=False,
                     )
                 ],
                 tags=[],


### PR DESCRIPTION
### Context

To be able to check if subnets have mapPublicIpOnLaunch set to true or not, need to add attribute to code.


### Description

Added mapPublicIpOnLaunch attribute to vpc_service. Updated tests with new attribute.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
