### PR TITLE
feat(checks-metadata): only load checks metadata once

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -160,7 +160,11 @@ def prowler():
     findings = []
     if len(checks_to_execute):
         findings = execute_checks(
-            checks_to_execute, provider, audit_info, audit_output_options
+            checks_to_execute,
+            provider,
+            audit_info,
+            audit_output_options,
+            bulk_checks_metadata,
         )
     else:
         logger.error(

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -385,13 +385,13 @@ def import_check(check_path: str) -> ModuleType:
 
 def run_check(check: Check, output_options: Provider_Output_Options) -> list:
     findings = []
-    if output_options.verbose:
-        print(
-            f"\nCheck ID: {check.check_metadata.CheckID} - {Fore.MAGENTA}{check.check_metadata.ServiceName}{Fore.YELLOW} [{check.check_metadata.Severity}]{Style.RESET_ALL}"
-        )
-        logger.debug(f"Executing check: {check.check_metadata.CheckID}")
+
     try:
-        print(check)
+        if output_options.verbose:
+            print(
+                f"\nCheck ID: {check.check_metadata.CheckID} - {Fore.MAGENTA}{check.check_metadata.ServiceName}{Fore.YELLOW} [{check.check_metadata.Severity}]{Style.RESET_ALL}"
+            )
+            logger.debug(f"Executing check: {check.check_metadata.CheckID}")
         findings = check.execute()
     except Exception as error:
         if not output_options.only_logs:

--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -55,23 +55,14 @@ class Check_Metadata_Model(BaseModel):
     Compliance: list = None
 
 
-class Check(ABC):  # , Check_Metadata_Model):
+class Check(ABC):
     """Prowler Check"""
 
     check_metadata: Check_Metadata_Model
 
     def __init__(self, metadata):
         """Check's init function. Calls the CheckMetadataModel init."""
-        # # Parse the Check's metadata file
-        # metadata_file = (
-        #     os.path.abspath(sys.modules[self.__module__].__file__)[:-3]
-        #     + ".metadata.json"
-        # )
-        # # Store it to validate them with Pydantic
-        # data = Check_Metadata_Model.parse_file(metadata_file).dict()
         self.check_metadata = metadata
-        # Calls parents init function
-        # super().__init__(**data)
 
     def metadata(self) -> dict:
         """Return the JSON representation of the check's metadata"""

--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -56,24 +55,27 @@ class Check_Metadata_Model(BaseModel):
     Compliance: list = None
 
 
-class Check(ABC, Check_Metadata_Model):
+class Check(ABC):  # , Check_Metadata_Model):
     """Prowler Check"""
 
-    def __init__(self, **data):
+    check_metadata: Check_Metadata_Model
+
+    def __init__(self, metadata):
         """Check's init function. Calls the CheckMetadataModel init."""
-        # Parse the Check's metadata file
-        metadata_file = (
-            os.path.abspath(sys.modules[self.__module__].__file__)[:-3]
-            + ".metadata.json"
-        )
-        # Store it to validate them with Pydantic
-        data = Check_Metadata_Model.parse_file(metadata_file).dict()
+        # # Parse the Check's metadata file
+        # metadata_file = (
+        #     os.path.abspath(sys.modules[self.__module__].__file__)[:-3]
+        #     + ".metadata.json"
+        # )
+        # # Store it to validate them with Pydantic
+        # data = Check_Metadata_Model.parse_file(metadata_file).dict()
+        self.check_metadata = metadata
         # Calls parents init function
-        super().__init__(**data)
+        # super().__init__(**data)
 
     def metadata(self) -> dict:
         """Return the JSON representation of the check's metadata"""
-        return self.json()
+        return self.check_metadata.json()
 
     @abstractmethod
     def execute(self):

--- a/prowler/lib/outputs/models.py
+++ b/prowler/lib/outputs/models.py
@@ -435,7 +435,7 @@ class Check_Output_JSON(BaseModel):
     Risk: str
     RelatedUrl: str
     Remediation: Remediation
-    Compliance: Optional[dict]
+    Compliance: Optional[list]
     Categories: List[str]
     DependsOn: List[str]
     RelatedTo: List[str]


### PR DESCRIPTION
### Context

In Prowler we were loading twice check compliance metadata, once at first when loading the bulk to allow filtering and when instantiating a `Check` object when executing it


### Description

Use the bulk check metadata information to not load again the same info

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
