### PR TITLE
fix(rds checks): test if key exists prior checking it

### DIFF
--- a/prowler/providers/aws/services/rds/rds_instance_deletion_protection/rds_instance_deletion_protection.py
+++ b/prowler/providers/aws/services/rds/rds_instance_deletion_protection/rds_instance_deletion_protection.py
@@ -13,7 +13,12 @@ class rds_instance_deletion_protection(Check):
             report.resource_tags = db_instance.tags
             # Check if is member of a cluster
             if db_instance.cluster_id:
-                if rds_client.db_clusters[db_instance.cluster_arn].deletion_protection:
+                if (
+                    db_instance.cluster_arn in rds_client.db_clusters
+                    and rds_client.db_clusters[
+                        db_instance.cluster_arn
+                    ].deletion_protection
+                ):
                     report.status = "PASS"
                     report.status_extended = f"RDS Instance {db_instance.id} deletion protection is enabled at cluster {db_instance.cluster_id} level."
                 else:

--- a/prowler/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az.py
+++ b/prowler/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az.py
@@ -13,7 +13,10 @@ class rds_instance_multi_az(Check):
             report.resource_tags = db_instance.tags
             # Check if is member of a cluster
             if db_instance.cluster_id:
-                if rds_client.db_clusters[db_instance.cluster_arn].multi_az:
+                if (
+                    db_instance.cluster_arn in rds_client.db_clusters
+                    and rds_client.db_clusters[db_instance.cluster_arn].multi_az
+                ):
                     report.status = "PASS"
                     report.status_extended = f"RDS Instance {db_instance.id} has multi-AZ enabled at cluster {db_instance.cluster_id} level."
                 else:


### PR DESCRIPTION
### Context

In checks `rds_instance_deletion_protection`& `rds_instance_multi_az` a key from a dict was being referenced without checking its existence

### Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
