### PR TITLE
fix(gcp): Status extended ends with a dot

### DIFF
--- a/prowler/providers/gcp/services/bigquery/bigquery_dataset_cmk_encryption/bigquery_dataset_cmk_encryption.py
+++ b/prowler/providers/gcp/services/bigquery/bigquery_dataset_cmk_encryption/bigquery_dataset_cmk_encryption.py
@@ -12,12 +12,10 @@ class bigquery_dataset_cmk_encryption(Check):
             report.resource_name = dataset.name
             report.location = dataset.region
             report.status = "PASS"
-            report.status_extended = (
-                f"Dataset {dataset.name} is encrypted with Customer-Managed Keys (CMKs)"
-            )
+            report.status_extended = f"Dataset {dataset.name} is encrypted with Customer-Managed Keys (CMKs)."
             if not dataset.cmk_encryption:
                 report.status = "FAIL"
-                report.status_extended = f"Dataset {dataset.name} is not encrypted with Customer-Managed Keys (CMKs)"
+                report.status_extended = f"Dataset {dataset.name} is not encrypted with Customer-Managed Keys (CMKs)."
             findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/bigquery/bigquery_dataset_public_access/bigquery_dataset_public_access.py
+++ b/prowler/providers/gcp/services/bigquery/bigquery_dataset_public_access/bigquery_dataset_public_access.py
@@ -13,12 +13,12 @@ class bigquery_dataset_public_access(Check):
             report.location = dataset.region
             report.status = "PASS"
             report.status_extended = (
-                f"Dataset {dataset.name} is not publicly accessible"
+                f"Dataset {dataset.name} is not publicly accessible."
             )
             if dataset.public:
                 report.status = "FAIL"
                 report.status_extended = (
-                    f"Dataset {dataset.name} is publicly accessible!"
+                    f"Dataset {dataset.name} is publicly accessible."
                 )
             findings.append(report)
 

--- a/prowler/providers/gcp/services/bigquery/bigquery_table_cmk_encryption/bigquery_table_cmk_encryption.py
+++ b/prowler/providers/gcp/services/bigquery/bigquery_table_cmk_encryption/bigquery_table_cmk_encryption.py
@@ -13,11 +13,11 @@ class bigquery_table_cmk_encryption(Check):
             report.location = table.region
             report.status = "PASS"
             report.status_extended = (
-                f"Table {table.name} is encrypted with Customer-Managed Keys (CMKs)"
+                f"Table {table.name} is encrypted with Customer-Managed Keys (CMKs)."
             )
             if not table.cmk_encryption:
                 report.status = "FAIL"
-                report.status_extended = f"Table {table.name} is not encrypted with Customer-Managed Keys (CMKs)"
+                report.status_extended = f"Table {table.name} is not encrypted with Customer-Managed Keys (CMKs)."
             findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_automated_backups/cloudsql_instance_automated_backups.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_automated_backups/cloudsql_instance_automated_backups.py
@@ -13,11 +13,11 @@ class cloudsql_instance_automated_backups(Check):
             report.location = instance.region
             report.status = "PASS"
             report.status_extended = (
-                f"Database Instance {instance.name} has automated backups configured"
+                f"Database Instance {instance.name} has automated backups configured."
             )
             if not instance.automated_backups:
                 report.status = "FAIL"
-                report.status_extended = f"Database Instance {instance.name} does not have automated backups configured"
+                report.status_extended = f"Database Instance {instance.name} does not have automated backups configured."
             findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_private_ip_assignment/cloudsql_instance_private_ip_assignment.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_private_ip_assignment/cloudsql_instance_private_ip_assignment.py
@@ -12,12 +12,12 @@ class cloudsql_instance_private_ip_assignment(Check):
             report.resource_name = instance.name
             report.location = instance.region
             report.status = "PASS"
-            report.status_extended = f"Database Instance {instance.name} does not have private IP assignments"
+            report.status_extended = f"Database Instance {instance.name} does not have private IP assignments."
             for address in instance.ip_addresses:
                 if address["type"] != "PRIVATE":
                     report.status = "FAIL"
                     report.status_extended = (
-                        f"Database Instance {instance.name} has public IP assignments"
+                        f"Database Instance {instance.name} has public IP assignments."
                     )
                     break
             findings.append(report)

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_public_access/cloudsql_instance_public_access.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_public_access/cloudsql_instance_public_access.py
@@ -12,11 +12,11 @@ class cloudsql_instance_public_access(Check):
             report.resource_name = instance.name
             report.location = instance.region
             report.status = "PASS"
-            report.status_extended = f"Database Instance {instance.name} does not whitelist all Public IP Addresses"
+            report.status_extended = f"Database Instance {instance.name} does not whitelist all Public IP Addresses."
             for network in instance.authorized_networks:
                 if network["value"] == "0.0.0.0/0":
                     report.status = "FAIL"
-                    report.status_extended = f"Database Instance {instance.name} whitelist all Public IP Addresses"
+                    report.status_extended = f"Database Instance {instance.name} whitelist all Public IP Addresses."
             findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_contained_database_authentication_flag/cloudsql_instance_sqlserver_contained_database_authentication_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_contained_database_authentication_flag/cloudsql_instance_sqlserver_contained_database_authentication_flag.py
@@ -13,14 +13,14 @@ class cloudsql_instance_sqlserver_contained_database_authentication_flag(Check):
                 report.resource_name = instance.name
                 report.location = instance.region
                 report.status = "PASS"
-                report.status_extended = f"SQL Server Instance {instance.name} has 'contained database authentication' flag set to 'off'"
+                report.status_extended = f"SQL Server Instance {instance.name} has 'contained database authentication' flag set to 'off'."
                 for flag in instance.flags:
                     if (
                         flag["name"] == "contained database authentication"
                         and flag["value"] == "on"
                     ):
                         report.status = "FAIL"
-                        report.status_extended = f"SQL Server Instance {instance.name} has 'contained database authentication' flag set to 'on'"
+                        report.status_extended = f"SQL Server Instance {instance.name} has 'contained database authentication' flag set to 'on'."
                         break
                 findings.append(report)
 

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_trace_flag/cloudsql_instance_sqlserver_trace_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_trace_flag/cloudsql_instance_sqlserver_trace_flag.py
@@ -13,11 +13,11 @@ class cloudsql_instance_sqlserver_trace_flag(Check):
                 report.resource_name = instance.name
                 report.location = instance.region
                 report.status = "PASS"
-                report.status_extended = f"SQL Server Instance {instance.name} has '3625 (trace flag)' flag set to 'on'"
+                report.status_extended = f"SQL Server Instance {instance.name} has '3625 (trace flag)' flag set to 'on'."
                 for flag in instance.flags:
                     if flag["name"] == "3625" and flag["value"] == "off":
                         report.status = "FAIL"
-                        report.status_extended = f"SQL Server Instance {instance.name} has '3625 (trace flag)' flag set to 'off'"
+                        report.status_extended = f"SQL Server Instance {instance.name} has '3625 (trace flag)' flag set to 'off'."
                         break
                 findings.append(report)
 

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_ssl_connections/cloudsql_instance_ssl_connections.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_ssl_connections/cloudsql_instance_ssl_connections.py
@@ -13,11 +13,11 @@ class cloudsql_instance_ssl_connections(Check):
             report.location = instance.region
             report.status = "PASS"
             report.status_extended = (
-                f"Database Instance {instance.name} requires SSL connections"
+                f"Database Instance {instance.name} requires SSL connections."
             )
             if not instance.ssl:
                 report.status = "FAIL"
-                report.status_extended = f"Database Instance {instance.name} does not require SSL connections"
+                report.status_extended = f"Database Instance {instance.name} does not require SSL connections."
             findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/cloudstorage/cloudstorage_bucket_log_retention_policy_lock/cloudstorage_bucket_log_retention_policy_lock.py
+++ b/prowler/providers/gcp/services/cloudstorage/cloudstorage_bucket_log_retention_policy_lock/cloudstorage_bucket_log_retention_policy_lock.py
@@ -22,14 +22,14 @@ class cloudstorage_bucket_log_retention_policy_lock(Check):
                 report.location = bucket.region
                 report.status = "FAIL"
                 report.status_extended = (
-                    f"Log Sink Bucket {bucket.name} has no Retention Policy"
+                    f"Log Sink Bucket {bucket.name} has no Retention Policy."
                 )
                 if bucket.retention_policy:
                     report.status = "FAIL"
-                    report.status_extended = f"Log Sink Bucket {bucket.name} has no Retention Policy but without Bucket Lock"
+                    report.status_extended = f"Log Sink Bucket {bucket.name} has no Retention Policy but without Bucket Lock."
                     if bucket.retention_policy["isLocked"]:
                         report.status = "PASS"
-                        report.status_extended = f"Log Sink Bucket {bucket.name} has a Retention Policy with Bucket Lock"
+                        report.status_extended = f"Log Sink Bucket {bucket.name} has a Retention Policy with Bucket Lock."
                 findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/cloudstorage/cloudstorage_bucket_public_access/cloudstorage_bucket_public_access.py
+++ b/prowler/providers/gcp/services/cloudstorage/cloudstorage_bucket_public_access/cloudstorage_bucket_public_access.py
@@ -14,10 +14,10 @@ class cloudstorage_bucket_public_access(Check):
             report.resource_name = bucket.name
             report.location = bucket.region
             report.status = "PASS"
-            report.status_extended = f"Bucket {bucket.name} is not publicly accessible"
+            report.status_extended = f"Bucket {bucket.name} is not publicly accessible."
             if bucket.public:
                 report.status = "FAIL"
-                report.status_extended = f"Bucket {bucket.name} is publicly accessible!"
+                report.status_extended = f"Bucket {bucket.name} is publicly accessible."
             findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/cloudstorage/cloudstorage_bucket_uniform_bucket_level_access/cloudstorage_bucket_uniform_bucket_level_access.py
+++ b/prowler/providers/gcp/services/cloudstorage/cloudstorage_bucket_uniform_bucket_level_access/cloudstorage_bucket_uniform_bucket_level_access.py
@@ -15,12 +15,12 @@ class cloudstorage_bucket_uniform_bucket_level_access(Check):
             report.location = bucket.region
             report.status = "PASS"
             report.status_extended = (
-                f"Bucket {bucket.name} has uniform Bucket Level Access enabled"
+                f"Bucket {bucket.name} has uniform Bucket Level Access enabled."
             )
             if not bucket.uniform_bucket_level_access:
                 report.status = "FAIL"
                 report.status_extended = (
-                    f"Bucket {bucket.name} has uniform Bucket Level Access disabled"
+                    f"Bucket {bucket.name} has uniform Bucket Level Access disabled."
                 )
             findings.append(report)
 

--- a/prowler/providers/gcp/services/compute/compute_instance_confidential_computing_enabled/compute_instance_confidential_computing_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_confidential_computing_enabled/compute_instance_confidential_computing_enabled.py
@@ -13,11 +13,11 @@ class compute_instance_confidential_computing_enabled(Check):
             report.location = instance.zone
             report.status = "PASS"
             report.status_extended = (
-                f"VM Instance {instance.name} has Confidential Computing enabled"
+                f"VM Instance {instance.name} has Confidential Computing enabled."
             )
             if not instance.confidential_computing:
                 report.status = "FAIL"
-                report.status_extended = f"VM Instance {instance.name} does not have Confidential Computing enabled"
+                report.status_extended = f"VM Instance {instance.name} does not have Confidential Computing enabled."
             findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/compute/compute_instance_default_service_account_in_use/compute_instance_default_service_account_in_use.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_default_service_account_in_use/compute_instance_default_service_account_in_use.py
@@ -12,7 +12,7 @@ class compute_instance_default_service_account_in_use(Check):
             report.resource_name = instance.name
             report.location = instance.zone
             report.status = "PASS"
-            report.status_extended = f"The default service account is not configured to be used with VM Instance {instance.name}"
+            report.status_extended = f"The default service account is not configured to be used with VM Instance {instance.name}."
             if (
                 any(
                     [
@@ -23,7 +23,7 @@ class compute_instance_default_service_account_in_use(Check):
                 and instance.name[:4] != "gke-"
             ):
                 report.status = "FAIL"
-                report.status_extended = f"The default service account is configured to be used with VM Instance {instance.name}"
+                report.status_extended = f"The default service account is configured to be used with VM Instance {instance.name}."
             findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/compute/compute_instance_default_service_account_in_use_with_full_api_access/compute_instance_default_service_account_in_use_with_full_api_access.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_default_service_account_in_use_with_full_api_access/compute_instance_default_service_account_in_use_with_full_api_access.py
@@ -12,7 +12,7 @@ class compute_instance_default_service_account_in_use_with_full_api_access(Check
             report.resource_name = instance.name
             report.location = instance.zone
             report.status = "PASS"
-            report.status_extended = f"The VM Instance {instance.name} is not configured to use the default service account with full access to all cloud APIs "
+            report.status_extended = f"The VM Instance {instance.name} is not configured to use the default service account with full access to all cloud APIs."
             for service_account in instance.service_accounts:
                 if (
                     "-compute@developer.gserviceaccount.com" in service_account["email"]
@@ -21,7 +21,7 @@ class compute_instance_default_service_account_in_use_with_full_api_access(Check
                     and instance.name[:4] != "gke-"
                 ):
                     report.status = "FAIL"
-                    report.status_extended = f"The VM Instance {instance.name} is configured to use the default service account with full access to all cloud APIs "
+                    report.status_extended = f"The VM Instance {instance.name} is configured to use the default service account with full access to all cloud APIs."
                     break
             findings.append(report)
 

--- a/prowler/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled.py
@@ -12,7 +12,7 @@ class compute_instance_encryption_with_csek_enabled(Check):
             report.resource_name = instance.name
             report.location = instance.zone
             report.status = "FAIL"
-            report.status_extended = f"The VM Instance {instance.name} has the following unencrypted disks: '{', '.join([i[0] for i in instance.disks_encryption if not i[1]])}'"
+            report.status_extended = f"The VM Instance {instance.name} has the following unencrypted disks: '{', '.join([i[0] for i in instance.disks_encryption if not i[1]])}'."
             if all([i[1] for i in instance.disks_encryption]):
                 report.status = "PASS"
                 report.status_extended = (

--- a/prowler/providers/gcp/services/compute/compute_instance_ip_forwarding_is_enabled/compute_instance_ip_forwarding_is_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_ip_forwarding_is_enabled/compute_instance_ip_forwarding_is_enabled.py
@@ -13,12 +13,12 @@ class compute_instance_ip_forwarding_is_enabled(Check):
             report.location = instance.zone
             report.status = "PASS"
             report.status_extended = (
-                f"The IP Forwarding of VM Instance {instance.name} is not enabled"
+                f"The IP Forwarding of VM Instance {instance.name} is not enabled."
             )
             if instance.ip_forward and instance.name[:4] != "gke-":
                 report.status = "FAIL"
                 report.status_extended = (
-                    f"The IP Forwarding of VM Instance {instance.name} is enabled"
+                    f"The IP Forwarding of VM Instance {instance.name} is enabled."
                 )
             findings.append(report)
 

--- a/prowler/providers/gcp/services/compute/compute_instance_serial_ports_in_use/compute_instance_serial_ports_in_use.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_serial_ports_in_use/compute_instance_serial_ports_in_use.py
@@ -12,9 +12,7 @@ class compute_instance_serial_ports_in_use(Check):
             report.resource_name = instance.name
             report.location = instance.zone
             report.status = "PASS"
-            report.status_extended = (
-                f"VM Instance {instance.name} has Enable Connecting to Serial Ports off"
-            )
+            report.status_extended = f"VM Instance {instance.name} has Enable Connecting to Serial Ports off."
             if instance.metadata.get("items"):
                 for item in instance.metadata["items"]:
                     if item["key"] == "serial-port-enable" and item["value"] in [
@@ -22,7 +20,7 @@ class compute_instance_serial_ports_in_use(Check):
                         "true",
                     ]:
                         report.status = "FAIL"
-                        report.status_extended = f"VM Instance {instance.name} has Enable Connecting to Serial Ports set to on"
+                        report.status_extended = f"VM Instance {instance.name} has Enable Connecting to Serial Ports set to on."
                         break
             findings.append(report)
 

--- a/prowler/providers/gcp/services/compute/compute_instance_shielded_vm_enabled/compute_instance_shielded_vm_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_shielded_vm_enabled/compute_instance_shielded_vm_enabled.py
@@ -12,13 +12,13 @@ class compute_instance_shielded_vm_enabled(Check):
             report.resource_name = instance.name
             report.location = instance.zone
             report.status = "PASS"
-            report.status_extended = f"VM Instance {instance.name} has vTPM or Integrity Monitoring set to on"
+            report.status_extended = f"VM Instance {instance.name} has vTPM or Integrity Monitoring set to on."
             if (
                 not instance.shielded_enabled_vtpm
                 or not instance.shielded_enabled_integrity_monitoring
             ):
                 report.status = "FAIL"
-                report.status_extended = f"VM Instance {instance.name} doesn't have vTPM and Integrity Monitoring set to on"
+                report.status_extended = f"VM Instance {instance.name} doesn't have vTPM and Integrity Monitoring set to on."
             findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/compute/compute_loadbalancer_logging_enabled/compute_loadbalancer_logging_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_loadbalancer_logging_enabled/compute_loadbalancer_logging_enabled.py
@@ -12,11 +12,11 @@ class compute_loadbalancer_logging_enabled(Check):
             report.resource_name = lb.name
             report.location = compute_client.region
             report.status = "PASS"
-            report.status_extended = f"LoadBalancer {lb.name} has logging enabled"
+            report.status_extended = f"LoadBalancer {lb.name} has logging enabled."
             if not lb.logging:
                 report.status = "FAIL"
                 report.status_extended = (
-                    f"LoadBalancer {lb.name} does not have logging enabled"
+                    f"LoadBalancer {lb.name} does not have logging enabled."
                 )
             findings.append(report)
 

--- a/prowler/providers/gcp/services/compute/compute_network_default_in_use/compute_network_default_in_use.py
+++ b/prowler/providers/gcp/services/compute/compute_network_default_in_use/compute_network_default_in_use.py
@@ -17,7 +17,7 @@ class compute_network_default_in_use(Check):
                 report.location = "global"
                 report.status = "FAIL"
                 report.status_extended = (
-                    f"Default network is in use in project {network.project_id}"
+                    f"Default network is in use in project {network.project_id}."
                 )
                 findings.append(report)
 
@@ -30,7 +30,7 @@ class compute_network_default_in_use(Check):
                 report.location = "global"
                 report.status = "PASS"
                 report.status_extended = (
-                    f"Default network does not exist in project {project}"
+                    f"Default network does not exist in project {project}."
                 )
 
         return findings

--- a/prowler/providers/gcp/services/compute/compute_network_dns_logging_enabled/compute_network_dns_logging_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_network_dns_logging_enabled/compute_network_dns_logging_enabled.py
@@ -14,13 +14,13 @@ class compute_network_dns_logging_enabled(Check):
             report.location = compute_client.region
             report.status = "FAIL"
             report.status_extended = (
-                f"Network {network.name} does not have DNS logging enabled"
+                f"Network {network.name} does not have DNS logging enabled."
             )
             for policy in dns_client.policies:
                 if network.name in policy.networks and policy.logging:
                     report.status = "PASS"
                     report.status_extended = (
-                        f"Network {network.name} has DNS logging enabled"
+                        f"Network {network.name} has DNS logging enabled."
                     )
                     break
             findings.append(report)

--- a/prowler/providers/gcp/services/compute/compute_network_not_legacy/compute_network_not_legacy.py
+++ b/prowler/providers/gcp/services/compute/compute_network_not_legacy/compute_network_not_legacy.py
@@ -12,10 +12,10 @@ class compute_network_not_legacy(Check):
             report.resource_name = network.name
             report.location = compute_client.region
             report.status = "PASS"
-            report.status_extended = f"Network {network.name} is not legacy"
+            report.status_extended = f"Network {network.name} is not legacy."
             if network.subnet_mode == "legacy":
                 report.status = "FAIL"
-                report.status_extended = f"Legacy network {network.name} exists"
+                report.status_extended = f"Legacy network {network.name} exists."
             findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled.py
@@ -11,11 +11,11 @@ class compute_project_os_login_enabled(Check):
             report.resource_id = project.id
             report.location = "global"
             report.status = "PASS"
-            report.status_extended = f"Project {project.id} has OS Login enabled"
+            report.status_extended = f"Project {project.id} has OS Login enabled."
             if not project.enable_oslogin:
                 report.status = "FAIL"
                 report.status_extended = (
-                    f"Project {project.id} does not have OS Login enabled"
+                    f"Project {project.id} does not have OS Login enabled."
                 )
             findings.append(report)
 

--- a/prowler/providers/gcp/services/compute/compute_subnet_flow_logs_enabled/compute_subnet_flow_logs_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_subnet_flow_logs_enabled/compute_subnet_flow_logs_enabled.py
@@ -12,10 +12,10 @@ class compute_subnet_flow_logs_enabled(Check):
             report.resource_name = subnet.name
             report.location = subnet.region
             report.status = "PASS"
-            report.status_extended = f"Subnet {subnet.name} in network {subnet.network} has flow logs enabled"
+            report.status_extended = f"Subnet {subnet.name} in network {subnet.network} has flow logs enabled."
             if not subnet.flow_logs:
                 report.status = "FAIL"
-                report.status_extended = f"Subnet {subnet.name} in network {subnet.network} does not have flow logs enabled"
+                report.status_extended = f"Subnet {subnet.name} in network {subnet.network} does not have flow logs enabled."
             findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/iam/iam_account_access_approval_enabled/iam_account_access_approval_enabled.py
+++ b/prowler/providers/gcp/services/iam/iam_account_access_approval_enabled/iam_account_access_approval_enabled.py
@@ -13,11 +13,13 @@ class iam_account_access_approval_enabled(Check):
             report.resource_id = project_id
             report.location = accessapproval_client.region
             report.status = "PASS"
-            report.status_extended = f"Project {project_id} has Access Approval enabled"
+            report.status_extended = (
+                f"Project {project_id} has Access Approval enabled."
+            )
             if project_id not in accessapproval_client.settings:
                 report.status = "FAIL"
                 report.status_extended = (
-                    f"Project {project_id} does not have Access Approval enabled"
+                    f"Project {project_id} does not have Access Approval enabled."
                 )
             findings.append(report)
 

--- a/prowler/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled.py
+++ b/prowler/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled.py
@@ -13,11 +13,11 @@ class iam_audit_logs_enabled(Check):
             report.location = cloudresourcemanager_client.region
             report.resource_id = project.id
             report.status = "PASS"
-            report.status_extended = f"Audit Logs are enabled for project {project.id}"
+            report.status_extended = f"Audit Logs are enabled for project {project.id}."
             if not project.audit_logging:
                 report.status = "FAIL"
                 report.status_extended = (
-                    f"Audit Logs are not enabled for project {project.id}"
+                    f"Audit Logs are not enabled for project {project.id}."
                 )
             findings.append(report)
 

--- a/prowler/providers/gcp/services/iam/iam_organization_essential_contacts_configured/iam_organization_essential_contacts_configured.py
+++ b/prowler/providers/gcp/services/iam/iam_organization_essential_contacts_configured/iam_organization_essential_contacts_configured.py
@@ -15,12 +15,12 @@ class iam_organization_essential_contacts_configured(Check):
             report.location = essentialcontacts_client.region
             report.status = "FAIL"
             report.status_extended = (
-                f"Organization {org.name} does not have essential contacts configured"
+                f"Organization {org.name} does not have essential contacts configured."
             )
             if org.contacts:
                 report.status = "PASS"
                 report.status_extended = (
-                    f"Organization {org.name} has essential contacts configured"
+                    f"Organization {org.name} has essential contacts configured."
                 )
             findings.append(report)
 

--- a/prowler/providers/gcp/services/iam/iam_role_kms_enforce_separation_of_duties/iam_role_kms_enforce_separation_of_duties.py
+++ b/prowler/providers/gcp/services/iam/iam_role_kms_enforce_separation_of_duties/iam_role_kms_enforce_separation_of_duties.py
@@ -15,7 +15,7 @@ class iam_role_kms_enforce_separation_of_duties(Check):
             report.location = cloudresourcemanager_client.region
             report.resource_id = project
             report.status = "PASS"
-            report.status_extended = f"Principle of separation of duties was enforced for KMS-Related Roles in project {project}"
+            report.status_extended = f"Principle of separation of duties was enforced for KMS-Related Roles in project {project}."
             for binding in cloudresourcemanager_client.bindings:
                 if binding.project_id == project:
                     if "roles/cloudkms.admin" in binding.role:
@@ -30,7 +30,7 @@ class iam_role_kms_enforce_separation_of_duties(Check):
                                 non_compliant_members.append(member)
             if non_compliant_members:
                 report.status = "FAIL"
-                report.status_extended = f"Principle of separation of duties was not enforced for KMS-Related Roles in project {project} in members {','.join(non_compliant_members)}"
+                report.status_extended = f"Principle of separation of duties was not enforced for KMS-Related Roles in project {project} in members {','.join(non_compliant_members)}."
             findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/iam/iam_role_sa_enforce_separation_of_duties/iam_role_sa_enforce_separation_of_duties.py
+++ b/prowler/providers/gcp/services/iam/iam_role_sa_enforce_separation_of_duties/iam_role_sa_enforce_separation_of_duties.py
@@ -14,7 +14,7 @@ class iam_role_sa_enforce_separation_of_duties(Check):
             report.location = cloudresourcemanager_client.region
             report.resource_id = project
             report.status = "PASS"
-            report.status_extended = f"Principle of separation of duties was enforced for Service-Account Related Roles in project {project}"
+            report.status_extended = f"Principle of separation of duties was enforced for Service-Account Related Roles in project {project}."
             for binding in cloudresourcemanager_client.bindings:
                 if binding.project_id == project and (
                     "roles/iam.serviceAccountUser" in binding.role
@@ -23,7 +23,7 @@ class iam_role_sa_enforce_separation_of_duties(Check):
                     non_compliant_members.extend(binding.members)
             if non_compliant_members:
                 report.status = "FAIL"
-                report.status_extended = f"Principle of separation of duties was not enforced for Service-Account Related Roles in project {project} in members {','.join(non_compliant_members)}"
+                report.status_extended = f"Principle of separation of duties was not enforced for Service-Account Related Roles in project {project} in members {','.join(non_compliant_members)}."
             findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/iam/iam_sa_no_administrative_privileges/iam_sa_no_administrative_privileges.py
+++ b/prowler/providers/gcp/services/iam/iam_sa_no_administrative_privileges/iam_sa_no_administrative_privileges.py
@@ -16,7 +16,7 @@ class iam_sa_no_administrative_privileges(Check):
             report.location = iam_client.region
             report.status = "PASS"
             report.status_extended = (
-                f"Account {account.email} has no administrative privileges"
+                f"Account {account.email} has no administrative privileges."
             )
             for binding in cloudresourcemanager_client.bindings:
                 if f"serviceAccount:{account.email}" in binding.members and (
@@ -25,7 +25,7 @@ class iam_sa_no_administrative_privileges(Check):
                     or "editor" in binding.role.lower()
                 ):
                     report.status = "FAIL"
-                    report.status_extended = f"Account {account.email} has administrative privileges with {binding.role}"
+                    report.status_extended = f"Account {account.email} has administrative privileges with {binding.role}."
             findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/iam/iam_sa_user_managed_key_rotate_90_days/iam_sa_user_managed_key_rotate_90_days.py
+++ b/prowler/providers/gcp/services/iam/iam_sa_user_managed_key_rotate_90_days/iam_sa_user_managed_key_rotate_90_days.py
@@ -17,10 +17,10 @@ class iam_sa_user_managed_key_rotate_90_days(Check):
                     report.resource_name = account.email
                     report.location = iam_client.region
                     report.status = "PASS"
-                    report.status_extended = f"User-managed key {key.name} for account {account.email} was rotated over the last 90 days ({last_rotated} days ago)"
+                    report.status_extended = f"User-managed key {key.name} for account {account.email} was rotated over the last 90 days ({last_rotated} days ago)."
                     if last_rotated > 90:
                         report.status = "FAIL"
-                        report.status_extended = f"User-managed key {key.name} for account {account.email} was not rotated over the last 90 days ({last_rotated} days ago)"
+                        report.status_extended = f"User-managed key {key.name} for account {account.email} was not rotated over the last 90 days ({last_rotated} days ago)."
                     findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
+++ b/prowler/providers/gcp/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
@@ -17,7 +17,7 @@ class kms_key_not_publicly_accessible(Check):
                 if member == "allUsers" or member == "allAuthenticatedUsers":
                     report.status = "FAIL"
                     report.status_extended = (
-                        f"Key {key.name} may be publicly accessible!"
+                        f"Key {key.name} may be publicly accessible."
                     )
             findings.append(report)
 

--- a/prowler/providers/gcp/services/logging/logging_sink_created/logging_sink_created.py
+++ b/prowler/providers/gcp/services/logging/logging_sink_created/logging_sink_created.py
@@ -14,10 +14,10 @@ class logging_sink_created(Check):
             report.resource_name = sink.name
             report.location = logging_client.region
             report.status = "FAIL"
-            report.status_extended = f"Sink {sink.name} is enabled but not exporting copies of all the log entries in project {sink.project_id}"
+            report.status_extended = f"Sink {sink.name} is enabled but not exporting copies of all the log entries in project {sink.project_id}."
             if sink.filter == "all":
                 report.status = "PASS"
-                report.status_extended = f"Sink {sink.name} is enabled exporting copies of all the log entries in project {sink.project_id}"
+                report.status_extended = f"Sink {sink.name} is enabled exporting copies of all the log entries in project {sink.project_id}."
             findings.append(report)
 
         for project in logging_client.project_ids:
@@ -28,7 +28,7 @@ class logging_sink_created(Check):
                 report.resource_name = ""
                 report.location = logging_client.region
                 report.status = "FAIL"
-                report.status_extended = f"There are no logging sinks to export copies of all the log entries in project {project}"
+                report.status_extended = f"There are no logging sinks to export copies of all the log entries in project {project}."
                 findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/serviceusage/serviceusage_cloudasset_inventory_enabled/serviceusage_cloudasset_inventory_enabled.py
+++ b/prowler/providers/gcp/services/serviceusage/serviceusage_cloudasset_inventory_enabled/serviceusage_cloudasset_inventory_enabled.py
@@ -15,7 +15,7 @@ class serviceusage_cloudasset_inventory_enabled(Check):
             report.location = serviceusage_client.region
             report.status = "FAIL"
             report.status_extended = (
-                f"Cloud Asset Inventory is not enabled in project {project_id}"
+                f"Cloud Asset Inventory is not enabled in project {project_id}."
             )
             for active_service in serviceusage_client.active_services.get(
                 project_id, []
@@ -23,7 +23,7 @@ class serviceusage_cloudasset_inventory_enabled(Check):
                 if active_service.name == "cloudasset.googleapis.com":
                     report.status = "PASS"
                     report.status_extended = (
-                        f"Cloud Asset Inventory is enabled in project {project_id}"
+                        f"Cloud Asset Inventory is enabled in project {project_id}."
                     )
                     break
             findings.append(report)

--- a/tests/providers/gcp/services/bigquery/bigquery_dataset_public_access/bigquery_dataset_public_access_test.py
+++ b/tests/providers/gcp/services/bigquery/bigquery_dataset_public_access/bigquery_dataset_public_access_test.py
@@ -1,4 +1,3 @@
-from re import search
 from unittest import mock
 
 GCP_PROJECT_ID = "123456789012"
@@ -50,9 +49,9 @@ class Test_bigquery_dataset_public_access:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert search(
-                f"Dataset {dataset.name} is not publicly accessible",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == f"Dataset {dataset.name} is not publicly accessible."
             )
             assert result[0].resource_id == dataset.id
             assert result[0].resource_name == dataset.name
@@ -88,9 +87,9 @@ class Test_bigquery_dataset_public_access:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert search(
-                f"Dataset {dataset.name} is publicly accessible!",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == f"Dataset {dataset.name} is publicly accessible."
             )
             assert result[0].resource_id == dataset.id
             assert result[0].resource_name == dataset.name

--- a/tests/providers/gcp/services/compute/compute_default_service_account_in_use_with_full_api_access/compute_default_service_account_in_use_with_full_api_access_test.py
+++ b/tests/providers/gcp/services/compute/compute_default_service_account_in_use_with_full_api_access/compute_default_service_account_in_use_with_full_api_access_test.py
@@ -1,4 +1,3 @@
-from re import search
 from unittest import mock
 
 GCP_PROJECT_ID = "123456789012"
@@ -62,9 +61,9 @@ class Test_compute_instance_default_service_account_in_use_with_full_api_access:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert search(
-                f"The VM Instance {instance.name} is not configured to use the default service account with full access to all cloud APIs ",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == f"The VM Instance {instance.name} is not configured to use the default service account with full access to all cloud APIs."
             )
             assert result[0].resource_id == instance.id
 
@@ -110,9 +109,9 @@ class Test_compute_instance_default_service_account_in_use_with_full_api_access:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert search(
-                f"The VM Instance {instance.name} is not configured to use the default service account with full access to all cloud APIs ",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == f"The VM Instance {instance.name} is not configured to use the default service account with full access to all cloud APIs."
             )
             assert result[0].resource_id == instance.id
 
@@ -158,8 +157,8 @@ class Test_compute_instance_default_service_account_in_use_with_full_api_access:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert search(
-                f"The VM Instance {instance.name} is configured to use the default service account with full access to all cloud APIs ",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == f"The VM Instance {instance.name} is configured to use the default service account with full access to all cloud APIs."
             )
             assert result[0].resource_id == instance.id


### PR DESCRIPTION
### Description

GCP check's `report.status_extended` must ends with a dot.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
