### PR TITLE
feat(checks): dump all checks as a json file

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -113,6 +113,12 @@ def prowler():
         provider,
     )
 
+    if args.list_checks_json:
+        import json
+        output = {provider: sorted(checks_to_execute)}
+        print(json.dumps(output, indent=2, default=str))
+        sys.exit()
+
     # If -l/--list-checks passed as argument, print checks to execute and quit
     if args.list_checks:
         print_checks(provider, sorted(checks_to_execute), bulk_checks_metadata)

--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -12,11 +12,11 @@ from prowler.lib.check.check import (
     exclude_services_to_run,
     execute_checks,
     list_categories,
+    list_checks_json,
     list_services,
     parse_checks_from_folder,
     print_categories,
     print_checks,
-    print_checks_json,
     print_compliance_frameworks,
     print_compliance_requirements,
     print_services,
@@ -116,7 +116,7 @@ def prowler():
 
     # if --list-checks-json, dump a json file and exit
     if args.list_checks_json:
-        print_checks_json(provider, sorted(checks_to_execute))
+        print(list_checks_json(provider, sorted(checks_to_execute)))
         sys.exit()
 
     # If -l/--list-checks passed as argument, print checks to execute and quit

--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -113,10 +113,9 @@ def prowler():
         provider,
     )
 
+    # if --list-checks-json, dump a json file and exit
     if args.list_checks_json:
-        import json
-        output = {provider: sorted(checks_to_execute)}
-        print(json.dumps(output, indent=2, default=str))
+        print_checks(provider, sorted(checks_to_execute))
         sys.exit()
 
     # If -l/--list-checks passed as argument, print checks to execute and quit

--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -16,6 +16,7 @@ from prowler.lib.check.check import (
     parse_checks_from_folder,
     print_categories,
     print_checks,
+    print_checks_json,
     print_compliance_frameworks,
     print_compliance_requirements,
     print_services,
@@ -115,7 +116,7 @@ def prowler():
 
     # if --list-checks-json, dump a json file and exit
     if args.list_checks_json:
-        print_checks(provider, sorted(checks_to_execute))
+        print_checks_json(provider, sorted(checks_to_execute))
         sys.exit()
 
     # If -l/--list-checks passed as argument, print checks to execute and quit

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -270,6 +270,13 @@ def print_compliance_requirements(
                     )
 
 
+def print_checks_json(provider: str, check_list: set):
+    import json
+
+    output = {provider: sorted(checks_to_execute)}
+    print(json.dumps(output, indent=2, default=str))
+
+
 def print_checks(
     provider: str,
     check_list: set,

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -1,5 +1,6 @@
 import functools
 import importlib
+import json
 import os
 import re
 import shutil
@@ -270,11 +271,13 @@ def print_compliance_requirements(
                     )
 
 
-def print_checks_json(provider: str, check_list: set):
-    import json
-
-    output = {provider: sorted(check_list)}
-    print(json.dumps(output, indent=2, default=str))
+def list_checks_json(provider: str, check_list: set):
+    try:
+        output = {provider: check_list}
+        return json.dumps(output, indent=2, default=str)
+    except Exception as e:
+        logger.critical(f"{e.__class__.__name__}[{e.__traceback__.tb_lineno}]: {e}")
+        sys.exit(1)
 
 
 def print_checks(

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -273,7 +273,7 @@ def print_compliance_requirements(
 def print_checks_json(provider: str, check_list: set):
     import json
 
-    output = {provider: sorted(checks_to_execute)}
+    output = {provider: sorted(check_list)}
     print(json.dumps(output, indent=2, default=str))
 
 

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -245,6 +245,9 @@ Detailed documentation at https://docs.prowler.cloud
             "-l", "--list-checks", action="store_true", help="List checks"
         )
         list_group.add_argument(
+            "-j", "--list-checks-json", action="store_true", help="Output a list of checks in json"
+        )
+        list_group.add_argument(
             "--list-services", action="store_true", help="List services"
         )
         list_group.add_argument(

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -245,7 +245,9 @@ Detailed documentation at https://docs.prowler.cloud
             "-l", "--list-checks", action="store_true", help="List checks"
         )
         list_group.add_argument(
-            "-j", "--list-checks-json", action="store_true", help="Output a list of checks in json"
+            "--list-checks-json",
+            action="store_true",
+            help="Output a list of checks in json for use with --checks-file",
         )
         list_group.add_argument(
             "--list-services", action="store_true", help="List services"

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -90,7 +90,7 @@ Detailed documentation at https://docs.prowler.cloud
             )
 
         # Only Logging Configuration
-        if args.only_logs:
+        if args.only_logs or args.list_checks_json:
             args.no_banner = True
 
         return args

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -12,6 +12,7 @@ from prowler.lib.check.check import (
     exclude_checks_to_run,
     exclude_services_to_run,
     list_categories,
+    list_checks_json,
     list_modules,
     list_services,
     parse_checks_from_file,
@@ -595,3 +596,20 @@ class Test_Check:
         assert audit_metadata.services_scanned == 1
         assert audit_metadata.expected_checks == expected_checks
         assert audit_metadata.completed_checks == 1
+
+    def test_list_checks_json_aws_lambda_and_s3(self):
+        provider = "aws"
+        check_list = {
+            "awslambda_function_invoke_api_operations_cloudtrail_logging_enabled",
+            "awslambda_function_no_secrets_in_code",
+            "awslambda_function_no_secrets_in_variables",
+            "awslambda_function_not_publicly_accessible",
+            "awslambda_function_url_cors_policy",
+            "awslambda_function_url_public",
+            "awslambda_function_using_supported_runtimes",
+        }
+        checks_json = list_checks_json(provider, sorted(check_list))
+        assert (
+            checks_json
+            == '{\n  "aws": [\n    "awslambda_function_invoke_api_operations_cloudtrail_logging_enabled",\n    "awslambda_function_no_secrets_in_code",\n    "awslambda_function_no_secrets_in_variables",\n    "awslambda_function_not_publicly_accessible",\n    "awslambda_function_url_cors_policy",\n    "awslambda_function_url_public",\n    "awslambda_function_using_supported_runtimes"\n  ]\n}'
+        )

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -592,6 +592,12 @@ class Test_Parser:
         parsed = self.parser.parse(command)
         assert parsed.list_checks
 
+    def test_list_checks_parser_list_checks_json(self):
+        argument = "--list-checks-json"
+        command = [prowler_command, argument]
+        parsed = self.parser.parse(command)
+        assert parsed.list_checks_json
+
     def test_list_checks_parser_list_services(self):
         argument = "--list-services"
         command = [prowler_command, argument]


### PR DESCRIPTION
### Context

This PR adds a CLI option to dump all the available checks into a json file that can be consumed by the `--checks-file` flag. 

### Description

```bash
prowler aws -jb > my_checks.json
# user edits my_checks.json to remove the ones they don't want
prowler aws --checks-file my_checks.json
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
