### PR TITLE
fix(ssm_incidents): Handle empty name

### DIFF
--- a/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
+++ b/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
@@ -123,7 +123,7 @@ class SSMIncidents:
                         ResponsePlan(
                             arn=response_plan.get("Arn", ""),
                             region=regional_client.region,
-                            name=response_plan["Name"],
+                            name=response_plan.get("Name", ""),
                         )
                     )
         except Exception as error:


### PR DESCRIPTION
### Description

Handle empty name in SSM Incidents `ResponsePlan`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
