### PR TITLE
feat(allowlist): add exceptions to allowlist

### DIFF
--- a/docs/tutorials/allowlist.md
+++ b/docs/tutorials/allowlist.md
@@ -11,6 +11,7 @@ You can use `-w`/`--allowlist-file` with the path of your allowlist yaml file, b
     ### Resources and tags are lists that can have either Regex or Keywords.
     ### Tags is an optional list that matches on tuples of 'key=value' and are "ANDed" together.
     ### Use an alternation Regex to match one of multiple tags with "ORed" logic.
+    ### For each check you can except Accounts, Regions, Resources and/or Tags.
     ###########################  ALLOWLIST EXAMPLE  ###########################
     Allowlist:
       Accounts:
@@ -53,6 +54,33 @@ You can use `-w`/`--allowlist-file` with the path of your allowlist yaml file, b
                 - "*"
               Tags:
                 - "environment=dev"    # Will ignore every resource containing the tag 'environment=dev' in every account and region
+
+        "*":
+          Checks:
+            "ecs_task_definitions_no_environment_secrets":
+              Regions:
+                - "*"
+              Resources:
+                - "*"
+              Exceptions:
+                Accounts:
+                  - "0123456789012"
+                Regions:
+                  - "eu-west-1"
+                  - "eu-south-2"        # Will ignore every resource in check ecs_task_definitions_no_environment_secrets except the ones in account 0123456789012 located in eu-south-2 or eu-west-1
+
+        "123456789012":
+          Checks:
+            "*":
+              Regions:
+                - "*"
+              Resources:
+                - "*"
+              Exceptions:
+                Resources:
+                  - "test"
+                Tags:
+                  - "environment=prod"   # Will ignore every resource except in account 123456789012 except the ones containing the string "test" and tag environment=prod
 
 
 ## Supported Allowlist Locations

--- a/prowler/config/allowlist.yaml
+++ b/prowler/config/allowlist.yaml
@@ -45,6 +45,34 @@ Allowlist:
           Tags:
             - "environment=dev"    # Will ignore every resource containing the tag 'environment=dev' in every account and region
 
+    "*":
+      Checks:
+        "ecs_task_definitions_no_environment_secrets":
+          Regions:
+            - "*"
+          Resources:
+            - "*"
+          Exceptions:
+            Accounts:
+              - "0123456789012"
+            Regions:
+              - "eu-west-1"
+              - "eu-south-2"        # Will ignore every resource in check ecs_task_definitions_no_environment_secrets except the ones in account 0123456789012 located in eu-south-2 or eu-west-1
+
+    "123456789012":
+      Checks:
+        "*":
+          Regions:
+            - "*"
+          Resources:
+            - "*"
+          Exceptions:
+            Resources:
+              - "test"
+            Tags:
+              - "environment=prod"   # Will ignore every resource except in account 123456789012 except the ones containing the string "test" and tag environment=prod
+
+
 
 # EXAMPLE: CONTROL TOWER (to migrate)
 # When using Control Tower, guardrails prevent access to certain protected resources. The allowlist

--- a/prowler/config/allowlist.yaml
+++ b/prowler/config/allowlist.yaml
@@ -2,6 +2,7 @@
 ### Resources and tags are lists that can have either Regex or Keywords.
 ### Tags is an optional list that matches on tuples of 'key=value' and are "ANDed" together.
 ### Use an alternation Regex to match one of multiple tags with "ORed" logic.
+### For each check you can except Accounts, Regions, Resources and/or Tags.
 ###########################  ALLOWLIST EXAMPLE  ###########################
 Allowlist:
   Accounts:

--- a/tests/providers/aws/lib/allowlist/allowlist_test.py
+++ b/tests/providers/aws/lib/allowlist/allowlist_test.py
@@ -308,20 +308,44 @@ class Test_Allowlist:
         }
 
         assert is_allowlisted_in_check(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler", ""
+            allowlist,
+            AWS_ACCOUNT_NUMBER,
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION,
+            "prowler",
+            "",
         )
 
         assert is_allowlisted_in_check(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler-test", ""
+            allowlist,
+            AWS_ACCOUNT_NUMBER,
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION,
+            "prowler-test",
+            "",
         )
 
         assert is_allowlisted_in_check(
-            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "test-prowler", ""
+            allowlist,
+            AWS_ACCOUNT_NUMBER,
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION,
+            "test-prowler",
+            "",
         )
 
         assert not (
             is_allowlisted_in_check(
-                allowlist, AWS_ACCOUNT_NUMBER, "check_test", "us-east-2", "test", ""
+                allowlist,
+                AWS_ACCOUNT_NUMBER,
+                AWS_ACCOUNT_NUMBER,
+                "check_test",
+                "us-east-2",
+                "test",
+                "",
             )
         )
 
@@ -343,6 +367,7 @@ class Test_Allowlist:
         assert is_allowlisted_in_check(
             allowlist,
             AWS_ACCOUNT_NUMBER,
+            AWS_ACCOUNT_NUMBER,
             "s3_bucket_public_access",
             AWS_REGION,
             "prowler",
@@ -351,6 +376,7 @@ class Test_Allowlist:
 
         assert is_allowlisted_in_check(
             allowlist,
+            AWS_ACCOUNT_NUMBER,
             AWS_ACCOUNT_NUMBER,
             "s3_bucket_public_access",
             AWS_REGION,
@@ -361,6 +387,7 @@ class Test_Allowlist:
         assert is_allowlisted_in_check(
             allowlist,
             AWS_ACCOUNT_NUMBER,
+            AWS_ACCOUNT_NUMBER,
             "s3_bucket_public_access",
             AWS_REGION,
             "test-prowler",
@@ -370,6 +397,7 @@ class Test_Allowlist:
         assert not (
             is_allowlisted_in_check(
                 allowlist,
+                AWS_ACCOUNT_NUMBER,
                 AWS_ACCOUNT_NUMBER,
                 "iam_user_hardware_mfa_enabled",
                 AWS_REGION,

--- a/tests/providers/aws/lib/allowlist/allowlist_test.py
+++ b/tests/providers/aws/lib/allowlist/allowlist_test.py
@@ -7,6 +7,7 @@ from prowler.providers.aws.lib.allowlist.allowlist import (
     is_allowlisted_in_check,
     is_allowlisted_in_region,
     is_allowlisted_in_tags,
+    is_excepted,
     parse_allowlist_file,
 )
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
@@ -509,4 +510,74 @@ class Test_Allowlist:
             check_allowlist["Resources"][0],
             "prowler-test",
             "environment=prod | project=myproj",
+        )
+
+    def test_is_excepted(self):
+        # Allowlist example
+        check_allowlist = {
+            "check_test": {
+                "Regions": ["us-east-1", "eu-west-1"],
+                "Resources": ["*"],
+                "Tags": ["environment=dev"],
+                "Exceptions": {
+                    "Accounts": [AWS_ACCOUNT_NUMBER],
+                    "Regions": ["eu-central-1", "eu-south-3"],
+                    "Resources": ["test"],
+                    "Tags": ["environment=test", "project=.*"],
+                },
+            }
+        }
+
+        assert is_excepted(
+            check_allowlist,
+            "check_test",
+            AWS_ACCOUNT_NUMBER,
+            "eu-central-1",
+            "test",
+            "environment=test",
+        )
+
+        assert is_excepted(
+            check_allowlist,
+            "check_test",
+            AWS_ACCOUNT_NUMBER,
+            "eu-south-3",
+            "test",
+            "environment=test",
+        )
+
+        assert is_excepted(
+            check_allowlist,
+            "check_test",
+            AWS_ACCOUNT_NUMBER,
+            "eu-south-3",
+            "test123",
+            "environment=test",
+        )
+
+        assert not is_excepted(
+            check_allowlist,
+            "check_test",
+            AWS_ACCOUNT_NUMBER,
+            "eu-south-2",
+            "test",
+            "environment=test",
+        )
+
+        assert not is_excepted(
+            check_allowlist,
+            "check_test",
+            AWS_ACCOUNT_NUMBER,
+            "eu-south-3",
+            "prowler",
+            "environment=test",
+        )
+
+        assert not is_excepted(
+            check_allowlist,
+            "check_test",
+            AWS_ACCOUNT_NUMBER,
+            "eu-south-3",
+            "test",
+            "environment=pro",
         )


### PR DESCRIPTION
### Description

Now, you can add exceptions to your allowlist at the check level, for example:
```
Allowlist:
  Accounts:
    "*":
      Checks:
        "ecs_task_definitions_no_environment_secrets":
          Regions:
            - "*"
          Resources:
            - "*"
          Exceptions:
            Accounts:
              - "0123456789012"
            Regions:
              - "eu-west-1"
              - "eu-south-2"        # Will ignore every resource in check ecs_task_definitions_no_environment_secrets except the ones in account 0123456789012 located in eu-south-2 or eu-west-1

    "123456789012":
      Checks:
        "*":
          Regions:
            - "*"
          Resources:
            - "*"
          Exceptions:
            Resources:
              - "test"
            Tags:
              - "environment=prod"   # Will ignore every resource except in account 123456789012 except the ones containing the string "test" and tag environment=prod
```
### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
