### PR TITLE
fix(allowlist): single account checks handling

### DIFF
--- a/prowler/providers/aws/lib/allowlist/allowlist.py
+++ b/prowler/providers/aws/lib/allowlist/allowlist.py
@@ -116,6 +116,7 @@ def parse_allowlist_file(audit_info, allowlist_file):
 def is_allowlisted(allowlist, audited_account, check, region, resource, tags):
     try:
         allowlisted_checks = {}
+        checks_multi_account = {}
         # By default is not allowlisted
         is_finding_allowlisted = False
         # First set account key from allowlist dict

--- a/prowler/providers/aws/lib/allowlist/allowlist.py
+++ b/prowler/providers/aws/lib/allowlist/allowlist.py
@@ -116,7 +116,6 @@ def parse_allowlist_file(audit_info, allowlist_file):
 def is_allowlisted(allowlist, audited_account, check, region, resource, tags):
     try:
         allowlisted_checks = {}
-        checks_multi_account = {}
         # By default is not allowlisted
         is_finding_allowlisted = False
         # First set account key from allowlist dict
@@ -127,8 +126,8 @@ def is_allowlisted(allowlist, audited_account, check, region, resource, tags):
         # want to merge allowlisted checks from * to the other accounts check list
         if "*" in allowlist["Accounts"]:
             checks_multi_account = allowlist["Accounts"]["*"]["Checks"]
+            allowlisted_checks.update(checks_multi_account)
         # Test if it is allowlisted
-        allowlisted_checks.update(checks_multi_account)
         if is_allowlisted_in_check(
             allowlisted_checks,
             audited_account,

--- a/tests/providers/aws/lib/allowlist/allowlist_test.py
+++ b/tests/providers/aws/lib/allowlist/allowlist_test.py
@@ -305,6 +305,30 @@ class Test_Allowlist:
             )
         )
 
+    def test_is_allowlisted_single_account(self):
+        allowlist = {
+            "Accounts": {
+                AWS_ACCOUNT_NUMBER: {
+                    "Checks": {
+                        "check_test": {
+                            "Regions": [AWS_REGION],
+                            "Resources": ["prowler"],
+                        }
+                    }
+                }
+            }
+        }
+
+        assert is_allowlisted(
+            allowlist, AWS_ACCOUNT_NUMBER, "check_test", AWS_REGION, "prowler", ""
+        )
+
+        assert not (
+            is_allowlisted(
+                allowlist, AWS_ACCOUNT_NUMBER, "check_test", "us-east-2", "test", ""
+            )
+        )
+
     def test_is_allowlisted_in_region(self):
         # Allowlist example
         allowlisted_regions = [AWS_REGION, "eu-west-1"]


### PR DESCRIPTION
### Context

Fix #2584 

Allowlist feature was not working properly when a single account was the only entry of the `allowlist.yaml` file


### Description

Initialise `checks_multi_account` as empty dict to add it filled or not when adding the allowlisted checks from all the AWS accounts


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
