### PR TITLE
fix(s3_bucket_policy_public_write_access): look at account and bucket-level public access block settings

### DIFF
--- a/prowler/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access.py
@@ -23,13 +23,17 @@ class s3_bucket_policy_public_write_access(Check):
                 and s3control_client.account_public_access_block.restrict_public_buckets
             ):
                 report.status = "PASS"
-                report.status_extended = "All S3 public access blocked at account level."
+                report.status_extended = (
+                    "All S3 public access blocked at account level."
+                )
             elif (
                 bucket.public_access_block
                 and bucket.public_access_block.restrict_public_buckets
             ):
                 report.status = "PASS"
-                report.status_extended = f"S3 public access blocked at bucket level for {bucket.name}."
+                report.status_extended = (
+                    f"S3 public access blocked at bucket level for {bucket.name}."
+                )
             else:
                 report.status = "PASS"
                 report.status_extended = f"S3 Bucket {bucket.name} does not allow public write access in the bucket policy."

--- a/prowler/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access.py
@@ -1,5 +1,6 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.s3.s3_client import s3_client
+from prowler.providers.aws.services.s3.s3control_client import s3control_client
 
 
 class s3_bucket_policy_public_write_access(Check):
@@ -17,6 +18,18 @@ class s3_bucket_policy_public_write_access(Check):
                 report.status_extended = (
                     f"S3 Bucket {bucket.name} does not have a bucket policy."
                 )
+            elif (
+                s3control_client.account_public_access_block
+                and s3control_client.account_public_access_block.restrict_public_buckets
+            ):
+                report.status = "PASS"
+                report.status_extended = "All S3 public access blocked at account level."
+            elif (
+                bucket.public_access_block
+                and bucket.public_access_block.restrict_public_buckets
+            ):
+                report.status = "PASS"
+                report.status_extended = f"S3 public access blocked at bucket level for {bucket.name}."
             else:
                 report.status = "PASS"
                 report.status_extended = f"S3 Bucket {bucket.name} does not allow public write access in the bucket policy."


### PR DESCRIPTION
…to reduce false positivies

### Context

The s3_bucket_policy_public_write_access check will report a false positive if the bucket policy has statements that allow public write, but the policy is neutered by a Block Public Access setting. 

### Description

If the Account or Bucket has `restrict_public_buckets` set, then the bucket automatically passes this check

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
