### PR TITLE
fix(s3): `__get_object_lock_configuration__` warning logs

### DIFF
--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -291,8 +291,19 @@ class S3:
             regional_client.get_object_lock_configuration(Bucket=bucket.name)
             bucket.object_lock = True
         except Exception as error:
-            if "ObjectLockConfigurationNotFoundError" in str(error):
+            if (
+                "ObjectLockConfigurationNotFoundError" in str(error)
+                or error.response["Error"]["Code"] == "NoSuchBucket"
+            ):
                 bucket.object_lock = False
+                if regional_client:
+                    logger.warning(
+                        f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
+                else:
+                    logger.warning(
+                        f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
             else:
                 if regional_client:
                     logger.error(


### PR DESCRIPTION
### Description

Change `error` logs for `warning` in the `__get_object_lock_configuration__` if the `NoSuchBucket` exception is raised.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
