### PR TITLE
fix(cloudwatch secrets): fix nonetype error handling

### DIFF
--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_no_secrets_in_logs/cloudwatch_log_group_no_secrets_in_logs.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_no_secrets_in_logs/cloudwatch_log_group_no_secrets_in_logs.py
@@ -57,10 +57,13 @@ class cloudwatch_log_group_no_secrets_in_logs(Check):
                                 event_detect_secrets_output = detect_secrets_scan(
                                     log_event_data
                                 )
-                                for secret in event_detect_secrets_output:
-                                    log_stream_secrets[cloudwatch_timestamp].add_secret(
-                                        secret["line_number"], secret["type"]
-                                    )
+                                if event_detect_secrets_output:
+                                    for secret in event_detect_secrets_output:
+                                        log_stream_secrets[
+                                            cloudwatch_timestamp
+                                        ].add_secret(
+                                            secret["line_number"], secret["type"]
+                                        )
                             else:
                                 log_stream_secrets[cloudwatch_timestamp].add_secret(
                                     1, secret["type"]

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_no_secrets_in_logs/cloudwatch_log_group_no_secrets_in_logs_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_no_secrets_in_logs/cloudwatch_log_group_no_secrets_in_logs_test.py
@@ -79,7 +79,12 @@ class Test_cloudwatch_log_group_no_secrets_in_logs:
         logs_client.put_log_events(
             logGroupName="test",
             logStreamName="test stream",
-            logEvents=[{"timestamp": 0, "message": "line"}],
+            logEvents=[
+                {
+                    "timestamp": int(unix_time_millis()),
+                    "message": "non sensitive message",
+                }
+            ],
         )
         from prowler.providers.aws.services.cloudwatch.cloudwatch_service import Logs
 


### PR DESCRIPTION
### Context

Check `cloudwatch_log_group_no_secrets_in_logs` was failing under certain conditions 
```
ERROR: cloudwatch_log_group_no_secrets_in_logs -- TypeError[60]: 'NoneType' object is not iterable
```

### Description

Handle when call to `detect_secrets_scan` in `cloudwatch_log_group_no_secrets_in_logs` returns `None`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
