### PR TITLE
fix(ecs_task_def_secrets): Improve description to explain findings

### DIFF
--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.metadata.json
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.metadata.json
@@ -12,7 +12,7 @@
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
   "Severity": "critical",
   "ResourceType": "AwsEcsTaskDefinition",
-  "Description": "Check if secrets exists in ECS task definitions environment variables",
+  "Description": "Check if secrets exists in ECS task definitions environment variables. If a secret is detected, the line number shown in the finding matches with the environment variable \"Name\" attribute starting to count at the \"environment\" key from the ECS Task Definition in JSON format.",
   "Risk": "The use of a hard-coded password increases the possibility of password guessing. If hard-coded passwords are used; it is possible that malicious users gain access through the account in question.",
   "RelatedUrl": "",
   "Remediation": {


### PR DESCRIPTION
### Context

Fixes #2620 

### Description

Improve `ecs_task_definitions_no_environment_secrets` description to explain how to read the findings.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
