### PR TITLE
fix(ec2_instance_secrets_user_data): Include line numbers in status

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data.py
@@ -38,9 +38,19 @@ class ec2_instance_secrets_user_data(Check):
                     with default_settings():
                         secrets.scan_file(temp_user_data_file.name)
 
-                    if secrets.json():
+                    detect_secrets_output = secrets.json()
+                    if detect_secrets_output:
+                        secrets_string = ", ".join(
+                            [
+                                f"{secret['type']} on line {secret['line_number']}"
+                                for secret in detect_secrets_output[
+                                    temp_user_data_file.name
+                                ]
+                            ]
+                        )
                         report.status = "FAIL"
-                        report.status_extended = f"Potential secret found in EC2 instance {instance.id} User Data."
+                        report.status_extended = f"Potential secret found in EC2 instance {instance.id} User Data -> {secrets_string}."
+
                     else:
                         report.status = "PASS"
                         report.status_extended = (

--- a/tests/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data_test.py
@@ -86,7 +86,7 @@ class Test_ec2_instance_secrets_user_data:
         ), mock.patch(
             "prowler.providers.aws.services.ec2.ec2_instance_secrets_user_data.ec2_instance_secrets_user_data.ec2_client",
             new=EC2(current_audit_info),
-        ) as ec2_client:
+        ):
             from prowler.providers.aws.services.ec2.ec2_instance_secrets_user_data.ec2_instance_secrets_user_data import (
                 ec2_instance_secrets_user_data,
             )
@@ -103,7 +103,7 @@ class Test_ec2_instance_secrets_user_data:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{ec2_client.audited_partition}:ec2:{AWS_REGION}:{ec2_client.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
             assert result[0].resource_tags is None
             assert result[0].region == AWS_REGION

--- a/tests/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data_test.py
@@ -86,7 +86,7 @@ class Test_ec2_instance_secrets_user_data:
         ), mock.patch(
             "prowler.providers.aws.services.ec2.ec2_instance_secrets_user_data.ec2_instance_secrets_user_data.ec2_client",
             new=EC2(current_audit_info),
-        ):
+        ) as ec2_client:
             from prowler.providers.aws.services.ec2.ec2_instance_secrets_user_data.ec2_instance_secrets_user_data import (
                 ec2_instance_secrets_user_data,
             )
@@ -101,6 +101,12 @@ class Test_ec2_instance_secrets_user_data:
                 == f"No secrets found in EC2 instance {instance.id} User Data."
             )
             assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{ec2_client.audited_partition}:ec2:{AWS_REGION}:{ec2_client.audited_account}:instance/{instance.id}"
+            )
+            assert result[0].resource_tags is None
+            assert result[0].region == AWS_REGION
 
     @mock_ec2
     def test_one_ec2_with_secrets(self):
@@ -134,13 +140,15 @@ class Test_ec2_instance_secrets_user_data:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Potential secret found in EC2 instance {instance.id} User Data."
+                == f"Potential secret found in EC2 instance {instance.id} User Data -> Secret Keyword on line 1."
             )
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
                 == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
+            assert result[0].resource_tags is None
+            assert result[0].region == AWS_REGION
 
     @mock_ec2
     def test_one_ec2_file_with_secrets(self):
@@ -177,13 +185,15 @@ class Test_ec2_instance_secrets_user_data:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Potential secret found in EC2 instance {instance.id} User Data."
+                == f"Potential secret found in EC2 instance {instance.id} User Data -> Secret Keyword on line 1, Hex High Entropy String on line 3, Secret Keyword on line 3, Secret Keyword on line 4."
             )
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
                 == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
+            assert result[0].resource_tags is None
+            assert result[0].region == AWS_REGION
 
     @mock_ec2
     def test_one_launch_configurations_without_user_data(self):
@@ -221,3 +231,5 @@ class Test_ec2_instance_secrets_user_data:
                 result[0].resource_arn
                 == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
+            assert result[0].resource_tags is None
+            assert result[0].region == AWS_REGION


### PR DESCRIPTION
### Context

Fixes #2632 

### Description

Include line numbers in status in the `ec2_instance_secrets_user_data` check.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
