### PR TITLE
fix(typo): spelling typo in organizations_scp_check_deny_regions

### DIFF
--- a/prowler/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions.metadata.json
+++ b/prowler/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions.metadata.json
@@ -21,7 +21,7 @@
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "Restrict AWS Regiosn using SCP piolicies.",
+      "Text": "Restrict AWS Regions using SCP policies.",
       "Url": "https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_examples_general.html#example-scp-deny-region"
     }
   },


### PR DESCRIPTION
### Description

Fix spelling typo in `organizations_scp_check_deny_regions` detected by @jchrisfarris 

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
