### PR TITLE
fix(is_account_only_allowed_in_condition): Context name on conditions are case-insensitive

### DIFF
--- a/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
+++ b/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
@@ -1,8 +1,18 @@
-# lista de cuentas y te devuelva las válidas
 def is_account_only_allowed_in_condition(
     condition_statement: dict, source_account: str
 ):
+    """
+    is_account_only_allowed_in_condition parses the IAM Condition policy block and returns True if the source_account passed as argument is within, False if not.
+
+    @param condition_statement: dict with IAM Condition block
+
+    @param source_account: str 12 digit AWS Account number
+    """
     is_condition_valid = False
+
+    # The conditions must be defined in lowercase since the context key names are not case-sensitive.
+    # For example, including the aws:SourceAccount context key is equivalent to testing for AWS:SourceAccount
+    # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html
     valid_condition_options = {
         "StringEquals": [
             "aws:sourceaccount",
@@ -26,29 +36,29 @@ def is_account_only_allowed_in_condition(
     for condition_operator, condition_operator_key in valid_condition_options.items():
         if condition_operator in condition_statement:
             for value in condition_operator_key:
+                # We need to transform the condition_statement into lowercase
                 condition_statement[condition_operator] = {
                     k.lower(): v
                     for k, v in condition_statement[condition_operator].items()
                 }
-                if value.lower() in condition_statement[condition_operator]:
+
+                if value in condition_statement[condition_operator]:
                     # values are a list
                     if isinstance(
-                        condition_statement[condition_operator][value.lower()],
+                        condition_statement[condition_operator][value],
                         list,
                     ):
                         # if there is an arn/account without the source account -> we do not consider it safe
                         # here by default we assume is true and look for false entries
                         is_condition_valid = True
-                        for item in condition_statement[condition_operator][
-                            value.lower()
-                        ]:
+                        for item in condition_statement[condition_operator][value]:
                             if source_account not in item:
                                 is_condition_valid = False
                                 break
 
                     # value is a string
                     elif isinstance(
-                        condition_statement[condition_operator][value.lower()],
+                        condition_statement[condition_operator][value],
                         str,
                     ):
                         if (

--- a/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
+++ b/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
@@ -5,49 +5,55 @@ def is_account_only_allowed_in_condition(
     is_condition_valid = False
     valid_condition_options = {
         "StringEquals": [
-            "aws:SourceAccount",
-            "aws:SourceOwner",
-            "s3:ResourceAccount",
-            "aws:PrincipalAccount",
-            "aws:ResourceAccount",
+            "aws:sourceaccount",
+            "aws:sourceowner",
+            "s3:resourceaccount",
+            "aws:principalaccount",
+            "aws:resourceaccount",
         ],
         "StringLike": [
-            "aws:SourceAccount",
-            "aws:SourceOwner",
-            "aws:SourceArn",
-            "aws:PrincipalArn",
-            "aws:ResourceAccount",
-            "aws:PrincipalAccount",
+            "aws:sourceaccount",
+            "aws:sourceowner",
+            "aws:sourcearn",
+            "aws:principalarn",
+            "aws:resourceaccount",
+            "aws:principalaccount",
         ],
-        "ArnLike": ["aws:SourceArn", "aws:PrincipalArn"],
-        "ArnEquals": ["aws:SourceArn", "aws:PrincipalArn"],
+        "ArnLike": ["aws:sourcearn", "aws:principalarn"],
+        "ArnEquals": ["aws:sourcearn", "aws:principalarn"],
     }
 
     for condition_operator, condition_operator_key in valid_condition_options.items():
         if condition_operator in condition_statement:
             for value in condition_operator_key:
-                if value in condition_statement[condition_operator]:
+                condition_statement[condition_operator] = {
+                    k.lower(): v
+                    for k, v in condition_statement[condition_operator].items()
+                }
+                if value.lower() in condition_statement[condition_operator]:
                     # values are a list
                     if isinstance(
-                        condition_statement[condition_operator][value],
+                        condition_statement[condition_operator][value.lower()],
                         list,
                     ):
                         # if there is an arn/account without the source account -> we do not consider it safe
                         # here by default we assume is true and look for false entries
                         is_condition_valid = True
-                        for item in condition_statement[condition_operator][value]:
+                        for item in condition_statement[condition_operator][
+                            value.lower()
+                        ]:
                             if source_account not in item:
                                 is_condition_valid = False
                                 break
 
                     # value is a string
                     elif isinstance(
-                        condition_statement[condition_operator][value],
+                        condition_statement[condition_operator][value.lower()],
                         str,
                     ):
                         if (
                             source_account
-                            in condition_statement[condition_operator][value]
+                            in condition_statement[condition_operator][value.lower()]
                         ):
                             is_condition_valid = True
 

--- a/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
+++ b/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
@@ -4,9 +4,14 @@ def is_account_only_allowed_in_condition(
     """
     is_account_only_allowed_in_condition parses the IAM Condition policy block and returns True if the source_account passed as argument is within, False if not.
 
-    @param condition_statement: dict with IAM Condition block
+    @param condition_statement: dict with an IAM Condition block, e.g.:
+        {
+            "StringLike": {
+                "AWS:SourceAccount": 111122223333
+            }
+        }
 
-    @param source_account: str 12 digit AWS Account number
+    @param source_account: str with a 12-digit AWS Account number, e.g.: 111122223333
     """
     is_condition_valid = False
 
@@ -63,7 +68,7 @@ def is_account_only_allowed_in_condition(
                     ):
                         if (
                             source_account
-                            in condition_statement[condition_operator][value.lower()]
+                            in condition_statement[condition_operator][value]
                         ):
                             is_condition_valid = True
 

--- a/tests/providers/aws/lib/policy_condition_parser/policy_condition_parser_test.py
+++ b/tests/providers/aws/lib/policy_condition_parser/policy_condition_parser_test.py
@@ -7,6 +7,7 @@ NON_TRUSTED_AWS_ACCOUNT_NUMBER = "111222333444"
 
 
 class Test_policy_condition_parser:
+    # Test lowercase context key name --> aws
     def test_condition_parser_string_equals_aws_SourceAccount_list(self):
         condition_statement = {
             "StringEquals": {"aws:SourceAccount": [TRUSTED_AWS_ACCOUNT_NUMBER]}
@@ -629,6 +630,634 @@ class Test_policy_condition_parser:
     def test_condition_parser_string_like_aws_ResourceAccount_str_not_valid(self):
         condition_statement = {
             "StringLike": {"aws:ResourceAccount": NON_TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    # Test uppercase context key name --> AWS
+    def test_condition_parser_string_equals_AWS_SourceAccount_list(self):
+        condition_statement = {
+            "StringEquals": {"AWS:SourceAccount": [TRUSTED_AWS_ACCOUNT_NUMBER]}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_AWS_SourceAccount_list_not_valid(self):
+        condition_statement = {
+            "StringEquals": {
+                "AWS:SourceAccount": [
+                    TRUSTED_AWS_ACCOUNT_NUMBER,
+                    NON_TRUSTED_AWS_ACCOUNT_NUMBER,
+                ]
+            }
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_AWS_SourceAccount_str(self):
+        condition_statement = {
+            "StringEquals": {"AWS:SourceAccount": TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_AWS_SourceAccount_str_not_valid(self):
+        condition_statement = {
+            "StringEquals": {"AWS:SourceAccount": NON_TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_SourceAccount_list(self):
+        condition_statement = {
+            "StringLike": {"AWS:SourceAccount": [TRUSTED_AWS_ACCOUNT_NUMBER]}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_SourceAccount_list_not_valid(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:SourceAccount": [
+                    TRUSTED_AWS_ACCOUNT_NUMBER,
+                    NON_TRUSTED_AWS_ACCOUNT_NUMBER,
+                ]
+            }
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_SourceAccount_str(self):
+        condition_statement = {
+            "StringLike": {"AWS:SourceAccount": TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_SourceAccount_str_not_valid(self):
+        condition_statement = {
+            "StringLike": {"AWS:SourceAccount": NON_TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_AWS_SourceOwner_str(self):
+        condition_statement = {
+            "StringEquals": {"AWS:SourceOwner": TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_AWS_SourceOwner_str_not_valid(self):
+        condition_statement = {
+            "StringEquals": {"AWS:SourceOwner": NON_TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_AWS_SourceOwner_list(self):
+        condition_statement = {
+            "StringEquals": {"AWS:SourceOwner": [TRUSTED_AWS_ACCOUNT_NUMBER]}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_AWS_SourceOwner_list_not_valid(self):
+        condition_statement = {
+            "StringEquals": {
+                "AWS:SourceOwner": [
+                    TRUSTED_AWS_ACCOUNT_NUMBER,
+                    NON_TRUSTED_AWS_ACCOUNT_NUMBER,
+                ]
+            }
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_SourceOwner_list(self):
+        condition_statement = {
+            "StringLike": {"AWS:SourceOwner": [TRUSTED_AWS_ACCOUNT_NUMBER]}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_SourceOwner_list_not_valid(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:SourceOwner": [
+                    TRUSTED_AWS_ACCOUNT_NUMBER,
+                    NON_TRUSTED_AWS_ACCOUNT_NUMBER,
+                ]
+            }
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_SourceOwner_str(self):
+        condition_statement = {
+            "StringLike": {"AWS:SourceOwner": TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_SourceOwner_str_not_valid(self):
+        condition_statement = {
+            "StringLike": {"AWS:SourceOwner": NON_TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_S3_ResourceAccount_list(self):
+        condition_statement = {
+            "StringEquals": {"S3:ResourceAccount": [TRUSTED_AWS_ACCOUNT_NUMBER]}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_S3_ResourceAccount_list_not_valid(self):
+        condition_statement = {
+            "StringEquals": {
+                "S3:ResourceAccount": [
+                    TRUSTED_AWS_ACCOUNT_NUMBER,
+                    NON_TRUSTED_AWS_ACCOUNT_NUMBER,
+                ]
+            }
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_S3_ResourceAccount_str(self):
+        condition_statement = {
+            "StringEquals": {"S3:ResourceAccount": TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_S3_ResourceAccount_str_not_valid(self):
+        condition_statement = {
+            "StringEquals": {"S3:ResourceAccount": NON_TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_AWS_PrincipalAccount_list(self):
+        condition_statement = {
+            "StringEquals": {"AWS:PrincipalAccount": [TRUSTED_AWS_ACCOUNT_NUMBER]}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_AWS_PrincipalAccount_list_not_valid(self):
+        condition_statement = {
+            "StringEquals": {
+                "AWS:PrincipalAccount": [
+                    TRUSTED_AWS_ACCOUNT_NUMBER,
+                    NON_TRUSTED_AWS_ACCOUNT_NUMBER,
+                ]
+            }
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_AWS_PrincipalAccount_str(self):
+        condition_statement = {
+            "StringEquals": {"AWS:PrincipalAccount": TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_AWS_PrincipalAccount_str_not_valid(self):
+        condition_statement = {
+            "StringEquals": {"AWS:PrincipalAccount": NON_TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_PrincipalAccount_list(self):
+        condition_statement = {
+            "StringLike": {"AWS:PrincipalAccount": [TRUSTED_AWS_ACCOUNT_NUMBER]}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_PrincipalAccount_list_not_valid(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:PrincipalAccount": [
+                    TRUSTED_AWS_ACCOUNT_NUMBER,
+                    NON_TRUSTED_AWS_ACCOUNT_NUMBER,
+                ]
+            }
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_PrincipalAccount_str(self):
+        condition_statement = {
+            "StringLike": {"AWS:PrincipalAccount": TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_PrincipalAccount_str_not_valid(self):
+        condition_statement = {
+            "StringLike": {"AWS:PrincipalAccount": NON_TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_like_AWS_SourceArn_list(self):
+        condition_statement = {
+            "ArnLike": {
+                "AWS:SourceArn": [
+                    f"arn:aws:cloudtrail:*:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*"
+                ]
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_like_AWS_SourceArn_list_not_valid(self):
+        condition_statement = {
+            "ArnLike": {
+                "AWS:SourceArn": [
+                    f"arn:aws:cloudtrail:*:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*",
+                    f"arn:aws:cloudtrail:*:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*",
+                ]
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_like_AWS_SourceArn_str(self):
+        condition_statement = {
+            "ArnLike": {
+                "AWS:SourceArn": f"arn:aws:cloudtrail:*:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*"
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_like_AWS_SourceArn_str_not_valid(self):
+        condition_statement = {
+            "ArnLike": {
+                "AWS:SourceArn": f"arn:aws:cloudtrail:*:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*"
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_like_AWS_PrincipalArn_list(self):
+        condition_statement = {
+            "ArnLike": {
+                "AWS:PrincipalArn": [
+                    f"arn:aws:cloudtrail:*:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*"
+                ]
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_like_AWS_PrincipalArn_list_not_valid(self):
+        condition_statement = {
+            "ArnLike": {
+                "AWS:PrincipalArn": [
+                    f"arn:aws:cloudtrail:*:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*",
+                    f"arn:aws:cloudtrail:*:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*",
+                ]
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_like_AWS_PrincipalArn_str(self):
+        condition_statement = {
+            "ArnLike": {
+                "AWS:PrincipalArn": f"arn:aws:cloudtrail:*:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*"
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_like_AWS_PrincipalArn_str_not_valid(self):
+        condition_statement = {
+            "ArnLike": {
+                "AWS:PrincipalArn": f"arn:aws:cloudtrail:*:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*"
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_equals_AWS_SourceArn_list(self):
+        condition_statement = {
+            "ArnEquals": {
+                "AWS:SourceArn": [
+                    f"arn:aws:cloudtrail:eu-west-1:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test"
+                ]
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_equals_AWS_SourceArn_list_not_valid(self):
+        condition_statement = {
+            "ArnEquals": {
+                "AWS:SourceArn": [
+                    f"arn:aws:cloudtrail:eu-west-1:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test",
+                    f"arn:aws:cloudtrail:eu-west-1:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test",
+                ]
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_equals_AWS_SourceArn_str(self):
+        condition_statement = {
+            "ArnEquals": {
+                "AWS:SourceArn": f"arn:aws:cloudtrail:eu-west-1:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test"
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_equals_AWS_SourceArn_str_not_valid(self):
+        condition_statement = {
+            "ArnEquals": {
+                "AWS:SourceArn": f"arn:aws:cloudtrail:eu-west-1:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test"
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_equals_AWS_PrincipalArn_list(self):
+        condition_statement = {
+            "ArnEquals": {
+                "AWS:PrincipalArn": [
+                    f"arn:aws:cloudtrail:eu-west-1:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test"
+                ]
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_equals_AWS_PrincipalArn_list_not_valid(self):
+        condition_statement = {
+            "ArnEquals": {
+                "AWS:PrincipalArn": [
+                    f"arn:aws:cloudtrail:eu-west-1:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test",
+                    f"arn:aws:cloudtrail:eu-west-1:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test",
+                ]
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_equals_AWS_PrincipalArn_str(self):
+        condition_statement = {
+            "ArnEquals": {
+                "AWS:PrincipalArn": f"arn:aws:cloudtrail:eu-west-1:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test"
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_arn_equals_AWS_PrincipalArn_str_not_valid(self):
+        condition_statement = {
+            "ArnEquals": {
+                "AWS:PrincipalArn": f"arn:aws:cloudtrail:eu-west-1:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test"
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_SourceArn_list(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:SourceArn": [
+                    f"arn:aws:cloudtrail:eu-west-1:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test"
+                ]
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_SourceArn_list_not_valid(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:SourceArn": [
+                    f"arn:aws:cloudtrail:eu-west-1:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test",
+                    f"arn:aws:cloudtrail:eu-west-1:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test",
+                ]
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_SourceArn_str(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:SourceArn": f"arn:aws:cloudtrail:eu-west-1:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test"
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_SourceArn_str_not_valid(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:SourceArn": f"arn:aws:cloudtrail:eu-west-1:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test"
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_PrincipalArn_list(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:PrincipalArn": [
+                    f"arn:aws:cloudtrail:eu-west-1:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test"
+                ]
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_PrincipalArn_list_not_valid(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:PrincipalArn": [
+                    f"arn:aws:cloudtrail:eu-west-1:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test",
+                    f"arn:aws:cloudtrail:eu-west-1:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test",
+                ]
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_PrincipalArn_str(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:PrincipalArn": f"arn:aws:cloudtrail:eu-west-1:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test"
+            }
+        }
+
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_PrincipalArn_str_not_valid(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:PrincipalArn": f"arn:aws:cloudtrail:eu-west-1:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/test"
+            }
+        }
+
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_AWS_ResourceAccount_list(self):
+        condition_statement = {
+            "StringEquals": {"AWS:ResourceAccount": [TRUSTED_AWS_ACCOUNT_NUMBER]}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_AWS_ResourceAccount_list_not_valid(self):
+        condition_statement = {
+            "StringEquals": {
+                "AWS:ResourceAccount": [
+                    TRUSTED_AWS_ACCOUNT_NUMBER,
+                    NON_TRUSTED_AWS_ACCOUNT_NUMBER,
+                ]
+            }
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_AWS_ResourceAccount_str(self):
+        condition_statement = {
+            "StringEquals": {"AWS:ResourceAccount": TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_AWS_ResourceAccount_str_not_valid(self):
+        condition_statement = {
+            "StringEquals": {"AWS:ResourceAccount": NON_TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_ResourceAccount_list(self):
+        condition_statement = {
+            "StringLike": {"AWS:ResourceAccount": [TRUSTED_AWS_ACCOUNT_NUMBER]}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_ResourceAccount_list_not_valid(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:ResourceAccount": [
+                    TRUSTED_AWS_ACCOUNT_NUMBER,
+                    NON_TRUSTED_AWS_ACCOUNT_NUMBER,
+                ]
+            }
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_ResourceAccount_str(self):
+        condition_statement = {
+            "StringLike": {"AWS:ResourceAccount": TRUSTED_AWS_ACCOUNT_NUMBER}
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_like_AWS_ResourceAccount_str_not_valid(self):
+        condition_statement = {
+            "StringLike": {"AWS:ResourceAccount": NON_TRUSTED_AWS_ACCOUNT_NUMBER}
         }
         assert not is_account_only_allowed_in_condition(
             condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER


### PR DESCRIPTION
### Context

Fixes #2723 

Context name on conditions are case-insensitive


### Description

Change policy condition comparison to make it case-insensitive

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
