### PR TITLE
fix(apigw): Update metadata for API GW checks

### DIFF
--- a/prowler/providers/aws/services/apigatewayv2/apigatewayv2_access_logging_enabled/apigatewayv2_access_logging_enabled.metadata.json
+++ b/prowler/providers/aws/services/apigatewayv2/apigatewayv2_access_logging_enabled/apigatewayv2_access_logging_enabled.metadata.json
@@ -21,8 +21,8 @@
       "Terraform": "https://docs.bridgecrew.io/docs/bc_aws_logging_30#cloudformation"
     },
     "Recommendation": {
-      "Text": "Implement Amazon Cognito or a Lambda function to control access to your API.",
-      "Url": "https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-authorizers.html"
+      "Text": "Monitoring is an important part of maintaining the reliability, availability and performance of API Gateway and your AWS solutions. You should collect monitoring data from all of the parts of your AWS solution. CloudTrail provides a record of actions taken by a user, role, or an AWS service in API Gateway. Using the information collected by CloudTrail, you can determine the request that was made to API Gateway, the IP address from which the request was made, who made the request, etc.",
+      "Url": "https://docs.aws.amazon.com/apigateway/latest/developerguide/security-monitoring.html"
     }
   },
   "Categories": [],

--- a/prowler/providers/aws/services/apigatewayv2/apigatewayv2_authorizers_enabled/apigatewayv2_authorizers_enabled.metadata.json
+++ b/prowler/providers/aws/services/apigatewayv2/apigatewayv2_authorizers_enabled/apigatewayv2_authorizers_enabled.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "apigatewayv2_authorizers_enabled",
-  "CheckTitle": "Checks if API Gateway V2 has Access Logging enabled.",
+  "CheckTitle": "Checks if API Gateway V2 has configured authorizers.",
   "CheckType": [
     "Logging and Monitoring"
   ],
@@ -10,8 +10,8 @@
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
   "Severity": "medium",
   "ResourceType": "AwsApiGatewayV2Api",
-  "Description": "Checks if API Gateway V2 has Access Logging enabled.",
-  "Risk": "If not enabled the logging of API calls is not possible. This information is important for monitoring API access.",
+  "Description": "Checks if API Gateway V2 has configured authorizers.",
+  "Risk": "If no authorizer is enabled anyone can use the service.",
   "RelatedUrl": "",
   "Remediation": {
     "Code": {
@@ -21,8 +21,8 @@
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "Enable Access Logging in the API stage.",
-      "Url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-stage-accesslogsettings.html"
+      "Text": "Implement Amazon Cognito or a Lambda function to control access to your API",
+      "Url": "https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html"
     }
   },
   "Categories": [],


### PR DESCRIPTION
### Context

Metadata from checks `apigatewayv2_access_logging_enabled` and `apigatewayv2_authorizers_enabled` were wrong

Fixes #2504 #2505 

### Description

Update metadata from checks : 
- `apigatewayv2_access_logging_enabled`  -> Change `Remediation` block
- `apigatewayv2_authorizers_enabled` -> Change `Description`, `Risk` and `Remediation block`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
