### PR TITLE
feat(lambda service): mapping lambda service to awslambda

### DIFF
--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -93,6 +93,9 @@ def exclude_checks_to_run(checks_to_execute: set, excluded_checks: list) -> set:
 def exclude_services_to_run(
     checks_to_execute: set, excluded_services: list, provider: str
 ) -> set:
+    excluded_services = [
+        "awslambda" if service == "lambda" else service for service in excluded_services
+    ]
     # Recover checks from the input services
     for service in excluded_services:
         modules = recover_checks_from_provider(provider, service)
@@ -581,6 +584,9 @@ def update_audit_metadata(
 
 def recover_checks_from_service(service_list: list, provider: str) -> list:
     checks = set()
+    service_list = [
+        "awslambda" if service == "lambda" else service for service in service_list
+    ]
     for service in service_list:
         modules = recover_checks_from_provider(provider, service)
         if not modules:


### PR DESCRIPTION
### Context

To launch `lambda` service in Prowler is needed to enter `awslambda` since `lambda` is a reserved word in Python


### Description

Map `lambda` to `awslambda` when passing it as a service in cli 


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
