### PR TITLE
fix(shub): handle default output filename error

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -220,7 +220,9 @@ def prowler():
     # Resolve previous fails of Security Hub
     if provider == "aws" and args.security_hub and not args.skip_sh_update:
         resolve_security_hub_previous_findings(
-            args.output_directory, args.output_filename, audit_info
+            audit_output_options.output_directory,
+            audit_output_options.output_filename,
+            audit_info,
         )
 
     # Display summary table


### PR DESCRIPTION
### Motivation

Fixes #2708 

### Description

Handle default output filename error in Security Hub integration.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
