### PR TITLE
fix(s3_bucket_level_public_access_block): check s3 public access block at account level

### DIFF
--- a/prowler/providers/aws/services/s3/s3_bucket_level_public_access_block/s3_bucket_level_public_access_block.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_level_public_access_block/s3_bucket_level_public_access_block.py
@@ -1,5 +1,6 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.s3.s3_client import s3_client
+from prowler.providers.aws.services.s3.s3control_client import s3control_client
 
 
 class s3_bucket_level_public_access_block(Check):
@@ -18,7 +19,14 @@ class s3_bucket_level_public_access_block(Check):
                     bucket.public_access_block.ignore_public_acls
                     and bucket.public_access_block.restrict_public_buckets
                 ):
-                    report.status = "FAIL"
-                    report.status_extended = f"Block Public Access is not configured for the S3 Bucket {bucket.name}."
+                    if (
+                        s3control_client.account_public_access_block
+                        and s3control_client.account_public_access_block.ignore_public_acls
+                        and s3control_client.account_public_access_block.restrict_public_buckets
+                    ):
+                        report.status_extended = f"Block Public Access is configured for the S3 Bucket {bucket.name} at account {s3_client.audited_account} level."
+                    else:
+                        report.status = "FAIL"
+                        report.status_extended = f"Block Public Access is not configured for the S3 Bucket {bucket.name}."
                 findings.append(report)
         return findings

--- a/tests/providers/aws/services/s3/s3_bucket_level_public_access_block/s3_bucket_level_public_access_block_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_level_public_access_block/s3_bucket_level_public_access_block_test.py
@@ -5,7 +5,6 @@ from boto3 import client, session
 from moto import mock_s3, mock_s3control
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.aws.services.s3.s3_service import S3Control
 from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -48,7 +47,7 @@ class Test_s3_bucket_level_public_access_block:
 
     @mock_s3
     def test_no_buckets(self):
-        from prowler.providers.aws.services.s3.s3_service import S3
+        from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
         audit_info = self.set_mocked_audit_info()
 
@@ -99,7 +98,7 @@ class Test_s3_bucket_level_public_access_block:
                 "RestrictPublicBuckets": False,
             },
         )
-        from prowler.providers.aws.services.s3.s3_service import S3
+        from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
         audit_info = self.set_mocked_audit_info()
 
@@ -161,7 +160,7 @@ class Test_s3_bucket_level_public_access_block:
                 "RestrictPublicBuckets": False,
             },
         )
-        from prowler.providers.aws.services.s3.s3_service import S3
+        from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
         audit_info = self.set_mocked_audit_info()
 
@@ -223,7 +222,7 @@ class Test_s3_bucket_level_public_access_block:
                 "RestrictPublicBuckets": True,
             },
         )
-        from prowler.providers.aws.services.s3.s3_service import S3
+        from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
         audit_info = self.set_mocked_audit_info()
 
@@ -285,7 +284,7 @@ class Test_s3_bucket_level_public_access_block:
                 "RestrictPublicBuckets": False,
             },
         )
-        from prowler.providers.aws.services.s3.s3_service import S3
+        from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
         audit_info = self.set_mocked_audit_info()
 

--- a/tests/providers/aws/services/s3/s3_bucket_level_public_access_block/s3_bucket_level_public_access_block_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_level_public_access_block/s3_bucket_level_public_access_block_test.py
@@ -2,7 +2,7 @@ from re import search
 from unittest import mock
 
 from boto3 import client, session
-from moto import mock_s3
+from moto import mock_s3, mock_s3control
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.common.models import Audit_Metadata
@@ -70,12 +70,23 @@ class Test_s3_bucket_level_public_access_block:
                 assert len(result) == 0
 
     @mock_s3
+    @mock_s3control
     def test_bucket_without_public_block(self):
         s3_client = client("s3", region_name=AWS_REGION)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         s3_client.put_public_access_block(
             Bucket=bucket_name_us,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client.put_public_access_block(
+            AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
                 "BlockPublicAcls": False,
                 "IgnorePublicAcls": False,
@@ -117,6 +128,7 @@ class Test_s3_bucket_level_public_access_block:
                 assert result[0].region == AWS_REGION
 
     @mock_s3
+    @mock_s3control
     def test_bucket_public_block(self):
         s3_client = client("s3", region_name=AWS_REGION)
         bucket_name_us = "bucket_test_us"
@@ -128,6 +140,16 @@ class Test_s3_bucket_level_public_access_block:
                 "IgnorePublicAcls": True,
                 "BlockPublicPolicy": True,
                 "RestrictPublicBuckets": True,
+            },
+        )
+        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client.put_public_access_block(
+            AccountId=AWS_ACCOUNT_NUMBER,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
             },
         )
         from prowler.providers.aws.services.s3.s3_service import S3
@@ -164,6 +186,65 @@ class Test_s3_bucket_level_public_access_block:
                 assert result[0].region == AWS_REGION
 
     @mock_s3
+    @mock_s3control
+    def test_bucket_public_block_at_account(self):
+        s3_client = client("s3", region_name=AWS_REGION)
+        bucket_name_us = "bucket_test_us"
+        s3_client.create_bucket(Bucket=bucket_name_us)
+        s3_client.put_public_access_block(
+            Bucket=bucket_name_us,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client.put_public_access_block(
+            AccountId=AWS_ACCOUNT_NUMBER,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": True,
+                "IgnorePublicAcls": True,
+                "BlockPublicPolicy": True,
+                "RestrictPublicBuckets": True,
+            },
+        )
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        audit_info = self.set_mocked_audit_info()
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block.s3_client",
+                new=S3(audit_info),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block import (
+                    s3_bucket_level_public_access_block,
+                )
+
+                check = s3_bucket_level_public_access_block()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert search(
+                    f"Block Public Access is configured for the S3 Bucket {bucket_name_us} at account {AWS_ACCOUNT_NUMBER} level.",
+                    result[0].status_extended,
+                )
+                assert result[0].resource_id == bucket_name_us
+                assert (
+                    result[0].resource_arn
+                    == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
+                )
+                assert result[0].region == AWS_REGION
+
+    @mock_s3
+    @mock_s3control
     def test_bucket_can_not_retrieve_public_access_block(self):
         s3_client = client("s3", region_name=AWS_REGION)
         bucket_name_us = "bucket_test_us"
@@ -175,6 +256,16 @@ class Test_s3_bucket_level_public_access_block:
                 "IgnorePublicAcls": True,
                 "BlockPublicPolicy": True,
                 "RestrictPublicBuckets": True,
+            },
+        )
+        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client.put_public_access_block(
+            AccountId=AWS_ACCOUNT_NUMBER,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
             },
         )
         from prowler.providers.aws.services.s3.s3_service import S3

--- a/tests/providers/aws/services/s3/s3_bucket_level_public_access_block/s3_bucket_level_public_access_block_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_level_public_access_block/s3_bucket_level_public_access_block_test.py
@@ -5,6 +5,7 @@ from boto3 import client, session
 from moto import mock_s3, mock_s3control
 
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.aws.services.s3.s3_service import S3Control
 from prowler.providers.common.models import Audit_Metadata
 
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -59,15 +60,19 @@ class Test_s3_bucket_level_public_access_block:
                 "prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block.s3_client",
                 new=S3(audit_info),
             ):
-                # Test Check
-                from prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block import (
-                    s3_bucket_level_public_access_block,
-                )
+                with mock.patch(
+                    "prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block.s3control_client",
+                    new=S3Control(audit_info),
+                ):
+                    # Test Check
+                    from prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block import (
+                        s3_bucket_level_public_access_block,
+                    )
 
-                check = s3_bucket_level_public_access_block()
-                result = check.execute()
+                    check = s3_bucket_level_public_access_block()
+                    result = check.execute()
 
-                assert len(result) == 0
+                    assert len(result) == 0
 
     @mock_s3
     @mock_s3control
@@ -106,26 +111,30 @@ class Test_s3_bucket_level_public_access_block:
                 "prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block.s3_client",
                 new=S3(audit_info),
             ):
-                # Test Check
-                from prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block import (
-                    s3_bucket_level_public_access_block,
-                )
+                with mock.patch(
+                    "prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block.s3control_client",
+                    new=S3Control(audit_info),
+                ):
+                    # Test Check
+                    from prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block import (
+                        s3_bucket_level_public_access_block,
+                    )
 
-                check = s3_bucket_level_public_access_block()
-                result = check.execute()
+                    check = s3_bucket_level_public_access_block()
+                    result = check.execute()
 
-                assert len(result) == 1
-                assert result[0].status == "FAIL"
-                assert search(
-                    "Block Public Access is not configured",
-                    result[0].status_extended,
-                )
-                assert result[0].resource_id == bucket_name_us
-                assert (
-                    result[0].resource_arn
-                    == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
-                )
-                assert result[0].region == AWS_REGION
+                    assert len(result) == 1
+                    assert result[0].status == "FAIL"
+                    assert search(
+                        "Block Public Access is not configured",
+                        result[0].status_extended,
+                    )
+                    assert result[0].resource_id == bucket_name_us
+                    assert (
+                        result[0].resource_arn
+                        == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
+                    )
+                    assert result[0].region == AWS_REGION
 
     @mock_s3
     @mock_s3control
@@ -164,26 +173,30 @@ class Test_s3_bucket_level_public_access_block:
                 "prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block.s3_client",
                 new=S3(audit_info),
             ):
-                # Test Check
-                from prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block import (
-                    s3_bucket_level_public_access_block,
-                )
+                with mock.patch(
+                    "prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block.s3control_client",
+                    new=S3Control(audit_info),
+                ):
+                    # Test Check
+                    from prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block import (
+                        s3_bucket_level_public_access_block,
+                    )
 
-                check = s3_bucket_level_public_access_block()
-                result = check.execute()
+                    check = s3_bucket_level_public_access_block()
+                    result = check.execute()
 
-                assert len(result) == 1
-                assert result[0].status == "PASS"
-                assert search(
-                    "Block Public Access is configured",
-                    result[0].status_extended,
-                )
-                assert result[0].resource_id == bucket_name_us
-                assert (
-                    result[0].resource_arn
-                    == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
-                )
-                assert result[0].region == AWS_REGION
+                    assert len(result) == 1
+                    assert result[0].status == "PASS"
+                    assert search(
+                        "Block Public Access is configured",
+                        result[0].status_extended,
+                    )
+                    assert result[0].resource_id == bucket_name_us
+                    assert (
+                        result[0].resource_arn
+                        == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
+                    )
+                    assert result[0].region == AWS_REGION
 
     @mock_s3
     @mock_s3control
@@ -222,26 +235,30 @@ class Test_s3_bucket_level_public_access_block:
                 "prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block.s3_client",
                 new=S3(audit_info),
             ):
-                # Test Check
-                from prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block import (
-                    s3_bucket_level_public_access_block,
-                )
+                with mock.patch(
+                    "prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block.s3control_client",
+                    new=S3Control(audit_info),
+                ):
+                    # Test Check
+                    from prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block import (
+                        s3_bucket_level_public_access_block,
+                    )
 
-                check = s3_bucket_level_public_access_block()
-                result = check.execute()
+                    check = s3_bucket_level_public_access_block()
+                    result = check.execute()
 
-                assert len(result) == 1
-                assert result[0].status == "PASS"
-                assert search(
-                    f"Block Public Access is configured for the S3 Bucket {bucket_name_us} at account {AWS_ACCOUNT_NUMBER} level.",
-                    result[0].status_extended,
-                )
-                assert result[0].resource_id == bucket_name_us
-                assert (
-                    result[0].resource_arn
-                    == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
-                )
-                assert result[0].region == AWS_REGION
+                    assert len(result) == 1
+                    assert result[0].status == "PASS"
+                    assert search(
+                        f"Block Public Access is configured for the S3 Bucket {bucket_name_us} at account {AWS_ACCOUNT_NUMBER} level.",
+                        result[0].status_extended,
+                    )
+                    assert result[0].resource_id == bucket_name_us
+                    assert (
+                        result[0].resource_arn
+                        == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
+                    )
+                    assert result[0].region == AWS_REGION
 
     @mock_s3
     @mock_s3control
@@ -284,12 +301,16 @@ class Test_s3_bucket_level_public_access_block:
                 "prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block.s3_client",
                 new=s3,
             ):
-                # Test Check
-                from prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block import (
-                    s3_bucket_level_public_access_block,
-                )
+                with mock.patch(
+                    "prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block.s3control_client",
+                    new=S3Control(audit_info),
+                ):
+                    # Test Check
+                    from prowler.providers.aws.services.s3.s3_bucket_level_public_access_block.s3_bucket_level_public_access_block import (
+                        s3_bucket_level_public_access_block,
+                    )
 
-                check = s3_bucket_level_public_access_block()
-                result = check.execute()
+                    check = s3_bucket_level_public_access_block()
+                    result = check.execute()
 
-                assert len(result) == 0
+                    assert len(result) == 0


### PR DESCRIPTION
### Description

Mark as Pass if s3 public access block is configured at account level in `s3_bucket_level_public_access_block`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
