### PR TITLE
feat(aws): New AWSService class as parent

### DIFF
--- a/prowler/providers/aws/lib/service/service.py
+++ b/prowler/providers/aws/lib/service/service.py
@@ -1,3 +1,5 @@
+import threading
+
 from prowler.providers.aws.aws_provider import (
     generate_regional_clients,
     get_default_region,
@@ -37,3 +39,15 @@ class AWS_Service:
         # Get a single region and client if the service needs it (e.g. AWS Global Service)
         self.region = get_default_region(self.service, audit_info)
         self.client = self.session.client(self.service, self.region)
+
+    def __get_session__(self):
+        return self.session
+
+    def __threading_call__(self, call):
+        threads = []
+        for regional_client in self.regional_clients.values():
+            threads.append(threading.Thread(target=call, args=(regional_client,)))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()

--- a/prowler/providers/aws/lib/service/service.py
+++ b/prowler/providers/aws/lib/service/service.py
@@ -37,6 +37,8 @@ class AWSService:
             )
 
         # Get a single region and client if the service needs it (e.g. AWS Global Service)
+        # We cannot include this within an else because some services needs both the regional_clients
+        # and a single client like S3
         self.region = get_default_region(self.service, audit_info)
         self.client = self.session.client(self.service, self.region)
 

--- a/prowler/providers/aws/lib/service/service.py
+++ b/prowler/providers/aws/lib/service/service.py
@@ -25,9 +25,8 @@ class AWS_Service:
         self.session = audit_info.audit_session
 
         # We receive the service using __class__.__name__ or the service name in lowercase
-        if not self.service.islower():
-            # e.g.: AccessAnalyzer --> we need a lowercase string, so service.lower()
-            self.service = service.lower()
+        # e.g.: AccessAnalyzer --> we need a lowercase string, so service.lower()
+        self.service = service.lower() if not service.islower() else service
 
         # Generate Regional Clients
         if not global_service:

--- a/prowler/providers/aws/lib/service/service.py
+++ b/prowler/providers/aws/lib/service/service.py
@@ -6,26 +6,33 @@ from prowler.providers.aws.aws_provider import (
 
 class AWS_Service:
     def __init__(self, service, audit_info, global_service=False):
-        # We receive the service using __class__.__name__
-        # e.g.: AccessAnalyzer --> we need a lowercase string, so service.lower()
-        self.service = service.lower()
+        # Audit Information
         self.audit_info = audit_info
-        self.session = audit_info.audit_session
         self.audited_account = audit_info.audited_account
         self.audited_account_arn = audit_info.audited_account_arn
         self.audited_partition = audit_info.audited_partition
         self.audit_resources = audit_info.audit_resources
-        self.region = get_default_region(self.service, audit_info)
+        self.audited_checks = audit_info.audit_metadata.expected_checks
+
+        # AWS Session
+        self.session = audit_info.audit_session
+
+        # We receive the service using __class__.__name__
+        # e.g.: AccessAnalyzer --> we need a lowercase string, so service.lower()
+        self.service = service.lower()
+
+        # Generate Regional Clients
         self.regional_clients = generate_regional_clients(
             self.service, audit_info, global_service
         )
-        self.audited_checks = audit_info.audit_metadata.expected_checks
 
-        # Check this for S3
+        # Get a single region if the service needs it
+        self.region = get_default_region(self.service, audit_info)
         if self.service in ["iam", "fms", "s3", "organizations"]:
             self.client = self.session.client(self.service, self.region)
 
-        # Check this
+        # If the service is global we need to set a single client and a region
+        # that replaces the default region set
         if global_service:
             self.client = list(self.regional_clients.values())[0]
             self.region = self.client.region

--- a/prowler/providers/aws/lib/service/service.py
+++ b/prowler/providers/aws/lib/service/service.py
@@ -1,0 +1,31 @@
+from prowler.providers.aws.aws_provider import (
+    generate_regional_clients,
+    get_default_region,
+)
+
+
+class AWS_Service:
+    def __init__(self, service, audit_info, global_service=False):
+        # We receive the service using __class__.__name__
+        # e.g.: AccessAnalyzer --> we need a lowercase string, so service.lower()
+        self.service = service.lower()
+        self.audit_info = audit_info
+        self.session = audit_info.audit_session
+        self.audited_account = audit_info.audited_account
+        self.audited_account_arn = audit_info.audited_account_arn
+        self.audited_partition = audit_info.audited_partition
+        self.audit_resources = audit_info.audit_resources
+        self.region = get_default_region(self.service, audit_info)
+        self.regional_clients = generate_regional_clients(
+            self.service, audit_info, global_service
+        )
+        self.audited_checks = audit_info.audit_metadata.expected_checks
+
+        # Check this for S3
+        if self.service in ["iam", "fms", "s3", "organizations"]:
+            self.client = self.session.client(self.service, self.region)
+
+        # Check this
+        if global_service:
+            self.client = list(self.regional_clients.values())[0]
+            self.region = self.client.region

--- a/prowler/providers/aws/lib/service/service.py
+++ b/prowler/providers/aws/lib/service/service.py
@@ -6,8 +6,8 @@ from prowler.providers.aws.aws_provider import (
 )
 
 
-class AWS_Service:
-    """The AWS_Service class offers a parent class for each AWS Service to generate:
+class AWSService:
+    """The AWSService class offers a parent class for each AWS Service to generate:
     - AWS Regional Clients
     - Shared information like the account ID and ARN, the the AWS partition and the checks audited
     - AWS Session

--- a/prowler/providers/aws/services/accessanalyzer/accessanalyzer_service.py
+++ b/prowler/providers/aws/services/accessanalyzer/accessanalyzer_service.py
@@ -6,17 +6,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## AccessAnalyzer
-class AccessAnalyzer:
+class AccessAnalyzer(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "accessanalyzer"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.analyzers = []
         self.__threading_call__(self.__list_analyzers__)
         self.__list_findings__()

--- a/prowler/providers/aws/services/accessanalyzer/accessanalyzer_service.py
+++ b/prowler/providers/aws/services/accessanalyzer/accessanalyzer_service.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## AccessAnalyzer
-class AccessAnalyzer(AWS_Service):
+class AccessAnalyzer(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.analyzers = []
         self.__threading_call__(self.__list_analyzers__)

--- a/prowler/providers/aws/services/accessanalyzer/accessanalyzer_service.py
+++ b/prowler/providers/aws/services/accessanalyzer/accessanalyzer_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from botocore.exceptions import ClientError
@@ -18,18 +17,6 @@ class AccessAnalyzer(AWS_Service):
         self.__threading_call__(self.__list_analyzers__)
         self.__list_findings__()
         self.__get_finding_status__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_analyzers__(self, regional_client):
         logger.info("AccessAnalyzer - Listing Analyzers...")

--- a/prowler/providers/aws/services/account/account_service.py
+++ b/prowler/providers/aws/services/account/account_service.py
@@ -1,19 +1,11 @@
-from prowler.providers.aws.aws_provider import (
-    generate_regional_clients,
-    get_default_region,
-)
-
-
 ################## Account
-class Account:
+from prowler.providers.aws.lib.service.service import AWS_Service
+
+
+class Account(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "account"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account_arn = audit_info.audited_account_arn
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
 
     def __get_session__(self):
         return self.session

--- a/prowler/providers/aws/services/account/account_service.py
+++ b/prowler/providers/aws/services/account/account_service.py
@@ -1,10 +1,10 @@
 ################## Account
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
-class Account(AWS_Service):
+class Account(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
 
 

--- a/prowler/providers/aws/services/account/account_service.py
+++ b/prowler/providers/aws/services/account/account_service.py
@@ -7,8 +7,5 @@ class Account(AWS_Service):
         # Call AWS_Service's __init__
         super().__init__(__class__.__name__, audit_info)
 
-    def __get_session__(self):
-        return self.session
-
 
 ### This service don't need boto3 calls

--- a/prowler/providers/aws/services/acm/acm_service.py
+++ b/prowler/providers/aws/services/acm/acm_service.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## ACM
-class ACM(AWS_Service):
+class ACM(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.certificates = []
         self.__threading_call__(self.__list_certificates__)

--- a/prowler/providers/aws/services/acm/acm_service.py
+++ b/prowler/providers/aws/services/acm/acm_service.py
@@ -6,17 +6,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## ACM
-class ACM:
+class ACM(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "acm"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.certificates = []
         self.__threading_call__(self.__list_certificates__)
         self.__describe_certificates__()

--- a/prowler/providers/aws/services/acm/acm_service.py
+++ b/prowler/providers/aws/services/acm/acm_service.py
@@ -1,4 +1,3 @@
-import threading
 from datetime import datetime
 from typing import Optional
 
@@ -18,18 +17,6 @@ class ACM(AWS_Service):
         self.__threading_call__(self.__list_certificates__)
         self.__describe_certificates__()
         self.__list_tags_for_certificate__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_certificates__(self, regional_client):
         logger.info("ACM - Listing Certificates...")

--- a/prowler/providers/aws/services/apigateway/apigateway_service.py
+++ b/prowler/providers/aws/services/apigateway/apigateway_service.py
@@ -4,13 +4,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## APIGateway
-class APIGateway(AWS_Service):
+class APIGateway(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.rest_apis = []
         self.__threading_call__(self.__get_rest_apis__)

--- a/prowler/providers/aws/services/apigateway/apigateway_service.py
+++ b/prowler/providers/aws/services/apigateway/apigateway_service.py
@@ -5,18 +5,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## APIGateway
-class APIGateway:
+class APIGateway(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "apigateway"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.audited_partition = audit_info.audited_partition
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.rest_apis = []
         self.__threading_call__(self.__get_rest_apis__)
         self.__get_authorizers__()

--- a/prowler/providers/aws/services/apigateway/apigateway_service.py
+++ b/prowler/providers/aws/services/apigateway/apigateway_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from pydantic import BaseModel
@@ -18,18 +17,6 @@ class APIGateway(AWS_Service):
         self.__get_authorizers__()
         self.__get_rest_api__()
         self.__get_stages__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __get_rest_apis__(self, regional_client):
         logger.info("APIGateway - Getting Rest APIs...")

--- a/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
+++ b/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
@@ -5,18 +5,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## ApiGatewayV2
-class ApiGatewayV2:
+class ApiGatewayV2(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "apigatewayv2"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.apis = []
         self.__threading_call__(self.__get_apis__)
         self.__get_authorizers__()

--- a/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
+++ b/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from pydantic import BaseModel
@@ -17,18 +16,6 @@ class ApiGatewayV2(AWS_Service):
         self.__threading_call__(self.__get_apis__)
         self.__get_authorizers__()
         self.__get_stages__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __get_apis__(self, regional_client):
         logger.info("APIGatewayv2 - Getting APIs...")

--- a/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
+++ b/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
@@ -4,13 +4,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## ApiGatewayV2
-class ApiGatewayV2(AWS_Service):
+class ApiGatewayV2(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.apis = []
         self.__threading_call__(self.__get_apis__)

--- a/prowler/providers/aws/services/appstream/appstream_service.py
+++ b/prowler/providers/aws/services/appstream/appstream_service.py
@@ -4,13 +4,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## AppStream
-class AppStream(AWS_Service):
+class AppStream(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.fleets = []
         self.__threading_call__(self.__describe_fleets__)

--- a/prowler/providers/aws/services/appstream/appstream_service.py
+++ b/prowler/providers/aws/services/appstream/appstream_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from pydantic import BaseModel
@@ -16,18 +15,6 @@ class AppStream(AWS_Service):
         self.fleets = []
         self.__threading_call__(self.__describe_fleets__)
         self.__list_tags_for_resource__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_fleets__(self, regional_client):
         logger.info("AppStream - Describing Fleets...")

--- a/prowler/providers/aws/services/appstream/appstream_service.py
+++ b/prowler/providers/aws/services/appstream/appstream_service.py
@@ -5,17 +5,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## AppStream
-class AppStream:
+class AppStream(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "appstream"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.fleets = []
         self.__threading_call__(self.__describe_fleets__)
         self.__list_tags_for_resource__()

--- a/prowler/providers/aws/services/autoscaling/autoscaling_service.py
+++ b/prowler/providers/aws/services/autoscaling/autoscaling_service.py
@@ -1,5 +1,3 @@
-import threading
-
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
@@ -16,18 +14,6 @@ class AutoScaling(AWS_Service):
         self.__threading_call__(self.__describe_launch_configurations__)
         self.groups = []
         self.__threading_call__(self.__describe_auto_scaling_groups__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_launch_configurations__(self, regional_client):
         logger.info("AutoScaling - Describing Launch Configurations...")

--- a/prowler/providers/aws/services/autoscaling/autoscaling_service.py
+++ b/prowler/providers/aws/services/autoscaling/autoscaling_service.py
@@ -2,13 +2,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## AutoScaling
-class AutoScaling(AWS_Service):
+class AutoScaling(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.launch_configurations = []
         self.__threading_call__(self.__describe_launch_configurations__)

--- a/prowler/providers/aws/services/autoscaling/autoscaling_service.py
+++ b/prowler/providers/aws/services/autoscaling/autoscaling_service.py
@@ -4,17 +4,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## AutoScaling
-class AutoScaling:
+class AutoScaling(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "autoscaling"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.launch_configurations = []
         self.__threading_call__(self.__describe_launch_configurations__)
         self.groups = []

--- a/prowler/providers/aws/services/awslambda/awslambda_service.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_service.py
@@ -11,17 +11,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## Lambda
-class Lambda:
+class Lambda(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "lambda"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.functions = {}
         self.__threading_call__(self.__list_functions__)
         self.__list_tags_for_resource__()

--- a/prowler/providers/aws/services/awslambda/awslambda_service.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_service.py
@@ -10,13 +10,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## Lambda
-class Lambda(AWS_Service):
+class Lambda(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.functions = {}
         self.__threading_call__(self.__list_functions__)

--- a/prowler/providers/aws/services/awslambda/awslambda_service.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_service.py
@@ -1,6 +1,5 @@
 import io
 import json
-import threading
 import zipfile
 from enum import Enum
 from typing import Any, Optional
@@ -33,18 +32,6 @@ class Lambda(AWS_Service):
 
         self.__threading_call__(self.__get_policy__)
         self.__threading_call__(self.__get_function_url_config__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_functions__(self, regional_client):
         logger.info("Lambda - Listing Functions...")

--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## Backup
-class Backup(AWS_Service):
+class Backup(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.backup_vaults = []
         self.__threading_call__(self.__list_backup_vaults__)

--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -6,23 +6,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import (
-    generate_regional_clients,
-    get_default_region,
-)
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## Backup
-class Backup:
+class Backup(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "backup"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account_arn = audit_info.audited_account_arn
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.backup_vaults = []
         self.__threading_call__(self.__list_backup_vaults__)
         self.backup_plans = []

--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -1,4 +1,3 @@
-import threading
 from datetime import datetime
 from typing import Optional
 
@@ -20,15 +19,6 @@ class Backup(AWS_Service):
         self.__threading_call__(self.__list_backup_plans__)
         self.backup_report_plans = []
         self.__threading_call__(self.__list_backup_report_plans__)
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_backup_vaults__(self, regional_client):
         logger.info("Backup - Listing Backup Vaults...")

--- a/prowler/providers/aws/services/cloudformation/cloudformation_service.py
+++ b/prowler/providers/aws/services/cloudformation/cloudformation_service.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## CloudFormation
-class CloudFormation(AWS_Service):
+class CloudFormation(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.stacks = []
         self.__threading_call__(self.__describe_stacks__)

--- a/prowler/providers/aws/services/cloudformation/cloudformation_service.py
+++ b/prowler/providers/aws/services/cloudformation/cloudformation_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from botocore.client import ClientError
@@ -17,18 +16,6 @@ class CloudFormation(AWS_Service):
         self.stacks = []
         self.__threading_call__(self.__describe_stacks__)
         self.__describe_stack__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_stacks__(self, regional_client):
         """Get ALL CloudFormation Stacks"""

--- a/prowler/providers/aws/services/cloudformation/cloudformation_service.py
+++ b/prowler/providers/aws/services/cloudformation/cloudformation_service.py
@@ -6,17 +6,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## CloudFormation
-class CloudFormation:
+class CloudFormation(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "cloudformation"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.stacks = []
         self.__threading_call__(self.__describe_stacks__)
         self.__describe_stack__()

--- a/prowler/providers/aws/services/cloudfront/cloudfront_service.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_service.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## CloudFront
-class CloudFront(AWS_Service):
+class CloudFront(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info, global_service=True)
         self.distributions = {}
         self.__list_distributions__(self.client, self.region)

--- a/prowler/providers/aws/services/cloudfront/cloudfront_service.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_service.py
@@ -18,9 +18,6 @@ class CloudFront(AWS_Service):
         self.__get_distribution_config__(self.client, self.distributions, self.region)
         self.__list_tags_for_resource__(self.client, self.distributions, self.region)
 
-    def __get_session__(self):
-        return self.session
-
     def __list_distributions__(self, client, region) -> dict:
         logger.info("CloudFront - Listing Distributions...")
         try:

--- a/prowler/providers/aws/services/cloudfront/cloudfront_service.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_service.py
@@ -5,23 +5,17 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## CloudFront
-class CloudFront:
+class CloudFront(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "cloudfront"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        global_client = generate_regional_clients(
-            self.service, audit_info, global_service=True
-        )
+        global_service = True
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info, global_service)
         self.distributions = {}
-        if global_client:
-            self.client = list(global_client.values())[0]
-            self.region = self.client.region
+        if global_service:
             self.__list_distributions__(self.client, self.region)
             self.__get_distribution_config__(
                 self.client, self.distributions, self.region

--- a/prowler/providers/aws/services/cloudfront/cloudfront_service.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_service.py
@@ -11,18 +11,12 @@ from prowler.providers.aws.lib.service.service import AWS_Service
 ################## CloudFront
 class CloudFront(AWS_Service):
     def __init__(self, audit_info):
-        global_service = True
         # Call AWS_Service's __init__
-        super().__init__(__class__.__name__, audit_info, global_service)
+        super().__init__(__class__.__name__, audit_info, global_service=True)
         self.distributions = {}
-        if global_service:
-            self.__list_distributions__(self.client, self.region)
-            self.__get_distribution_config__(
-                self.client, self.distributions, self.region
-            )
-            self.__list_tags_for_resource__(
-                self.client, self.distributions, self.region
-            )
+        self.__list_distributions__(self.client, self.region)
+        self.__get_distribution_config__(self.client, self.distributions, self.region)
+        self.__list_tags_for_resource__(self.client, self.distributions, self.region)
 
     def __get_session__(self):
         return self.session

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -7,23 +7,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import (
-    generate_regional_clients,
-    get_default_region,
-)
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################### CLOUDTRAIL
-class Cloudtrail:
+class Cloudtrail(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "cloudtrail"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account_arn = audit_info.audited_account_arn
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.trails = []
         self.__threading_call__(self.__get_trails__)
         self.__get_trail_status__()

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -1,4 +1,3 @@
-import threading
 from datetime import datetime
 from typing import Optional
 
@@ -21,18 +20,6 @@ class Cloudtrail(AWS_Service):
         self.__get_insight_selectors__()
         self.__get_event_selectors__()
         self.__list_tags_for_resource__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __get_trails__(self, regional_client):
         logger.info("Cloudtrail - Getting trails...")

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -6,13 +6,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################### CLOUDTRAIL
-class Cloudtrail(AWS_Service):
+class Cloudtrail(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.trails = []
         self.__threading_call__(self.__get_trails__)

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_cross_account_sharing_disabled/cloudwatch_cross_account_sharing_disabled.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_cross_account_sharing_disabled/cloudwatch_cross_account_sharing_disabled.py
@@ -8,8 +8,8 @@ class cloudwatch_cross_account_sharing_disabled(Check):
         report = Check_Report_AWS(self.metadata())
         report.status = "PASS"
         report.status_extended = "CloudWatch doesn't allow cross-account sharing"
-        report.resource_arn = iam_client.account_arn
-        report.resource_id = iam_client.account
+        report.resource_arn = iam_client.audited_account_arn
+        report.resource_id = iam_client.audited_account
         report.region = iam_client.region
         for role in iam_client.roles:
             if role.name == "CloudWatch-CrossAccountSharingRole":

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
@@ -7,23 +7,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## CloudWatch
-class CloudWatch:
+class CloudWatch(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "cloudwatch"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.audited_partition = audit_info.audited_partition
-        self.region = list(
-            generate_regional_clients(
-                self.service, audit_info, global_service=True
-            ).keys()
-        )[0]
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.metric_alarms = []
         self.__threading_call__(self.__describe_alarms__)
         self.__list_tags_for_resource__()
@@ -85,14 +76,10 @@ class CloudWatch:
 
 
 ################## CloudWatch Logs
-class Logs:
+class Logs(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "logs"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.metric_filters = []
         self.log_groups = []
         self.__threading_call__(self.__describe_metric_filters__)

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
@@ -6,13 +6,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## CloudWatch
-class CloudWatch(AWS_Service):
+class CloudWatch(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.metric_alarms = []
         self.__threading_call__(self.__describe_alarms__)
@@ -63,9 +63,9 @@ class CloudWatch(AWS_Service):
 
 
 ################## CloudWatch Logs
-class Logs(AWS_Service):
+class Logs(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.metric_filters = []
         self.log_groups = []

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
@@ -1,4 +1,3 @@
-import threading
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -18,18 +17,6 @@ class CloudWatch(AWS_Service):
         self.metric_alarms = []
         self.__threading_call__(self.__describe_alarms__)
         self.__list_tags_for_resource__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_alarms__(self, regional_client):
         logger.info("CloudWatch - Describing alarms...")
@@ -93,18 +80,6 @@ class Logs(AWS_Service):
             )
             self.__threading_call__(self.__get_log_events__)
         self.__list_tags_for_resource__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_metric_filters__(self, regional_client):
         logger.info("CloudWatch Logs - Describing metric filters...")

--- a/prowler/providers/aws/services/codeartifact/codeartifact_service.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_service.py
@@ -6,13 +6,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## CodeArtifact
-class CodeArtifact(AWS_Service):
+class CodeArtifact(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         # repositories is a dictionary containing all the codeartifact service information
         self.repositories = {}

--- a/prowler/providers/aws/services/codeartifact/codeartifact_service.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_service.py
@@ -1,4 +1,3 @@
-import threading
 from enum import Enum
 from typing import Optional
 
@@ -20,18 +19,6 @@ class CodeArtifact(AWS_Service):
         self.__threading_call__(self.__list_repositories__)
         self.__threading_call__(self.__list_packages__)
         self.__list_tags_for_resource__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_repositories__(self, regional_client):
         logger.info("CodeArtifact - Listing Repositories...")

--- a/prowler/providers/aws/services/codeartifact/codeartifact_service.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_service.py
@@ -7,17 +7,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## CodeArtifact
-class CodeArtifact:
+class CodeArtifact(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "codeartifact"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         # repositories is a dictionary containing all the codeartifact service information
         self.repositories = {}
         self.__threading_call__(self.__list_repositories__)

--- a/prowler/providers/aws/services/codebuild/codebuild_service.py
+++ b/prowler/providers/aws/services/codebuild/codebuild_service.py
@@ -4,13 +4,13 @@ from typing import Optional
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################### Codebuild
-class Codebuild(AWS_Service):
+class Codebuild(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.projects = []
         self.__threading_call__(self.__list_projects__)

--- a/prowler/providers/aws/services/codebuild/codebuild_service.py
+++ b/prowler/providers/aws/services/codebuild/codebuild_service.py
@@ -5,18 +5,14 @@ from typing import Optional
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################### Codebuild
-class Codebuild:
+class Codebuild(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "codebuild"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.projects = []
         self.__threading_call__(self.__list_projects__)
         self.__list_builds_for_project__()

--- a/prowler/providers/aws/services/codebuild/codebuild_service.py
+++ b/prowler/providers/aws/services/codebuild/codebuild_service.py
@@ -1,5 +1,4 @@
 import datetime
-import threading
 from dataclasses import dataclass
 from typing import Optional
 
@@ -16,18 +15,6 @@ class Codebuild(AWS_Service):
         self.projects = []
         self.__threading_call__(self.__list_projects__)
         self.__list_builds_for_project__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_projects__(self, regional_client):
         logger.info("Codebuild - listing projects")

--- a/prowler/providers/aws/services/config/config_service.py
+++ b/prowler/providers/aws/services/config/config_service.py
@@ -5,19 +5,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## Config
-class Config:
+class Config(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "config"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account_arn = audit_info.audited_account_arn
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.recorders = []
         self.__threading_call__(self.__describe_configuration_recorder_status__)
 

--- a/prowler/providers/aws/services/config/config_service.py
+++ b/prowler/providers/aws/services/config/config_service.py
@@ -4,13 +4,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## Config
-class Config(AWS_Service):
+class Config(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.recorders = []
         self.__threading_call__(self.__describe_configuration_recorder_status__)

--- a/prowler/providers/aws/services/config/config_service.py
+++ b/prowler/providers/aws/services/config/config_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from pydantic import BaseModel
@@ -15,18 +14,6 @@ class Config(AWS_Service):
         super().__init__(__class__.__name__, audit_info)
         self.recorders = []
         self.__threading_call__(self.__describe_configuration_recorder_status__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_configuration_recorder_status__(self, regional_client):
         logger.info("Config - Listing Recorders...")

--- a/prowler/providers/aws/services/directoryservice/directoryservice_service.py
+++ b/prowler/providers/aws/services/directoryservice/directoryservice_service.py
@@ -8,17 +8,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## DirectoryService
-class DirectoryService:
+class DirectoryService(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "ds"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__("ds", audit_info)
         self.directories = {}
         self.__threading_call__(self.__describe_directories__)
         self.__threading_call__(self.__list_log_subscriptions__)

--- a/prowler/providers/aws/services/directoryservice/directoryservice_service.py
+++ b/prowler/providers/aws/services/directoryservice/directoryservice_service.py
@@ -1,4 +1,3 @@
-import threading
 from datetime import datetime
 from enum import Enum
 from typing import Optional, Union
@@ -23,18 +22,6 @@ class DirectoryService(AWS_Service):
         self.__threading_call__(self.__list_certificates__)
         self.__threading_call__(self.__get_snapshot_limits__)
         self.__list_tags_for_resource__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_directories__(self, regional_client):
         logger.info("DirectoryService - Describing Directories...")

--- a/prowler/providers/aws/services/directoryservice/directoryservice_service.py
+++ b/prowler/providers/aws/services/directoryservice/directoryservice_service.py
@@ -7,13 +7,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## DirectoryService
-class DirectoryService(AWS_Service):
+class DirectoryService(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__("ds", audit_info)
         self.directories = {}
         self.__threading_call__(self.__describe_directories__)

--- a/prowler/providers/aws/services/drs/drs_service.py
+++ b/prowler/providers/aws/services/drs/drs_service.py
@@ -1,5 +1,3 @@
-import threading
-
 from botocore.client import ClientError
 from pydantic import BaseModel
 
@@ -15,18 +13,6 @@ class DRS(AWS_Service):
         super().__init__(__class__.__name__, audit_info)
         self.drs_services = []
         self.__threading_call__(self.__describe_jobs__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_jobs__(self, regional_client):
         logger.info("DRS - Describe Jobs...")

--- a/prowler/providers/aws/services/drs/drs_service.py
+++ b/prowler/providers/aws/services/drs/drs_service.py
@@ -3,13 +3,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## DRS (Elastic Disaster Recovery Service)
-class DRS(AWS_Service):
+class DRS(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.drs_services = []
         self.__threading_call__(self.__describe_jobs__)

--- a/prowler/providers/aws/services/drs/drs_service.py
+++ b/prowler/providers/aws/services/drs/drs_service.py
@@ -5,24 +5,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import (
-    generate_regional_clients,
-    get_default_region,
-)
+from prowler.providers.aws.lib.service.service import AWS_Service
+
 
 ################## DRS (Elastic Disaster Recovery Service)
-
-
-class DRS:
+class DRS(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "drs"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account_arn = audit_info.audited_account_arn
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.drs_services = []
         self.__threading_call__(self.__describe_jobs__)
 

--- a/prowler/providers/aws/services/dynamodb/dynamodb_service.py
+++ b/prowler/providers/aws/services/dynamodb/dynamodb_service.py
@@ -6,18 +6,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## DynamoDB
-class DynamoDB:
+class DynamoDB(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "dynamodb"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.audited_partition = audit_info.audited_partition
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.tables = []
         self.__threading_call__(self.__list_tables__)
         self.__describe_table__()
@@ -126,13 +122,10 @@ class DynamoDB:
 
 
 ################## DynamoDB DAX
-class DAX:
+class DAX(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "dax"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.clusters = []
         self.__threading_call__(self.__describe_clusters__)
         self.__list_tags_for_resource__()

--- a/prowler/providers/aws/services/dynamodb/dynamodb_service.py
+++ b/prowler/providers/aws/services/dynamodb/dynamodb_service.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## DynamoDB
-class DynamoDB(AWS_Service):
+class DynamoDB(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.tables = []
         self.__threading_call__(self.__list_tables__)
@@ -109,9 +109,9 @@ class DynamoDB(AWS_Service):
 
 
 ################## DynamoDB DAX
-class DAX(AWS_Service):
+class DAX(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.clusters = []
         self.__threading_call__(self.__describe_clusters__)

--- a/prowler/providers/aws/services/dynamodb/dynamodb_service.py
+++ b/prowler/providers/aws/services/dynamodb/dynamodb_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from botocore.client import ClientError
@@ -19,18 +18,6 @@ class DynamoDB(AWS_Service):
         self.__describe_table__()
         self.__describe_continuous_backups__()
         self.__list_tags_for_resource__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_tables__(self, regional_client):
         logger.info("DynamoDB - Listing tables...")
@@ -129,18 +116,6 @@ class DAX(AWS_Service):
         self.clusters = []
         self.__threading_call__(self.__describe_clusters__)
         self.__list_tags_for_resource__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_clusters__(self, regional_client):
         logger.info("DynamoDB DAX - Describing clusters...")

--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -6,14 +6,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
 
 
 ################## EC2
-class EC2(AWS_Service):
+class EC2(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.instances = []
         self.__threading_call__(self.__describe_instances__)

--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -1,4 +1,3 @@
-import threading
 from datetime import datetime
 from typing import Optional
 
@@ -37,18 +36,6 @@ class EC2(AWS_Service):
         self.__threading_call__(self.__get_ebs_encryption_by_default__)
         self.elastic_ips = []
         self.__threading_call__(self.__describe_addresses__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_instances__(self, regional_client):
         logger.info("EC2 - Describing EC2 Instances...")

--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -7,21 +7,15 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
 
 
 ################## EC2
-class EC2:
+class EC2(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "ec2"
-        self.session = audit_info.audit_session
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account = audit_info.audited_account
-        self.audited_account_arn = audit_info.audited_account_arn
-        self.audit_resources = audit_info.audit_resources
-        self.audited_checks = audit_info.audit_metadata.expected_checks
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.instances = []
         self.__threading_call__(self.__describe_instances__)
         self.__get_instance_user_data__()

--- a/prowler/providers/aws/services/ecr/ecr_service.py
+++ b/prowler/providers/aws/services/ecr/ecr_service.py
@@ -1,4 +1,3 @@
-import threading
 from datetime import datetime
 from json import loads
 from typing import Optional
@@ -24,18 +23,6 @@ class ECR(AWS_Service):
         self.__threading_call__(self.__get_repository_lifecycle_policy__)
         self.__threading_call__(self.__get_registry_scanning_configuration__)
         self.__threading_call__(self.__list_tags_for_resource__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_registries_and_repositories__(self, regional_client):
         logger.info("ECR - Describing registries and repositories...")

--- a/prowler/providers/aws/services/ecr/ecr_service.py
+++ b/prowler/providers/aws/services/ecr/ecr_service.py
@@ -8,16 +8,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################################ ECR
-class ECR:
+class ECR(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "ecr"
-        self.session = audit_info.audit_session
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.registry_id = audit_info.audited_account
         self.registries = {}
         self.__threading_call__(self.__describe_registries_and_repositories__)

--- a/prowler/providers/aws/services/ecr/ecr_service.py
+++ b/prowler/providers/aws/services/ecr/ecr_service.py
@@ -7,13 +7,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################################ ECR
-class ECR(AWS_Service):
+class ECR(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.registry_id = audit_info.audited_account
         self.registries = {}

--- a/prowler/providers/aws/services/ecs/ecs_service.py
+++ b/prowler/providers/aws/services/ecs/ecs_service.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################################ ECS
-class ECS(AWS_Service):
+class ECS(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.task_definitions = []
         self.__threading_call__(self.__list_task_definitions__)

--- a/prowler/providers/aws/services/ecs/ecs_service.py
+++ b/prowler/providers/aws/services/ecs/ecs_service.py
@@ -1,4 +1,3 @@
-import threading
 from re import sub
 from typing import Optional
 
@@ -17,18 +16,6 @@ class ECS(AWS_Service):
         self.task_definitions = []
         self.__threading_call__(self.__list_task_definitions__)
         self.__describe_task_definition__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_task_definitions__(self, regional_client):
         logger.info("ECS - Listing Task Definitions...")

--- a/prowler/providers/aws/services/ecs/ecs_service.py
+++ b/prowler/providers/aws/services/ecs/ecs_service.py
@@ -6,16 +6,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################################ ECS
-class ECS:
+class ECS(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "ecs"
-        self.session = audit_info.audit_session
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.task_definitions = []
         self.__threading_call__(self.__list_task_definitions__)
         self.__describe_task_definition__()

--- a/prowler/providers/aws/services/efs/efs_service.py
+++ b/prowler/providers/aws/services/efs/efs_service.py
@@ -6,13 +6,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################### EFS
-class EFS(AWS_Service):
+class EFS(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.filesystems = []
         self.__threading_call__(self.__describe_file_systems__)

--- a/prowler/providers/aws/services/efs/efs_service.py
+++ b/prowler/providers/aws/services/efs/efs_service.py
@@ -7,18 +7,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################### EFS
-class EFS:
+class EFS(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "efs"
-        self.session = audit_info.audit_session
-        self.audit_resources = audit_info.audit_resources
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.filesystems = []
         self.__threading_call__(self.__describe_file_systems__)
         self.__describe_file_system_policies__()

--- a/prowler/providers/aws/services/efs/efs_service.py
+++ b/prowler/providers/aws/services/efs/efs_service.py
@@ -1,5 +1,4 @@
 import json
-import threading
 from typing import Optional
 
 from botocore.client import ClientError
@@ -18,18 +17,6 @@ class EFS(AWS_Service):
         self.filesystems = []
         self.__threading_call__(self.__describe_file_systems__)
         self.__describe_file_system_policies__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_file_systems__(self, regional_client):
         logger.info("EFS - Describing file systems...")

--- a/prowler/providers/aws/services/eks/eks_service.py
+++ b/prowler/providers/aws/services/eks/eks_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from pydantic import BaseModel
@@ -18,18 +17,6 @@ class EKS(AWS_Service):
         self.clusters = []
         self.__threading_call__(self.__list_clusters__)
         self.__describe_cluster__(self.regional_clients)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_clusters__(self, regional_client):
         logger.info("EKS listing clusters...")

--- a/prowler/providers/aws/services/eks/eks_service.py
+++ b/prowler/providers/aws/services/eks/eks_service.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
 from prowler.providers.aws.aws_provider import generate_regional_clients
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################################ EKS
-class EKS(AWS_Service):
+class EKS(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.regional_clients = generate_regional_clients(self.service, audit_info)
         self.clusters = []

--- a/prowler/providers/aws/services/eks/eks_service.py
+++ b/prowler/providers/aws/services/eks/eks_service.py
@@ -6,16 +6,14 @@ from pydantic import BaseModel
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
 from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################################ EKS
-class EKS:
+class EKS(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "eks"
-        self.session = audit_info.audit_session
-        self.audit_resources = audit_info.audit_resources
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account = audit_info.audited_account
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.regional_clients = generate_regional_clients(self.service, audit_info)
         self.clusters = []
         self.__threading_call__(self.__list_clusters__)

--- a/prowler/providers/aws/services/elb/elb_service.py
+++ b/prowler/providers/aws/services/elb/elb_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from pydantic import BaseModel
@@ -17,18 +16,6 @@ class ELB(AWS_Service):
         self.__threading_call__(self.__describe_load_balancers__)
         self.__threading_call__(self.__describe_load_balancer_attributes__)
         self.__describe_tags__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_load_balancers__(self, regional_client):
         logger.info("ELB - Describing load balancers...")

--- a/prowler/providers/aws/services/elb/elb_service.py
+++ b/prowler/providers/aws/services/elb/elb_service.py
@@ -5,18 +5,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################### ELB
-class ELB:
+class ELB(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "elb"
-        self.session = audit_info.audit_session
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.loadbalancers = []
         self.__threading_call__(self.__describe_load_balancers__)
         self.__threading_call__(self.__describe_load_balancer_attributes__)

--- a/prowler/providers/aws/services/elb/elb_service.py
+++ b/prowler/providers/aws/services/elb/elb_service.py
@@ -4,13 +4,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################### ELB
-class ELB(AWS_Service):
+class ELB(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.loadbalancers = []
         self.__threading_call__(self.__describe_load_balancers__)

--- a/prowler/providers/aws/services/elbv2/elbv2_service.py
+++ b/prowler/providers/aws/services/elbv2/elbv2_service.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################### ELBv2
-class ELBv2(AWS_Service):
+class ELBv2(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.loadbalancersv2 = []
         self.__threading_call__(self.__describe_load_balancers__)

--- a/prowler/providers/aws/services/elbv2/elbv2_service.py
+++ b/prowler/providers/aws/services/elbv2/elbv2_service.py
@@ -6,16 +6,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################### ELBv2
-class ELBv2:
+class ELBv2(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "elbv2"
-        self.session = audit_info.audit_session
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.loadbalancersv2 = []
         self.__threading_call__(self.__describe_load_balancers__)
         self.listeners = []

--- a/prowler/providers/aws/services/elbv2/elbv2_service.py
+++ b/prowler/providers/aws/services/elbv2/elbv2_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from botocore.client import ClientError
@@ -21,18 +20,6 @@ class ELBv2(AWS_Service):
         self.__threading_call__(self.__describe_load_balancer_attributes__)
         self.__threading_call__(self.__describe_rules__)
         self.__describe_tags__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_load_balancers__(self, regional_client):
         logger.info("ELBv2 - Describing load balancers...")

--- a/prowler/providers/aws/services/emr/emr_service.py
+++ b/prowler/providers/aws/services/emr/emr_service.py
@@ -1,4 +1,3 @@
-import threading
 from enum import Enum
 from typing import Optional
 
@@ -20,18 +19,6 @@ class EMR(AWS_Service):
         self.__threading_call__(self.__list_clusters__)
         self.__threading_call__(self.__describe_cluster__)
         self.__threading_call__(self.__get_block_public_access_configuration__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_clusters__(self, regional_client):
         logger.info("EMR - Listing Clusters...")

--- a/prowler/providers/aws/services/emr/emr_service.py
+++ b/prowler/providers/aws/services/emr/emr_service.py
@@ -6,13 +6,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## EMR
-class EMR(AWS_Service):
+class EMR(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.clusters = {}
         self.block_public_access_configuration = {}

--- a/prowler/providers/aws/services/emr/emr_service.py
+++ b/prowler/providers/aws/services/emr/emr_service.py
@@ -7,19 +7,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## EMR
-class EMR:
+class EMR(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "emr"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account_arn = audit_info.audited_account_arn
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.clusters = {}
         self.block_public_access_configuration = {}
         self.__threading_call__(self.__list_clusters__)

--- a/prowler/providers/aws/services/fms/fms_service.py
+++ b/prowler/providers/aws/services/fms/fms_service.py
@@ -3,23 +3,16 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
+
+# from prowler.providers.aws.aws_provider import generate_regional_clients
 
 
 ################## FMS
-class FMS:
+class FMS(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "fms"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account_arn = audit_info.audited_account_arn
-        self.audit_resources = audit_info.audit_resources
-        global_client = generate_regional_clients(
-            self.service, audit_info, global_service=True
-        )
-        self.client = list(global_client.values())[0]
-        self.region = self.client.region
+        # # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info, global_service=True)
         self.fms_admin_account = True
         self.fms_policies = []
         self.__list_policies__()

--- a/prowler/providers/aws/services/fms/fms_service.py
+++ b/prowler/providers/aws/services/fms/fms_service.py
@@ -3,15 +3,15 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 # from prowler.providers.aws.aws_provider import generate_regional_clients
 
 
 ################## FMS
-class FMS(AWS_Service):
+class FMS(AWSService):
     def __init__(self, audit_info):
-        # # Call AWS_Service's __init__
+        # # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info, global_service=True)
         self.fms_admin_account = True
         self.fms_policies = []

--- a/prowler/providers/aws/services/glacier/glacier_service.py
+++ b/prowler/providers/aws/services/glacier/glacier_service.py
@@ -6,13 +6,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## Glacier
-class Glacier(AWS_Service):
+class Glacier(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.vaults = {}
         self.__threading_call__(self.__list_vaults__)

--- a/prowler/providers/aws/services/glacier/glacier_service.py
+++ b/prowler/providers/aws/services/glacier/glacier_service.py
@@ -7,17 +7,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## Glacier
-class Glacier:
+class Glacier(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "glacier"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.vaults = {}
         self.__threading_call__(self.__list_vaults__)
         self.__threading_call__(self.__get_vault_access_policy__)

--- a/prowler/providers/aws/services/glacier/glacier_service.py
+++ b/prowler/providers/aws/services/glacier/glacier_service.py
@@ -1,5 +1,4 @@
 import json
-import threading
 from typing import Optional
 
 from botocore.client import ClientError
@@ -19,18 +18,6 @@ class Glacier(AWS_Service):
         self.__threading_call__(self.__list_vaults__)
         self.__threading_call__(self.__get_vault_access_policy__)
         self.__list_tags_for_vault__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_vaults__(self, regional_client):
         logger.info("Glacier - Listing Vaults...")

--- a/prowler/providers/aws/services/globalaccelerator/globalaccelerator_service.py
+++ b/prowler/providers/aws/services/globalaccelerator/globalaccelerator_service.py
@@ -2,15 +2,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################### GlobalAccelerator
-class GlobalAccelerator:
+class GlobalAccelerator(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "globalaccelerator"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.accelerators = {}
         if audit_info.audited_partition == "aws":
             # Global Accelerator is a global service that supports endpoints in multiple AWS Regions

--- a/prowler/providers/aws/services/globalaccelerator/globalaccelerator_service.py
+++ b/prowler/providers/aws/services/globalaccelerator/globalaccelerator_service.py
@@ -19,9 +19,6 @@ class GlobalAccelerator(AWS_Service):
             self.client = self.session.client(self.service, self.region)
             self.__list_accelerators__()
 
-    def __get_session__(self):
-        return self.session
-
     def __list_accelerators__(self):
         logger.info("GlobalAccelerator - Listing Accelerators...")
         try:

--- a/prowler/providers/aws/services/globalaccelerator/globalaccelerator_service.py
+++ b/prowler/providers/aws/services/globalaccelerator/globalaccelerator_service.py
@@ -2,13 +2,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################### GlobalAccelerator
-class GlobalAccelerator(AWS_Service):
+class GlobalAccelerator(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.accelerators = {}
         if audit_info.audited_partition == "aws":

--- a/prowler/providers/aws/services/glue/glue_service.py
+++ b/prowler/providers/aws/services/glue/glue_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from pydantic import BaseModel
@@ -25,18 +24,6 @@ class Glue(AWS_Service):
         self.__threading_call__(self.__get_security_configurations__)
         self.jobs = []
         self.__threading_call__(self.__get_jobs__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __get_connections__(self, regional_client):
         logger.info("Glue - Getting connections...")

--- a/prowler/providers/aws/services/glue/glue_service.py
+++ b/prowler/providers/aws/services/glue/glue_service.py
@@ -5,19 +5,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## Glue
-class Glue:
+class Glue(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "glue"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account_arn = audit_info.audited_account_arn
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.connections = []
         self.__threading_call__(self.__get_connections__)
         self.tables = []

--- a/prowler/providers/aws/services/glue/glue_service.py
+++ b/prowler/providers/aws/services/glue/glue_service.py
@@ -4,13 +4,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## Glue
-class Glue(AWS_Service):
+class Glue(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.connections = []
         self.__threading_call__(self.__get_connections__)

--- a/prowler/providers/aws/services/guardduty/guardduty_service.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from pydantic import BaseModel
@@ -20,18 +19,6 @@ class GuardDuty(AWS_Service):
         self.__list_members__()
         self.__get_administrator_account__()
         self.__list_tags_for_resource__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_detectors__(self, regional_client):
         logger.info("GuardDuty - listing detectors...")

--- a/prowler/providers/aws/services/guardduty/guardduty_service.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_service.py
@@ -5,18 +5,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################################ GuardDuty
-class GuardDuty:
+class GuardDuty(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "guardduty"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.audited_partition = audit_info.audited_partition
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.detectors = []
         self.__threading_call__(self.__list_detectors__)
         self.__get_detector__()

--- a/prowler/providers/aws/services/guardduty/guardduty_service.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_service.py
@@ -4,13 +4,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################################ GuardDuty
-class GuardDuty(AWS_Service):
+class GuardDuty(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.detectors = []
         self.__threading_call__(self.__list_detectors__)

--- a/prowler/providers/aws/services/iam/iam_password_policy_expires_passwords_within_90_days_or_less/iam_password_policy_expires_passwords_within_90_days_or_less.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_expires_passwords_within_90_days_or_less/iam_password_policy_expires_passwords_within_90_days_or_less.py
@@ -7,8 +7,8 @@ class iam_password_policy_expires_passwords_within_90_days_or_less(Check):
         findings = []
         report = Check_Report_AWS(self.metadata())
         report.region = iam_client.region
-        report.resource_arn = iam_client.account_arn
-        report.resource_id = iam_client.account
+        report.resource_arn = iam_client.audited_account_arn
+        report.resource_id = iam_client.audited_account
         # Check if password policy exists
         if iam_client.password_policy:
             # Check if password policy expiration exists

--- a/prowler/providers/aws/services/iam/iam_password_policy_lowercase/iam_password_policy_lowercase.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_lowercase/iam_password_policy_lowercase.py
@@ -7,8 +7,8 @@ class iam_password_policy_lowercase(Check):
         findings = []
         report = Check_Report_AWS(self.metadata())
         report.region = iam_client.region
-        report.resource_arn = iam_client.account_arn
-        report.resource_id = iam_client.account
+        report.resource_arn = iam_client.audited_account_arn
+        report.resource_id = iam_client.audited_account
         # Check if password policy exists
         if iam_client.password_policy:
             # Check if lowercase flag is set

--- a/prowler/providers/aws/services/iam/iam_password_policy_minimum_length_14/iam_password_policy_minimum_length_14.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_minimum_length_14/iam_password_policy_minimum_length_14.py
@@ -7,8 +7,8 @@ class iam_password_policy_minimum_length_14(Check):
         findings = []
         report = Check_Report_AWS(self.metadata())
         report.region = iam_client.region
-        report.resource_arn = iam_client.account_arn
-        report.resource_id = iam_client.account
+        report.resource_arn = iam_client.audited_account_arn
+        report.resource_id = iam_client.audited_account
         # Check if password policy exists
         if iam_client.password_policy:
             # Check password policy length

--- a/prowler/providers/aws/services/iam/iam_password_policy_number/iam_password_policy_number.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_number/iam_password_policy_number.py
@@ -7,8 +7,8 @@ class iam_password_policy_number(Check):
         findings = []
         report = Check_Report_AWS(self.metadata())
         report.region = iam_client.region
-        report.resource_arn = iam_client.account_arn
-        report.resource_id = iam_client.account
+        report.resource_arn = iam_client.audited_account_arn
+        report.resource_id = iam_client.audited_account
         # Check if password policy exists
         if iam_client.password_policy:
             # Check if number flag is set

--- a/prowler/providers/aws/services/iam/iam_password_policy_reuse_24/iam_password_policy_reuse_24.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_reuse_24/iam_password_policy_reuse_24.py
@@ -7,8 +7,8 @@ class iam_password_policy_reuse_24(Check):
         findings = []
         report = Check_Report_AWS(self.metadata())
         report.region = iam_client.region
-        report.resource_arn = iam_client.account_arn
-        report.resource_id = iam_client.account
+        report.resource_arn = iam_client.audited_account_arn
+        report.resource_id = iam_client.audited_account
         # Check if password policy exists
         if iam_client.password_policy:
             # Check if reuse prevention flag is set

--- a/prowler/providers/aws/services/iam/iam_password_policy_symbol/iam_password_policy_symbol.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_symbol/iam_password_policy_symbol.py
@@ -7,8 +7,8 @@ class iam_password_policy_symbol(Check):
         findings = []
         report = Check_Report_AWS(self.metadata())
         report.region = iam_client.region
-        report.resource_arn = iam_client.account_arn
-        report.resource_id = iam_client.account
+        report.resource_arn = iam_client.audited_account_arn
+        report.resource_id = iam_client.audited_account
         # Check if password policy exists
         if iam_client.password_policy:
             # Check if symbol flag is set

--- a/prowler/providers/aws/services/iam/iam_password_policy_uppercase/iam_password_policy_uppercase.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_uppercase/iam_password_policy_uppercase.py
@@ -7,8 +7,8 @@ class iam_password_policy_uppercase(Check):
         findings = []
         report = Check_Report_AWS(self.metadata())
         report.region = iam_client.region
-        report.resource_arn = iam_client.account_arn
-        report.resource_id = iam_client.account
+        report.resource_arn = iam_client.audited_account_arn
+        report.resource_id = iam_client.audited_account
         # Check if password policy exists
         if iam_client.password_policy:
             # Check if uppercase flag is set

--- a/prowler/providers/aws/services/iam/iam_role_cross_account_readonlyaccess_policy/iam_role_cross_account_readonlyaccess_policy.py
+++ b/prowler/providers/aws/services/iam/iam_role_cross_account_readonlyaccess_policy/iam_role_cross_account_readonlyaccess_policy.py
@@ -34,7 +34,7 @@ class iam_role_cross_account_readonlyaccess_policy(Check):
                                                 "AWS"
                                             ]:
                                                 if (
-                                                    iam_client.account
+                                                    iam_client.audited_account
                                                     not in aws_account
                                                     or "*" == aws_account
                                                 ):
@@ -42,7 +42,7 @@ class iam_role_cross_account_readonlyaccess_policy(Check):
                                                     break
                                         else:
                                             if (
-                                                iam_client.account
+                                                iam_client.audited_account
                                                 not in statement["Principal"]["AWS"]
                                                 or "*" == statement["Principal"]["AWS"]
                                             ):
@@ -58,14 +58,15 @@ class iam_role_cross_account_readonlyaccess_policy(Check):
                                 if type(statement["Principal"]["AWS"]) == list:
                                     for aws_account in statement["Principal"]["AWS"]:
                                         if (
-                                            iam_client.account not in aws_account
+                                            iam_client.audited_account
+                                            not in aws_account
                                             or "*" == aws_account
                                         ):
                                             cross_account_access = True
                                             break
                                 else:
                                     if (
-                                        iam_client.account
+                                        iam_client.audited_account
                                         not in statement["Principal"]["AWS"]
                                         or "*" == statement["Principal"]["AWS"]
                                     ):

--- a/prowler/providers/aws/services/iam/iam_role_cross_service_confused_deputy_prevention/iam_role_cross_service_confused_deputy_prevention.py
+++ b/prowler/providers/aws/services/iam/iam_role_cross_service_confused_deputy_prevention/iam_role_cross_service_confused_deputy_prevention.py
@@ -32,7 +32,7 @@ class iam_role_cross_service_confused_deputy_prevention(Check):
                                 "StringEquals" in statement["Condition"]
                                 and "aws:SourceAccount"
                                 in statement["Condition"]["StringEquals"]
-                                and iam_client.account
+                                and iam_client.audited_account
                                 in str(
                                     statement["Condition"]["StringEquals"][
                                         "aws:SourceAccount"
@@ -43,7 +43,7 @@ class iam_role_cross_service_confused_deputy_prevention(Check):
                                 "StringLike" in statement["Condition"]
                                 and "aws:SourceAccount"
                                 in statement["Condition"]["StringLike"]
-                                and iam_client.account
+                                and iam_client.audited_account
                                 in str(
                                     statement["Condition"]["StringLike"][
                                         "aws:SourceAccount"
@@ -54,7 +54,7 @@ class iam_role_cross_service_confused_deputy_prevention(Check):
                                 "ArnEquals" in statement["Condition"]
                                 and "aws:SourceArn"
                                 in statement["Condition"]["ArnEquals"]
-                                and iam_client.account
+                                and iam_client.audited_account
                                 in str(
                                     statement["Condition"]["ArnEquals"]["aws:SourceArn"]
                                 )
@@ -62,7 +62,7 @@ class iam_role_cross_service_confused_deputy_prevention(Check):
                             or (
                                 "ArnLike" in statement["Condition"]
                                 and "aws:SourceArn" in statement["Condition"]["ArnLike"]
-                                and iam_client.account
+                                and iam_client.audited_account
                                 in str(
                                     statement["Condition"]["ArnLike"]["aws:SourceArn"]
                                 )

--- a/prowler/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.py
+++ b/prowler/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.py
@@ -6,13 +6,13 @@ class iam_root_hardware_mfa_enabled(Check):
     def execute(self) -> Check_Report_AWS:
         findings = []
         # This check is only avaible in Commercial Partition
-        if iam_client.partition == "aws":
+        if iam_client.audited_partition == "aws":
             if iam_client.account_summary:
                 virtual_mfa = False
                 report = Check_Report_AWS(self.metadata())
                 report.region = iam_client.region
                 report.resource_id = "<root_account>"
-                report.resource_arn = iam_client.account_arn
+                report.resource_arn = iam_client.audited_account_arn
 
                 if iam_client.account_summary["SummaryMap"]["AccountMFAEnabled"] > 0:
                     virtual_mfas = iam_client.virtual_mfa_devices

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 def is_service_role(role):
@@ -47,9 +47,9 @@ def is_service_role(role):
 
 
 ################## IAM
-class IAM(AWS_Service):
+class IAM(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.users = self.__get_users__()
         self.roles = self.__get_roles__()

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -86,9 +86,6 @@ class IAM(AWS_Service):
     def __get_client__(self):
         return self.client
 
-    def __get_session__(self):
-        return self.session
-
     def __get_roles__(self):
         logger.info("IAM - List Roles...")
         try:

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 def is_service_role(role):
@@ -47,20 +47,10 @@ def is_service_role(role):
 
 
 ################## IAM
-class IAM:
+class IAM(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "iam"
-        self.session = audit_info.audit_session
-        self.account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.partition = audit_info.audited_partition
-        self.account_arn = audit_info.audited_account_arn
-        self.client = self.session.client(self.service)
-        global_client = generate_regional_clients(
-            self.service, audit_info, global_service=True
-        )
-        self.client = list(global_client.values())[0]
-        self.region = self.client.region
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.users = self.__get_users__()
         self.roles = self.__get_roles__()
         self.account_summary = self.__get_account_summary__()

--- a/prowler/providers/aws/services/inspector2/inspector2_service.py
+++ b/prowler/providers/aws/services/inspector2/inspector2_service.py
@@ -1,5 +1,3 @@
-import threading
-
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
@@ -15,18 +13,6 @@ class Inspector2(AWS_Service):
         self.inspectors = []
         self.__threading_call__(self.__batch_get_account_status__)
         self.__list_findings__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __batch_get_account_status__(self, regional_client):
         # We use this function to check if inspector2 is enabled

--- a/prowler/providers/aws/services/inspector2/inspector2_service.py
+++ b/prowler/providers/aws/services/inspector2/inspector2_service.py
@@ -4,23 +4,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import (
-    generate_regional_clients,
-    get_default_region,
-)
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################################ Inspector2
-class Inspector2:
+class Inspector2(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "inspector2"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account_arn = audit_info.audited_account_arn
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.inspectors = []
         self.__threading_call__(self.__batch_get_account_status__)
         self.__list_findings__()

--- a/prowler/providers/aws/services/inspector2/inspector2_service.py
+++ b/prowler/providers/aws/services/inspector2/inspector2_service.py
@@ -2,13 +2,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################################ Inspector2
-class Inspector2(AWS_Service):
+class Inspector2(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.inspectors = []
         self.__threading_call__(self.__batch_get_account_status__)

--- a/prowler/providers/aws/services/kms/kms_service.py
+++ b/prowler/providers/aws/services/kms/kms_service.py
@@ -6,17 +6,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## KMS
-class KMS:
+class KMS(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "kms"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.keys = []
         self.__threading_call__(self.__list_keys__)
         if self.keys:

--- a/prowler/providers/aws/services/kms/kms_service.py
+++ b/prowler/providers/aws/services/kms/kms_service.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## KMS
-class KMS(AWS_Service):
+class KMS(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.keys = []
         self.__threading_call__(self.__list_keys__)

--- a/prowler/providers/aws/services/kms/kms_service.py
+++ b/prowler/providers/aws/services/kms/kms_service.py
@@ -1,5 +1,4 @@
 import json
-import threading
 from typing import Optional
 
 from pydantic import BaseModel
@@ -21,18 +20,6 @@ class KMS(AWS_Service):
             self.__get_key_rotation_status__()
             self.__get_key_policy__()
             self.__list_resource_tags__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_keys__(self, regional_client):
         logger.info("KMS - Listing Keys...")

--- a/prowler/providers/aws/services/macie/macie_service.py
+++ b/prowler/providers/aws/services/macie/macie_service.py
@@ -1,5 +1,3 @@
-import threading
-
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
@@ -13,18 +11,6 @@ class Macie(AWS_Service):
         super().__init__("macie2", audit_info)
         self.sessions = []
         self.__threading_call__(self.__get_macie_session__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __get_macie_session__(self, regional_client):
         logger.info("Macie - Get Macie Session...")

--- a/prowler/providers/aws/services/macie/macie_service.py
+++ b/prowler/providers/aws/services/macie/macie_service.py
@@ -1,13 +1,13 @@
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## Macie
-class Macie(AWS_Service):
+class Macie(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__("macie2", audit_info)
         self.sessions = []
         self.__threading_call__(self.__get_macie_session__)

--- a/prowler/providers/aws/services/macie/macie_service.py
+++ b/prowler/providers/aws/services/macie/macie_service.py
@@ -3,18 +3,14 @@ import threading
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## Macie
-class Macie:
+class Macie(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "macie2"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account_arn = audit_info.audited_account_arn
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__("macie2", audit_info)
         self.sessions = []
         self.__threading_call__(self.__get_macie_session__)
 

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
@@ -1,5 +1,3 @@
-import threading
-
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
@@ -15,18 +13,6 @@ class NetworkFirewall(AWS_Service):
         self.network_firewalls = []
         self.__threading_call__(self.__list_firewalls__)
         self.__describe_firewall__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_firewalls__(self, regional_client):
         logger.info("Network Firewall - Listing Network Firewalls...")

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
@@ -2,13 +2,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## NetworkFirewall
-class NetworkFirewall(AWS_Service):
+class NetworkFirewall(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__("network-firewall", audit_info)
         self.network_firewalls = []
         self.__threading_call__(self.__list_firewalls__)

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
@@ -4,22 +4,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import (
-    generate_regional_clients,
-    get_default_region,
-)
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## NetworkFirewall
-class NetworkFirewall:
+class NetworkFirewall(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "network-firewall"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__("network-firewall", audit_info)
         self.network_firewalls = []
         self.__threading_call__(self.__list_firewalls__)
         self.__describe_firewall__()

--- a/prowler/providers/aws/services/opensearch/opensearch_service.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service.py
@@ -6,18 +6,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################################ OpenSearch
-class OpenSearchService:
+class OpenSearchService(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "opensearch"
-        self.session = audit_info.audit_session
-        self.audit_resources = audit_info.audit_resources
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account = audit_info.audited_account
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__("opensearch", audit_info)
         self.opensearch_domains = []
         self.__threading_call__(self.__list_domain_names__)
         self.__describe_domain_config__(self.regional_clients)

--- a/prowler/providers/aws/services/opensearch/opensearch_service.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service.py
@@ -1,4 +1,3 @@
-import threading
 from json import JSONDecodeError, loads
 from typing import Optional
 
@@ -19,18 +18,6 @@ class OpenSearchService(AWS_Service):
         self.__describe_domain_config__(self.regional_clients)
         self.__describe_domain__(self.regional_clients)
         self.__list_tags__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_domain_names__(self, regional_client):
         logger.info("OpenSearch - listing domain names...")

--- a/prowler/providers/aws/services/opensearch/opensearch_service.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################################ OpenSearch
-class OpenSearchService(AWS_Service):
+class OpenSearchService(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__("opensearch", audit_info)
         self.opensearch_domains = []
         self.__threading_call__(self.__list_domain_names__)

--- a/prowler/providers/aws/services/organizations/organizations_service.py
+++ b/prowler/providers/aws/services/organizations/organizations_service.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 available_organizations_policies = [
     "SERVICE_CONTROL_POLICY",
@@ -17,17 +17,10 @@ available_organizations_policies = [
 
 
 ################## Organizations
-class Organizations:
+class Organizations(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "organizations"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        global_client = generate_regional_clients(
-            self.service, audit_info, global_service=True
-        )
-        self.client = list(global_client.values())[0]
-        self.region = self.client.region
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.organizations = []
         self.policies = []
         self.delegated_administrators = []

--- a/prowler/providers/aws/services/organizations/organizations_service.py
+++ b/prowler/providers/aws/services/organizations/organizations_service.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 available_organizations_policies = [
     "SERVICE_CONTROL_POLICY",
@@ -17,9 +17,9 @@ available_organizations_policies = [
 
 
 ################## Organizations
-class Organizations(AWS_Service):
+class Organizations(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.organizations = []
         self.policies = []

--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -6,18 +6,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## RDS
-class RDS:
+class RDS(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "rds"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.db_instances = []
         self.db_clusters = {}
         self.db_snapshots = []

--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## RDS
-class RDS(AWS_Service):
+class RDS(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.db_instances = []
         self.db_clusters = {}

--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from botocore.client import ClientError
@@ -27,18 +26,6 @@ class RDS(AWS_Service):
         self.__threading_call__(self.__describe_db_cluster_snapshots__)
         self.__threading_call__(self.__describe_db_cluster_snapshot_attributes__)
         self.__threading_call__(self.__describe_db_engine_versions__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_db_instances__(self, regional_client):
         logger.info("RDS - Describe Instances...")

--- a/prowler/providers/aws/services/redshift/redshift_service.py
+++ b/prowler/providers/aws/services/redshift/redshift_service.py
@@ -4,13 +4,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################################ Redshift
-class Redshift(AWS_Service):
+class Redshift(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.clusters = []
         self.__threading_call__(self.__describe_clusters__)

--- a/prowler/providers/aws/services/redshift/redshift_service.py
+++ b/prowler/providers/aws/services/redshift/redshift_service.py
@@ -5,18 +5,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################################ Redshift
-class Redshift:
+class Redshift(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "redshift"
-        self.session = audit_info.audit_session
-        self.audit_resources = audit_info.audit_resources
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account = audit_info.audited_account
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.clusters = []
         self.__threading_call__(self.__describe_clusters__)
         self.__describe_logging_status__(self.regional_clients)

--- a/prowler/providers/aws/services/redshift/redshift_service.py
+++ b/prowler/providers/aws/services/redshift/redshift_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from pydantic import BaseModel
@@ -17,18 +16,6 @@ class Redshift(AWS_Service):
         self.__threading_call__(self.__describe_clusters__)
         self.__describe_logging_status__(self.regional_clients)
         self.__describe_cluster_snapshots__(self.regional_clients)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_clusters__(self, regional_client):
         logger.info("Redshift - describing clusters...")

--- a/prowler/providers/aws/services/resourceexplorer2/resourceexplorer2_service.py
+++ b/prowler/providers/aws/services/resourceexplorer2/resourceexplorer2_service.py
@@ -2,13 +2,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################################ ResourceExplorer2
-class ResourceExplorer2(AWS_Service):
+class ResourceExplorer2(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__("resource-explorer-2", audit_info)
         self.indexes = []
         self.__threading_call__(self.__list_indexes__)

--- a/prowler/providers/aws/services/resourceexplorer2/resourceexplorer2_service.py
+++ b/prowler/providers/aws/services/resourceexplorer2/resourceexplorer2_service.py
@@ -4,23 +4,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import (
-    generate_regional_clients,
-    get_default_region,
-)
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################################ ResourceExplorer2
-class ResourceExplorer2:
+class ResourceExplorer2(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "resource-explorer-2"
-        self.session = audit_info.audit_session
-        self.audit_resources = audit_info.audit_resources
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account_arn = audit_info.audited_account_arn
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__("resource-explorer-2", audit_info)
         self.indexes = []
         self.__threading_call__(self.__list_indexes__)
 

--- a/prowler/providers/aws/services/resourceexplorer2/resourceexplorer2_service.py
+++ b/prowler/providers/aws/services/resourceexplorer2/resourceexplorer2_service.py
@@ -1,5 +1,3 @@
-import threading
-
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
@@ -14,18 +12,6 @@ class ResourceExplorer2(AWS_Service):
         super().__init__("resource-explorer-2", audit_info)
         self.indexes = []
         self.__threading_call__(self.__list_indexes__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_indexes__(self, regional_client):
         logger.info("ResourceExplorer - list indexes...")

--- a/prowler/providers/aws/services/route53/route53_service.py
+++ b/prowler/providers/aws/services/route53/route53_service.py
@@ -4,24 +4,18 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## Route53
-class Route53:
+class Route53(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "route53"
-        self.session = audit_info.audit_session
-        self.audited_partition = audit_info.audited_partition
-        self.audit_resources = audit_info.audit_resources
+        global_service = True
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info, global_service)
         self.hosted_zones = {}
         self.record_sets = []
-        global_client = generate_regional_clients(
-            self.service, audit_info, global_service=True
-        )
-        if global_client:
-            self.client = list(global_client.values())[0]
-            self.region = self.client.region
+        if global_service:
             self.__list_hosted_zones__()
             self.__list_query_logging_configs__()
             self.__list_tags_for_resource__()
@@ -149,11 +143,10 @@ class RecordSet(BaseModel):
 
 
 ################## Route53Domains
-class Route53Domains:
+class Route53Domains(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "route53domains"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.domains = {}
         if audit_info.audited_partition == "aws":
             # Route53Domains is a global service that supports endpoints in multiple AWS Regions

--- a/prowler/providers/aws/services/route53/route53_service.py
+++ b/prowler/providers/aws/services/route53/route53_service.py
@@ -4,13 +4,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## Route53
-class Route53(AWS_Service):
+class Route53(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info, global_service=True)
         self.hosted_zones = {}
         self.record_sets = []
@@ -138,9 +138,9 @@ class RecordSet(BaseModel):
 
 
 ################## Route53Domains
-class Route53Domains(AWS_Service):
+class Route53Domains(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.domains = {}
         if audit_info.audited_partition == "aws":

--- a/prowler/providers/aws/services/route53/route53_service.py
+++ b/prowler/providers/aws/services/route53/route53_service.py
@@ -10,16 +10,14 @@ from prowler.providers.aws.lib.service.service import AWS_Service
 ################## Route53
 class Route53(AWS_Service):
     def __init__(self, audit_info):
-        global_service = True
         # Call AWS_Service's __init__
-        super().__init__(__class__.__name__, audit_info, global_service)
+        super().__init__(__class__.__name__, audit_info, global_service=True)
         self.hosted_zones = {}
         self.record_sets = []
-        if global_service:
-            self.__list_hosted_zones__()
-            self.__list_query_logging_configs__()
-            self.__list_tags_for_resource__()
-            self.__list_resource_record_sets__()
+        self.__list_hosted_zones__()
+        self.__list_query_logging_configs__()
+        self.__list_tags_for_resource__()
+        self.__list_resource_record_sets__()
 
     def __get_session__(self):
         return self.session

--- a/prowler/providers/aws/services/route53/route53_service.py
+++ b/prowler/providers/aws/services/route53/route53_service.py
@@ -19,9 +19,6 @@ class Route53(AWS_Service):
         self.__list_tags_for_resource__()
         self.__list_resource_record_sets__()
 
-    def __get_session__(self):
-        return self.session
-
     def __list_hosted_zones__(self):
         logger.info("Route53 - Listing Hosting Zones...")
         try:
@@ -154,9 +151,6 @@ class Route53Domains(AWS_Service):
             self.__list_domains__()
             self.__get_domain_detail__()
             self.__list_tags_for_domain__()
-
-    def __get_session__(self):
-        return self.session
 
     def __list_domains__(self):
         logger.info("Route53Domains - Listing Domains...")

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -7,20 +7,15 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## S3
-class S3:
+class S3(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "s3"
-        self.session = audit_info.audit_session
-        self.client = self.session.client(self.service)
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account_arn = audit_info.audited_account_arn
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
+
         self.buckets = self.__list_buckets__(audit_info)
         self.__threading_call__(self.__get_bucket_versioning__)
         self.__threading_call__(self.__get_bucket_logging__)
@@ -345,17 +340,12 @@ class S3:
 
 
 ################## S3Control
-class S3Control:
+class S3Control(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "s3control"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        global_client = generate_regional_clients(
-            self.service, audit_info, global_service=True
-        )
-        if global_client:
-            self.client = list(global_client.values())[0]
-            self.region = self.client.region
+        global_service = True
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info, global_service)
+        if global_service:
             self.account_public_access_block = self.__get_public_access_block__()
 
     def __get_session__(self):

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -342,11 +342,9 @@ class S3(AWS_Service):
 ################## S3Control
 class S3Control(AWS_Service):
     def __init__(self, audit_info):
-        global_service = True
         # Call AWS_Service's __init__
-        super().__init__(__class__.__name__, audit_info, global_service)
-        if global_service:
-            self.account_public_access_block = self.__get_public_access_block__()
+        super().__init__(__class__.__name__, audit_info, global_service=True)
+        self.account_public_access_block = self.__get_public_access_block__()
 
     def __get_session__(self):
         return self.session

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -7,13 +7,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## S3
-class S3(AWS_Service):
+class S3(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
 
         self.buckets = self.__list_buckets__(audit_info)
@@ -338,9 +338,9 @@ class S3(AWS_Service):
 
 
 ################## S3Control
-class S3Control(AWS_Service):
+class S3Control(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info, global_service=True)
         self.account_public_access_block = self.__get_public_access_block__()
 

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -27,9 +27,7 @@ class S3(AWS_Service):
         self.__threading_call__(self.__get_object_lock_configuration__)
         self.__threading_call__(self.__get_bucket_tagging__)
 
-    def __get_session__(self):
-        return self.session
-
+    # In the S3 service we override the "__threading_call__" method because we spawn a process per bucket instead of per region
     def __threading_call__(self, call):
         threads = []
         for bucket in self.buckets:
@@ -345,9 +343,6 @@ class S3Control(AWS_Service):
         # Call AWS_Service's __init__
         super().__init__(__class__.__name__, audit_info, global_service=True)
         self.account_public_access_block = self.__get_public_access_block__()
-
-    def __get_session__(self):
-        return self.session
 
     def __get_public_access_block__(self):
         logger.info("S3 - Get account public access block...")

--- a/prowler/providers/aws/services/sagemaker/sagemaker_service.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_service.py
@@ -6,16 +6,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################################ SageMaker
-class SageMaker:
+class SageMaker(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "sagemaker"
-        self.session = audit_info.audit_session
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.sagemaker_notebook_instances = []
         self.sagemaker_models = []
         self.sagemaker_training_jobs = []

--- a/prowler/providers/aws/services/sagemaker/sagemaker_service.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from botocore.client import ClientError
@@ -24,18 +23,6 @@ class SageMaker(AWS_Service):
         self.__describe_notebook_instance__(self.regional_clients)
         self.__describe_training_job__(self.regional_clients)
         self.__list_tags_for_resource__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_notebook_instances__(self, regional_client):
         logger.info("SageMaker - listing notebook instances...")

--- a/prowler/providers/aws/services/sagemaker/sagemaker_service.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_service.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################################ SageMaker
-class SageMaker(AWS_Service):
+class SageMaker(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.sagemaker_notebook_instances = []
         self.sagemaker_models = []

--- a/prowler/providers/aws/services/secretsmanager/secretsmanager_service.py
+++ b/prowler/providers/aws/services/secretsmanager/secretsmanager_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from pydantic import BaseModel
@@ -15,18 +14,6 @@ class SecretsManager(AWS_Service):
         super().__init__(__class__.__name__, audit_info)
         self.secrets = {}
         self.__threading_call__(self.__list_secrets__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_secrets__(self, regional_client):
         logger.info("SecretsManager - Listing Secrets...")

--- a/prowler/providers/aws/services/secretsmanager/secretsmanager_service.py
+++ b/prowler/providers/aws/services/secretsmanager/secretsmanager_service.py
@@ -5,17 +5,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## SecretsManager
-class SecretsManager:
+class SecretsManager(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "secretsmanager"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.secrets = {}
         self.__threading_call__(self.__list_secrets__)
 

--- a/prowler/providers/aws/services/secretsmanager/secretsmanager_service.py
+++ b/prowler/providers/aws/services/secretsmanager/secretsmanager_service.py
@@ -4,13 +4,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## SecretsManager
-class SecretsManager(AWS_Service):
+class SecretsManager(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.secrets = {}
         self.__threading_call__(self.__list_secrets__)

--- a/prowler/providers/aws/services/securityhub/securityhub_service.py
+++ b/prowler/providers/aws/services/securityhub/securityhub_service.py
@@ -1,5 +1,3 @@
-import threading
-
 from botocore.client import ClientError
 from pydantic import BaseModel
 
@@ -15,18 +13,6 @@ class SecurityHub(AWS_Service):
         super().__init__(__class__.__name__, audit_info)
         self.securityhubs = []
         self.__threading_call__(self.__describe_hub__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_hub__(self, regional_client):
         logger.info("SecurityHub - Describing Hub...")

--- a/prowler/providers/aws/services/securityhub/securityhub_service.py
+++ b/prowler/providers/aws/services/securityhub/securityhub_service.py
@@ -3,13 +3,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## SecurityHub
-class SecurityHub(AWS_Service):
+class SecurityHub(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.securityhubs = []
         self.__threading_call__(self.__describe_hub__)

--- a/prowler/providers/aws/services/securityhub/securityhub_service.py
+++ b/prowler/providers/aws/services/securityhub/securityhub_service.py
@@ -5,17 +5,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## SecurityHub
-class SecurityHub:
+class SecurityHub(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "securityhub"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.securityhubs = []
         self.__threading_call__(self.__describe_hub__)
 

--- a/prowler/providers/aws/services/shield/shield_service.py
+++ b/prowler/providers/aws/services/shield/shield_service.py
@@ -15,9 +15,6 @@ class Shield(AWS_Service):
         if self.enabled:
             self.__list_protections__()
 
-    def __get_session__(self):
-        return self.session
-
     def __get_subscription_state__(self):
         logger.info("Shield - Getting Subscription State...")
         try:

--- a/prowler/providers/aws/services/shield/shield_service.py
+++ b/prowler/providers/aws/services/shield/shield_service.py
@@ -7,15 +7,13 @@ from prowler.providers.aws.lib.service.service import AWS_Service
 ################### Shield
 class Shield(AWS_Service):
     def __init__(self, audit_info):
-        global_service = True
         # Call AWS_Service's __init__
-        super().__init__(__class__.__name__, audit_info, global_service)
+        super().__init__(__class__.__name__, audit_info, global_service=True)
         self.protections = {}
         self.enabled = False
-        if global_service:
-            self.enabled = self.__get_subscription_state__()
-            if self.enabled:
-                self.__list_protections__()
+        self.enabled = self.__get_subscription_state__()
+        if self.enabled:
+            self.__list_protections__()
 
     def __get_session__(self):
         return self.session

--- a/prowler/providers/aws/services/shield/shield_service.py
+++ b/prowler/providers/aws/services/shield/shield_service.py
@@ -1,13 +1,13 @@
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################### Shield
-class Shield(AWS_Service):
+class Shield(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info, global_service=True)
         self.protections = {}
         self.enabled = False

--- a/prowler/providers/aws/services/shield/shield_service.py
+++ b/prowler/providers/aws/services/shield/shield_service.py
@@ -1,23 +1,18 @@
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################### Shield
-class Shield:
+class Shield(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "shield"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        global_client = generate_regional_clients(
-            self.service, audit_info, global_service=True
-        )
+        global_service = True
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info, global_service)
         self.protections = {}
         self.enabled = False
-        if global_client:
-            self.client = list(global_client.values())[0]
-            self.region = self.client.region
+        if global_service:
             self.enabled = self.__get_subscription_state__()
             if self.enabled:
                 self.__list_protections__()

--- a/prowler/providers/aws/services/sns/sns_service.py
+++ b/prowler/providers/aws/services/sns/sns_service.py
@@ -1,4 +1,3 @@
-import threading
 from json import loads
 from typing import Optional
 
@@ -18,18 +17,6 @@ class SNS(AWS_Service):
         self.__threading_call__(self.__list_topics__)
         self.__get_topic_attributes__(self.regional_clients)
         self.__list_tags_for_resource__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_topics__(self, regional_client):
         logger.info("SNS - listing topics...")

--- a/prowler/providers/aws/services/sns/sns_service.py
+++ b/prowler/providers/aws/services/sns/sns_service.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################################ SNS
-class SNS(AWS_Service):
+class SNS(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.topics = []
         self.__threading_call__(self.__list_topics__)

--- a/prowler/providers/aws/services/sns/sns_service.py
+++ b/prowler/providers/aws/services/sns/sns_service.py
@@ -6,16 +6,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################################ SNS
-class SNS:
+class SNS(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "sns"
-        self.session = audit_info.audit_session
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.topics = []
         self.__threading_call__(self.__list_topics__)
         self.__get_topic_attributes__(self.regional_clients)

--- a/prowler/providers/aws/services/sqs/sqs_service.py
+++ b/prowler/providers/aws/services/sqs/sqs_service.py
@@ -1,4 +1,3 @@
-import threading
 from json import loads
 from typing import Optional
 
@@ -18,18 +17,6 @@ class SQS(AWS_Service):
         self.__threading_call__(self.__list_queues__)
         self.__get_queue_attributes__(self.regional_clients)
         self.__list_queue_tags__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_queues__(self, regional_client):
         logger.info("SQS - describing queues...")

--- a/prowler/providers/aws/services/sqs/sqs_service.py
+++ b/prowler/providers/aws/services/sqs/sqs_service.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################################ SQS
-class SQS(AWS_Service):
+class SQS(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.queues = []
         self.__threading_call__(self.__list_queues__)

--- a/prowler/providers/aws/services/sqs/sqs_service.py
+++ b/prowler/providers/aws/services/sqs/sqs_service.py
@@ -6,18 +6,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################################ SQS
-class SQS:
+class SQS(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "sqs"
-        self.session = audit_info.audit_session
-        self.audit_resources = audit_info.audit_resources
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.queues = []
         self.__threading_call__(self.__list_queues__)
         self.__get_queue_attributes__(self.regional_clients)

--- a/prowler/providers/aws/services/ssm/ssm_service.py
+++ b/prowler/providers/aws/services/ssm/ssm_service.py
@@ -8,18 +8,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## SSM
-class SSM:
+class SSM(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "ssm"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.documents = {}
         self.compliance_resources = {}
         self.managed_instances = {}

--- a/prowler/providers/aws/services/ssm/ssm_service.py
+++ b/prowler/providers/aws/services/ssm/ssm_service.py
@@ -7,13 +7,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## SSM
-class SSM(AWS_Service):
+class SSM(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.documents = {}
         self.compliance_resources = {}

--- a/prowler/providers/aws/services/ssm/ssm_service.py
+++ b/prowler/providers/aws/services/ssm/ssm_service.py
@@ -1,5 +1,4 @@
 import json
-import threading
 from enum import Enum
 from typing import Optional
 
@@ -24,18 +23,6 @@ class SSM(AWS_Service):
         self.__threading_call__(self.__describe_document_permission__)
         self.__threading_call__(self.__list_resource_compliance_summaries__)
         self.__threading_call__(self.__describe_instance_information__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_documents__(self, regional_client):
         logger.info("SSM - Listing Documents...")

--- a/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
+++ b/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
@@ -1,5 +1,3 @@
-import threading
-
 from botocore.client import ClientError
 from pydantic import BaseModel
 
@@ -25,18 +23,6 @@ class SSMIncidents(AWS_Service):
         self.response_plans = []
         self.__threading_call__(self.__list_response_plans__)
         self.__list_tags_for_resource__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_replication_sets__(self):
         logger.info("SSMIncidents - Listing Replication Sets...")

--- a/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
+++ b/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 # Note:
 # This service is a bit special because it creates a resource (Replication Set) in one region, but you can list it in from any region using list_replication_sets
@@ -13,9 +13,9 @@ from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## SSMIncidents
-class SSMIncidents(AWS_Service):
+class SSMIncidents(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__("ssm-incidents", audit_info)
         self.replication_set = []
         self.__list_replication_sets__()

--- a/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
+++ b/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
@@ -5,10 +5,7 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import (
-    generate_regional_clients,
-    get_default_region,
-)
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 # Note:
 # This service is a bit special because it creates a resource (Replication Set) in one region, but you can list it in from any region using list_replication_sets
@@ -18,16 +15,10 @@ from prowler.providers.aws.aws_provider import (
 
 
 ################## SSMIncidents
-class SSMIncidents:
+class SSMIncidents(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "ssm-incidents"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account_arn = audit_info.audited_account_arn
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.region = get_default_region(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__("ssm-incidents", audit_info)
         self.replication_set = []
         self.__list_replication_sets__()
         self.__get_replication_set__()

--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_errors_and_warnings/trustedadvisor_errors_and_warnings.py
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_errors_and_warnings/trustedadvisor_errors_and_warnings.py
@@ -25,7 +25,8 @@ class trustedadvisor_errors_and_warnings(Check):
             report = Check_Report_AWS(self.metadata())
             report.status = "INFO"
             report.status_extended = "Amazon Web Services Premium Support Subscription is required to use this service."
-            report.resource_id = trustedadvisor_client.account
+            report.resource_id = trustedadvisor_client.audited_account
+            report.resource_arn = trustedadvisor_client.audited_account_arn
             report.region = trustedadvisor_client.region
             findings.append(report)
 

--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
@@ -29,9 +29,6 @@ class TrustedAdvisor(AWS_Service):
             self.__describe_trusted_advisor_checks__()
             self.__describe_trusted_advisor_check_result__()
 
-    def __get_session__(self):
-        return self.session
-
     def __describe_trusted_advisor_checks__(self):
         logger.info("TrustedAdvisor - Describing Checks...")
         try:

--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
@@ -4,13 +4,13 @@ from botocore.client import ClientError
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################################ TrustedAdvisor
-class TrustedAdvisor(AWS_Service):
+class TrustedAdvisor(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__("support", audit_info)
         self.checks = []
         self.enabled = True

--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
@@ -4,7 +4,6 @@ from botocore.client import ClientError
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
-from prowler.providers.aws.aws_provider import get_default_region
 from prowler.providers.aws.lib.service.service import AWS_Service
 
 
@@ -19,10 +18,10 @@ class TrustedAdvisor(AWS_Service):
         # But only in us-east-1 or us-gov-west-1 https://docs.aws.amazon.com/general/latest/gr/awssupport.html
         if audit_info.audited_partition != "aws-cn":
             if audit_info.audited_partition == "aws":
-                self.region = get_default_region(self.service, audit_info)
                 support_region = "us-east-1"
             else:
                 support_region = "us-gov-west-1"
+
             self.client = audit_info.audit_session.client(
                 self.service, region_name=support_region
             )

--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
@@ -5,14 +5,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.providers.aws.aws_provider import get_default_region
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################################ TrustedAdvisor
-class TrustedAdvisor:
+class TrustedAdvisor(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "support"
-        self.session = audit_info.audit_session
-        self.account = audit_info.audited_account
+        # Call AWS_Service's __init__
+        super().__init__("support", audit_info)
         self.checks = []
         self.enabled = True
         # Support API is not available in China Partition

--- a/prowler/providers/aws/services/vpc/vpc_service.py
+++ b/prowler/providers/aws/services/vpc/vpc_service.py
@@ -7,22 +7,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import (
-    generate_regional_clients,
-    get_default_region,
-)
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################## VPC
-class VPC:
+class VPC(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "ec2"
-        self.session = audit_info.audit_session
-        self.audited_account = audit_info.audited_account
-        self.audit_resources = audit_info.audit_resources
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account_arn = audit_info.audited_account_arn
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__("ec2", audit_info)
         self.vpcs = {}
         self.vpc_peering_connections = []
         self.vpc_endpoints = []
@@ -36,7 +28,6 @@ class VPC:
         self.__describe_vpc_endpoint_service_permissions__()
         self.vpc_subnets = {}
         self.__threading_call__(self.__describe_vpc_subnets__)
-        self.region = get_default_region(self.service, audit_info)
 
     def __get_session__(self):
         return self.session

--- a/prowler/providers/aws/services/vpc/vpc_service.py
+++ b/prowler/providers/aws/services/vpc/vpc_service.py
@@ -6,13 +6,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################## VPC
-class VPC(AWS_Service):
+class VPC(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__("ec2", audit_info)
         self.vpcs = {}
         self.vpc_peering_connections = []

--- a/prowler/providers/aws/services/vpc/vpc_service.py
+++ b/prowler/providers/aws/services/vpc/vpc_service.py
@@ -1,5 +1,4 @@
 import json
-import threading
 from typing import Optional
 
 from botocore.client import ClientError
@@ -28,18 +27,6 @@ class VPC(AWS_Service):
         self.__describe_vpc_endpoint_service_permissions__()
         self.vpc_subnets = {}
         self.__threading_call__(self.__describe_vpc_subnets__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_vpcs__(self, regional_client):
         logger.info("VPC - Describing VPCs...")

--- a/prowler/providers/aws/services/waf/waf_service.py
+++ b/prowler/providers/aws/services/waf/waf_service.py
@@ -4,16 +4,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################### WAF
-class WAF:
+class WAF(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "waf-regional"
-        self.session = audit_info.audit_session
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__("waf-regional", audit_info)
         self.web_acls = []
         self.__threading_call__(self.__list_web_acls__)
         self.__threading_call__(self.__list_resources_for_web_acl__)

--- a/prowler/providers/aws/services/waf/waf_service.py
+++ b/prowler/providers/aws/services/waf/waf_service.py
@@ -2,13 +2,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################### WAF
-class WAF(AWS_Service):
+class WAF(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__("waf-regional", audit_info)
         self.web_acls = []
         self.__threading_call__(self.__list_web_acls__)

--- a/prowler/providers/aws/services/waf/waf_service.py
+++ b/prowler/providers/aws/services/waf/waf_service.py
@@ -1,5 +1,3 @@
-import threading
-
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
@@ -15,18 +13,6 @@ class WAF(AWS_Service):
         self.web_acls = []
         self.__threading_call__(self.__list_web_acls__)
         self.__threading_call__(self.__list_resources_for_web_acl__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_web_acls__(self, regional_client):
         logger.info("WAF - Listing Regional Web ACLs...")

--- a/prowler/providers/aws/services/wafv2/wafv2_service.py
+++ b/prowler/providers/aws/services/wafv2/wafv2_service.py
@@ -4,16 +4,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################### WAFv2
-class WAFv2:
+class WAFv2(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "wafv2"
-        self.session = audit_info.audit_session
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.web_acls = []
         self.__threading_call__(self.__list_web_acls__)
         self.__threading_call__(self.__list_resources_for_web_acl__)

--- a/prowler/providers/aws/services/wafv2/wafv2_service.py
+++ b/prowler/providers/aws/services/wafv2/wafv2_service.py
@@ -1,5 +1,3 @@
-import threading
-
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
@@ -15,18 +13,6 @@ class WAFv2(AWS_Service):
         self.web_acls = []
         self.__threading_call__(self.__list_web_acls__)
         self.__threading_call__(self.__list_resources_for_web_acl__)
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_web_acls__(self, regional_client):
         logger.info("WAFv2 - Listing Regional Web ACLs...")

--- a/prowler/providers/aws/services/wafv2/wafv2_service.py
+++ b/prowler/providers/aws/services/wafv2/wafv2_service.py
@@ -2,13 +2,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################### WAFv2
-class WAFv2(AWS_Service):
+class WAFv2(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.web_acls = []
         self.__threading_call__(self.__list_web_acls__)

--- a/prowler/providers/aws/services/wellarchitected/wellarchitected_service.py
+++ b/prowler/providers/aws/services/wellarchitected/wellarchitected_service.py
@@ -4,13 +4,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################################ WellArchitected
-class WellArchitected(AWS_Service):
+class WellArchitected(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.workloads = []
         self.__threading_call__(self.__list_workloads__)

--- a/prowler/providers/aws/services/wellarchitected/wellarchitected_service.py
+++ b/prowler/providers/aws/services/wellarchitected/wellarchitected_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from pydantic import BaseModel
@@ -16,18 +15,6 @@ class WellArchitected(AWS_Service):
         self.workloads = []
         self.__threading_call__(self.__list_workloads__)
         self.__list_tags_for_resource__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __list_workloads__(self, regional_client):
         logger.info("WellArchitected - Listing Workloads...")

--- a/prowler/providers/aws/services/wellarchitected/wellarchitected_service.py
+++ b/prowler/providers/aws/services/wellarchitected/wellarchitected_service.py
@@ -5,16 +5,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################################ WellArchitected
-class WellArchitected:
+class WellArchitected(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "wellarchitected"
-        self.session = audit_info.audit_session
-        self.audit_resources = audit_info.audit_resources
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.workloads = []
         self.__threading_call__(self.__list_workloads__)
         self.__list_tags_for_resource__()

--- a/prowler/providers/aws/services/workspaces/workspaces_service.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_service.py
@@ -4,13 +4,13 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.lib.service.service import AWS_Service
+from prowler.providers.aws.lib.service.service import AWSService
 
 
 ################################ WorkSpaces
-class WorkSpaces(AWS_Service):
+class WorkSpaces(AWSService):
     def __init__(self, audit_info):
-        # Call AWS_Service's __init__
+        # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.workspaces = []
         self.__threading_call__(self.__describe_workspaces__)

--- a/prowler/providers/aws/services/workspaces/workspaces_service.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_service.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional
 
 from pydantic import BaseModel
@@ -16,18 +15,6 @@ class WorkSpaces(AWS_Service):
         self.workspaces = []
         self.__threading_call__(self.__describe_workspaces__)
         self.__describe_tags__()
-
-    def __get_session__(self):
-        return self.session
-
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
     def __describe_workspaces__(self, regional_client):
         logger.info("WorkSpaces - describing workspaces...")

--- a/prowler/providers/aws/services/workspaces/workspaces_service.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_service.py
@@ -5,18 +5,14 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
+from prowler.providers.aws.lib.service.service import AWS_Service
 
 
 ################################ WorkSpaces
-class WorkSpaces:
+class WorkSpaces(AWS_Service):
     def __init__(self, audit_info):
-        self.service = "workspaces"
-        self.session = audit_info.audit_session
-        self.audit_resources = audit_info.audit_resources
-        self.audited_partition = audit_info.audited_partition
-        self.audited_account = audit_info.audited_account
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # Call AWS_Service's __init__
+        super().__init__(__class__.__name__, audit_info)
         self.workspaces = []
         self.__threading_call__(self.__describe_workspaces__)
         self.__describe_tags__()

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -27,6 +27,7 @@ from prowler.providers.aws.aws_provider import (
     get_regions_from_audit_resources,
 )
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -158,6 +159,12 @@ class Test_Check:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -69,6 +69,7 @@ from prowler.lib.outputs.outputs import (
 from prowler.lib.utils.utils import hash_sha512, open_file
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.lib.security_hub.security_hub import send_to_security_hub
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_ID = "123456789012"
 
@@ -116,6 +117,12 @@ class Test_Outputs:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         test_output_modes = [
             ["csv"],
@@ -436,6 +443,12 @@ class Test_Outputs:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         finding = Check_Report(
             load_check_metadata(
@@ -507,6 +520,12 @@ class Test_Outputs:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         finding = Check_Report(
             load_check_metadata(
@@ -592,6 +611,12 @@ class Test_Outputs:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         finding = Check_Report(
             load_check_metadata(
@@ -677,6 +702,12 @@ class Test_Outputs:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         with patch(
             "prowler.lib.outputs.json.get_check_compliance",
@@ -953,6 +984,12 @@ class Test_Outputs:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         finding = Check_Report(
             load_check_metadata(
@@ -1080,6 +1117,12 @@ class Test_Outputs:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         # Creat mock bucket
         bucket_name = "test_bucket"
@@ -1131,6 +1174,12 @@ class Test_Outputs:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         # Creat mock bucket
         bucket_name = "test_bucket"
@@ -1189,6 +1238,12 @@ class Test_Outputs:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         # Creat mock bucket
         bucket_name = "test_bucket"
@@ -1298,6 +1353,12 @@ class Test_Outputs:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         finding = Check_Report(
             load_check_metadata(

--- a/tests/lib/outputs/slack_test.py
+++ b/tests/lib/outputs/slack_test.py
@@ -12,6 +12,7 @@ from prowler.providers.azure.lib.audit_info.models import (
     Azure_Audit_Info,
     Azure_Identity_Info,
 )
+from prowler.providers.common.models import Audit_Metadata
 from prowler.providers.gcp.lib.audit_info.models import GCP_Audit_Info
 
 AWS_ACCOUNT_ID = "123456789012"
@@ -44,6 +45,12 @@ class Test_Slack_Integration:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         gcp_audit_info = GCP_Audit_Info(
             credentials=None,

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -12,6 +12,7 @@ from prowler.providers.aws.aws_provider import (
     get_global_region,
 )
 from prowler.providers.aws.lib.audit_info.models import AWS_Assume_Role, AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 ACCOUNT_ID = 123456789012
 AWS_REGION = "us-east-1"
@@ -62,6 +63,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         # Call assume_role
@@ -185,6 +192,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         # Call assume_role
@@ -271,6 +284,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         # Call assume_role
@@ -354,6 +373,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         # Call assume_role
@@ -411,6 +436,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         generate_regional_clients_response = generate_regional_clients(
             "ec2", audit_info
@@ -443,6 +474,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         generate_regional_clients_response = generate_regional_clients(
             "route53", audit_info, global_service=True
@@ -474,6 +511,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         generate_regional_clients_response = generate_regional_clients(
             "shield", audit_info, global_service=True
@@ -502,6 +545,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         assert get_default_region("ec2", audit_info) == "eu-west-1"
 
@@ -525,6 +574,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         assert get_default_region("ec2", audit_info) == "eu-west-1"
 
@@ -548,6 +603,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         assert get_default_region("ec2", audit_info) == "eu-west-1"
 
@@ -571,6 +632,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         assert get_default_region("ec2", audit_info) == "us-east-1"
 
@@ -592,6 +659,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         assert get_default_region("ec2", audit_info) == "us-east-1"
 
@@ -613,6 +686,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         assert get_global_region(audit_info) == "us-gov-east-1"
 
@@ -634,6 +713,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         assert get_global_region(audit_info) == "cn-north-1"
 
@@ -655,6 +740,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         assert get_global_region(audit_info) == "aws-iso-global"
 
@@ -677,6 +768,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         with patch(
             "prowler.providers.aws.aws_provider.parse_json_file",
@@ -728,6 +825,12 @@ class Test_AWS_Provider:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         with patch(
             "prowler.providers.aws.aws_provider.parse_json_file",

--- a/tests/providers/aws/lib/allowlist/allowlist_test.py
+++ b/tests/providers/aws/lib/allowlist/allowlist_test.py
@@ -11,6 +11,7 @@ from prowler.providers.aws.lib.allowlist.allowlist import (
     parse_allowlist_file,
 )
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -39,6 +40,12 @@ class Test_Allowlist:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/lib/service/service_test.py
+++ b/tests/providers/aws/lib/service/service_test.py
@@ -1,0 +1,71 @@
+from boto3 import session
+from mock import patch
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.aws.lib.service.service import AWSService
+from prowler.providers.common.models import Audit_Metadata
+
+AWS_ACCOUNT_NUMBER = "123456789012"
+AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+AWS_PARTITION = "aws"
+AWS_REGION = "us-east-1"
+
+
+def mock_generate_regional_clients(service, audit_info, _):
+    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
+    regional_client.region = AWS_REGION
+    return {AWS_REGION: regional_client}
+
+
+@patch(
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
+    new=mock_generate_regional_clients,
+)
+class Test_AWSService:
+    # Mocked Audit Info
+    def set_mocked_audit_info(self):
+        audit_info = AWS_Audit_Info(
+            session_config=None,
+            original_session=None,
+            audit_session=session.Session(
+                profile_name=None,
+                botocore_session=None,
+            ),
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_account_arn=AWS_ACCOUNT_ARN,
+            audited_user_id=None,
+            audited_partition=AWS_PARTITION,
+            audited_identity_arn=None,
+            profile=None,
+            profile_region=None,
+            credentials=None,
+            assumed_role_info=None,
+            audited_regions=None,
+            organizations_metadata=None,
+            audit_resources=[],
+            mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
+        )
+        return audit_info
+
+    def test_AWSService_init(self):
+        audit_info = self.set_mocked_audit_info()
+        service = AWSService("s3", audit_info)
+
+        assert service.audit_info == audit_info
+        assert service.audited_account == AWS_ACCOUNT_NUMBER
+        assert service.audited_account_arn == AWS_ACCOUNT_ARN
+        assert service.audited_partition == AWS_PARTITION
+        assert service.audit_resources == []
+        assert service.audited_checks == []
+        assert service.session == audit_info.audit_session
+        assert service.service == "s3"
+        assert len(service.regional_clients) == 1
+        assert service.regional_clients[AWS_REGION].__class__.__name__ == "S3"
+        assert service.region == AWS_REGION
+        assert service.client.__class__.__name__ == "S3"

--- a/tests/providers/aws/services/accessanalyzer/accessanalyzer_service_test.py
+++ b/tests/providers/aws/services/accessanalyzer/accessanalyzer_service_test.py
@@ -7,6 +7,7 @@ from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.accessanalyzer.accessanalyzer_service import (
     AccessAnalyzer,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -57,7 +58,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -66,7 +67,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.accessanalyzer.accessanalyzer_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_AccessAnalyzer_Service:
@@ -91,6 +92,12 @@ class Test_AccessAnalyzer_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/acm/acm_service_test.py
+++ b/tests/providers/aws/services/acm/acm_service_test.py
@@ -8,6 +8,7 @@ from mock import patch
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.acm.acm_service import ACM
+from prowler.providers.common.models import Audit_Metadata
 
 # from moto import mock_acm
 
@@ -79,7 +80,7 @@ def mock_make_api_call(self, operation_name, kwargs):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -87,7 +88,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch(
-    "prowler.providers.aws.services.acm.acm_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
@@ -117,6 +118,12 @@ class Test_ACM_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/apigateway/apigateway_authorizers_enabled/apigateway_authorizers_enabled_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_authorizers_enabled/apigateway_authorizers_enabled_test.py
@@ -5,6 +5,7 @@ from moto import mock_apigateway, mock_iam, mock_lambda
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_apigateway_authorizers_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/apigateway/apigateway_client_certificate_enabled/apigateway_client_certificate_enabled_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_client_certificate_enabled/apigateway_client_certificate_enabled_test.py
@@ -5,6 +5,7 @@ from moto import mock_apigateway
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.apigateway.apigateway_service import Stage
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_apigateway_client_certificate_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/apigateway/apigateway_endpoint_public/apigateway_endpoint_public_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_endpoint_public/apigateway_endpoint_public_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_apigateway
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_apigateway_endpoint_public:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/apigateway/apigateway_logging_enabled/apigateway_logging_enabled_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_logging_enabled/apigateway_logging_enabled_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_apigateway
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_apigateway_logging_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/apigateway/apigateway_service_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_service_test.py
@@ -3,6 +3,7 @@ from moto import mock_apigateway
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.apigateway.apigateway_service import APIGateway
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -31,6 +32,12 @@ class Test_APIGateway_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/apigateway/apigateway_waf_acl_attached/apigateway_waf_acl_attached_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_waf_acl_attached/apigateway_waf_acl_attached_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_apigateway, mock_wafv2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_apigateway_waf_acl_attached:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/apigatewayv2/apigatewayv2_access_logging_enabled/apigatewayv2_access_logging_enabled_test.py
+++ b/tests/providers/aws/services/apigatewayv2/apigatewayv2_access_logging_enabled/apigatewayv2_access_logging_enabled_test.py
@@ -6,6 +6,7 @@ from mock import patch
 from moto import mock_apigatewayv2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -60,6 +61,12 @@ class Test_apigatewayv2_access_logging_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/apigatewayv2/apigatewayv2_authorizers_enabled/apigatewayv2_authorizers_enabled_test.py
+++ b/tests/providers/aws/services/apigatewayv2/apigatewayv2_authorizers_enabled/apigatewayv2_authorizers_enabled_test.py
@@ -6,6 +6,7 @@ from mock import patch
 from moto import mock_apigatewayv2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -60,6 +61,12 @@ class Test_apigatewayv2_authorizers_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/apigatewayv2/apigatewayv2_service_test.py
+++ b/tests/providers/aws/services/apigatewayv2/apigatewayv2_service_test.py
@@ -7,6 +7,7 @@ from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.apigatewayv2.apigatewayv2_service import (
     ApiGatewayV2,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -62,6 +63,12 @@ class Test_ApiGatewayV2_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/appstream/appstream_service_test.py
+++ b/tests/providers/aws/services/appstream/appstream_service_test.py
@@ -6,6 +6,7 @@ from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.appstream.appstream_service import AppStream
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -50,7 +51,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -59,7 +60,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.appstream.appstream_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_AppStream_Service:
@@ -84,6 +85,12 @@ class Test_AppStream_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/autoscaling/autoscaling_find_secrets_ec2_launch_configuration/autoscaling_find_secrets_ec2_launch_configuration_test.py
+++ b/tests/providers/aws/services/autoscaling/autoscaling_find_secrets_ec2_launch_configuration/autoscaling_find_secrets_ec2_launch_configuration_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_autoscaling
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_autoscaling_find_secrets_ec2_launch_configuration:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/autoscaling/autoscaling_group_multiple_az/autoscaling_group_multiple_az_test.py
+++ b/tests/providers/aws/services/autoscaling/autoscaling_group_multiple_az/autoscaling_group_multiple_az_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_autoscaling
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_autoscaling_group_multiple_az:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/autoscaling/autoscaling_service_test.py
+++ b/tests/providers/aws/services/autoscaling/autoscaling_service_test.py
@@ -5,6 +5,7 @@ from moto import mock_autoscaling
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.autoscaling.autoscaling_service import AutoScaling
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -33,6 +34,12 @@ class Test_AutoScaling_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled_test.py
@@ -7,12 +7,13 @@ from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.awslambda.awslambda_service import Function
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -20,7 +21,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch(
-    "prowler.providers.aws.services.accessanalyzer.accessanalyzer_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_awslambda_function_invoke_api_operations_cloudtrail_logging_enabled:
@@ -46,6 +47,12 @@ class Test_awslambda_function_invoke_api_operations_cloudtrail_logging_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/awslambda/awslambda_service_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_service_test.py
@@ -47,7 +47,7 @@ def mock_request_get(_):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client_eu_west_1 = audit_info.audit_session.client(
         service, region_name=AWS_REGION
     )
@@ -63,7 +63,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 
 @patch(
-    "prowler.providers.aws.services.awslambda.awslambda_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_Lambda_Service:

--- a/tests/providers/aws/services/backup/backup_service_test.py
+++ b/tests/providers/aws/services/backup/backup_service_test.py
@@ -6,6 +6,7 @@ from boto3 import session
 
 from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.backup.backup_service import Backup
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -59,7 +60,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -68,7 +69,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.backup.backup_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_Backup_Service:
@@ -94,6 +95,12 @@ class Test_Backup_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/cloudformation/cloudformation_service_test.py
+++ b/tests/providers/aws/services/cloudformation/cloudformation_service_test.py
@@ -13,6 +13,7 @@ from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.cloudformation.cloudformation_service import (
     CloudFormation,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -120,7 +121,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -129,7 +130,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.cloudformation.cloudformation_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_CloudFormation_Service:
@@ -145,7 +146,7 @@ class Test_CloudFormation_Service:
             audited_account=None,
             audited_account_arn=None,
             audited_user_id=None,
-            audited_partition=None,
+            audited_partition="aws",
             audited_identity_arn=None,
             profile=None,
             profile_region=None,
@@ -155,6 +156,12 @@ class Test_CloudFormation_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/cloudfront/cloudfront_service_test.py
+++ b/tests/providers/aws/services/cloudfront/cloudfront_service_test.py
@@ -10,6 +10,7 @@ from prowler.providers.aws.services.cloudfront.cloudfront_service import (
     CloudFront,
     ViewerProtocolPolicy,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -176,6 +177,12 @@ class Test_CloudFront_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
@@ -8,6 +8,7 @@ from moto import mock_cloudtrail, mock_iam, mock_s3
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.cloudtrail.cloudtrail_service import Cloudtrail
 from prowler.providers.aws.services.s3.s3_service import S3
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -37,6 +38,12 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_cloudwatch_logging_enabled/cloudtrail_cloudwatch_logging_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_cloudwatch_logging_enabled/cloudtrail_cloudwatch_logging_enabled_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_cloudtrail, mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -32,6 +33,12 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_insights_exist/cloudtrail_insights_exist_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_insights_exist/cloudtrail_insights_exist_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.cloudtrail.cloudtrail_service import Cloudtrail
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_cloudtrail_insights_exist:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_kms_encryption_enabled/cloudtrail_kms_encryption_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_kms_encryption_enabled/cloudtrail_kms_encryption_enabled_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_cloudtrail, mock_kms, mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_cloudtrail_kms_encryption_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_log_file_validation_enabled/cloudtrail_log_file_validation_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_log_file_validation_enabled/cloudtrail_log_file_validation_enabled_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_cloudtrail, mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_cloudtrail_log_file_validation_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_access_logging_enabled/cloudtrail_logs_s3_bucket_access_logging_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_access_logging_enabled/cloudtrail_logs_s3_bucket_access_logging_enabled_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_cloudtrail, mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_cloudtrail_logs_s3_bucket_access_logging_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_cloudtrail, mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_test.py
@@ -6,6 +6,7 @@ from moto import mock_cloudtrail, mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.cloudtrail.cloudtrail_service import Trail
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -32,6 +33,12 @@ class Test_cloudtrail_multi_region_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_read_enabled/cloudtrail_s3_dataevents_read_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_read_enabled/cloudtrail_s3_dataevents_read_enabled_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_cloudtrail, mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_cloudtrail_s3_dataevents_read_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_write_enabled/cloudtrail_s3_dataevents_write_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_write_enabled/cloudtrail_s3_dataevents_write_enabled_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_cloudtrail, mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_cloudtrail_s3_dataevents_write_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_service_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_service_test.py
@@ -3,6 +3,7 @@ from moto import mock_cloudtrail, mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.cloudtrail.cloudtrail_service import Cloudtrail
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -30,6 +31,12 @@ class Test_Cloudtrail_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_acls_alarm_configured/cloudwatch_changes_to_network_acls_alarm_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_acls_alarm_configured/cloudwatch_changes_to_network_acls_alarm_configured_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_gateways_alarm_configured/cloudwatch_changes_to_network_gateways_alarm_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_gateways_alarm_configured/cloudwatch_changes_to_network_gateways_alarm_configured_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_route_tables_alarm_configured/cloudwatch_changes_to_network_route_tables_alarm_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_route_tables_alarm_configured/cloudwatch_changes_to_network_route_tables_alarm_configured_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_vpcs_alarm_configured/cloudwatch_changes_to_vpcs_alarm_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_vpcs_alarm_configured/cloudwatch_changes_to_vpcs_alarm_configured_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_cross_account_sharing_disabled/cloudwatch_cross_account_sharing_disabled_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_cross_account_sharing_disabled/cloudwatch_cross_account_sharing_disabled_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_cloudwatch_cross_account_sharing_disabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_kms_encryption_enabled/cloudwatch_log_group_kms_encryption_enabled_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_kms_encryption_enabled/cloudwatch_log_group_kms_encryption_enabled_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_logs
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_cloudwatch_log_group_kms_encryption_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_no_secrets_in_logs/cloudwatch_log_group_no_secrets_in_logs_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_no_secrets_in_logs/cloudwatch_log_group_no_secrets_in_logs_test.py
@@ -6,6 +6,7 @@ from moto import mock_logs
 from moto.core.utils import unix_time_millis
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -33,6 +34,12 @@ class Test_cloudwatch_log_group_no_secrets_in_logs:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_retention_policy_specific_days_enabled/cloudwatch_log_group_retention_policy_specific_days_enabled_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_retention_policy_specific_days_enabled/cloudwatch_log_group_retention_policy_specific_days_enabled_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_logs
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_cloudwatch_log_group_retention_policy_specific_days_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_authentication_failures/cloudwatch_log_metric_filter_authentication_failures_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_authentication_failures/cloudwatch_log_metric_filter_authentication_failures_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_aws_organizations_changes/cloudwatch_log_metric_filter_aws_organizations_changes_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_aws_organizations_changes/cloudwatch_log_metric_filter_aws_organizations_changes_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk/cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk/cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_policy_changes/cloudwatch_log_metric_filter_policy_changes_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_policy_changes/cloudwatch_log_metric_filter_policy_changes_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_root_usage/cloudwatch_log_metric_filter_root_usage_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_root_usage/cloudwatch_log_metric_filter_root_usage_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_cloudwatch_log_metric_filter_root_usage:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_security_group_changes/cloudwatch_log_metric_filter_security_group_changes_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_security_group_changes/cloudwatch_log_metric_filter_security_group_changes_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_sign_in_without_mfa/cloudwatch_log_metric_filter_sign_in_without_mfa_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_sign_in_without_mfa/cloudwatch_log_metric_filter_sign_in_without_mfa_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_unauthorized_api_calls/cloudwatch_log_metric_filter_unauthorized_api_calls_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_unauthorized_api_calls/cloudwatch_log_metric_filter_unauthorized_api_calls_test.py
@@ -5,6 +5,7 @@ from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/codeartifact/codeartifact_service_test.py
+++ b/tests/providers/aws/services/codeartifact/codeartifact_service_test.py
@@ -11,6 +11,7 @@ from prowler.providers.aws.services.codeartifact.codeartifact_service import (
     OriginInformationValues,
     RestrictionValues,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -90,7 +91,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -99,7 +100,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.codeartifact.codeartifact_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_CodeArtifact_Service:
@@ -124,6 +125,12 @@ class Test_CodeArtifact_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/codebuild/codebuild_service_test.py
+++ b/tests/providers/aws/services/codebuild/codebuild_service_test.py
@@ -6,6 +6,7 @@ from boto3 import session
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.codebuild.codebuild_service import Codebuild
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -40,7 +41,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -48,7 +49,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.codebuild.codebuild_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_Codebuild_Service:
@@ -73,6 +74,12 @@ class Test_Codebuild_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/config/config_recorder_all_regions_enabled/config_recorder_all_regions_enabled_test.py
+++ b/tests/providers/aws/services/config/config_recorder_all_regions_enabled/config_recorder_all_regions_enabled_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_config
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_config_recorder_all_regions_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/config/config_service_test.py
+++ b/tests/providers/aws/services/config/config_service_test.py
@@ -3,6 +3,7 @@ from moto import mock_config
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.config.config_service import Config
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -31,6 +32,12 @@ class Test_Config_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/directoryservice/directoryservice_service_test.py
+++ b/tests/providers/aws/services/directoryservice/directoryservice_service_test.py
@@ -16,6 +16,7 @@ from prowler.providers.aws.services.directoryservice.directoryservice_service im
     EventTopicStatus,
     RadiusStatus,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -105,7 +106,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -114,7 +115,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.directoryservice.directoryservice_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_DirectoryService_Service:
@@ -139,6 +140,12 @@ class Test_DirectoryService_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/drs/drs_service_test.py
+++ b/tests/providers/aws/services/drs/drs_service_test.py
@@ -6,6 +6,7 @@ from boto3 import session
 
 from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.drs.drs_service import DRS
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "us-east-1"
@@ -42,7 +43,7 @@ def mock_make_api_call(self, operation_name, kwargs):
     return make_api_call(self, operation_name, kwargs)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -51,7 +52,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.drs.drs_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_DRS_Service:
@@ -77,6 +78,12 @@ class Test_DRS_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/dynamodb/dynamodb_accelerator_cluster_encryption_enabled/dynamodb_accelerator_cluster_encryption_enabled_test.py
+++ b/tests/providers/aws/services/dynamodb/dynamodb_accelerator_cluster_encryption_enabled/dynamodb_accelerator_cluster_encryption_enabled_test.py
@@ -6,6 +6,7 @@ from moto import mock_dax
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 
@@ -32,6 +33,12 @@ class Test_dynamodb_accelerator_cluster_encryption_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/dynamodb/dynamodb_service_test.py
+++ b/tests/providers/aws/services/dynamodb/dynamodb_service_test.py
@@ -3,6 +3,7 @@ from moto import mock_dax, mock_dynamodb
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.dynamodb.dynamodb_service import DAX, DynamoDB
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -31,6 +32,12 @@ class Test_DynamoDB_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/dynamodb/dynamodb_tables_kms_cmk_encryption_enabled/dynamodb_tables_kms_cmk_encryption_enabled_test.py
+++ b/tests/providers/aws/services/dynamodb/dynamodb_tables_kms_cmk_encryption_enabled/dynamodb_tables_kms_cmk_encryption_enabled_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_dynamodb
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_dynamodb_tables_kms_cmk_encryption_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/dynamodb/dynamodb_tables_pitr_enabled/dynamodb_tables_pitr_enabled_test.py
+++ b/tests/providers/aws/services/dynamodb/dynamodb_tables_pitr_enabled/dynamodb_tables_pitr_enabled_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_dynamodb
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_dynamodb_tables_pitr_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot_test.py
@@ -11,14 +11,14 @@ AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
 
 
 @patch(
-    "prowler.providers.aws.services.ec2.ec2_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_ec2_ebs_public_snapshot:

--- a/tests/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted_test.py
@@ -11,14 +11,14 @@ AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
 
 
 @patch(
-    "prowler.providers.aws.services.ec2.ec2_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_ec2_ebs_snapshots_encrypted:

--- a/tests/providers/aws/services/ecr/ecr_service_test.py
+++ b/tests/providers/aws/services/ecr/ecr_service_test.py
@@ -7,6 +7,7 @@ from moto import mock_ecr
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.ecr.ecr_service import ECR, ScanningRule
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
@@ -81,7 +82,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -90,7 +91,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.ecr.ecr_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_ECR_Service:
@@ -116,6 +117,12 @@ class Test_ECR_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/ecs/ecs_service_test.py
+++ b/tests/providers/aws/services/ecs/ecs_service_test.py
@@ -5,19 +5,20 @@ from moto import mock_ecs
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.ecs.ecs_service import ECS
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
 
 
 @patch(
-    "prowler.providers.aws.services.ecs.ecs_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_ECS_Service:
@@ -43,6 +44,12 @@ class Test_ECS_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/efs/efs_service_test.py
+++ b/tests/providers/aws/services/efs/efs_service_test.py
@@ -7,6 +7,7 @@ from moto import mock_efs
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.efs.efs_service import EFS
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -41,7 +42,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -50,7 +51,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.efs.efs_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_EFS:
@@ -75,6 +76,12 @@ class Test_EFS:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/eks/eks_service_test.py
+++ b/tests/providers/aws/services/eks/eks_service_test.py
@@ -5,6 +5,7 @@ from moto import mock_ec2, mock_eks
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.eks.eks_service import EKS
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
@@ -15,14 +16,14 @@ cidr_block_subnet_1 = "10.0.0.0/22"
 cidr_block_subnet_2 = "10.0.4.0/22"
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
 
 
 @patch(
-    "prowler.providers.aws.services.eks.eks_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_EKS_Service:
@@ -48,6 +49,12 @@ class Test_EKS_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/elb/elb_insecure_ssl_ciphers/elb_insecure_ssl_ciphers_test.py
+++ b/tests/providers/aws/services/elb/elb_insecure_ssl_ciphers/elb_insecure_ssl_ciphers_test.py
@@ -5,6 +5,7 @@ from boto3 import client, resource, session
 from moto import mock_ec2, mock_elb
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_elb_insecure_ssl_ciphers:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/elb/elb_internet_facing/elb_internet_facing_test.py
+++ b/tests/providers/aws/services/elb/elb_internet_facing/elb_internet_facing_test.py
@@ -5,6 +5,7 @@ from boto3 import client, resource, session
 from moto import mock_ec2, mock_elb
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_elb_request_smugling:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/elb/elb_logging_enabled/elb_logging_enabled_test.py
+++ b/tests/providers/aws/services/elb/elb_logging_enabled/elb_logging_enabled_test.py
@@ -5,6 +5,7 @@ from boto3 import client, resource, session
 from moto import mock_ec2, mock_elb
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_elb_logging_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/elb/elb_service_test.py
+++ b/tests/providers/aws/services/elb/elb_service_test.py
@@ -3,6 +3,7 @@ from moto import mock_ec2, mock_elb
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.elb.elb_service import ELB
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -31,6 +32,12 @@ class Test_ELB_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/elb/elb_ssl_listeners/elb_ssl_listeners_test.py
+++ b/tests/providers/aws/services/elb/elb_ssl_listeners/elb_ssl_listeners_test.py
@@ -5,6 +5,7 @@ from boto3 import client, resource, session
 from moto import mock_ec2, mock_elb
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_elb_ssl_listeners:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/elbv2/elbv2_deletion_protection/elbv2_deletion_protection_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_deletion_protection/elbv2_deletion_protection_test.py
@@ -5,6 +5,7 @@ from boto3 import client, resource, session
 from moto import mock_ec2, mock_elbv2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_elbv2_deletion_protection:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/elbv2/elbv2_desync_mitigation_mode/elbv2_desync_mitigation_mode_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_desync_mitigation_mode/elbv2_desync_mitigation_mode_test.py
@@ -5,6 +5,7 @@ from boto3 import client, resource, session
 from moto import mock_ec2, mock_elbv2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_elbv2_desync_mitigation_mode:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/elbv2/elbv2_insecure_ssl_ciphers/elbv2_insecure_ssl_ciphers_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_insecure_ssl_ciphers/elbv2_insecure_ssl_ciphers_test.py
@@ -5,6 +5,7 @@ from boto3 import client, resource, session
 from moto import mock_ec2, mock_elbv2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_elbv2_insecure_ssl_ciphers:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/elbv2/elbv2_internet_facing/elbv2_internet_facing_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_internet_facing/elbv2_internet_facing_test.py
@@ -5,6 +5,7 @@ from boto3 import client, resource, session
 from moto import mock_ec2, mock_elbv2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_elbv2_internet_facing:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info
@@ -109,7 +116,7 @@ class Test_elbv2_internet_facing:
 
     @mock_ec2
     @mock_elbv2
-    def test_elbv2_with_deletion_protection(self):
+    def test_elbv2_internet_facing(self):
         conn = client("elbv2", region_name=AWS_REGION)
         ec2 = resource("ec2", region_name=AWS_REGION)
 

--- a/tests/providers/aws/services/elbv2/elbv2_listeners_underneath/elbv2_listeners_underneath_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_listeners_underneath/elbv2_listeners_underneath_test.py
@@ -5,6 +5,7 @@ from boto3 import client, resource, session
 from moto import mock_ec2, mock_elbv2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_elbv2_listeners_underneath:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/elbv2/elbv2_logging_enabled/elbv2_logging_enabled_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_logging_enabled/elbv2_logging_enabled_test.py
@@ -5,6 +5,7 @@ from boto3 import client, resource, session
 from moto import mock_ec2, mock_elbv2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_elbv2_logging_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info
@@ -59,7 +66,7 @@ class Test_elbv2_logging_enabled:
 
     @mock_ec2
     @mock_elbv2
-    def test_elbv2_without_deletion_protection(self):
+    def test_elbv2_without_logging_enabled(self):
         conn = client("elbv2", region_name=AWS_REGION)
         ec2 = resource("ec2", region_name=AWS_REGION)
 
@@ -119,7 +126,7 @@ class Test_elbv2_logging_enabled:
 
     @mock_ec2
     @mock_elbv2
-    def test_elbv2_with_deletion_protection(self):
+    def test_elbv2_with_logging_enabled(self):
         conn = client("elbv2", region_name=AWS_REGION)
         ec2 = resource("ec2", region_name=AWS_REGION)
 

--- a/tests/providers/aws/services/elbv2/elbv2_service_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_service_test.py
@@ -3,6 +3,7 @@ from moto import mock_ec2, mock_elbv2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -31,6 +32,12 @@ class Test_ELBv2_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/elbv2/elbv2_ssl_listeners/elbv2_ssl_listeners_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_ssl_listeners/elbv2_ssl_listeners_test.py
@@ -5,6 +5,7 @@ from boto3 import client, resource, session
 from moto import mock_ec2, mock_elbv2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_elbv2_ssl_listeners:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/elbv2/elbv2_waf_acl_attached/elbv2_waf_acl_attached_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_waf_acl_attached/elbv2_waf_acl_attached_test.py
@@ -6,6 +6,7 @@ from boto3 import client, resource, session
 from moto import mock_ec2, mock_elbv2, mock_wafv2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -54,6 +55,12 @@ class Test_elbv2_waf_acl_attached:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/emr/emr_service_test.py
+++ b/tests/providers/aws/services/emr/emr_service_test.py
@@ -8,6 +8,7 @@ from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.emr.emr_service import EMR, ClusterStatus
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -37,14 +38,14 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
 
 
 @patch(
-    "prowler.providers.aws.services.emr.emr_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
@@ -70,6 +71,12 @@ class Test_EMR_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/fms/fms_service_test.py
+++ b/tests/providers/aws/services/fms/fms_service_test.py
@@ -6,6 +6,7 @@ from boto3 import session
 
 from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.fms.fms_service import FMS
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "us-east-1"
@@ -86,6 +87,12 @@ class Test_FMS_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/glacier/glacier_service_test.py
+++ b/tests/providers/aws/services/glacier/glacier_service_test.py
@@ -7,6 +7,7 @@ from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.glacier.glacier_service import Glacier
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -63,7 +64,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -72,7 +73,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.glacier.glacier_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_Glacier_Service:
@@ -97,6 +98,12 @@ class Test_Glacier_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/globalaccelerator/globalaccelerator_service_test.py
+++ b/tests/providers/aws/services/globalaccelerator/globalaccelerator_service_test.py
@@ -7,6 +7,7 @@ from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.globalaccelerator.globalaccelerator_service import (
     GlobalAccelerator,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "us-west-2"
@@ -71,6 +72,12 @@ class Test_GlobalAccelerator_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/glue/glue_service_test.py
+++ b/tests/providers/aws/services/glue/glue_service_test.py
@@ -6,6 +6,7 @@ from moto import mock_glue
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.glue.glue_service import Glue
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -104,7 +105,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -113,7 +114,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.glue.glue_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_Glue_Service:
@@ -139,6 +140,12 @@ class Test_Glue_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/guardduty/guardduty_service_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_service_test.py
@@ -7,6 +7,7 @@ from moto import mock_guardduty
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.guardduty.guardduty_service import GuardDuty
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER_ADMIN = "123456789013"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -47,7 +48,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -55,7 +56,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.guardduty.guardduty_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_GuardDuty_Service:
@@ -81,6 +82,12 @@ class Test_GuardDuty_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/iam/iam_administrator_access_with_mfa/iam_administrator_access_with_mfa_test.py
+++ b/tests/providers/aws/services/iam/iam_administrator_access_with_mfa/iam_administrator_access_with_mfa_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -35,6 +36,12 @@ class Test_iam_administrator_access_with_mfa_test:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/iam/iam_avoid_root_usage/iam_avoid_root_usage_test.py
+++ b/tests/providers/aws/services/iam/iam_avoid_root_usage/iam_avoid_root_usage_test.py
@@ -7,6 +7,7 @@ from boto3 import session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -36,6 +37,12 @@ class Test_iam_avoid_root_usage:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/iam/iam_aws_attached_policy_no_administrative_privileges/iam_aws_attached_policy_no_administrative_privileges_test.py
+++ b/tests/providers/aws/services/iam/iam_aws_attached_policy_no_administrative_privileges/iam_aws_attached_policy_no_administrative_privileges_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_iam_aws_attached_policy_no_administrative_privileges_test:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_check_saml_providers_sts/iam_check_saml_providers_sts_test.py
+++ b/tests/providers/aws/services/iam/iam_check_saml_providers_sts/iam_check_saml_providers_sts_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -33,6 +34,12 @@ class Test_iam_check_saml_providers_sts:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/iam/iam_customer_attached_policy_no_administrative_privileges/iam_customer_attached_policy_no_administrative_privileges_test.py
+++ b/tests/providers/aws/services/iam/iam_customer_attached_policy_no_administrative_privileges/iam_customer_attached_policy_no_administrative_privileges_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -32,6 +33,12 @@ class Test_iam_customer_attached_policy_no_administrative_privileges_test:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_customer_unattached_policy_no_administrative_privileges/iam_customer_unattached_policy_no_administrative_privileges_test.py
+++ b/tests/providers/aws/services/iam/iam_customer_unattached_policy_no_administrative_privileges/iam_customer_unattached_policy_no_administrative_privileges_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -32,6 +33,12 @@ class Test_iam_customer_unattached_policy_no_administrative_privileges_test:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_disable_30_days_credentials/iam_disable_30_days_credentials_test.py
+++ b/tests/providers/aws/services/iam/iam_disable_30_days_credentials/iam_disable_30_days_credentials_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -35,6 +36,12 @@ class Test_iam_disable_30_days_credentials_test:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/iam/iam_disable_45_days_credentials/iam_disable_45_days_credentials_test.py
+++ b/tests/providers/aws/services/iam/iam_disable_45_days_credentials/iam_disable_45_days_credentials_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -35,6 +36,12 @@ class Test_iam_disable_45_days_credentials_test:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/iam/iam_disable_90_days_credentials/iam_disable_90_days_credentials_test.py
+++ b/tests/providers/aws/services/iam/iam_disable_90_days_credentials/iam_disable_90_days_credentials_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -35,6 +36,12 @@ class Test_iam_disable_90_days_credentials_test:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption_test.py
+++ b/tests/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -35,6 +36,12 @@ class Test_iam_no_custom_policy_permissive_role_assumption:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/iam/iam_no_expired_server_certificates_stored/iam_no_expired_server_certificates_stored_test.py
+++ b/tests/providers/aws/services/iam/iam_no_expired_server_certificates_stored/iam_no_expired_server_certificates_stored_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -34,6 +35,12 @@ class Test_iam_no_expired_server_certificates_stored_test:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key_test.py
+++ b/tests/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -34,6 +35,12 @@ class Test_iam_no_root_access_key_test:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/iam/iam_password_policy_expires_passwords_within_90_days_or_less/iam_password_policy_expires_passwords_within_90_days_or_less_test.py
+++ b/tests/providers/aws/services/iam/iam_password_policy_expires_passwords_within_90_days_or_less/iam_password_policy_expires_passwords_within_90_days_or_less_test.py
@@ -5,6 +5,7 @@ from boto3 import session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -34,6 +35,12 @@ class Test_iam_password_policy_expires_passwords_within_90_days_or_less:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/iam/iam_password_policy_lowercase/iam_password_policy_lowercase_test.py
+++ b/tests/providers/aws/services/iam/iam_password_policy_lowercase/iam_password_policy_lowercase_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_iam_password_policy_lowercase:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_password_policy_minimum_length_14/iam_password_policy_minimum_length_14_test.py
+++ b/tests/providers/aws/services/iam/iam_password_policy_minimum_length_14/iam_password_policy_minimum_length_14_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_iam_password_policy_minimum_length_14:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_password_policy_number/iam_password_policy_number_test.py
+++ b/tests/providers/aws/services/iam/iam_password_policy_number/iam_password_policy_number_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_iam_password_policy_number:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_password_policy_reuse_24/iam_password_policy_reuse_24_test.py
+++ b/tests/providers/aws/services/iam/iam_password_policy_reuse_24/iam_password_policy_reuse_24_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -30,6 +31,12 @@ class Test_iam_password_policy_reuse_24:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_password_policy_symbol/iam_password_policy_symbol_test.py
+++ b/tests/providers/aws/services/iam/iam_password_policy_symbol/iam_password_policy_symbol_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_iam_password_policy_symbol:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_password_policy_uppercase/iam_password_policy_uppercase_test.py
+++ b/tests/providers/aws/services/iam/iam_password_policy_uppercase/iam_password_policy_uppercase_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -30,6 +31,12 @@ class Test_iam_password_policy_uppercase:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation_test.py
+++ b/tests/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_iam_policy_allows_privilege_escalation:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_policy_attached_only_to_group_or_roles/iam_policy_attached_only_to_group_or_roles_test.py
+++ b/tests/providers/aws/services/iam/iam_policy_attached_only_to_group_or_roles/iam_policy_attached_only_to_group_or_roles_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
@@ -32,6 +33,12 @@ class Test_iam_policy_attached_only_to_group_or_roles:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_policy_no_full_access_to_cloudtrail/iam_policy_no_full_access_to_cloudtrail_test.py
+++ b/tests/providers/aws/services/iam/iam_policy_no_full_access_to_cloudtrail/iam_policy_no_full_access_to_cloudtrail_test.py
@@ -6,6 +6,7 @@ from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.iam.iam_service import IAM
+from prowler.providers.common.models import Audit_Metadata
 
 
 class Test_iam_policy_no_full_access_to_cloudtrail:
@@ -31,6 +32,12 @@ class Test_iam_policy_no_full_access_to_cloudtrail:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/iam/iam_policy_no_full_access_to_kms/iam_policy_no_full_access_to_kms_test.py
+++ b/tests/providers/aws/services/iam/iam_policy_no_full_access_to_kms/iam_policy_no_full_access_to_kms_test.py
@@ -6,6 +6,7 @@ from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.iam.iam_service import IAM
+from prowler.providers.common.models import Audit_Metadata
 
 
 class Test_iam_policy_no_full_access_to_kms:
@@ -31,6 +32,12 @@ class Test_iam_policy_no_full_access_to_kms:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/iam/iam_role_cross_account_readonlyaccess_policy/iam_role_cross_account_readonlyaccess_policy_test.py
+++ b/tests/providers/aws/services/iam/iam_role_cross_account_readonlyaccess_policy/iam_role_cross_account_readonlyaccess_policy_test.py
@@ -6,6 +6,7 @@ from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.iam.iam_service import Role
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_ID = "123456789012"
@@ -33,6 +34,12 @@ class Test_iam_role_cross_account_readonlyaccess_policy:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_role_cross_service_confused_deputy_prevention/iam_role_cross_service_confused_deputy_prevention_test.py
+++ b/tests/providers/aws/services/iam/iam_role_cross_service_confused_deputy_prevention/iam_role_cross_service_confused_deputy_prevention_test.py
@@ -6,6 +6,7 @@ from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.iam.iam_service import Role
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_ID = "123456789012"
@@ -33,6 +34,12 @@ class Test_iam_role_cross_service_confused_deputy_prevention:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled_test.py
+++ b/tests/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_iam_root_hardware_mfa_enabled_test:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info
@@ -101,5 +108,6 @@ class Test_iam_root_hardware_mfa_enabled_test:
             )
             assert result[0].resource_id == "<root_account>"
             assert (
-                result[0].resource_arn == f"arn:aws:iam::{service_client.account}:root"
+                result[0].resource_arn
+                == f"arn:aws:iam::{service_client.audited_account}:root"
             )

--- a/tests/providers/aws/services/iam/iam_root_mfa_enabled/iam_root_mfa_enabled_test.py
+++ b/tests/providers/aws/services/iam/iam_root_mfa_enabled/iam_root_mfa_enabled_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_iam_root_mfa_enabled_test:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days_test.py
+++ b/tests/providers/aws/services/iam/iam_rotate_access_key_90_days/iam_rotate_access_key_90_days_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_iam_rotate_access_key_90_days_test:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created_test.py
+++ b/tests/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created_test.py
@@ -7,6 +7,7 @@ from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.iam.iam_service import IAM
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -34,6 +35,12 @@ class Test_iam_securityaudit_role_created:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/iam/iam_service_test.py
+++ b/tests/providers/aws/services/iam/iam_service_test.py
@@ -6,6 +6,7 @@ from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.iam.iam_service import IAM, is_service_role
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 TEST_DATETIME = "2023-01-01T12:01:01+00:00"
@@ -34,6 +35,12 @@ class Test_IAM_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/iam/iam_support_role_created/iam_support_role_created_test.py
+++ b/tests/providers/aws/services/iam/iam_support_role_created/iam_support_role_created_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -32,6 +33,12 @@ class Test_iam_support_role_created:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_user_hardware_mfa_enabled/iam_user_hardware_mfa_enabled_test.py
+++ b/tests/providers/aws/services/iam/iam_user_hardware_mfa_enabled/iam_user_hardware_mfa_enabled_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_iam_user_hardware_mfa_enabled_test:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access_test.py
+++ b/tests/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -30,6 +31,12 @@ class Test_iam_user_mfa_enabled_console_access_test:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_user_no_setup_initial_access_key/iam_user_no_setup_initial_access_key_test.py
+++ b/tests/providers/aws/services/iam/iam_user_no_setup_initial_access_key/iam_user_no_setup_initial_access_key_test.py
@@ -6,6 +6,7 @@ from boto3 import session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -32,6 +33,12 @@ class Test_iam_user_no_setup_initial_access_key_test:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/iam/iam_user_two_active_access_key/iam_user_two_active_access_key_test.py
+++ b/tests/providers/aws/services/iam/iam_user_two_active_access_key/iam_user_two_active_access_key_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_iam
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 
@@ -31,6 +32,12 @@ class Test_iam_user_two_active_access_key:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/inspector2/inspector2_service_test.py
+++ b/tests/providers/aws/services/inspector2/inspector2_service_test.py
@@ -6,6 +6,7 @@ from boto3 import session
 
 from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.inspector2.inspector2_service import Inspector2
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_ID = "123456789012"
@@ -68,7 +69,7 @@ def mock_make_api_call(self, operation_name, kwargs):
     return make_api_call(self, operation_name, kwargs)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -77,7 +78,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.inspector2.inspector2_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_Inspector2_Service:
@@ -103,6 +104,12 @@ class Test_Inspector2_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used_test.py
+++ b/tests/providers/aws/services/kms/kms_cmk_are_used/kms_cmk_are_used_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_kms
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_kms_cmk_are_used:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled_test.py
+++ b/tests/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_kms
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_kms_cmk_rotation_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_kms
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -32,6 +33,12 @@ class Test_kms_key_not_publicly_accessible:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/kms/kms_service_test.py
+++ b/tests/providers/aws/services/kms/kms_service_test.py
@@ -5,6 +5,7 @@ from moto import mock_kms
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.kms.kms_service import KMS
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -33,6 +34,12 @@ class Test_ACM_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/macie/macie_service_test.py
+++ b/tests/providers/aws/services/macie/macie_service_test.py
@@ -6,6 +6,7 @@ from boto3 import session
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.macie.macie_service import Macie, Session
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -34,7 +35,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -43,7 +44,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.macie.macie_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_Macie_Service:
@@ -68,6 +69,12 @@ class Test_Macie_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc_test.py
@@ -7,6 +7,7 @@ from prowler.providers.aws.services.networkfirewall.networkfirewall_service impo
     Firewall,
 )
 from prowler.providers.aws.services.vpc.vpc_service import VPCs, VpcSubnet
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -41,6 +42,12 @@ class Test_networkfirewall_in_all_vpc:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_service_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_service_test.py
@@ -7,6 +7,7 @@ from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.networkfirewall.networkfirewall_service import (
     NetworkFirewall,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "us-east-1"
@@ -51,7 +52,7 @@ def mock_make_api_call(self, operation_name, kwargs):
     return make_api_call(self, operation_name, kwargs)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -60,7 +61,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.networkfirewall.networkfirewall_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_NetworkFirewall_Service:
@@ -86,6 +87,12 @@ class Test_NetworkFirewall_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/opensearch/opensearch_service_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_test.py
@@ -8,6 +8,7 @@ from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.opensearch.opensearch_service import (
     OpenSearchService,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
@@ -91,7 +92,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -99,7 +100,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.opensearch.opensearch_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_OpenSearchService_Service:
@@ -125,6 +126,12 @@ class Test_OpenSearchService_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/organizations/organizations_account_part_of_organizations/organizations_account_part_of_organizations_test.py
+++ b/tests/providers/aws/services/organizations/organizations_account_part_of_organizations/organizations_account_part_of_organizations_test.py
@@ -8,6 +8,7 @@ from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.organizations.organizations_service import (
     Organizations,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 
@@ -35,6 +36,12 @@ class Test_organizations_account_part_of_organizations:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/organizations/organizations_delegated_administrators/organizations_delegated_administrators_test.py
+++ b/tests/providers/aws/services/organizations/organizations_delegated_administrators/organizations_delegated_administrators_test.py
@@ -8,6 +8,7 @@ from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.organizations.organizations_service import (
     Organizations,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 
@@ -35,6 +36,12 @@ class Test_organizations_delegated_administrators:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions_test.py
+++ b/tests/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions_test.py
@@ -8,6 +8,7 @@ from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.organizations.organizations_service import (
     Organizations,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 
@@ -39,6 +40,12 @@ class Test_organizations_scp_check_deny_regions:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/organizations/organizations_service_test.py
+++ b/tests/providers/aws/services/organizations/organizations_service_test.py
@@ -8,6 +8,7 @@ from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.organizations.organizations_service import (
     Organizations,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 
@@ -40,6 +41,12 @@ class Test_Organizations_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/organizations/organizations_tags_policies_enabled_and_attached/organizations_tags_policies_enabled_and_attached_test.py
+++ b/tests/providers/aws/services/organizations/organizations_tags_policies_enabled_and_attached/organizations_tags_policies_enabled_and_attached_test.py
@@ -7,6 +7,7 @@ from prowler.providers.aws.services.organizations.organizations_service import (
     Organization,
     Policy,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -38,6 +39,12 @@ class Test_organizations_tags_policies_enabled_and_attached:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/rds/rds_instance_backup_enabled/rds_instance_backup_enabled_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_backup_enabled/rds_instance_backup_enabled_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_rds
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -54,6 +55,12 @@ class Test_rds_instance_backup_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/rds/rds_instance_deletion_protection/rds_instance_deletion_protection_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_deletion_protection/rds_instance_deletion_protection_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_rds
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -54,6 +55,12 @@ class Test_rds_instance_deletion_protection:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/rds/rds_instance_deprecated_engine_version/rds_instance_deprecated_engine_version_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_deprecated_engine_version/rds_instance_deprecated_engine_version_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_rds
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -53,6 +54,12 @@ class Test_rds_instance_deprecated_engine_version:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/rds/rds_instance_enhanced_monitoring_enabled/rds_instance_enhanced_monitoring_enabled_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_enhanced_monitoring_enabled/rds_instance_enhanced_monitoring_enabled_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_rds
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -53,6 +54,12 @@ class Test_rds_instance_enhanced_monitoring_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/rds/rds_instance_integration_cloudwatch_logs/rds_instance_integration_cloudwatch_logs_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_integration_cloudwatch_logs/rds_instance_integration_cloudwatch_logs_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_rds
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -53,6 +54,12 @@ class Test_rds_instance_integration_cloudwatch_logs:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/rds/rds_instance_minor_version_upgrade_enabled/rds_instance_minor_version_upgrade_enabled_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_minor_version_upgrade_enabled/rds_instance_minor_version_upgrade_enabled_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_rds
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -53,6 +54,12 @@ class Test_rds_instance_minor_version_upgrade_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az_test.py
@@ -7,6 +7,7 @@ from moto import mock_rds
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.rds.rds_service import DBCluster, DBInstance
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -54,6 +55,12 @@ class Test_rds_instance_multi_az:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_rds
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -53,6 +54,12 @@ class Test_rds_instance_no_public_access:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/rds/rds_instance_storage_encrypted/rds_instance_storage_encrypted_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_storage_encrypted/rds_instance_storage_encrypted_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_rds
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -53,6 +54,12 @@ class Test_rds_instance_storage_encrypted:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_rds
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -53,6 +54,12 @@ class Test_rds_instance_transport_encrypted:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/rds/rds_service_test.py
+++ b/tests/providers/aws/services/rds/rds_service_test.py
@@ -6,6 +6,7 @@ from moto import mock_rds
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.rds.rds_service import RDS
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -52,6 +53,12 @@ class Test_RDS_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/rds/rds_snapshots_public_access/rds_snapshots_public_access_test.py
+++ b/tests/providers/aws/services/rds/rds_snapshots_public_access/rds_snapshots_public_access_test.py
@@ -6,6 +6,7 @@ from boto3 import client, session
 from moto import mock_rds
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -61,6 +62,12 @@ class Test_rds_snapshots_public_access:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/redshift/redshift_service_test.py
+++ b/tests/providers/aws/services/redshift/redshift_service_test.py
@@ -7,6 +7,7 @@ from moto import mock_redshift
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.redshift.redshift_service import Redshift
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
@@ -45,7 +46,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -53,7 +54,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.redshift.redshift_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_Redshift_Service:
@@ -79,6 +80,12 @@ class Test_Redshift_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/resourceexplorer2/resourceexplorer2_indexes_found/resourceexplorer2_indexes_found_test.py
+++ b/tests/providers/aws/services/resourceexplorer2/resourceexplorer2_indexes_found/resourceexplorer2_indexes_found_test.py
@@ -6,6 +6,7 @@ from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.resourceexplorer2.resourceexplorer2_service import (
     Indexes,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -35,6 +36,12 @@ class Test_resourceexplorer2_indexes_found:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/resourceexplorer2/resourceexplorer2_service_test.py
+++ b/tests/providers/aws/services/resourceexplorer2/resourceexplorer2_service_test.py
@@ -7,6 +7,7 @@ from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.resourceexplorer2.resourceexplorer2_service import (
     ResourceExplorer2,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
@@ -30,7 +31,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -38,7 +39,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.resourceexplorer2.resourceexplorer2_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_ResourceExplorer2_Service:
@@ -64,6 +65,12 @@ class Test_ResourceExplorer2_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/route53/route53_public_hosted_zones_cloudwatch_logging_enabled/route53_public_hosted_zones_cloudwatch_logging_enabled_test.py
+++ b/tests/providers/aws/services/route53/route53_public_hosted_zones_cloudwatch_logging_enabled/route53_public_hosted_zones_cloudwatch_logging_enabled_test.py
@@ -16,6 +16,9 @@ class Test_route53_public_hosted_zones_cloudwatch_logging_enabled:
         route53.hosted_zones = {}
 
         with mock.patch(
+            "prowler.providers.aws.services.route53.route53_service.Route53",
+            new=route53,
+        ), mock.patch(
             "prowler.providers.aws.services.route53.route53_public_hosted_zones_cloudwatch_logging_enabled.route53_public_hosted_zones_cloudwatch_logging_enabled.route53_client",
             new=route53,
         ):
@@ -49,6 +52,9 @@ class Test_route53_public_hosted_zones_cloudwatch_logging_enabled:
         }
 
         with mock.patch(
+            "prowler.providers.aws.services.route53.route53_service.Route53",
+            new=route53,
+        ), mock.patch(
             "prowler.providers.aws.services.route53.route53_public_hosted_zones_cloudwatch_logging_enabled.route53_public_hosted_zones_cloudwatch_logging_enabled.route53_client",
             new=route53,
         ):
@@ -84,6 +90,9 @@ class Test_route53_public_hosted_zones_cloudwatch_logging_enabled:
         }
 
         with mock.patch(
+            "prowler.providers.aws.services.route53.route53_service.Route53",
+            new=route53,
+        ), mock.patch(
             "prowler.providers.aws.services.route53.route53_public_hosted_zones_cloudwatch_logging_enabled.route53_public_hosted_zones_cloudwatch_logging_enabled.route53_client",
             new=route53,
         ):
@@ -119,6 +128,9 @@ class Test_route53_public_hosted_zones_cloudwatch_logging_enabled:
         }
 
         with mock.patch(
+            "prowler.providers.aws.services.route53.route53_service.Route53",
+            new=route53,
+        ), mock.patch(
             "prowler.providers.aws.services.route53.route53_public_hosted_zones_cloudwatch_logging_enabled.route53_public_hosted_zones_cloudwatch_logging_enabled.route53_client",
             new=route53,
         ):

--- a/tests/providers/aws/services/route53/route53_service_test.py
+++ b/tests/providers/aws/services/route53/route53_service_test.py
@@ -6,6 +6,7 @@ from moto import mock_logs, mock_route53
 
 from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.route53.route53_service import Route53
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "us-east-1"
@@ -56,6 +57,12 @@ class Test_Route53_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/route53/route53domains_service_test.py
+++ b/tests/providers/aws/services/route53/route53domains_service_test.py
@@ -6,6 +6,7 @@ from boto3 import session
 
 from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.route53.route53_service import Route53Domains
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "us-east-1"
@@ -92,6 +93,12 @@ class Test_Route53_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/s3/s3_account_level_public_access_blocks/s3_account_level_public_access_blocks_test.py
+++ b/tests/providers/aws/services/s3/s3_account_level_public_access_blocks/s3_account_level_public_access_blocks_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_s3, mock_s3control
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
@@ -34,6 +35,12 @@ class Test_s3_account_level_public_access_blocks:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/s3/s3_bucket_acl_prohibited/s3_bucket_acl_prohibited_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_acl_prohibited/s3_bucket_acl_prohibited_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
@@ -35,6 +36,12 @@ class Test_s3_bucket_acl_prohibited:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/s3/s3_bucket_default_encryption/s3_bucket_default_encryption_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_default_encryption/s3_bucket_default_encryption_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -35,6 +36,12 @@ class Test_s3_bucket_default_encryption:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/s3/s3_bucket_level_public_access_block/s3_bucket_level_public_access_block_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_level_public_access_block/s3_bucket_level_public_access_block_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -35,6 +36,12 @@ class Test_s3_bucket_level_public_access_block:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/s3/s3_bucket_no_mfa_delete/s3_bucket_no_mfa_delete_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_no_mfa_delete/s3_bucket_no_mfa_delete_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
@@ -35,6 +36,12 @@ class Test_s3_bucket_no_mfa_delete:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/s3/s3_bucket_object_lock/s3_bucket_object_lock_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_object_lock/s3_bucket_object_lock_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
@@ -35,6 +36,12 @@ class Test_s3_bucket_object_lock:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/s3/s3_bucket_object_versioning/s3_bucket_object_versioning_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_object_versioning/s3_bucket_object_versioning_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
@@ -35,6 +36,12 @@ class Test_s3_bucket_object_versioning:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
@@ -35,6 +36,12 @@ class Test_s3_bucket_policy_public_write_access:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/s3/s3_bucket_public_access/s3_bucket_public_access_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_public_access/s3_bucket_public_access_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_s3, mock_s3control
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
@@ -35,6 +36,12 @@ class Test_s3_bucket_public_access:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/s3/s3_bucket_public_list_acl/s3_bucket_public_list_acl_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_public_list_acl/s3_bucket_public_list_acl_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_s3, mock_s3control
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
@@ -34,6 +35,12 @@ class Test_s3_bucket_public_list_acl:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/s3/s3_bucket_public_write_acl/s3_bucket_public_write_acl_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_public_write_acl/s3_bucket_public_write_acl_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_s3, mock_s3control
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
@@ -34,6 +35,12 @@ class Test_s3_bucket_public_write_acl:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/s3/s3_bucket_secure_transport_policy/s3_bucket_secure_transport_policy_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_secure_transport_policy/s3_bucket_secure_transport_policy_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
@@ -35,6 +36,12 @@ class Test_s3_bucket_secure_transport_policy:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/s3/s3_bucket_server_access_logging_enabled/s3_bucket_server_access_logging_enabled_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_server_access_logging_enabled/s3_bucket_server_access_logging_enabled_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_s3
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
@@ -35,6 +36,12 @@ class Test_s3_bucket_server_access_logging_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/s3/s3_service_test.py
+++ b/tests/providers/aws/services/s3/s3_service_test.py
@@ -5,6 +5,7 @@ from moto import mock_s3, mock_s3control
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.s3.s3_service import S3, S3Control
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -34,6 +35,12 @@ class Test_S3_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
@@ -6,6 +6,7 @@ from boto3 import session
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.sagemaker.sagemaker_service import SageMaker
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
@@ -92,7 +93,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -100,7 +101,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.sagemaker.sagemaker_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_SageMaker_Service:
@@ -126,6 +127,12 @@ class Test_SageMaker_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/secretsmanager/secretsmanager_service_test.py
+++ b/tests/providers/aws/services/secretsmanager/secretsmanager_service_test.py
@@ -10,13 +10,14 @@ from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.secretsmanager.secretsmanager_service import (
     SecretsManager,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -24,7 +25,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch(
-    "prowler.providers.aws.services.secretsmanager.secretsmanager_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_SecretsManager_Service:
@@ -49,6 +50,12 @@ class Test_SecretsManager_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/securityhub/securityhub_service_test.py
+++ b/tests/providers/aws/services/securityhub/securityhub_service_test.py
@@ -5,6 +5,7 @@ from boto3 import session
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.securityhub.securityhub_service import SecurityHub
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -45,7 +46,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -54,7 +55,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.securityhub.securityhub_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_SecurityHub_Service:
@@ -79,6 +80,12 @@ class Test_SecurityHub_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/shield/shield_advanced_protection_in_associated_elastic_ips/shield_advanced_protection_in_associated_elastic_ips_test.py
+++ b/tests/providers/aws/services/shield/shield_advanced_protection_in_associated_elastic_ips/shield_advanced_protection_in_associated_elastic_ips_test.py
@@ -13,7 +13,7 @@ AWS_REGION = "eu-west-1"
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -21,7 +21,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch(
-    "prowler.providers.aws.services.accessanalyzer.accessanalyzer_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_shield_advanced_protection_in_associated_elastic_ips:

--- a/tests/providers/aws/services/shield/shield_advanced_protection_in_classic_load_balancers/shield_advanced_protection_in_classic_load_balancers_test.py
+++ b/tests/providers/aws/services/shield/shield_advanced_protection_in_classic_load_balancers/shield_advanced_protection_in_classic_load_balancers_test.py
@@ -6,6 +6,7 @@ from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.shield.shield_service import Protection
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 
@@ -33,6 +34,12 @@ class Test_shield_advanced_protection_in_classic_load_balancers:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/shield/shield_advanced_protection_in_internet_facing_load_balancers/shield_advanced_protection_in_internet_facing_load_balancers_test.py
+++ b/tests/providers/aws/services/shield/shield_advanced_protection_in_internet_facing_load_balancers/shield_advanced_protection_in_internet_facing_load_balancers_test.py
@@ -7,12 +7,13 @@ from moto.core import DEFAULT_ACCOUNT_ID as AWS_ACCOUNT_NUMBER
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.shield.shield_service import Protection
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -20,7 +21,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch(
-    "prowler.providers.aws.services.accessanalyzer.accessanalyzer_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_shield_advanced_protection_in_internet_facing_load_balancers:
@@ -46,6 +47,12 @@ class Test_shield_advanced_protection_in_internet_facing_load_balancers:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/shield/shield_advanced_protection_in_route53_hosted_zones/shield_advanced_protection_in_route53_hosted_zones_test.py
+++ b/tests/providers/aws/services/shield/shield_advanced_protection_in_route53_hosted_zones/shield_advanced_protection_in_route53_hosted_zones_test.py
@@ -17,6 +17,9 @@ class Test_shield_advanced_protection_in_route53_hosted_zones:
             "prowler.providers.aws.services.shield.shield_service.Shield",
             new=shield_client,
         ), mock.patch(
+            "prowler.providers.aws.services.route53.route53_service.Route53",
+            new=shield_client,
+        ), mock.patch(
             "prowler.providers.aws.services.shield.shield_advanced_protection_in_route53_hosted_zones.shield_advanced_protection_in_route53_hosted_zones.route53_client",
             new=route53_client,
         ):
@@ -65,6 +68,9 @@ class Test_shield_advanced_protection_in_route53_hosted_zones:
 
         with mock.patch(
             "prowler.providers.aws.services.shield.shield_service.Shield",
+            new=shield_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.route53.route53_service.Route53",
             new=shield_client,
         ), mock.patch(
             "prowler.providers.aws.services.shield.shield_advanced_protection_in_route53_hosted_zones.shield_advanced_protection_in_route53_hosted_zones.route53_client",
@@ -116,6 +122,9 @@ class Test_shield_advanced_protection_in_route53_hosted_zones:
             "prowler.providers.aws.services.shield.shield_service.Shield",
             new=shield_client,
         ), mock.patch(
+            "prowler.providers.aws.services.route53.route53_service.Route53",
+            new=shield_client,
+        ), mock.patch(
             "prowler.providers.aws.services.shield.shield_advanced_protection_in_route53_hosted_zones.shield_advanced_protection_in_route53_hosted_zones.route53_client",
             new=route53_client,
         ):
@@ -163,6 +172,9 @@ class Test_shield_advanced_protection_in_route53_hosted_zones:
 
         with mock.patch(
             "prowler.providers.aws.services.shield.shield_service.Shield",
+            new=shield_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.route53.route53_service.Route53",
             new=shield_client,
         ), mock.patch(
             "prowler.providers.aws.services.shield.shield_advanced_protection_in_route53_hosted_zones.shield_advanced_protection_in_route53_hosted_zones.route53_client",

--- a/tests/providers/aws/services/shield/shield_service_test.py
+++ b/tests/providers/aws/services/shield/shield_service_test.py
@@ -5,6 +5,7 @@ from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.shield.shield_service import Shield
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -56,6 +57,12 @@ class Test_Shield_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/sns/sns_service_test.py
+++ b/tests/providers/aws/services/sns/sns_service_test.py
@@ -8,6 +8,7 @@ from moto import mock_sns
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.sns.sns_service import SNS
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
@@ -36,7 +37,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -44,7 +45,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.sns.sns_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_SNS_Service:
@@ -70,6 +71,12 @@ class Test_SNS_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/sqs/sqs_service_test.py
+++ b/tests/providers/aws/services/sqs/sqs_service_test.py
@@ -8,6 +8,7 @@ from moto import mock_sqs
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.sqs.sqs_service import SQS
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
@@ -38,7 +39,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -46,7 +47,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.sqs.sqs_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_SQS_Service:
@@ -72,6 +73,12 @@ class Test_SQS_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/ssm/ssm_service_test.py
+++ b/tests/providers/aws/services/ssm/ssm_service_test.py
@@ -8,6 +8,7 @@ from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.ssm.ssm_service import SSM, ResourceStatus
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -66,7 +67,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -127,7 +128,7 @@ mainSteps:
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.ssm.ssm_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_SSM_Service:
@@ -153,6 +154,12 @@ class Test_SSM_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/ssmincidents/ssmincidents_service_test.py
+++ b/tests/providers/aws/services/ssmincidents/ssmincidents_service_test.py
@@ -8,6 +8,7 @@ from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.ssmincidents.ssmincidents_service import (
     SSMIncidents,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 # Mock Test Region
 AWS_REGION = "us-east-1"
@@ -54,7 +55,7 @@ def mock_make_api_call(self, operation_name, kwargs):
     return make_api_call(self, operation_name, kwargs)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -63,7 +64,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.ssmincidents.ssmincidents_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_SSMIncidents_Service:
@@ -89,6 +90,12 @@ class Test_SSMIncidents_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/trustedadvisor/trustedadvisor_service_test.py
+++ b/tests/providers/aws/services/trustedadvisor/trustedadvisor_service_test.py
@@ -8,6 +8,7 @@ from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.trustedadvisor.trustedadvisor_service import (
     TrustedAdvisor,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -45,6 +46,12 @@ class Test_TrustedAdvisor_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/vpc/vpc_different_regions/vpc_different_regions_test.py
+++ b/tests/providers/aws/services/vpc/vpc_different_regions/vpc_different_regions_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_ec2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_vpc_different_regions:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries_test.py
+++ b/tests/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_ec2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -38,6 +39,12 @@ class Test_vpc_endpoint_connections_trust_boundaries:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/vpc/vpc_endpoint_services_allowed_principals_trust_boundaries/vpc_endpoint_services_allowed_principals_trust_boundaries_test.py
+++ b/tests/providers/aws/services/vpc/vpc_endpoint_services_allowed_principals_trust_boundaries/vpc_endpoint_services_allowed_principals_trust_boundaries_test.py
@@ -6,6 +6,7 @@ from mock import patch
 from moto import mock_ec2, mock_elbv2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -57,6 +58,12 @@ class Test_vpc_endpoint_services_allowed_principals_trust_boundaries:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/vpc/vpc_flow_logs_enabled/vpc_flow_logs_enabled_test.py
+++ b/tests/providers/aws/services/vpc/vpc_flow_logs_enabled/vpc_flow_logs_enabled_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_ec2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_vpc_flow_logs_enabled:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/vpc/vpc_peering_routing_tables_with_least_privilege/vpc_peering_routing_tables_with_least_privilege_test.py
+++ b/tests/providers/aws/services/vpc/vpc_peering_routing_tables_with_least_privilege/vpc_peering_routing_tables_with_least_privilege_test.py
@@ -4,6 +4,7 @@ from boto3 import client, resource, session
 from moto import mock_ec2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_vpc_peering_routing_tables_with_least_privilege:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/vpc/vpc_service_test.py
+++ b/tests/providers/aws/services/vpc/vpc_service_test.py
@@ -5,6 +5,7 @@ from moto import mock_ec2, mock_elbv2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC, Route
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -33,6 +34,12 @@ class Test_VPC_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/vpc/vpc_subnet_different_az/vpc_subnet_different_az_test.py
+++ b/tests/providers/aws/services/vpc/vpc_subnet_different_az/vpc_subnet_different_az_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_ec2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_vpc_subnet_different_az:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/vpc/vpc_subnet_no_public_ip_by_default/vpc_subnet_no_public_ip_by_default_test.py
+++ b/tests/providers/aws/services/vpc/vpc_subnet_no_public_ip_by_default/vpc_subnet_no_public_ip_by_default_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_ec2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_vpc_subnet_separate_private_public:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/vpc/vpc_subnet_separate_private_public/vpc_subnet_separate_private_public_test.py
+++ b/tests/providers/aws/services/vpc/vpc_subnet_separate_private_public/vpc_subnet_separate_private_public_test.py
@@ -4,6 +4,7 @@ from boto3 import client, session
 from moto import mock_ec2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -31,6 +32,12 @@ class Test_vpc_subnet_separate_private_public:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/aws/services/waf/waf_service_test.py
+++ b/tests/providers/aws/services/waf/waf_service_test.py
@@ -5,6 +5,7 @@ from boto3 import session
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.waf.waf_service import WAF
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -32,7 +33,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -41,7 +42,7 @@ def mock_generate_regional_clients(service, audit_info):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.waf.waf_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_WAF_Service:
@@ -67,6 +68,12 @@ class Test_WAF_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/wafv2/wafv2_service_test.py
+++ b/tests/providers/aws/services/wafv2/wafv2_service_test.py
@@ -3,6 +3,7 @@ from moto import mock_ec2, mock_elbv2, mock_wafv2
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "us-east-1"
@@ -31,6 +32,12 @@ class Test_WAFv2_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/wellarchitected/wellarchitected_service_test.py
+++ b/tests/providers/aws/services/wellarchitected/wellarchitected_service_test.py
@@ -8,6 +8,7 @@ from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.wellarchitected.wellarchitected_service import (
     WellArchitected,
 )
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
@@ -41,7 +42,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -49,7 +50,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.wellarchitected.wellarchitected_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_WellArchitected_Service:
@@ -75,6 +76,12 @@ class Test_WellArchitected_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/workspaces/workspaces_service_test.py
+++ b/tests/providers/aws/services/workspaces/workspaces_service_test.py
@@ -6,6 +6,7 @@ from boto3 import session
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.workspaces.workspaces_service import WorkSpaces
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_REGION = "eu-west-1"
@@ -37,7 +38,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info):
+def mock_generate_regional_clients(service, audit_info, _):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}
@@ -45,7 +46,7 @@ def mock_generate_regional_clients(service, audit_info):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 @patch(
-    "prowler.providers.aws.services.workspaces.workspaces_service.generate_regional_clients",
+    "prowler.providers.aws.lib.service.service.generate_regional_clients",
     new=mock_generate_regional_clients,
 )
 class Test_WorkSpaces_Service:
@@ -71,6 +72,12 @@ class Test_WorkSpaces_Service:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 

--- a/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
+++ b/tests/providers/aws/services/workspaces/workspaces_vpc_2private_1public_subnets_nat/workspaces_vpc_2private_1public_subnets_nat_test.py
@@ -7,6 +7,7 @@ from moto import mock_ec2
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC
 from prowler.providers.aws.services.workspaces.workspaces_service import WorkSpace
+from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -35,6 +36,12 @@ class Test_workspaces_vpc_2private_1public_subnets_nat:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/common/audit_info_test.py
+++ b/tests/providers/common/audit_info_test.py
@@ -17,6 +17,7 @@ from prowler.providers.common.audit_info import (
     get_tagged_resources,
     set_provider_audit_info,
 )
+from prowler.providers.common.models import Audit_Metadata
 from prowler.providers.gcp.gcp_provider import GCP_Provider
 from prowler.providers.gcp.lib.audit_info.models import GCP_Audit_Info
 
@@ -116,6 +117,12 @@ class Test_Set_Audit_Info:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
 
         return audit_info

--- a/tests/providers/common/common_outputs_test.py
+++ b/tests/providers/common/common_outputs_test.py
@@ -9,6 +9,7 @@ from prowler.providers.azure.lib.audit_info.audit_info import (
     Azure_Audit_Info,
     Azure_Identity_Info,
 )
+from prowler.providers.common.models import Audit_Metadata
 from prowler.providers.common.outputs import (
     Aws_Output_Options,
     Azure_Output_Options,
@@ -74,6 +75,12 @@ class Test_Common_Output_Options:
             organizations_metadata=None,
             audit_resources=None,
             mfa_enabled=False,
+            audit_metadata=Audit_Metadata(
+                services_scanned=0,
+                expected_checks=[],
+                completed_checks=0,
+                audit_progress=0,
+            ),
         )
         return audit_info
 


### PR DESCRIPTION
### Context

We needed a parent class for each AWS Service not to repeat code and to have a centralised point of initialising an AWS service class.

Thanks @Fennerr for the idea based on https://github.com/prowler-cloud/prowler/pull/2108. We are working on to test and integrate that code into Prowler but we need to break it down into a series of steps to achieve it.

### Description

New `AWSService` class as parent for each AWS service class.
- `__threading_call__` and `get_session` methods has been moved to the `AWSService` class.
- Fix some typos
- Include the `Audit_Metadata` in each `set_mocked_audit_info`.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
