### PR TITLE
fix(arn validator): include `:` in regex

### DIFF
--- a/prowler/providers/aws/lib/arn/arn.py
+++ b/prowler/providers/aws/lib/arn/arn.py
@@ -47,5 +47,5 @@ def parse_iam_credentials_arn(arn: str) -> ARN:
 
 def is_valid_arn(arn: str) -> bool:
     """is_valid_arn returns True or False whether the given AWS ARN (Amazon Resource Name) is valid or not."""
-    regex = r"^arn:aws(-cn|-us-gov)?:[a-zA-Z0-9\-]+:([a-z]{2}-[a-z]+-\d{1})?:(\d{12})?:[a-zA-Z0-9\-_\/:]+(:\d+)?$"
+    regex = r"^arn:aws(-cn|-us-gov|-iso|-iso-b)?:[a-zA-Z0-9\-]+:([a-z]{2}-[a-z]+-\d{1})?:(\d{12})?:[a-zA-Z0-9\-_\/:]+(:\d+)?$"
     return re.match(regex, arn) is not None

--- a/prowler/providers/aws/lib/arn/arn.py
+++ b/prowler/providers/aws/lib/arn/arn.py
@@ -47,5 +47,5 @@ def parse_iam_credentials_arn(arn: str) -> ARN:
 
 def is_valid_arn(arn: str) -> bool:
     """is_valid_arn returns True or False whether the given AWS ARN (Amazon Resource Name) is valid or not."""
-    regex = r"^arn:aws(-cn|-us-gov)?:[a-zA-Z0-9\-]+:([a-z]{2}-[a-z]+-\d{1})?:(\d{12})?:[a-zA-Z0-9\-_\/]+(:\d+)?$"
+    regex = r"^arn:aws(-cn|-us-gov)?:[a-zA-Z0-9\-]+:([a-z]{2}-[a-z]+-\d{1})?:(\d{12})?:[a-zA-Z0-9\-_\/:]+(:\d+)?$"
     return re.match(regex, arn) is not None

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -895,6 +895,16 @@ class Test_Parser:
         assert resource_arn1 in parsed.resource_arn
         assert resource_arn2 in parsed.resource_arn
 
+    def test_aws_parser_resource_arn_lambda(self):
+        argument = "--resource-arn"
+        resource_arn1 = "arn:aws:iam::012345678910:user/test"
+        resource_arn2 = "arn:aws:lambda:eu-west-1:123456789012:function:lambda-function"
+        command = [prowler_command, argument, resource_arn1, resource_arn2]
+        parsed = self.parser.parse(command)
+        assert len(parsed.resource_arn) == 2
+        assert resource_arn1 in parsed.resource_arn
+        assert resource_arn2 in parsed.resource_arn
+
     def test_aws_parser_wrong_resource_arn(self):
         argument = "--resource-arn"
         resource_arn = "arn:azure:iam::account:user/test"

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -895,6 +895,16 @@ class Test_Parser:
         assert resource_arn1 in parsed.resource_arn
         assert resource_arn2 in parsed.resource_arn
 
+    def test_aws_parser_resource_arn_iso_partitions(self):
+        argument = "--resource-arn"
+        resource_arn1 = "arn:aws-iso:iam::012345678910:user/test"
+        resource_arn2 = "arn:aws-iso-b:ec2:us-east-1:123456789012:vpc/vpc-12345678"
+        command = [prowler_command, argument, resource_arn1, resource_arn2]
+        parsed = self.parser.parse(command)
+        assert len(parsed.resource_arn) == 2
+        assert resource_arn1 in parsed.resource_arn
+        assert resource_arn2 in parsed.resource_arn
+
     def test_aws_parser_resource_arn_lambda(self):
         argument = "--resource-arn"
         resource_arn1 = "arn:aws:iam::012345678910:user/test"

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -895,26 +895,6 @@ class Test_Parser:
         assert resource_arn1 in parsed.resource_arn
         assert resource_arn2 in parsed.resource_arn
 
-    def test_aws_parser_resource_arn_iso_partitions(self):
-        argument = "--resource-arn"
-        resource_arn1 = "arn:aws-iso:iam::012345678910:user/test"
-        resource_arn2 = "arn:aws-iso-b:ec2:us-east-1:123456789012:vpc/vpc-12345678"
-        command = [prowler_command, argument, resource_arn1, resource_arn2]
-        parsed = self.parser.parse(command)
-        assert len(parsed.resource_arn) == 2
-        assert resource_arn1 in parsed.resource_arn
-        assert resource_arn2 in parsed.resource_arn
-
-    def test_aws_parser_resource_arn_lambda(self):
-        argument = "--resource-arn"
-        resource_arn1 = "arn:aws:iam::012345678910:user/test"
-        resource_arn2 = "arn:aws:lambda:eu-west-1:123456789012:function:lambda-function"
-        command = [prowler_command, argument, resource_arn1, resource_arn2]
-        parsed = self.parser.parse(command)
-        assert len(parsed.resource_arn) == 2
-        assert resource_arn1 in parsed.resource_arn
-        assert resource_arn2 in parsed.resource_arn
-
     def test_aws_parser_wrong_resource_arn(self):
         argument = "--resource-arn"
         resource_arn = "arn:azure:iam::account:user/test"

--- a/tests/providers/aws/lib/arn/arn_test.py
+++ b/tests/providers/aws/lib/arn/arn_test.py
@@ -314,6 +314,11 @@ class Test_ARN_Parsing:
         assert is_valid_arn("arn:aws:iam::012345678910:user/test")
         assert is_valid_arn("arn:aws-cn:ec2:us-east-1:123456789012:vpc/vpc-12345678")
         assert is_valid_arn("arn:aws-us-gov:s3:::bucket")
+        assert is_valid_arn("arn:aws-iso:iam::012345678910:user/test")
+        assert is_valid_arn("arn:aws-iso-b:ec2:us-east-1:123456789012:vpc/vpc-12345678")
+        assert is_valid_arn(
+            "arn:aws:lambda:eu-west-1:123456789012:function:lambda-function"
+        )
         assert not is_valid_arn("arn:azure:::012345678910:user/test")
         assert not is_valid_arn("arn:aws:iam::account:user/test")
         assert not is_valid_arn("arn:aws:::012345678910:resource")


### PR DESCRIPTION
### Context

Arn parser was failing when input was a lambda arn like `arn:aws:lambda:eu-west-1:123456789012:function:lambda-function`


### Description

Fix the parser including `:` char in the last capturing group

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
