### PR TITLE
fix(opensearch): log exception as WARNING

### DIFF
--- a/prowler/providers/aws/services/opensearch/opensearch_service.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service.py
@@ -89,7 +89,7 @@ class OpenSearchService:
                         describe_domain["DomainConfig"]["AccessPolicies"]["Options"]
                     )
                 except JSONDecodeError as error:
-                    logger.error(
+                    logger.warning(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
                     continue


### PR DESCRIPTION
### Description

Log `JSONDecodeError` exception as `WARNING`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
