### PR TITLE
fix(vpc_endpoint_connections_trust_boundaries): Handle AWS Account ID as Principal

### DIFF
--- a/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
+++ b/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
@@ -1,6 +1,6 @@
 # lista de cuentas y te devuelva las válidas
 def is_account_only_allowed_in_condition(
-    condition_statement: dict, source_account_list: str
+    condition_statement: dict, source_account: str
 ):
     is_condition_valid = False
     valid_condition_options = {
@@ -27,22 +27,19 @@ def is_account_only_allowed_in_condition(
                         # here by default we assume is true and look for false entries
                         is_condition_valid = True
                         for item in condition_statement[condition_operator][value]:
-                            for account in source_account_list:
-                                if account not in item:
-                                    is_condition_valid = False
-                                    break
-                            if is_condition_valid is False:
+                            if source_account not in item:
+                                is_condition_valid = False
                                 break
+
                     # value is a string
                     elif isinstance(
                         condition_statement[condition_operator][value],
                         str,
                     ):
-                        for account in source_account_list:
-                            if (
-                                account
-                                in condition_statement[condition_operator][value]
-                            ):
-                                is_condition_valid = True
+                        if (
+                            source_account
+                            in condition_statement[condition_operator][value]
+                        ):
+                            is_condition_valid = True
 
     return is_condition_valid

--- a/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
+++ b/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
@@ -1,39 +1,48 @@
+# lista de cuentas y te devuelva las válidas
 def is_account_only_allowed_in_condition(
-    condition_statement: dict, source_account: str
+    condition_statement: dict, source_account_list: str
 ):
     is_condition_valid = False
     valid_condition_options = {
-        "StringEquals": "aws:SourceAccount",
-        "ArnLike": "aws:SourceArn",
-        "ArnEquals": "aws:SourceArn",
+        "StringEquals": [
+            "aws:SourceAccount",
+            "s3:ResourceAccount",
+            "aws:PrincipalAccount",
+        ],
+        "StringLike": ["aws:SourceArn", "aws:PrincipalArn"],
+        "ArnLike": ["aws:SourceArn", "aws:PrincipalArn"],
+        "ArnEquals": ["aws:SourceArn", "aws:PrincipalArn"],
     }
+
     for condition_operator, condition_operator_key in valid_condition_options.items():
         if condition_operator in condition_statement:
-            if condition_operator_key in condition_statement[condition_operator]:
-                # values are a list
-                if isinstance(
-                    condition_statement[condition_operator][condition_operator_key],
-                    list,
-                ):
-                    # if there is an arn/account without the source account -> we do not consider it safe
-                    # here by default we assume is true and look for false entries
-                    is_condition_valid = True
-                    for item in condition_statement[condition_operator][
-                        condition_operator_key
-                    ]:
-                        if source_account not in item:
-                            is_condition_valid = False
-                            break
-                # value is a string
-                elif isinstance(
-                    condition_statement[condition_operator][condition_operator_key], str
-                ):
-                    if (
-                        source_account
-                        in condition_statement[condition_operator][
-                            condition_operator_key
-                        ]
+            for value in condition_operator_key:
+                if value in condition_statement[condition_operator]:
+                    # values are a list
+                    if isinstance(
+                        condition_statement[condition_operator][value],
+                        list,
                     ):
+                        # if there is an arn/account without the source account -> we do not consider it safe
+                        # here by default we assume is true and look for false entries
                         is_condition_valid = True
+                        for item in condition_statement[condition_operator][value]:
+                            for account in source_account_list:
+                                if account not in item:
+                                    is_condition_valid = False
+                                    break
+                            if is_condition_valid is False:
+                                break
+                    # value is a string
+                    elif isinstance(
+                        condition_statement[condition_operator][value],
+                        str,
+                    ):
+                        for account in source_account_list:
+                            if (
+                                account
+                                in condition_statement[condition_operator][value]
+                            ):
+                                is_condition_valid = True
 
     return is_condition_valid

--- a/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible.py
@@ -34,7 +34,7 @@ class sqs_queues_not_publicly_accessible(Check):
                             if (
                                 "Condition" in statement
                                 and is_account_only_allowed_in_condition(
-                                    statement["Condition"], [sqs_client.audited_account]
+                                    statement["Condition"], sqs_client.audited_account
                                 )
                             ):
                                 report.status_extended = f"SQS queue {queue.id} is not public because its policy only allows access from the same account"

--- a/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible.py
@@ -34,7 +34,7 @@ class sqs_queues_not_publicly_accessible(Check):
                             if (
                                 "Condition" in statement
                                 and is_account_only_allowed_in_condition(
-                                    statement["Condition"], sqs_client.audited_account
+                                    statement["Condition"], [sqs_client.audited_account]
                                 )
                             ):
                                 report.status_extended = f"SQS queue {queue.id} is not public because its policy only allows access from the same account"

--- a/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
+++ b/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
@@ -2,6 +2,9 @@ from re import compile
 
 from prowler.config.config import get_config_var
 from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.lib.policy_condition_parser.policy_condition_parser import (
+    is_account_only_allowed_in_condition,
+)
 from prowler.providers.aws.services.vpc.vpc_client import vpc_client
 
 
@@ -13,17 +16,31 @@ class vpc_endpoint_connections_trust_boundaries(Check):
         for endpoint in vpc_client.vpc_endpoints:
             # Check VPC endpoint policy
             if endpoint.policy_document:
+                full_access = False
                 for statement in endpoint.policy_document["Statement"]:
                     if "*" == statement["Principal"]:
                         report = Check_Report_AWS(self.metadata())
                         report.region = endpoint.region
-                        report.status = "FAIL"
-                        report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} has full access."
                         report.resource_id = endpoint.id
                         report.resource_arn = endpoint.arn
                         report.resource_tags = endpoint.tags
+                        if (
+                            "Condition" in statement
+                            and is_account_only_allowed_in_condition(
+                                statement["Condition"], trusted_account_ids
+                            )
+                        ):
+                            report.status = "PASS"
+                            report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} can only be accessed from the same account."
+                        else:
+                            full_access = True
+                            report.status = "FAIL"
+                            report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} has full access."
+
                         findings.append(report)
-                        break
+
+                        if full_access:
+                            break
 
                     else:
                         if type(statement["Principal"]["AWS"]) == str:
@@ -34,13 +51,29 @@ class vpc_endpoint_connections_trust_boundaries(Check):
                             if principal_arn == "*":
                                 report = Check_Report_AWS(self.metadata())
                                 report.region = endpoint.region
-                                report.status = "FAIL"
-                                report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} has full access."
                                 report.resource_id = endpoint.id
                                 report.resource_arn = endpoint.arn
                                 report.resource_tags = endpoint.tags
+
+                                report.status = "FAIL"
+                                report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} has full access."
+                                if (
+                                    "Condition" in statement
+                                    and is_account_only_allowed_in_condition(
+                                        statement["Condition"], trusted_account_ids
+                                    )
+                                ):
+                                    report.status = "PASS"
+                                    report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} can only be accessed from the trusted account."
+
+                                else:
+                                    full_access = True
+                                    report.status = "FAIL"
+                                    report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} has full access."
+
                                 findings.append(report)
-                                break
+                                if full_access:
+                                    break
                             else:
                                 # Account ID can be an ARN or just a 12-digit string
                                 pattern = compile(r"^[0-9]{12}$")
@@ -63,12 +96,20 @@ class vpc_endpoint_connections_trust_boundaries(Check):
                                 else:
                                     report = Check_Report_AWS(self.metadata())
                                     report.region = endpoint.region
-                                    report.status = "FAIL"
-                                    report.status_extended = f"Found untrusted account {account_id} in VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id}."
                                     report.resource_id = endpoint.id
                                     report.resource_arn = endpoint.arn
                                     report.resource_tags = endpoint.tags
+                                    if (
+                                        "Condition" in statement
+                                        and is_account_only_allowed_in_condition(
+                                            statement["Condition"], trusted_account_ids
+                                        )
+                                    ):
+                                        report.status = "PASS"
+                                        report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} can only be accessed from the trusted account."
+                                    else:
+                                        report.status = "FAIL"
+                                        report.status_extended = f"Found untrusted account {account_id} in VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id}."
 
                                 findings.append(report)
-
         return findings

--- a/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
+++ b/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
@@ -13,6 +13,8 @@ class vpc_endpoint_connections_trust_boundaries(Check):
         findings = []
         # Get trusted account_ids from prowler.config.yaml
         trusted_account_ids = get_config_var("trusted_account_ids")
+        # Always include the same account as trusted
+        trusted_account_ids.append(vpc_client.audited_account)
         for endpoint in vpc_client.vpc_endpoints:
             # Check VPC endpoint policy
             if endpoint.policy_document:

--- a/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
+++ b/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
@@ -31,14 +31,16 @@ class vpc_endpoint_connections_trust_boundaries(Check):
                         else:
                             principals = statement["Principal"]["AWS"]
                         for principal_arn in principals:
-                            report = Check_Report_AWS(self.metadata())
-                            report.region = endpoint.region
                             if principal_arn == "*":
+                                report = Check_Report_AWS(self.metadata())
+                                report.region = endpoint.region
                                 report.status = "FAIL"
                                 report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} has full access."
                                 report.resource_id = endpoint.id
                                 report.resource_arn = endpoint.arn
                                 report.resource_tags = endpoint.tags
+                                findings.append(report)
+                                break
                             else:
                                 # Account ID can be an ARN or just a 12-digit string
                                 pattern = compile(r"^[0-9]{12}$")
@@ -51,17 +53,22 @@ class vpc_endpoint_connections_trust_boundaries(Check):
                                     account_id in trusted_account_ids
                                     or account_id in vpc_client.audited_account
                                 ):
+                                    report = Check_Report_AWS(self.metadata())
+                                    report.region = endpoint.region
                                     report.status = "PASS"
                                     report.status_extended = f"Found trusted account {account_id} in VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id}."
                                     report.resource_id = endpoint.id
                                     report.resource_arn = endpoint.arn
                                     report.resource_tags = endpoint.tags
                                 else:
+                                    report = Check_Report_AWS(self.metadata())
+                                    report.region = endpoint.region
                                     report.status = "FAIL"
                                     report.status_extended = f"Found untrusted account {account_id} in VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id}."
                                     report.resource_id = endpoint.id
                                     report.resource_arn = endpoint.arn
                                     report.resource_tags = endpoint.tags
-                            findings.append(report)
+
+                                findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
+++ b/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
@@ -44,6 +44,7 @@ class vpc_endpoint_connections_trust_boundaries(Check):
                             not access_from_trusted_accounts
                             or len(trusted_account_ids) == 0
                         ):
+                            access_from_trusted_accounts = False
                             report.status = "FAIL"
                             report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} can be accessed from non-trusted accounts."
                         else:
@@ -83,6 +84,7 @@ class vpc_endpoint_connections_trust_boundaries(Check):
                                     not access_from_trusted_accounts
                                     or len(trusted_account_ids) == 0
                                 ):
+                                    access_from_trusted_accounts = False
                                     report.status = "FAIL"
                                     report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} can be accessed from non-trusted accounts."
                                 else:
@@ -135,6 +137,7 @@ class vpc_endpoint_connections_trust_boundaries(Check):
                                         not access_from_trusted_accounts
                                         or len(trusted_account_ids) == 0
                                     ):
+                                        access_from_trusted_accounts = False
                                         report.status = "FAIL"
                                         report.status_extended = f"VPC Endpoint {endpoint.id} in VPC {endpoint.vpc_id} can be accessed from non-trusted accounts."
                                     else:

--- a/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
+++ b/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
@@ -1,3 +1,5 @@
+from re import compile
+
 from prowler.config.config import get_config_var
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.vpc.vpc_client import vpc_client
@@ -38,7 +40,13 @@ class vpc_endpoint_connections_trust_boundaries(Check):
                                 report.resource_arn = endpoint.arn
                                 report.resource_tags = endpoint.tags
                             else:
-                                account_id = principal_arn.split(":")[4]
+                                # Account ID can be an ARN or just a 12-digit string
+                                pattern = compile(r"^[0-9]{12}$")
+                                match = pattern.match(principal_arn)
+                                if not match:
+                                    account_id = principal_arn.split(":")[4]
+                                else:
+                                    account_id = match.string
                                 if (
                                     account_id in trusted_account_ids
                                     or account_id in vpc_client.audited_account

--- a/tests/providers/aws/lib/policy_condition_parser/policy_condition_parser_test.py
+++ b/tests/providers/aws/lib/policy_condition_parser/policy_condition_parser_test.py
@@ -9,13 +9,13 @@ class Test_policy_condition_parser:
     def test_condition_parser_string_equals_aws_SourceAccount_list(self):
         condition_statement = {"StringEquals": {"aws:SourceAccount": ["123456789012"]}}
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_equals_aws_SourceAccount_str(self):
         condition_statement = {"StringEquals": {"aws:SourceAccount": "123456789012"}}
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_equals_aws_SourceAccount_list_not_valid(self):
@@ -23,25 +23,25 @@ class Test_policy_condition_parser:
             "StringEquals": {"aws:SourceAccount": ["123456789012", "111222333444"]}
         }
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_equals_aws_SourceAccount_str_not_valid(self):
         condition_statement = {"StringEquals": {"aws:SourceAccount": "111222333444"}}
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_equals_s3_ResourceAccount_list(self):
         condition_statement = {"StringEquals": {"s3:ResourceAccount": ["123456789012"]}}
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_equals_s3_ResourceAccount_str(self):
         condition_statement = {"StringEquals": {"s3:ResourceAccount": "123456789012"}}
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_equals_s3_ResourceAccount_list_not_valid(self):
@@ -49,13 +49,13 @@ class Test_policy_condition_parser:
             "StringEquals": {"s3:ResourceAccount": ["123456789012", "111222333444"]}
         }
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_equals_s3_ResourceAccount_str_not_valid(self):
         condition_statement = {"StringEquals": {"s3:ResourceAccount": "111222333444"}}
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_equals_aws_PrincipalAccount_list(self):
@@ -63,13 +63,13 @@ class Test_policy_condition_parser:
             "StringEquals": {"aws:PrincipalAccount": ["123456789012"]}
         }
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_equals_aws_PrincipalAccount_str(self):
         condition_statement = {"StringEquals": {"aws:PrincipalAccount": "123456789012"}}
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_equals_aws_PrincipalAccount_list_not_valid(self):
@@ -77,13 +77,13 @@ class Test_policy_condition_parser:
             "StringEquals": {"aws:PrincipalAccount": ["123456789012", "111222333444"]}
         }
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_equals_aws_PrincipalAccount_str_not_valid(self):
         condition_statement = {"StringEquals": {"aws:PrincipalAccount": "111222333444"}}
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_like_aws_SourceArn_list(self):
@@ -92,7 +92,7 @@ class Test_policy_condition_parser:
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_like_aws_SourceArn_list_not_valid(self):
@@ -106,7 +106,7 @@ class Test_policy_condition_parser:
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_like_aws_SourceArn_str(self):
@@ -115,7 +115,7 @@ class Test_policy_condition_parser:
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_like_aws_SourceArn_str_not_valid(self):
@@ -124,7 +124,7 @@ class Test_policy_condition_parser:
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_like_aws_PrincipalArn_list(self):
@@ -135,7 +135,7 @@ class Test_policy_condition_parser:
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_like_aws_PrincipalArn_list_not_valid(self):
@@ -149,7 +149,7 @@ class Test_policy_condition_parser:
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_like_aws_PrincipalArn_str(self):
@@ -158,7 +158,7 @@ class Test_policy_condition_parser:
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_like_aws_PrincipalArn_str_not_valid(self):
@@ -167,7 +167,7 @@ class Test_policy_condition_parser:
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_equals_aws_SourceArn_list(self):
@@ -180,7 +180,7 @@ class Test_policy_condition_parser:
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_equals_aws_SourceArn_list_not_valid(self):
@@ -194,7 +194,7 @@ class Test_policy_condition_parser:
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_equals_aws_SourceArn_str(self):
@@ -205,7 +205,7 @@ class Test_policy_condition_parser:
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_equals_aws_SourceArn_str_not_valid(self):
@@ -216,7 +216,7 @@ class Test_policy_condition_parser:
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_equals_aws_PrincipalArn_list(self):
@@ -229,7 +229,7 @@ class Test_policy_condition_parser:
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_equals_aws_PrincipalArn_list_not_valid(self):
@@ -243,7 +243,7 @@ class Test_policy_condition_parser:
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_equals_aws_PrincipalArn_str(self):
@@ -254,7 +254,7 @@ class Test_policy_condition_parser:
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_arn_equals_aws_PrincipalArn_str_not_valid(self):
@@ -265,7 +265,7 @@ class Test_policy_condition_parser:
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_like_aws_SourceArn_list(self):
@@ -278,7 +278,7 @@ class Test_policy_condition_parser:
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_like_aws_SourceArn_list_not_valid(self):
@@ -292,7 +292,7 @@ class Test_policy_condition_parser:
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_like_aws_SourceArn_str(self):
@@ -303,7 +303,7 @@ class Test_policy_condition_parser:
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_like_aws_SourceArn_str_not_valid(self):
@@ -314,7 +314,7 @@ class Test_policy_condition_parser:
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_like_aws_PrincipalArn_list(self):
@@ -327,7 +327,7 @@ class Test_policy_condition_parser:
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_like_aws_PrincipalArn_list_not_valid(self):
@@ -341,7 +341,7 @@ class Test_policy_condition_parser:
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_like_aws_PrincipalArn_str(self):
@@ -352,7 +352,7 @@ class Test_policy_condition_parser:
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )
 
     def test_condition_parser_string_like_aws_PrincipalArn_str_not_valid(self):
@@ -363,5 +363,5 @@ class Test_policy_condition_parser:
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, [AWS_ACCOUNT_NUMBER]
+            condition_statement, AWS_ACCOUNT_NUMBER
         )

--- a/tests/providers/aws/lib/policy_condition_parser/policy_condition_parser_test.py
+++ b/tests/providers/aws/lib/policy_condition_parser/policy_condition_parser_test.py
@@ -6,42 +6,96 @@ AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_policy_condition_parser:
-    def test_condition_parser_string_equals_list(self):
+    def test_condition_parser_string_equals_aws_SourceAccount_list(self):
         condition_statement = {"StringEquals": {"aws:SourceAccount": ["123456789012"]}}
         assert is_account_only_allowed_in_condition(
-            condition_statement, AWS_ACCOUNT_NUMBER
+            condition_statement, [AWS_ACCOUNT_NUMBER]
         )
 
-    def test_condition_parser_string_equals_str(self):
+    def test_condition_parser_string_equals_aws_SourceAccount_str(self):
         condition_statement = {"StringEquals": {"aws:SourceAccount": "123456789012"}}
         assert is_account_only_allowed_in_condition(
-            condition_statement, AWS_ACCOUNT_NUMBER
+            condition_statement, [AWS_ACCOUNT_NUMBER]
         )
 
-    def test_condition_parser_string_equals_list_not_valid(self):
+    def test_condition_parser_string_equals_aws_SourceAccount_list_not_valid(self):
         condition_statement = {
             "StringEquals": {"aws:SourceAccount": ["123456789012", "111222333444"]}
         }
         assert not is_account_only_allowed_in_condition(
-            condition_statement, AWS_ACCOUNT_NUMBER
+            condition_statement, [AWS_ACCOUNT_NUMBER]
         )
 
-    def test_condition_parser_string_equals_str_not_valid(self):
+    def test_condition_parser_string_equals_aws_SourceAccount_str_not_valid(self):
         condition_statement = {"StringEquals": {"aws:SourceAccount": "111222333444"}}
         assert not is_account_only_allowed_in_condition(
-            condition_statement, AWS_ACCOUNT_NUMBER
+            condition_statement, [AWS_ACCOUNT_NUMBER]
         )
 
-    def test_condition_parser_arnlike_list(self):
+    def test_condition_parser_string_equals_s3_ResourceAccount_list(self):
+        condition_statement = {"StringEquals": {"s3:ResourceAccount": ["123456789012"]}}
+        assert is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_string_equals_s3_ResourceAccount_str(self):
+        condition_statement = {"StringEquals": {"s3:ResourceAccount": "123456789012"}}
+        assert is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_string_equals_s3_ResourceAccount_list_not_valid(self):
+        condition_statement = {
+            "StringEquals": {"s3:ResourceAccount": ["123456789012", "111222333444"]}
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_string_equals_s3_ResourceAccount_str_not_valid(self):
+        condition_statement = {"StringEquals": {"s3:ResourceAccount": "111222333444"}}
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_string_equals_aws_PrincipalAccount_list(self):
+        condition_statement = {
+            "StringEquals": {"aws:PrincipalAccount": ["123456789012"]}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_string_equals_aws_PrincipalAccount_str(self):
+        condition_statement = {"StringEquals": {"aws:PrincipalAccount": "123456789012"}}
+        assert is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_string_equals_aws_PrincipalAccount_list_not_valid(self):
+        condition_statement = {
+            "StringEquals": {"aws:PrincipalAccount": ["123456789012", "111222333444"]}
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_string_equals_aws_PrincipalAccount_str_not_valid(self):
+        condition_statement = {"StringEquals": {"aws:PrincipalAccount": "111222333444"}}
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_arn_like_aws_SourceArn_list(self):
         condition_statement = {
             "ArnLike": {"aws:SourceArn": ["arn:aws:cloudtrail:*:123456789012:trail/*"]}
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, AWS_ACCOUNT_NUMBER
+            condition_statement, [AWS_ACCOUNT_NUMBER]
         )
 
-    def test_condition_parser_arnlike_list_not_valid(self):
+    def test_condition_parser_arn_like_aws_SourceArn_list_not_valid(self):
         condition_statement = {
             "ArnLike": {
                 "aws:SourceArn": [
@@ -52,28 +106,71 @@ class Test_policy_condition_parser:
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, AWS_ACCOUNT_NUMBER
+            condition_statement, [AWS_ACCOUNT_NUMBER]
         )
 
-    def test_condition_parser_arnlike_str(self):
+    def test_condition_parser_arn_like_aws_SourceArn_str(self):
         condition_statement = {
             "ArnLike": {"aws:SourceArn": "arn:aws:cloudtrail:*:123456789012:trail/*"}
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, AWS_ACCOUNT_NUMBER
+            condition_statement, [AWS_ACCOUNT_NUMBER]
         )
 
-    def test_condition_parser_arnlike_str_not_valid(self):
+    def test_condition_parser_arn_like_aws_SourceArn_str_not_valid(self):
         condition_statement = {
             "ArnLike": {"aws:SourceArn": "arn:aws:cloudtrail:*:111222333444:trail/*"}
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, AWS_ACCOUNT_NUMBER
+            condition_statement, [AWS_ACCOUNT_NUMBER]
         )
 
-    def test_condition_parser_arnequals_list(self):
+    def test_condition_parser_arn_like_aws_PrincipalArn_list(self):
+        condition_statement = {
+            "ArnLike": {
+                "aws:PrincipalArn": ["arn:aws:cloudtrail:*:123456789012:trail/*"]
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_arn_like_aws_PrincipalArn_list_not_valid(self):
+        condition_statement = {
+            "ArnLike": {
+                "aws:PrincipalArn": [
+                    "arn:aws:cloudtrail:*:123456789012:trail/*",
+                    "arn:aws:cloudtrail:*:111222333444:trail/*",
+                ]
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_arn_like_aws_PrincipalArn_str(self):
+        condition_statement = {
+            "ArnLike": {"aws:PrincipalArn": "arn:aws:cloudtrail:*:123456789012:trail/*"}
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_arn_like_aws_PrincipalArn_str_not_valid(self):
+        condition_statement = {
+            "ArnLike": {"aws:PrincipalArn": "arn:aws:cloudtrail:*:111222333444:trail/*"}
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_arn_equals_aws_SourceArn_list(self):
         condition_statement = {
             "ArnEquals": {
                 "aws:SourceArn": [
@@ -83,10 +180,10 @@ class Test_policy_condition_parser:
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, AWS_ACCOUNT_NUMBER
+            condition_statement, [AWS_ACCOUNT_NUMBER]
         )
 
-    def test_condition_parser_arnequals_list_not_valid(self):
+    def test_condition_parser_arn_equals_aws_SourceArn_list_not_valid(self):
         condition_statement = {
             "ArnEquals": {
                 "aws:SourceArn": [
@@ -97,10 +194,10 @@ class Test_policy_condition_parser:
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, AWS_ACCOUNT_NUMBER
+            condition_statement, [AWS_ACCOUNT_NUMBER]
         )
 
-    def test_condition_parser_arnequals_str(self):
+    def test_condition_parser_arn_equals_aws_SourceArn_str(self):
         condition_statement = {
             "ArnEquals": {
                 "aws:SourceArn": "arn:aws:cloudtrail:eu-west-1:123456789012:trail/test"
@@ -108,10 +205,10 @@ class Test_policy_condition_parser:
         }
 
         assert is_account_only_allowed_in_condition(
-            condition_statement, AWS_ACCOUNT_NUMBER
+            condition_statement, [AWS_ACCOUNT_NUMBER]
         )
 
-    def test_condition_parser_arnequals_str_not_valid(self):
+    def test_condition_parser_arn_equals_aws_SourceArn_str_not_valid(self):
         condition_statement = {
             "ArnEquals": {
                 "aws:SourceArn": "arn:aws:cloudtrail:eu-west-1:111222333444:trail/test"
@@ -119,5 +216,152 @@ class Test_policy_condition_parser:
         }
 
         assert not is_account_only_allowed_in_condition(
-            condition_statement, AWS_ACCOUNT_NUMBER
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_arn_equals_aws_PrincipalArn_list(self):
+        condition_statement = {
+            "ArnEquals": {
+                "aws:PrincipalArn": [
+                    "arn:aws:cloudtrail:eu-west-1:123456789012:trail/test"
+                ]
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_arn_equals_aws_PrincipalArn_list_not_valid(self):
+        condition_statement = {
+            "ArnEquals": {
+                "aws:PrincipalArn": [
+                    "arn:aws:cloudtrail:eu-west-1:123456789012:trail/test",
+                    "arn:aws:cloudtrail:eu-west-1:111222333444:trail/test",
+                ]
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_arn_equals_aws_PrincipalArn_str(self):
+        condition_statement = {
+            "ArnEquals": {
+                "aws:PrincipalArn": "arn:aws:cloudtrail:eu-west-1:123456789012:trail/test"
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_arn_equals_aws_PrincipalArn_str_not_valid(self):
+        condition_statement = {
+            "ArnEquals": {
+                "aws:PrincipalArn": "arn:aws:cloudtrail:eu-west-1:111222333444:trail/test"
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_string_like_aws_SourceArn_list(self):
+        condition_statement = {
+            "StringLike": {
+                "aws:SourceArn": [
+                    "arn:aws:cloudtrail:eu-west-1:123456789012:trail/test"
+                ]
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_string_like_aws_SourceArn_list_not_valid(self):
+        condition_statement = {
+            "StringLike": {
+                "aws:SourceArn": [
+                    "arn:aws:cloudtrail:eu-west-1:123456789012:trail/test",
+                    "arn:aws:cloudtrail:eu-west-1:111222333444:trail/test",
+                ]
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_string_like_aws_SourceArn_str(self):
+        condition_statement = {
+            "StringLike": {
+                "aws:SourceArn": "arn:aws:cloudtrail:eu-west-1:123456789012:trail/test"
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_string_like_aws_SourceArn_str_not_valid(self):
+        condition_statement = {
+            "StringLike": {
+                "aws:SourceArn": "arn:aws:cloudtrail:eu-west-1:111222333444:trail/test"
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_string_like_aws_PrincipalArn_list(self):
+        condition_statement = {
+            "StringLike": {
+                "aws:PrincipalArn": [
+                    "arn:aws:cloudtrail:eu-west-1:123456789012:trail/test"
+                ]
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_string_like_aws_PrincipalArn_list_not_valid(self):
+        condition_statement = {
+            "StringLike": {
+                "aws:PrincipalArn": [
+                    "arn:aws:cloudtrail:eu-west-1:123456789012:trail/test",
+                    "arn:aws:cloudtrail:eu-west-1:111222333444:trail/test",
+                ]
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_string_like_aws_PrincipalArn_str(self):
+        condition_statement = {
+            "StringLike": {
+                "aws:PrincipalArn": "arn:aws:cloudtrail:eu-west-1:123456789012:trail/test"
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
+        )
+
+    def test_condition_parser_string_like_aws_PrincipalArn_str_not_valid(self):
+        condition_statement = {
+            "StringLike": {
+                "aws:PrincipalArn": "arn:aws:cloudtrail:eu-west-1:111222333444:trail/test"
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, [AWS_ACCOUNT_NUMBER]
         )

--- a/tests/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries_test.py
+++ b/tests/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries_test.py
@@ -263,7 +263,9 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     "Statement": [
                         {
                             "Effect": "Allow",
-                            "Principal": {"AWS": "arn:aws:iam::123456789010:root"},
+                            "Principal": {
+                                "AWS": f"arn:aws:iam::{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:root"
+                            },
                             "Action": "*",
                             "Resource": "*",
                         }
@@ -543,6 +545,69 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                 assert (
                     result[0].status_extended
                     == f"VPC Endpoint {vpc_endpoint['VpcEndpoint']['VpcEndpointId']} in VPC {vpc['VpcId']} can be accessed from non-trusted accounts."
+                )
+                assert (
+                    result[0].resource_id
+                    == vpc_endpoint["VpcEndpoint"]["VpcEndpointId"]
+                )
+                assert result[0].region == AWS_REGION
+
+    @mock_ec2
+    def test_vpc_endpoint_with_aws_principal_all_but_restricted_condition(self):
+        # Create VPC Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION)
+
+        vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
+
+        route_table = ec2_client.create_route_table(VpcId=vpc["VpcId"])["RouteTable"]
+        vpc_endpoint = ec2_client.create_vpc_endpoint(
+            VpcId=vpc["VpcId"],
+            ServiceName="com.amazonaws.us-east-1.s3",
+            RouteTableIds=[route_table["RouteTableId"]],
+            VpcEndpointType="Gateway",
+            PolicyDocument=json.dumps(
+                {
+                    "Statement": [
+                        {
+                            "Action": "*",
+                            "Effect": "Allow",
+                            "Principal": "*",
+                            "Resource": "*",
+                            "Condition": {
+                                "StringEquals": {
+                                    "aws:PrincipalAccount": AWS_ACCOUNT_NUMBER
+                                }
+                            },
+                        }
+                    ]
+                }
+            ),
+        )
+        from prowler.providers.aws.services.vpc.vpc_service import VPC
+
+        current_audit_info = self.set_mocked_audit_info()
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.vpc.vpc_endpoint_connections_trust_boundaries.vpc_endpoint_connections_trust_boundaries.vpc_client",
+                new=VPC(current_audit_info),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.vpc.vpc_endpoint_connections_trust_boundaries.vpc_endpoint_connections_trust_boundaries import (
+                    vpc_endpoint_connections_trust_boundaries,
+                )
+
+                check = vpc_endpoint_connections_trust_boundaries()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == f"VPC Endpoint {vpc_endpoint['VpcEndpoint']['VpcEndpointId']} in VPC {vpc['VpcId']} can only be accessed from trusted accounts."
                 )
                 assert (
                     result[0].resource_id

--- a/tests/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries_test.py
+++ b/tests/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries_test.py
@@ -8,11 +8,13 @@ from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
+TRUSTED_AWS_ACCOUNT_NUMBER = "111122223333"
+NON_TRUSTED_AWS_ACCOUNT_NUMBER = "000011112222"
 
 
 def mock_get_config_var(config_var):
     if config_var == "trusted_account_ids":
-        return ["123456789010"]
+        return [TRUSTED_AWS_ACCOUNT_NUMBER]
     return []
 
 
@@ -143,7 +145,9 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     "Statement": [
                         {
                             "Effect": "Allow",
-                            "Principal": {"AWS": "arn:aws:iam::123456789012:root"},
+                            "Principal": {
+                                "AWS": f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+                            },
                             "Action": "*",
                             "Resource": "*",
                         }
@@ -201,7 +205,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     "Statement": [
                         {
                             "Effect": "Allow",
-                            "Principal": {"AWS": "123456789012"},
+                            "Principal": {"AWS": AWS_ACCOUNT_NUMBER},
                             "Action": "*",
                             "Resource": "*",
                         }
@@ -304,9 +308,6 @@ class Test_vpc_endpoint_connections_trust_boundaries:
         # Create VPC Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION)
 
-        # Trusted AWS Account
-        trusted_account = "123456789010"
-
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
         route_table = ec2_client.create_route_table(VpcId=vpc["VpcId"])["RouteTable"]
@@ -321,7 +322,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                         {
                             "Effect": "Allow",
                             "Principal": {
-                                "AWS": f"arn:aws:iam::{trusted_account}:root"
+                                "AWS": f"arn:aws:iam::{TRUSTED_AWS_ACCOUNT_NUMBER}:root"
                             },
                             "Action": "*",
                             "Resource": "*",
@@ -358,7 +359,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     assert result[0].status == "PASS"
                     assert (
                         result[0].status_extended
-                        == f"Found trusted account {trusted_account} in VPC Endpoint {vpc_endpoint['VpcEndpoint']['VpcEndpointId']} in VPC {vpc['VpcId']}."
+                        == f"Found trusted account {TRUSTED_AWS_ACCOUNT_NUMBER} in VPC Endpoint {vpc_endpoint['VpcEndpoint']['VpcEndpointId']} in VPC {vpc['VpcId']}."
                     )
                     assert (
                         result[0].resource_id
@@ -384,7 +385,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     "Statement": [
                         {
                             "Effect": "Allow",
-                            "Principal": {"AWS": ["123456789010"]},
+                            "Principal": {"AWS": [TRUSTED_AWS_ACCOUNT_NUMBER]},
                             "Action": "*",
                             "Resource": "*",
                         }
@@ -420,10 +421,131 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     assert result[0].status == "PASS"
                     assert (
                         result[0].status_extended
-                        == f"Found trusted account 123456789010 in VPC Endpoint {vpc_endpoint['VpcEndpoint']['VpcEndpointId']} in VPC {vpc['VpcId']}."
+                        == f"Found trusted account {TRUSTED_AWS_ACCOUNT_NUMBER} in VPC Endpoint {vpc_endpoint['VpcEndpoint']['VpcEndpointId']} in VPC {vpc['VpcId']}."
                     )
                     assert (
                         result[0].resource_id
                         == vpc_endpoint["VpcEndpoint"]["VpcEndpointId"]
                     )
                     assert result[0].region == AWS_REGION
+
+    @mock_ec2
+    def test_vpc_endpoint_with_two_account_ids_one_trusted_one_not(self):
+        # Create VPC Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION)
+
+        vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
+
+        route_table = ec2_client.create_route_table(VpcId=vpc["VpcId"])["RouteTable"]
+        vpc_endpoint = ec2_client.create_vpc_endpoint(
+            VpcId=vpc["VpcId"],
+            ServiceName="com.amazonaws.us-east-1.s3",
+            RouteTableIds=[route_table["RouteTableId"]],
+            VpcEndpointType="Gateway",
+            PolicyDocument=json.dumps(
+                {
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": [
+                                    NON_TRUSTED_AWS_ACCOUNT_NUMBER,
+                                    TRUSTED_AWS_ACCOUNT_NUMBER,
+                                ]
+                            },
+                            "Action": "*",
+                            "Resource": "*",
+                        }
+                    ]
+                }
+            ),
+        )
+        from prowler.providers.aws.services.vpc.vpc_service import VPC
+
+        current_audit_info = self.set_mocked_audit_info()
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.vpc.vpc_endpoint_connections_trust_boundaries.vpc_endpoint_connections_trust_boundaries.vpc_client",
+                new=VPC(current_audit_info),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.vpc.vpc_endpoint_connections_trust_boundaries.vpc_endpoint_connections_trust_boundaries import (
+                    vpc_endpoint_connections_trust_boundaries,
+                )
+
+                check = vpc_endpoint_connections_trust_boundaries()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == f"VPC Endpoint {vpc_endpoint['VpcEndpoint']['VpcEndpointId']} in VPC {vpc['VpcId']} can be accessed from non-trusted accounts."
+                )
+                assert (
+                    result[0].resource_id
+                    == vpc_endpoint["VpcEndpoint"]["VpcEndpointId"]
+                )
+                assert result[0].region == AWS_REGION
+
+    @mock_ec2
+    def test_vpc_endpoint_with_aws_principal_all(self):
+        # Create VPC Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION)
+
+        vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
+
+        route_table = ec2_client.create_route_table(VpcId=vpc["VpcId"])["RouteTable"]
+        vpc_endpoint = ec2_client.create_vpc_endpoint(
+            VpcId=vpc["VpcId"],
+            ServiceName="com.amazonaws.us-east-1.s3",
+            RouteTableIds=[route_table["RouteTableId"]],
+            VpcEndpointType="Gateway",
+            PolicyDocument=json.dumps(
+                {
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"AWS": "*"},
+                            "Action": "*",
+                            "Resource": "*",
+                        }
+                    ]
+                }
+            ),
+        )
+        from prowler.providers.aws.services.vpc.vpc_service import VPC
+
+        current_audit_info = self.set_mocked_audit_info()
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.vpc.vpc_endpoint_connections_trust_boundaries.vpc_endpoint_connections_trust_boundaries.vpc_client",
+                new=VPC(current_audit_info),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.vpc.vpc_endpoint_connections_trust_boundaries.vpc_endpoint_connections_trust_boundaries import (
+                    vpc_endpoint_connections_trust_boundaries,
+                )
+
+                check = vpc_endpoint_connections_trust_boundaries()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == f"VPC Endpoint {vpc_endpoint['VpcEndpoint']['VpcEndpointId']} in VPC {vpc['VpcId']} can be accessed from non-trusted accounts."
+                )
+                assert (
+                    result[0].resource_id
+                    == vpc_endpoint["VpcEndpoint"]["VpcEndpointId"]
+                )
+                assert result[0].region == AWS_REGION

--- a/tests/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries_test.py
+++ b/tests/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries_test.py
@@ -117,7 +117,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"VPC Endpoint {vpc_endpoint['VpcEndpoint']['VpcEndpointId']} in VPC {vpc['VpcId']} has full access."
+                    == f"VPC Endpoint {vpc_endpoint['VpcEndpoint']['VpcEndpointId']} in VPC {vpc['VpcId']} can be accessed from non-trusted accounts."
                 )
                 assert (
                     result[0].resource_id
@@ -126,7 +126,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                 assert result[0].region == AWS_REGION
 
     @mock_ec2
-    def test_vpc_endpoint_with_trusted_account_with_arn(self):
+    def test_vpc_endpoint_with_trusted_account_arn(self):
         # Create VPC Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION)
 
@@ -184,7 +184,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                 assert result[0].region == AWS_REGION
 
     @mock_ec2
-    def test_vpc_endpoint_with_trusted_account(self):
+    def test_vpc_endpoint_with_trusted_account_id(self):
         # Create VPC Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION)
 
@@ -292,7 +292,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"Found untrusted account 123456789010 in VPC Endpoint {vpc_endpoint['VpcEndpoint']['VpcEndpointId']} in VPC {vpc['VpcId']}."
+                    == f"VPC Endpoint {vpc_endpoint['VpcEndpoint']['VpcEndpointId']} in VPC {vpc['VpcId']} can be accessed from non-trusted accounts."
                 )
                 assert (
                     result[0].resource_id
@@ -303,6 +303,9 @@ class Test_vpc_endpoint_connections_trust_boundaries:
     def test_vpc_endpoint_with_config_trusted_account_with_arn(self):
         # Create VPC Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION)
+
+        # Trusted AWS Account
+        trusted_account = "123456789010"
 
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
@@ -317,7 +320,9 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     "Statement": [
                         {
                             "Effect": "Allow",
-                            "Principal": {"AWS": "arn:aws:iam::123456789010:root"},
+                            "Principal": {
+                                "AWS": f"arn:aws:iam::{trusted_account}:root"
+                            },
                             "Action": "*",
                             "Resource": "*",
                         }
@@ -353,7 +358,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     assert result[0].status == "PASS"
                     assert (
                         result[0].status_extended
-                        == f"Found trusted account 123456789010 in VPC Endpoint {vpc_endpoint['VpcEndpoint']['VpcEndpointId']} in VPC {vpc['VpcId']}."
+                        == f"Found trusted account {trusted_account} in VPC Endpoint {vpc_endpoint['VpcEndpoint']['VpcEndpointId']} in VPC {vpc['VpcId']}."
                     )
                     assert (
                         result[0].resource_id


### PR DESCRIPTION
### Motivation

Fixes #2605 

### Description

Handle the AWS Account number as Principal in the vpc_endpoint_connections_trust_boundaries check.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
