### PR TITLE
Improve GuardDuty is Enabled Check

### DIFF
--- a/prowler/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled.py
@@ -1,5 +1,6 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.guardduty.guardduty_client import guardduty_client
+from prowler.providers.aws import aws_provider
 
 
 class guardduty_is_enabled(Check):
@@ -28,5 +29,21 @@ class guardduty_is_enabled(Check):
                 )
 
             findings.append(report)
+
+        for region in aws_provider.get_aws_available_regions():
+            has_detector = False
+            for finding in findings:
+                if finding.region == region:
+                    has_detector = True
+                    break
+
+            if not has_detector:
+                report = Check_Report_AWS(self.metadata())
+                report.region = region
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"GuardDuty in region {region} has no detectors"
+                )
+                findings.append(report)
 
         return findings


### PR DESCRIPTION
Adding check for region with no detectors

### Context

The guard duty is enabled check will not fail when a region has no detector at all.

### Description

This adds a simple check at the end of the guard duty check which goes through every region and checks if it didn't appear in the list of findings. If not it will create a new finding to indicate this region has no detector.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
