### PR TITLE
fix(test-vpc): use the right import paths

### DIFF
--- a/tests/providers/aws/services/vpc/vpc_subnet_no_public_ip_by_default/vpc_subnet_no_public_ip_by_default_test.py
+++ b/tests/providers/aws/services/vpc/vpc_subnet_no_public_ip_by_default/vpc_subnet_no_public_ip_by_default_test.py
@@ -10,7 +10,7 @@ AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
-class Test_vpc_subnet_separate_private_public:
+class Test_vpc_subnet_no_public_ip_by_default:
     def set_mocked_audit_info(self):
         audit_info = AWS_Audit_Info(
             session_config=None,
@@ -68,7 +68,7 @@ class Test_vpc_subnet_separate_private_public:
             new=current_audit_info,
         ):
             with mock.patch(
-                "prowler.providers.aws.services.vpc.vpc_subnet_separate_private_public.vpc_subnet_separate_private_public.vpc_client",
+                "prowler.providers.aws.services.vpc.vpc_subnet_no_public_ip_by_default.vpc_subnet_no_public_ip_by_default.vpc_client",
                 new=VPC(current_audit_info),
             ):
                 from prowler.providers.aws.services.vpc.vpc_subnet_no_public_ip_by_default.vpc_subnet_no_public_ip_by_default import (
@@ -112,7 +112,7 @@ class Test_vpc_subnet_separate_private_public:
             new=current_audit_info,
         ):
             with mock.patch(
-                "prowler.providers.aws.services.vpc.vpc_subnet_separate_private_public.vpc_subnet_separate_private_public.vpc_client",
+                "prowler.providers.aws.services.vpc.vpc_subnet_no_public_ip_by_default.vpc_subnet_no_public_ip_by_default.vpc_client",
                 new=VPC(current_audit_info),
             ):
                 from prowler.providers.aws.services.vpc.vpc_subnet_no_public_ip_by_default.vpc_subnet_no_public_ip_by_default import (


### PR DESCRIPTION
### Description

Fix the flaky tests `test_vpc_without_map_ip_on_launch` and `test_vpc_with_map_ip_on_launch` since they were been using a bad import path for the VPC client.

```
FAILED tests/providers/aws/services/vpc/vpc_subnet_no_public_ip_by_default/vpc_subnet_no_public_ip_by_default_test.py::Test_vpc_subnet_separate_private_public::test_vpc_without_map_ip_on_launch - AttributeError: 'list' object has no attribute 'values'
FAILED tests/providers/aws/services/vpc/vpc_subnet_no_public_ip_by_default/vpc_subnet_no_public_ip_by_default_test.py::Test_vpc_subnet_separate_private_public::test_vpc_with_map_ip_on_launch - AttributeError: 'list' object has no attribute 'values'
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
