### PR TITLE
fix(route53): correct Hosted Zone ARN

### DIFF
--- a/prowler/providers/aws/services/route53/route53_service.py
+++ b/prowler/providers/aws/services/route53/route53_service.py
@@ -37,7 +37,7 @@ class Route53:
             for page in list_hosted_zones_paginator.paginate():
                 for hosted_zone in page["HostedZones"]:
                     hosted_zone_id = hosted_zone["Id"].replace("/hostedzone/", "")
-                    arn = f"arn:{self.audited_partition}:route53:::{hosted_zone_id}"
+                    arn = f"arn:{self.audited_partition}:route53:::hostedzone/{hosted_zone_id}"
                     if not self.audit_resources or (
                         is_resource_filtered(arn, self.audit_resources)
                     ):

--- a/tests/providers/aws/services/route53/route53_dangling_ip_subdomain_takeover/route53_dangling_ip_subdomain_takeover_test.py
+++ b/tests/providers/aws/services/route53/route53_dangling_ip_subdomain_takeover/route53_dangling_ip_subdomain_takeover_test.py
@@ -161,7 +161,7 @@ class Test_route53_dangling_ip_subdomain_takeover:
                     assert result[0].resource_id == zone_id.replace("/hostedzone/", "")
                     assert (
                         result[0].resource_arn
-                        == f"arn:{audit_info.audited_partition}:route53:::{zone_id.replace('/hostedzone/','')}"
+                        == f"arn:{audit_info.audited_partition}:route53:::hostedzone/{zone_id.replace('/hostedzone/','')}"
                     )
 
     @mock_ec2
@@ -222,7 +222,7 @@ class Test_route53_dangling_ip_subdomain_takeover:
                     assert result[0].resource_id == zone_id.replace("/hostedzone/", "")
                     assert (
                         result[0].resource_arn
-                        == f"arn:{audit_info.audited_partition}:route53:::{zone_id.replace('/hostedzone/','')}"
+                        == f"arn:{audit_info.audited_partition}:route53:::hostedzone/{zone_id.replace('/hostedzone/','')}"
                     )
 
     @mock_ec2
@@ -283,7 +283,7 @@ class Test_route53_dangling_ip_subdomain_takeover:
                     assert result[0].resource_id == zone_id.replace("/hostedzone/", "")
                     assert (
                         result[0].resource_arn
-                        == f"arn:{audit_info.audited_partition}:route53:::{zone_id.replace('/hostedzone/','')}"
+                        == f"arn:{audit_info.audited_partition}:route53:::hostedzone/{zone_id.replace('/hostedzone/','')}"
                     )
 
     @mock_ec2
@@ -347,7 +347,7 @@ class Test_route53_dangling_ip_subdomain_takeover:
                     assert result[0].resource_id == zone_id.replace("/hostedzone/", "")
                     assert (
                         result[0].resource_arn
-                        == f"arn:{audit_info.audited_partition}:route53:::{zone_id.replace('/hostedzone/','')}"
+                        == f"arn:{audit_info.audited_partition}:route53:::hostedzone/{zone_id.replace('/hostedzone/','')}"
                     )
 
     @mock_ec2
@@ -417,5 +417,5 @@ class Test_route53_dangling_ip_subdomain_takeover:
                     assert result[0].resource_id == zone_id.replace("/hostedzone/", "")
                     assert (
                         result[0].resource_arn
-                        == f"arn:{audit_info.audited_partition}:route53:::{zone_id.replace('/hostedzone/','')}"
+                        == f"arn:{audit_info.audited_partition}:route53:::hostedzone/{zone_id.replace('/hostedzone/','')}"
                     )

--- a/tests/providers/aws/services/route53/route53_service_test.py
+++ b/tests/providers/aws/services/route53/route53_service_test.py
@@ -108,7 +108,7 @@ class Test_Route53_Service:
         assert route53.hosted_zones[hosted_zone_id].id == hosted_zone_id
         assert (
             route53.hosted_zones[hosted_zone_id].arn
-            == f"arn:aws:route53:::{hosted_zone_id}"
+            == f"arn:aws:route53:::hostedzone/{hosted_zone_id}"
         )
         assert route53.hosted_zones[hosted_zone_id].name == hosted_zone_name
         assert route53.hosted_zones[hosted_zone_id].private_zone
@@ -153,7 +153,7 @@ class Test_Route53_Service:
         assert route53.hosted_zones[hosted_zone_id].id == hosted_zone_id
         assert (
             route53.hosted_zones[hosted_zone_id].arn
-            == f"arn:aws:route53:::{hosted_zone_id}"
+            == f"arn:aws:route53:::hostedzone/{hosted_zone_id}"
         )
         assert route53.hosted_zones[hosted_zone_id].name == hosted_zone_name
         assert not route53.hosted_zones[hosted_zone_id].private_zone
@@ -185,7 +185,7 @@ class Test_Route53_Service:
         assert route53.hosted_zones[hosted_zone_id].id == hosted_zone_id
         assert (
             route53.hosted_zones[hosted_zone_id].arn
-            == f"arn:aws:route53:::{hosted_zone_id}"
+            == f"arn:aws:route53:::hostedzone/{hosted_zone_id}"
         )
         assert route53.hosted_zones[hosted_zone_id].name == hosted_zone_name
         assert route53.hosted_zones[hosted_zone_id].private_zone
@@ -213,7 +213,7 @@ class Test_Route53_Service:
         assert route53.hosted_zones[hosted_zone_id].id == hosted_zone_id
         assert (
             route53.hosted_zones[hosted_zone_id].arn
-            == f"arn:aws:route53:::{hosted_zone_id}"
+            == f"arn:aws:route53:::hostedzone/{hosted_zone_id}"
         )
         assert route53.hosted_zones[hosted_zone_id].name == hosted_zone_name
         assert not route53.hosted_zones[hosted_zone_id].private_zone


### PR DESCRIPTION
### Description

Fix Hosted Zone ARN.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
