### PR TITLE
fix(outputs): Not use reserved keyword list as variable

### DIFF
--- a/prowler/lib/outputs/models.py
+++ b/prowler/lib/outputs/models.py
@@ -230,15 +230,15 @@ def unroll_dict(dict: dict):
 
 
 def unroll_dict_to_list(dict: dict):
-    list = []
+    dict_list = []
     for key, value in dict.items():
         if isinstance(value, list):
             value = ", ".join(value)
-            list.append(f"{key}: {value}")
+            dict_list.append(f"{key}: {value}")
         else:
-            list.append(f"{key}: {value}")
+            dict_list.append(f"{key}: {value}")
 
-    return list
+    return dict_list
 
 
 def parse_html_string(str: str):

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -58,6 +58,7 @@ from prowler.lib.outputs.models import (
     parse_html_string,
     parse_json_tags,
     unroll_dict,
+    unroll_dict_to_list,
     unroll_list,
     unroll_tags,
 )
@@ -317,6 +318,17 @@ class Test_Outputs:
             == "CISA: your-systems-3, your-data-1, your-data-2 | CIS-1.4: 2.1.1 | CIS-1.5: 2.1.1 | GDPR: article_32 | AWS-Foundational-Security-Best-Practices: s3 | HIPAA: 164_308_a_1_ii_b, 164_308_a_4_ii_a, 164_312_a_2_iv, 164_312_c_1, 164_312_c_2, 164_312_e_2_ii | GxP-21-CFR-Part-11: 11.10-c, 11.30 | GxP-EU-Annex-11: 7.1-data-storage-damage-protection | NIST-800-171-Revision-2: 3_3_8, 3_5_10, 3_13_11, 3_13_16 | NIST-800-53-Revision-4: sc_28 | NIST-800-53-Revision-5: au_9_3, cm_6_a, cm_9_b, cp_9_d, cp_9_8, pm_11_b, sc_8_3, sc_8_4, sc_13_a, sc_16_1, sc_28_1, si_19_4 | ENS-RD2022: mp.si.2.aws.s3.1 | NIST-CSF-1.1: ds_1 | RBI-Cyber-Security-Framework: annex_i_1_3 | FFIEC: d3-pc-am-b-12 | PCI-3.2.1: s3 | FedRamp-Moderate-Revision-4: sc-13, sc-28 | FedRAMP-Low-Revision-4: sc-13"
         )
 
+    def test_unroll_dict_to_list(self):
+        dict_A = {"A": "B"}
+        list_A = ["A: B"]
+
+        assert unroll_dict_to_list(dict_A) == list_A
+
+        dict_B = {"A": ["B", "C"]}
+        list_B = ["A: B, C"]
+
+        assert unroll_dict_to_list(dict_B) == list_B
+
     def test_parse_html_string(self):
         string = "CISA: your-systems-3, your-data-1, your-data-2 | CIS-1.4: 2.1.1 | CIS-1.5: 2.1.1 | GDPR: article_32 | AWS-Foundational-Security-Best-Practices: s3 | HIPAA: 164_308_a_1_ii_b, 164_308_a_4_ii_a, 164_312_a_2_iv, 164_312_c_1, 164_312_c_2, 164_312_e_2_ii | GxP-21-CFR-Part-11: 11.10-c, 11.30 | GxP-EU-Annex-11: 7.1-data-storage-damage-protection | NIST-800-171-Revision-2: 3_3_8, 3_5_10, 3_13_11, 3_13_16 | NIST-800-53-Revision-4: sc_28 | NIST-800-53-Revision-5: au_9_3, cm_6_a, cm_9_b, cp_9_d, cp_9_8, pm_11_b, sc_8_3, sc_8_4, sc_13_a, sc_16_1, sc_28_1, si_19_4 | ENS-RD2022: mp.si.2.aws.s3.1 | NIST-CSF-1.1: ds_1 | RBI-Cyber-Security-Framework: annex_i_1_3 | FFIEC: d3-pc-am-b-12 | PCI-3.2.1: s3 | FedRamp-Moderate-Revision-4: sc-13, sc-28 | FedRAMP-Low-Revision-4: sc-13"
         assert (
@@ -381,7 +393,7 @@ class Test_Outputs:
 
     # def test_fill_json(self):
     #     input_audit_info = AWS_Audit_Info(
-    session_config = (None,)
+    #         session_config = None,
     #         original_session=None,
     #         audit_session=None,
     #         audited_account=AWS_ACCOUNT_ID,


### PR DESCRIPTION
### Description

Not use reserved keyworkd `list` as variable name.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
