### PR TITLE
fix(security hub): include custom output filename in `resolve_security_hub_previous_findings`

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -219,7 +219,9 @@ def prowler():
 
     # Resolve previous fails of Security Hub
     if provider == "aws" and args.security_hub and not args.skip_sh_update:
-        resolve_security_hub_previous_findings(args.output_directory, audit_info)
+        resolve_security_hub_previous_findings(
+            args.output_directory, args.output_filename, audit_info
+        )
 
     # Display summary table
     if not args.only_logs:

--- a/prowler/providers/aws/lib/security_hub/security_hub.py
+++ b/prowler/providers/aws/lib/security_hub/security_hub.py
@@ -4,11 +4,7 @@ from operator import itemgetter
 
 from boto3 import session
 
-from prowler.config.config import (
-    json_asff_file_suffix,
-    output_file_timestamp,
-    timestamp_utc,
-)
+from prowler.config.config import json_asff_file_suffix, timestamp_utc
 from prowler.lib.logger import logger
 from prowler.lib.outputs.models import Check_Output_JSON_ASFF
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
@@ -60,16 +56,14 @@ def send_to_security_hub(
 
 # Move previous Security Hub check findings to ARCHIVED (as prowler didn't re-detect them)
 def resolve_security_hub_previous_findings(
-    output_directory: str, audit_info: AWS_Audit_Info
+    output_directory: str, output_filename: str, audit_info: AWS_Audit_Info
 ) -> list:
     """
     resolve_security_hub_previous_findings archives all the findings that does not appear in the current execution
     """
     logger.info("Checking previous findings in Security Hub to archive them.")
     # Read current findings from json-asff file
-    with open(
-        f"{output_directory}/prowler-output-{audit_info.audited_account}-{output_file_timestamp}{json_asff_file_suffix}"
-    ) as f:
+    with open(f"{output_directory}/{output_filename}{json_asff_file_suffix}") as f:
         json_asff_file = json.load(f)
 
     # Sort by region


### PR DESCRIPTION
### Description

Include custom output filename in `resolve_security_hub_previous_findings`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
