### PR TITLE
fix(security hub): Adds logic to map to valid ASFF statuses

### DIFF
--- a/prowler/lib/outputs/json.py
+++ b/prowler/lib/outputs/json.py
@@ -74,7 +74,7 @@ def fill_json_asff(finding_output, audit_info, finding, output_options):
 
     # Ensures finding_status matches allowed values in ASFF
     finding_status = ""
-    if finding.status == "PASS" or finding.status == "INFO":
+    if finding.status == "PASS":
         finding_status = "PASSED"
     elif finding.status == "FAIL":
         finding_status = "FAILED"

--- a/prowler/lib/outputs/json.py
+++ b/prowler/lib/outputs/json.py
@@ -72,9 +72,19 @@ def fill_json_asff(finding_output, audit_info, finding, output_options):
             item = item[0:63]
         compliance_summary.append(item)
 
-    # Add ED to PASS or FAIL (PASSED/FAILED)
+    # Ensures finding_status matches allowed values in ASFF
+    finding_status = ""
+    if finding.status == "PASS" or finding.status == "INFO":
+        finding_status = "PASSED"
+    elif finding.status == "FAIL":
+        finding_status = "FAILED"
+    elif finding.status == "WARNING":
+        finding_status = "WARNING"
+    else:
+        finding_status = "NOT_AVAILABLE"
+
     finding_output.Compliance = Compliance(
-        Status=finding.status + "ED",
+        Status=finding_status,
         AssociatedStandards=associated_standards,
         RelatedRequirements=compliance_summary,
     )


### PR DESCRIPTION
### Context

When running prowler against our AWS infrastructure, reporting using ASFF to security hub, we are unable to report all results due to "Status" being set incorrectly in API requests to Security Hub.

### Description

AWS publishes the list of allowed values for Compliance Status here: https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_Compliance.html. This PR replaces blind `+ "ED"` text manipulation with a condition that maps the output of prowler into values accepted by Security Hub.  

We currently see "WARNINGED" and "INFOED", after this PR we will see "WARNING" and "INFO".  We are not currently seeing any statuses that will map to "NOT_AVAILABLE", but this should cover other AWS situations that are beyond the scope of my test runs here.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
