### PR TITLE
fix(checks_to_execute): --checks and --resource_arn working together

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -138,7 +138,8 @@ def prowler():
     # Once the audit_info is set and we have the eventual checks based on the resource identifier,
     # it is time to check what Prowler's checks are going to be executed
     if audit_info.audit_resources:
-        checks_to_execute = set_provider_execution_parameters(provider, audit_info)
+        checks_from_resources = set_provider_execution_parameters(provider, audit_info)
+        checks_to_execute = checks_to_execute.intersection(checks_from_resources)
 
     # Sort final check list
     checks_to_execute = sorted(checks_to_execute)


### PR DESCRIPTION
### Context

Right now if you input `--checks` and `--resource_arn` all the checks coming from the service present in the `--resource_arn` will be executed.


### Description

Find the intersection between the `--checks` and the checks coming from the service present in the `--resource_arn`.

#### Before 

```
./prowler.py --checks efs_not_publicly_accessible \
       --resource-arn arn:aws:elasticfilesystem:eu-west-1:XXXXXXXXXXXX:file-system/XXXXXXXXXXXX

Executing 3 checks, please wait...

Check ID: efs_encryption_at_rest_enabled - efs [medium]

Check ID: efs_have_backup_enabled - efs [medium]

Check ID: efs_not_publicly_accessible - efs [critical]
```

#### After
```
./prowler.py --checks efs_not_publicly_accessible \
       --resource-arn arn:aws:elasticfilesystem:eu-west-1:XXXXXXXXXXXX:file-system/XXXXXXXXXXXX

Executing 1 check, please wait...

Check ID: efs_not_publicly_accessible - efs [critical]
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
