### PR TITLE
fix(dataevents checks): add trails home region

### DIFF
--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_read_enabled/cloudtrail_s3_dataevents_read_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_read_enabled/cloudtrail_s3_dataevents_read_enabled.py
@@ -34,7 +34,7 @@ class cloudtrail_s3_dataevents_read_enabled(Check):
                                 report.resource_arn = trail.arn
                                 report.resource_tags = trail.tags
                                 report.status = "PASS"
-                                report.status_extended = f"Trail {trail.name} has a classic data event selector to record all S3 object-level API operations."
+                                report.status_extended = f"Trail {trail.name} from home region {trail.home_region} has a classic data event selector to record all S3 object-level API operations."
                 # advanced event selectors
                 elif data_event.is_advanced:
                     for field_selector in data_event.event_selector["FieldSelectors"]:
@@ -47,7 +47,7 @@ class cloudtrail_s3_dataevents_read_enabled(Check):
                             report.resource_arn = trail.arn
                             report.resource_tags = trail.tags
                             report.status = "PASS"
-                            report.status_extended = f"Trail {trail.name} has an advanced data event selector to record all S3 object-level API operations."
+                            report.status_extended = f"Trail {trail.name} from home region {trail.home_region} has an advanced data event selector to record all S3 object-level API operations."
 
         findings.append(report)
         return findings

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_write_enabled/cloudtrail_s3_dataevents_write_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_write_enabled/cloudtrail_s3_dataevents_write_enabled.py
@@ -34,7 +34,7 @@ class cloudtrail_s3_dataevents_write_enabled(Check):
                                 report.resource_arn = trail.arn
                                 report.resource_tags = trail.tags
                                 report.status = "PASS"
-                                report.status_extended = f"Trail {trail.name} has a classic data event selector to record all S3 object-level API operations."
+                                report.status_extended = f"Trail {trail.name} from home region {trail.home_region} has a classic data event selector to record all S3 object-level API operations."
                 # advanced event selectors
                 elif data_event.is_advanced:
                     for field_selector in data_event.event_selector["FieldSelectors"]:
@@ -47,6 +47,6 @@ class cloudtrail_s3_dataevents_write_enabled(Check):
                             report.resource_arn = trail.arn
                             report.resource_tags = trail.tags
                             report.status = "PASS"
-                            report.status_extended = f"Trail {trail.name} has an advanced data event selector to record all S3 object-level API operations."
+                            report.status_extended = f"Trail {trail.name} from home region {trail.home_region} has an advanced data event selector to record all S3 object-level API operations."
         findings.append(report)
         return findings


### PR DESCRIPTION
### Context

In cloudtrail checks that look for data events the home region of the trail is not included in `status_extended` field


### Description

Include home region in `status_extended` field for those checks to clarify where the trail comes from in case of multiregion trail


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
