### PR TITLE
chore(region): add `get_default_region` function in AWS Services

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -276,4 +276,20 @@ def get_default_region(service: str, audit_info: AWS_Audit_Info) -> str:
     if audit_info.profile_region in service_regions:
         # return profile region only if it is audited
         return audit_info.profile_region
-    return service_regions[0]
+    # return first audited region if specific regions are audited
+    if audit_info.audited_regions:
+        return audit_info.audited_regions[0]
+    # return global region of the partition when all regions are audited and there is no profile region
+    return get_global_region(audit_info)
+
+
+def get_global_region(audit_info: AWS_Audit_Info) -> str:
+    """get_global_region gets the global region based on the audited partition"""
+    if audit_info.audited_partition == "aws":
+        return "us-east-1"
+    if audit_info.audited_partition == "aws-cn":
+        return "cn-north-1"
+    if audit_info.audited_partition == "aws-us-gov":
+        return "us-gov-east-1"
+    # the rest are secret partitions
+    return "aws-iso-global"

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -265,3 +265,11 @@ def get_regions_from_audit_resources(audit_resources: list) -> list:
     if audited_regions:
         return audited_regions
     return None
+
+
+def get_default_region(audit_info: AWS_Audit_Info) -> str:
+    """get_default_region gets the default region based on the profile and audited regions"""
+    if audit_info.profile_region in audit_info.audited_regions:
+        # return profile region only if it is audited
+        return audit_info.profile_region
+    return audit_info.audited_regions[0]

--- a/prowler/providers/aws/services/account/account_service.py
+++ b/prowler/providers/aws/services/account/account_service.py
@@ -13,7 +13,7 @@ class Account:
         self.audited_partition = audit_info.audited_partition
         self.audited_account_arn = audit_info.audited_account_arn
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(audit_info)
+        self.region = get_default_region(self.service, audit_info)
 
     def __get_session__(self):
         return self.session

--- a/prowler/providers/aws/services/account/account_service.py
+++ b/prowler/providers/aws/services/account/account_service.py
@@ -1,4 +1,7 @@
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.aws_provider import (
+    generate_regional_clients,
+    get_default_region,
+)
 
 
 ################## Account
@@ -10,13 +13,7 @@ class Account:
         self.audited_partition = audit_info.audited_partition
         self.audited_account_arn = audit_info.audited_account_arn
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        # If the region is not set in the audit profile,
-        # we pick the first region from the regional clients list
-        self.region = (
-            audit_info.profile_region
-            if audit_info.profile_region
-            else list(self.regional_clients.keys())[0]
-        )
+        self.region = get_default_region(audit_info)
 
     def __get_session__(self):
         return self.session

--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -22,7 +22,7 @@ class Backup:
         self.audited_account_arn = audit_info.audited_account_arn
         self.audit_resources = audit_info.audit_resources
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(audit_info)
+        self.region = get_default_region(self.service, audit_info)
         self.backup_vaults = []
         self.__threading_call__(self.__list_backup_vaults__)
         self.backup_plans = []

--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -6,7 +6,10 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.aws_provider import (
+    generate_regional_clients,
+    get_default_region,
+)
 
 
 ################## Backup
@@ -19,13 +22,7 @@ class Backup:
         self.audited_account_arn = audit_info.audited_account_arn
         self.audit_resources = audit_info.audit_resources
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        # If the region is not set in the audit profile,
-        # we pick the first region from the regional clients list
-        self.region = (
-            audit_info.profile_region
-            if audit_info.profile_region
-            else list(self.regional_clients.keys())[0]
-        )
+        self.region = get_default_region(audit_info)
         self.backup_vaults = []
         self.__threading_call__(self.__list_backup_vaults__)
         self.backup_plans = []

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -23,7 +23,7 @@ class Cloudtrail:
         self.audited_account_arn = audit_info.audited_account_arn
         self.audit_resources = audit_info.audit_resources
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(audit_info)
+        self.region = get_default_region(self.service, audit_info)
         self.trails = []
         self.__threading_call__(self.__get_trails__)
         self.__get_trail_status__()

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -7,7 +7,10 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.aws_provider import (
+    generate_regional_clients,
+    get_default_region,
+)
 
 
 ################### CLOUDTRAIL
@@ -20,13 +23,7 @@ class Cloudtrail:
         self.audited_account_arn = audit_info.audited_account_arn
         self.audit_resources = audit_info.audit_resources
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        # If the region is not set in the audit profile,
-        # we pick the first region from the regional clients list
-        self.region = (
-            audit_info.profile_region
-            if audit_info.profile_region
-            else list(self.regional_clients.keys())[0]
-        )
+        self.region = get_default_region(audit_info)
         self.trails = []
         self.__threading_call__(self.__get_trails__)
         self.__get_trail_status__()

--- a/prowler/providers/aws/services/drs/drs_service.py
+++ b/prowler/providers/aws/services/drs/drs_service.py
@@ -5,7 +5,10 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.aws_provider import (
+    generate_regional_clients,
+    get_default_region,
+)
 
 ################## DRS (Elastic Disaster Recovery Service)
 
@@ -19,13 +22,7 @@ class DRS:
         self.audited_account_arn = audit_info.audited_account_arn
         self.audit_resources = audit_info.audit_resources
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        # If the region is not set in the audit profile,
-        # we pick the first region from the regional clients list
-        self.region = (
-            audit_info.profile_region
-            if audit_info.profile_region
-            else list(self.regional_clients.keys())[0]
-        )
+        self.region = get_default_region(audit_info)
         self.drs_services = []
         self.__threading_call__(self.__describe_jobs__)
 

--- a/prowler/providers/aws/services/drs/drs_service.py
+++ b/prowler/providers/aws/services/drs/drs_service.py
@@ -22,7 +22,7 @@ class DRS:
         self.audited_account_arn = audit_info.audited_account_arn
         self.audit_resources = audit_info.audit_resources
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(audit_info)
+        self.region = get_default_region(self.service, audit_info)
         self.drs_services = []
         self.__threading_call__(self.__describe_jobs__)
 

--- a/prowler/providers/aws/services/inspector2/inspector2_service.py
+++ b/prowler/providers/aws/services/inspector2/inspector2_service.py
@@ -4,7 +4,10 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.aws_provider import (
+    generate_regional_clients,
+    get_default_region,
+)
 
 
 ################################ Inspector2
@@ -17,13 +20,7 @@ class Inspector2:
         self.audited_account_arn = audit_info.audited_account_arn
         self.audit_resources = audit_info.audit_resources
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        # If the region is not set in the audit profile,
-        # we pick the first region from the regional clients list
-        self.region = (
-            audit_info.profile_region
-            if audit_info.profile_region
-            else list(self.regional_clients.keys())[0]
-        )
+        self.region = get_default_region(audit_info)
         self.inspectors = []
         self.__threading_call__(self.__batch_get_account_status__)
         self.__list_findings__()

--- a/prowler/providers/aws/services/inspector2/inspector2_service.py
+++ b/prowler/providers/aws/services/inspector2/inspector2_service.py
@@ -20,7 +20,7 @@ class Inspector2:
         self.audited_account_arn = audit_info.audited_account_arn
         self.audit_resources = audit_info.audit_resources
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(audit_info)
+        self.region = get_default_region(self.service, audit_info)
         self.inspectors = []
         self.__threading_call__(self.__batch_get_account_status__)
         self.__list_findings__()

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
@@ -19,7 +19,7 @@ class NetworkFirewall:
         self.audited_partition = audit_info.audited_partition
         self.audit_resources = audit_info.audit_resources
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(audit_info)
+        self.region = get_default_region(self.service, audit_info)
         self.network_firewalls = []
         self.__threading_call__(self.__list_firewalls__)
         self.__describe_firewall__()

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
@@ -4,7 +4,10 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.aws_provider import (
+    generate_regional_clients,
+    get_default_region,
+)
 
 
 ################## NetworkFirewall
@@ -16,13 +19,7 @@ class NetworkFirewall:
         self.audited_partition = audit_info.audited_partition
         self.audit_resources = audit_info.audit_resources
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        # If the region is not set in the audit profile,
-        # we pick the first region from the regional clients list
-        self.region = (
-            audit_info.profile_region
-            if audit_info.profile_region
-            else list(self.regional_clients.keys())[0]
-        )
+        self.region = get_default_region(audit_info)
         self.network_firewalls = []
         self.__threading_call__(self.__list_firewalls__)
         self.__describe_firewall__()

--- a/prowler/providers/aws/services/resourceexplorer2/resourceexplorer2_service.py
+++ b/prowler/providers/aws/services/resourceexplorer2/resourceexplorer2_service.py
@@ -4,7 +4,10 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.aws_provider import (
+    generate_regional_clients,
+    get_default_region,
+)
 
 
 ################################ ResourceExplorer2
@@ -17,13 +20,7 @@ class ResourceExplorer2:
         self.audited_partition = audit_info.audited_partition
         self.audited_account_arn = audit_info.audited_account_arn
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        # If the region is not set in the audit profile,
-        # we pick the first region from the regional clients list
-        self.region = (
-            audit_info.profile_region
-            if audit_info.profile_region
-            else list(self.regional_clients.keys())[0]
-        )
+        self.region = get_default_region(audit_info)
         self.indexes = []
         self.__threading_call__(self.__list_indexes__)
 

--- a/prowler/providers/aws/services/resourceexplorer2/resourceexplorer2_service.py
+++ b/prowler/providers/aws/services/resourceexplorer2/resourceexplorer2_service.py
@@ -20,7 +20,7 @@ class ResourceExplorer2:
         self.audited_partition = audit_info.audited_partition
         self.audited_account_arn = audit_info.audited_account_arn
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(audit_info)
+        self.region = get_default_region(self.service, audit_info)
         self.indexes = []
         self.__threading_call__(self.__list_indexes__)
 

--- a/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
+++ b/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
@@ -5,7 +5,10 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.aws_provider import (
+    generate_regional_clients,
+    get_default_region,
+)
 
 # Note:
 # This service is a bit special because it creates a resource (Replication Set) in one region, but you can list it in from any region using list_replication_sets
@@ -24,13 +27,7 @@ class SSMIncidents:
         self.audited_account_arn = audit_info.audited_account_arn
         self.audit_resources = audit_info.audit_resources
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        # If the region is not set in the audit profile,
-        # we pick the first region from the regional clients list
-        self.region = (
-            audit_info.profile_region
-            if audit_info.profile_region
-            else list(self.regional_clients.keys())[0]
-        )
+        self.region = get_default_region(audit_info)
         self.replication_set = []
         self.__list_replication_sets__()
         self.__get_replication_set__()

--- a/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
+++ b/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
@@ -27,7 +27,7 @@ class SSMIncidents:
         self.audited_account_arn = audit_info.audited_account_arn
         self.audit_resources = audit_info.audit_resources
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(audit_info)
+        self.region = get_default_region(self.service, audit_info)
         self.replication_set = []
         self.__list_replication_sets__()
         self.__get_replication_set__()

--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
@@ -4,6 +4,7 @@ from botocore.client import ClientError
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
+from prowler.providers.aws.aws_provider import get_default_region
 
 
 ################################ TrustedAdvisor
@@ -18,13 +19,14 @@ class TrustedAdvisor:
         # But only in us-east-1 or us-gov-west-1 https://docs.aws.amazon.com/general/latest/gr/awssupport.html
         if audit_info.audited_partition != "aws-cn":
             if audit_info.audited_partition == "aws":
+                self.region = get_default_region(audit_info)
                 support_region = "us-east-1"
             else:
                 support_region = "us-gov-west-1"
             self.client = audit_info.audit_session.client(
                 self.service, region_name=support_region
             )
-            self.client.region = self.region = support_region
+            self.client.region = support_region
             self.__describe_trusted_advisor_checks__()
             self.__describe_trusted_advisor_check_result__()
 

--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
@@ -19,7 +19,7 @@ class TrustedAdvisor:
         # But only in us-east-1 or us-gov-west-1 https://docs.aws.amazon.com/general/latest/gr/awssupport.html
         if audit_info.audited_partition != "aws-cn":
             if audit_info.audited_partition == "aws":
-                self.region = get_default_region(audit_info)
+                self.region = get_default_region(self.service, audit_info)
                 support_region = "us-east-1"
             else:
                 support_region = "us-gov-west-1"

--- a/prowler/providers/aws/services/vpc/vpc_service.py
+++ b/prowler/providers/aws/services/vpc/vpc_service.py
@@ -7,7 +7,10 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.aws_provider import (
+    generate_regional_clients,
+    get_default_region,
+)
 
 
 ################## VPC
@@ -33,11 +36,7 @@ class VPC:
         self.__describe_vpc_endpoint_service_permissions__()
         self.vpc_subnets = {}
         self.__threading_call__(self.__describe_vpc_subnets__)
-        self.region = (
-            audit_info.profile_region
-            if audit_info.profile_region
-            else list(self.regional_clients.keys())[0]
-        )
+        self.region = get_default_region(audit_info)
 
     def __get_session__(self):
         return self.session

--- a/prowler/providers/aws/services/vpc/vpc_service.py
+++ b/prowler/providers/aws/services/vpc/vpc_service.py
@@ -36,7 +36,7 @@ class VPC:
         self.__describe_vpc_endpoint_service_permissions__()
         self.vpc_subnets = {}
         self.__threading_call__(self.__describe_vpc_subnets__)
-        self.region = get_default_region(audit_info)
+        self.region = get_default_region(self.service, audit_info)
 
     def __get_session__(self):
         return self.session

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -7,6 +7,7 @@ from prowler.providers.aws.aws_provider import (
     AWS_Provider,
     assume_role,
     generate_regional_clients,
+    get_available_aws_service_regions,
     get_default_region,
     get_global_region,
 )
@@ -453,3 +454,55 @@ class Test_AWS_Provider:
             mfa_enabled=False,
         )
         assert get_global_region(audit_info) == "aws-iso-global"
+
+    def test_get_available_aws_service_regions(self):
+        audited_regions = ["us-east-1"]
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=None,
+            audited_account=None,
+            audited_account_arn=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            audited_user_id=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=audited_regions,
+            organizations_metadata=None,
+            audit_resources=None,
+            mfa_enabled=False,
+        )
+        with patch(
+            "prowler.providers.aws.aws_provider.parse_json_file",
+            return_value={
+                "services": {
+                    "ec2": {
+                        "regions": {
+                            "aws": [
+                                "af-south-1",
+                                "ca-central-1",
+                                "eu-central-1",
+                                "eu-central-2",
+                                "eu-north-1",
+                                "eu-south-1",
+                                "eu-south-2",
+                                "eu-west-1",
+                                "eu-west-2",
+                                "eu-west-3",
+                                "me-central-1",
+                                "me-south-1",
+                                "sa-east-1",
+                                "us-east-1",
+                                "us-east-2",
+                                "us-west-1",
+                                "us-west-2",
+                            ],
+                        }
+                    }
+                }
+            },
+        ):
+            assert get_available_aws_service_regions("ec2", audit_info) == ["us-east-1"]

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -455,7 +455,7 @@ class Test_AWS_Provider:
         )
         assert get_global_region(audit_info) == "aws-iso-global"
 
-    def test_get_available_aws_service_regions(self):
+    def test_get_available_aws_service_regions_with_us_east_1_audited(self):
         audited_regions = ["us-east-1"]
         audit_info = AWS_Audit_Info(
             session_config=None,
@@ -506,3 +506,54 @@ class Test_AWS_Provider:
             },
         ):
             assert get_available_aws_service_regions("ec2", audit_info) == ["us-east-1"]
+
+    def test_get_available_aws_service_regions_with_all_regions_audited(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=None,
+            audited_account=None,
+            audited_account_arn=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            audited_user_id=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=None,
+            organizations_metadata=None,
+            audit_resources=None,
+            mfa_enabled=False,
+        )
+        with patch(
+            "prowler.providers.aws.aws_provider.parse_json_file",
+            return_value={
+                "services": {
+                    "ec2": {
+                        "regions": {
+                            "aws": [
+                                "af-south-1",
+                                "ca-central-1",
+                                "eu-central-1",
+                                "eu-central-2",
+                                "eu-north-1",
+                                "eu-south-1",
+                                "eu-south-2",
+                                "eu-west-1",
+                                "eu-west-2",
+                                "eu-west-3",
+                                "me-central-1",
+                                "me-south-1",
+                                "sa-east-1",
+                                "us-east-1",
+                                "us-east-2",
+                                "us-west-1",
+                                "us-west-2",
+                            ],
+                        }
+                    }
+                }
+            },
+        ):
+            assert len(get_available_aws_service_regions("ec2", audit_info)) == 17

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -7,6 +7,7 @@ from prowler.providers.aws.aws_provider import (
     AWS_Provider,
     assume_role,
     generate_regional_clients,
+    get_default_region,
 )
 from prowler.providers.aws.lib.audit_info.models import AWS_Assume_Role, AWS_Audit_Info
 
@@ -275,3 +276,30 @@ class Test_AWS_Provider:
 
         # Shield does not exist in China
         assert generate_regional_clients_response == {}
+
+    def test_get_default_region(self):
+        audited_regions = ["eu-west-1", "us-east-1"]
+        profile_region = "us-east-1"
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=None,
+            audited_account=None,
+            audited_account_arn=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            audited_user_id=None,
+            profile=None,
+            profile_region=profile_region,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=audited_regions,
+            organizations_metadata=None,
+            audit_resources=None,
+            mfa_enabled=False,
+        )
+        assert get_default_region(audit_info) == "us-east-1"
+        audit_info.profile_region = "us-east-2"
+        assert get_default_region(audit_info) == "eu-west-1"
+        audit_info.profile_region = None
+        assert get_default_region(audit_info) == "eu-west-1"

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -304,4 +304,4 @@ class Test_AWS_Provider:
         audit_info.profile_region = None
         assert get_default_region("ec2", audit_info) == "eu-west-1"
         audit_info.audited_regions = None
-        assert get_default_region("ec2", audit_info) == "af-south-1"
+        assert get_default_region("ec2", audit_info) == "us-east-1"

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -278,8 +278,8 @@ class Test_AWS_Provider:
         assert generate_regional_clients_response == {}
 
     def test_get_default_region(self):
-        audited_regions = ["eu-west-1", "us-east-1"]
-        profile_region = "us-east-1"
+        audited_regions = ["eu-west-1"]
+        profile_region = "eu-west-1"
         audit_info = AWS_Audit_Info(
             session_config=None,
             original_session=None,
@@ -298,8 +298,10 @@ class Test_AWS_Provider:
             audit_resources=None,
             mfa_enabled=False,
         )
-        assert get_default_region(audit_info) == "us-east-1"
+        assert get_default_region("ec2", audit_info) == "eu-west-1"
         audit_info.profile_region = "us-east-2"
-        assert get_default_region(audit_info) == "eu-west-1"
+        assert get_default_region("ec2", audit_info) == "eu-west-1"
         audit_info.profile_region = None
-        assert get_default_region(audit_info) == "eu-west-1"
+        assert get_default_region("ec2", audit_info) == "eu-west-1"
+        audit_info.audited_regions = None
+        assert get_default_region("ec2", audit_info) == "af-south-1"

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -8,6 +8,7 @@ from prowler.providers.aws.aws_provider import (
     assume_role,
     generate_regional_clients,
     get_default_region,
+    get_global_region,
 )
 from prowler.providers.aws.lib.audit_info.models import AWS_Assume_Role, AWS_Audit_Info
 
@@ -299,9 +300,156 @@ class Test_AWS_Provider:
             mfa_enabled=False,
         )
         assert get_default_region("ec2", audit_info) == "eu-west-1"
-        audit_info.profile_region = "us-east-2"
+
+    def test_get_default_region_profile_region_not_audited(self):
+        audited_regions = ["eu-west-1"]
+        profile_region = "us-east-2"
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=None,
+            audited_account=None,
+            audited_account_arn=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            audited_user_id=None,
+            profile=None,
+            profile_region=profile_region,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=audited_regions,
+            organizations_metadata=None,
+            audit_resources=None,
+            mfa_enabled=False,
+        )
         assert get_default_region("ec2", audit_info) == "eu-west-1"
-        audit_info.profile_region = None
+
+    def test_get_default_region_non_profile_region(self):
+        audited_regions = ["eu-west-1"]
+        profile_region = None
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=None,
+            audited_account=None,
+            audited_account_arn=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            audited_user_id=None,
+            profile=None,
+            profile_region=profile_region,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=audited_regions,
+            organizations_metadata=None,
+            audit_resources=None,
+            mfa_enabled=False,
+        )
         assert get_default_region("ec2", audit_info) == "eu-west-1"
-        audit_info.audited_regions = None
+
+    def test_get_default_region_non_profile_or_audited_region(self):
+        audited_regions = None
+        profile_region = None
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=None,
+            audited_account=None,
+            audited_account_arn=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            audited_user_id=None,
+            profile=None,
+            profile_region=profile_region,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=audited_regions,
+            organizations_metadata=None,
+            audit_resources=None,
+            mfa_enabled=False,
+        )
         assert get_default_region("ec2", audit_info) == "us-east-1"
+
+    def test_aws_get_global_region(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=None,
+            audited_account=None,
+            audited_account_arn=None,
+            audited_partition="aws",
+            audited_identity_arn=None,
+            audited_user_id=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=None,
+            organizations_metadata=None,
+            audit_resources=None,
+            mfa_enabled=False,
+        )
+        assert get_default_region("ec2", audit_info) == "us-east-1"
+
+    def test_aws_gov_get_global_region(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=None,
+            audited_account=None,
+            audited_account_arn=None,
+            audited_partition="aws-us-gov",
+            audited_identity_arn=None,
+            audited_user_id=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=None,
+            organizations_metadata=None,
+            audit_resources=None,
+            mfa_enabled=False,
+        )
+        assert get_global_region(audit_info) == "us-gov-east-1"
+
+    def test_aws_cn_get_global_region(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=None,
+            audited_account=None,
+            audited_account_arn=None,
+            audited_partition="aws-cn",
+            audited_identity_arn=None,
+            audited_user_id=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=None,
+            organizations_metadata=None,
+            audit_resources=None,
+            mfa_enabled=False,
+        )
+        assert get_global_region(audit_info) == "cn-north-1"
+
+    def test_aws_iso_get_global_region(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=None,
+            audited_account=None,
+            audited_account_arn=None,
+            audited_partition="aws-iso",
+            audited_identity_arn=None,
+            audited_user_id=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=None,
+            organizations_metadata=None,
+            audit_resources=None,
+            mfa_enabled=False,
+        )
+        assert get_global_region(audit_info) == "aws-iso-global"

--- a/tests/providers/aws/services/resourceexplorer2/resourceexplorer2_service_test.py
+++ b/tests/providers/aws/services/resourceexplorer2/resourceexplorer2_service_test.py
@@ -60,7 +60,7 @@ class Test_ResourceExplorer2_Service:
             profile_region=None,
             credentials=None,
             assumed_role_info=None,
-            audited_regions="us-east-1",
+            audited_regions=["us-east-1"],
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,


### PR DESCRIPTION
### Description

Add `get_default_region` function in AWS Services to pick only the profile region if it is audited, if not, pick the first audited region.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
