### PR TITLE
fix(cloudtrail): Set status to INFO when trail is outside the audited account

### DIFF
--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete.py
@@ -27,7 +27,7 @@ class cloudtrail_bucket_requires_mfa_delete(Check):
                             report.status_extended = f"Trail {trail.name} bucket ({trail_bucket}) has MFA delete enabled."
                 # check if trail bucket is a cross account bucket
                 if not trail_bucket_is_in_account:
-                    report.status = "PASS"
+                    report.status = "INFO"
                     report.status_extended = f"Trail {trail.name} bucket ({trail_bucket}) is a cross-account bucket in another account out of Prowler's permissions scope, please check it manually."
 
                 findings.append(report)

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_access_logging_enabled/cloudtrail_logs_s3_bucket_access_logging_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_access_logging_enabled/cloudtrail_logs_s3_bucket_access_logging_enabled.py
@@ -35,6 +35,7 @@ class cloudtrail_logs_s3_bucket_access_logging_enabled(Check):
 
                 # check if trail is delivering logs in a cross account bucket
                 if not trail_bucket_is_in_account:
+                    report.status = "INFO"
                     report.status_extended = f"Trail {trail.name} is delivering logs in a cross-account bucket {trail_bucket} in another account out of Prowler's permissions scope, please check it manually"
                 findings.append(report)
 

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible.py
@@ -41,6 +41,7 @@ class cloudtrail_logs_s3_bucket_is_not_publicly_accessible(Check):
                                     break
                 # check if trail bucket is a cross account bucket
                 if not trail_bucket_is_in_account:
+                    report.status = "INFO"
                     report.status_extended = f"Trail {trail.name} bucket ({trail_bucket}) is a cross-account bucket in another account out of Prowler's permissions scope, please check it manually"
                 findings.append(report)
 

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
@@ -207,7 +207,7 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
             check = cloudtrail_bucket_requires_mfa_delete()
             result = check.execute()
             assert len(result) == 1
-            assert result[0].status == "PASS"
+            assert result[0].status == "INFO"
             assert (
                 result[0].status_extended
                 == f"Trail {trail_name_us} bucket ({bucket_name_us}) is a cross-account bucket in another account out of Prowler's permissions scope, please check it manually."
@@ -259,7 +259,7 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
             check = cloudtrail_bucket_requires_mfa_delete()
             result = check.execute()
             assert len(result) == 1
-            assert result[0].status == "PASS"
+            assert result[0].status == "INFO"
             assert (
                 result[0].status_extended
                 == f"Trail {trail_name_us} bucket ({bucket_name_us}) is a cross-account bucket in another account out of Prowler's permissions scope, please check it manually."

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_access_logging_enabled/cloudtrail_logs_s3_bucket_access_logging_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_access_logging_enabled/cloudtrail_logs_s3_bucket_access_logging_enabled_test.py
@@ -188,7 +188,7 @@ class Test_cloudtrail_logs_s3_bucket_access_logging_enabled:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].status == "FAIL"
+            assert result[0].status == "INFO"
             assert search(
                 "in another account out of Prowler's permissions scope, please check it manually",
                 result[0].status_extended,

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_test.py
@@ -250,7 +250,7 @@ class Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].status == "PASS"
+            assert result[0].status == "INFO"
             assert result[0].resource_id == trail_name_us
             assert result[0].resource_arn == trail_us["TrailARN"]
             assert search(


### PR DESCRIPTION
### Description

Testing https://github.com/prowler-cloud/prowler/issues/2438 I realized that we are raising `PASS` or `FAIL` when the bucket trail is a cross-account bucket in another account out of Prowler's permissions scope, so we cannot check anything against it.

Due to the fact that we state `please check it manually` in the `status_extended`, I think we need to raise an `INFO` finding.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
