### PR TITLE
feat(ecr_repositories_scan_vulnerabilities_in_latest_image): Minimum severity is configurable

### DIFF
--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -54,6 +54,13 @@ aws:
   organizations_enabled_regions: []
   organizations_trusted_delegated_administrators: []
 
+  # AWS ECR
+  # ecr_repositories_scan_vulnerabilities_in_latest_image
+  # CRITICAL
+  # HIGH
+  # MEDIUM
+  ecr_repository_vulnerability_minimum_severity: "MEDIUM"
+
 # Azure Configuration
 azure:
 

--- a/prowler/providers/aws/services/ecr/ecr_repositories_scan_vulnerabilities_in_latest_image/ecr_repositories_scan_vulnerabilities_in_latest_image.py
+++ b/prowler/providers/aws/services/ecr/ecr_repositories_scan_vulnerabilities_in_latest_image/ecr_repositories_scan_vulnerabilities_in_latest_image.py
@@ -5,6 +5,12 @@ from prowler.providers.aws.services.ecr.ecr_client import ecr_client
 class ecr_repositories_scan_vulnerabilities_in_latest_image(Check):
     def execute(self):
         findings = []
+
+        # Get minimun severity to report
+        minimum_severity = ecr_client.audit_config.get(
+            "ecr_repository_vulnerability_minimum_severity", "MEDIUM"
+        )
+
         for registry in ecr_client.registries.values():
             for repository in registry.repositories:
                 # First check if the repository has images
@@ -27,8 +33,23 @@ class ecr_repositories_scan_vulnerabilities_in_latest_image(Check):
                         report.status_extended = (
                             f"ECR repository {repository.name} with scan status FAILED."
                         )
-                    elif image.scan_findings_status != "FAILED":
-                        if image.scan_findings_severity_count and (
+                    elif (
+                        image.scan_findings_status != "FAILED"
+                        and image.scan_findings_severity_count
+                    ):
+                        if (
+                            minimum_severity == "CRITICAL"
+                            and image.scan_findings_severity_count.critical
+                        ):
+                            report.status = "FAIL"
+                            report.status_extended = f"ECR repository {repository.name} has imageTag {image.latest_tag} scanned with findings: CRITICAL->{image.scan_findings_severity_count.critical}."
+                        elif minimum_severity == "HIGH" and (
+                            image.scan_findings_severity_count.critical
+                            or image.scan_findings_severity_count.high
+                        ):
+                            report.status = "FAIL"
+                            report.status_extended = f"ECR repository {repository.name} has imageTag {image.latest_tag} scanned with findings: CRITICAL->{image.scan_findings_severity_count.critical}, HIGH->{image.scan_findings_severity_count.high}."
+                        elif minimum_severity == "MEDIUM" and (
                             image.scan_findings_severity_count.critical
                             or image.scan_findings_severity_count.high
                             or image.scan_findings_severity_count.medium


### PR DESCRIPTION
### Context

Fixes #2535 

### Description

Included a new config parameter `ecr_repository_vulnerability_minimum_severity` to set a minimum severity level for the `ecr_repositories_scan_vulnerabilities_in_latest_image` check.

Now you can get a `FAIL` finding only if a `CRITICAL` vulnerability is present in your ECR repository image.

The default behaviour is to set `MEDIUM` as the base severity level.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
