### PR TITLE
fix(test_only_aws_service_linked_roles): Flaky test

### DIFF
--- a/tests/providers/aws/services/iam/iam_role_cross_account_readonlyaccess_policy/iam_role_cross_account_readonlyaccess_policy_test.py
+++ b/tests/providers/aws/services/iam/iam_role_cross_account_readonlyaccess_policy/iam_role_cross_account_readonlyaccess_policy_test.py
@@ -279,11 +279,13 @@ class Test_iam_role_cross_account_readonlyaccess_policy:
             )
         )
 
+        current_audit_info = self.set_mocked_audit_info()
+
         with mock.patch(
-            "prowler.providers.aws.services.iam.iam_service.IAM",
-            new=iam_client,
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
         ), mock.patch(
-            "prowler.providers.aws.services.iam.iam_client.iam_client",
+            "prowler.providers.aws.services.iam.iam_role_cross_account_readonlyaccess_policy.iam_role_cross_account_readonlyaccess_policy.iam_client",
             new=iam_client,
         ):
             # Test Check


### PR DESCRIPTION
### Description

Fix flaky tests for the `iam_role_cross_account_readonlyaccess_policy` check.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
