### PR TITLE
fix(get_checks_from_input_arn): fix function and add tests

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -246,6 +246,8 @@ def get_checks_from_input_arn(audit_resources: list, provider: str) -> set:
             if any(sub_service in check for sub_service in sub_service_list):
                 if not (sub_service == "policy" and "password_policy" in check):
                     checks_from_arn.add(check)
+            else:
+                checks_from_arn.add(check)
 
     # Return final checks list
     return sorted(checks_from_arn)


### PR DESCRIPTION
### Context

Fix `get_checks_from_input_arn` in case there are no subservices 


### Description
Modify that function also adding tests. 
Also add more cases to `test_get_regions_from_audit_resources` 


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
