### PR TITLE
fix(iam-dynamodb): Handle errors

### DIFF
--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -442,10 +442,21 @@ class IAM(AWSService):
         logger.info("IAM - List Policies Version...")
         try:
             for policy in policies:
-                policy_version = self.client.get_policy_version(
-                    PolicyArn=policy.arn, VersionId=policy.version_id
-                )
-                policy.document = policy_version["PolicyVersion"]["Document"]
+                try:
+                    policy_version = self.client.get_policy_version(
+                        PolicyArn=policy.arn, VersionId=policy.version_id
+                    )
+                    policy.document = policy_version["PolicyVersion"]["Document"]
+                except ClientError as error:
+                    if error.response["Error"]["Code"] == "NoSuchEntity":
+                        logger.warning(
+                            f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
+                    else:
+                        logger.error(
+                            f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
+                    continue
         except Exception as error:
             logger.error(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"


### PR DESCRIPTION
### Description

Handle the following errors:
- DynamoDB --> `TableNotFoundException:86 -- An error occurred (TableNotFoundException) when calling the DescribeContinuousBackups operation`
- IAM -->  `NoSuchEntityException[458]: An error occurred (NoSuchEntity) when calling the GetPolicyVersion operation`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
