### PR TITLE
fix(organizations): request Organization Info after assume_role occurs

### DIFF
--- a/prowler/providers/common/audit_info.py
+++ b/prowler/providers/common/audit_info.py
@@ -145,39 +145,6 @@ Azure Identity Type: {Fore.YELLOW}[{audit_info.identity.identity_type}]{Style.RE
         ).partition
         current_audit_info.audited_account_arn = f"arn:{current_audit_info.audited_partition}:iam::{current_audit_info.audited_account}:root"
 
-        logger.info("Checking if organizations role assumption is needed ...")
-        if organizations_role_arn:
-            current_audit_info.assumed_role_info.role_arn = organizations_role_arn
-            current_audit_info.assumed_role_info.session_duration = (
-                input_session_duration
-            )
-            current_audit_info.assumed_role_info.external_id = input_external_id
-            current_audit_info.assumed_role_info.mfa_enabled = input_mfa
-
-            # Check if role arn is valid
-            try:
-                # this returns the arn already parsed into a dict to be used when it is needed to access its fields
-                role_arn_parsed = parse_iam_credentials_arn(
-                    current_audit_info.assumed_role_info.role_arn
-                )
-
-            except Exception as error:
-                logger.critical(f"{error.__class__.__name__} -- {error}")
-                sys.exit(1)
-
-            else:
-                logger.info(
-                    f"Getting organizations metadata for account {organizations_role_arn}"
-                )
-                assumed_credentials = assume_role(
-                    aws_provider.aws_session,
-                    aws_provider.role_info,
-                    sts_endpoint_region,
-                )
-                current_audit_info.organizations_metadata = get_organizations_metadata(
-                    current_audit_info.audited_account, assumed_credentials
-                )
-                logger.info("Organizations metadata retrieved")
 
         logger.info("Checking if role assumption is needed ...")
         if input_role:
@@ -235,6 +202,42 @@ Azure Identity Type: {Fore.YELLOW}[{audit_info.identity.identity_type}]{Style.RE
         else:
             logger.info("Audit session is the original one")
             current_audit_info.audit_session = current_audit_info.original_session
+
+        logger.info("Checking if organizations role assumption is needed ...")
+        if organizations_role_arn:
+            current_audit_info.assumed_role_info.role_arn = organizations_role_arn
+            current_audit_info.assumed_role_info.session_duration = (
+                input_session_duration
+            )
+            current_audit_info.assumed_role_info.external_id = input_external_id
+            current_audit_info.assumed_role_info.mfa_enabled = input_mfa
+
+            # Check if role arn is valid
+            try:
+                # this returns the arn already parsed into a dict to be used when it is needed to access its fields
+                role_arn_parsed = parse_iam_credentials_arn(
+                    current_audit_info.assumed_role_info.role_arn
+                )
+
+            except Exception as error:
+                logger.critical(f"{error.__class__.__name__} -- {error}")
+                sys.exit(1)
+
+            else:
+                logger.info(
+                    f"Getting organizations metadata for account {organizations_role_arn}"
+                )
+                assumed_credentials = assume_role(
+                    aws_provider.aws_session,
+                    aws_provider.role_info,
+                    sts_endpoint_region,
+                )
+                current_audit_info.organizations_metadata = get_organizations_metadata(
+                    current_audit_info.audited_account, assumed_credentials
+                )
+                logger.info("Organizations metadata retrieved")
+
+
 
         # Setting default region of session
         if current_audit_info.audit_session.region_name:

--- a/prowler/providers/common/audit_info.py
+++ b/prowler/providers/common/audit_info.py
@@ -145,7 +145,6 @@ Azure Identity Type: {Fore.YELLOW}[{audit_info.identity.identity_type}]{Style.RE
         ).partition
         current_audit_info.audited_account_arn = f"arn:{current_audit_info.audited_partition}:iam::{current_audit_info.audited_account}:root"
 
-
         logger.info("Checking if role assumption is needed ...")
         if input_role:
             current_audit_info.assumed_role_info.role_arn = input_role
@@ -236,8 +235,6 @@ Azure Identity Type: {Fore.YELLOW}[{audit_info.identity.identity_type}]{Style.RE
                     current_audit_info.audited_account, assumed_credentials
                 )
                 logger.info("Organizations metadata retrieved")
-
-
 
         # Setting default region of session
         if current_audit_info.audit_session.region_name:


### PR DESCRIPTION
### Context

Fix issue where the use of -R and -O leads to the wrong information being populated in the `OrganizationsInfo` data.

### Description

When called with -R
`current_audit_info.audited_account` is not set until after the audited_account's assume role credentials are fetched and validated. Moving this block of code means Prowler will fetch the right info from the Organizational Management Account.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
