### PR TITLE
fix(nacls): Tests

### DIFF
--- a/prowler/providers/aws/services/ec2/lib/network_acls.py
+++ b/prowler/providers/aws/services/ec2/lib/network_acls.py
@@ -2,8 +2,11 @@ from typing import Any
 
 
 # Network ACLs
-# Check if the network acls rules has ingress public access to the check_ports using the protocol
-def check_network_acl(rules: Any, protocol: str, port: str) -> bool:
+def check_network_acl(rules: Any, protocol: str, port: int) -> bool:
+    """check_network_acl returns True if the network acls rules has ingress public access to the check_ports using the protocol, otherwise return False
+    - True --> NACL open to the internet
+    - False --> NACL closed to the internet
+    """
 
     # Spliting IPv6 from IPv4 rules
     rules_IPv6 = list(
@@ -64,7 +67,6 @@ def check_network_acl(rules: Any, protocol: str, port: str) -> bool:
                 )
             )
         ):
-
             # Exist IPv4 deny for this port and if exist IPv6 there are not IPv6 Public access here
             return False
 

--- a/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_any_port/ec2_networkacl_allow_ingress_any_port_test.py
+++ b/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_any_port/ec2_networkacl_allow_ingress_any_port_test.py
@@ -10,7 +10,7 @@ AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
-class ec2_networkacl_allow_ingress_any_port:
+class Test_ec2_networkacl_allow_ingress_any_port:
     def set_mocked_audit_info(self):
         audit_info = AWS_Audit_Info(
             session_config=None,
@@ -64,7 +64,7 @@ class ec2_networkacl_allow_ingress_any_port:
             result = check.execute()
 
             # One default nacl per region
-            assert len(result) == 3
+            assert len(result) == 2
 
     @mock_ec2
     def test_ec2_non_default_compliant_nacl(self):
@@ -88,7 +88,7 @@ class ec2_networkacl_allow_ingress_any_port:
             result = check.execute()
 
             # One default sg per region
-            assert len(result) == 3
+            assert len(result) == 2
 
             # by default nacls are public
             assert result[0].status == "FAIL"

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434_test.py
@@ -11,7 +11,7 @@ AWS_REGION = "us-east-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
-class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434:
+class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434:
     def set_mocked_audit_info(self):
         audit_info = AWS_Audit_Info(
             session_config=None,

--- a/tests/providers/aws/services/ec2/lib/network_acls_test.py
+++ b/tests/providers/aws/services/ec2/lib/network_acls_test.py
@@ -58,7 +58,7 @@ allow_all_entry_ingress_IPv6 = {
 class Test_Network_Acls_IPv4_Only:
     def test_check_IPv4_only_ingress_port_default_entries_deny(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
         entries = []
 
         # Default IPv4 Ingress Deny
@@ -67,11 +67,11 @@ class Test_Network_Acls_IPv4_Only:
         # Default IPv4 Egress Deny
         entries.append(default_deny_entry_egress_IPv4)
 
-        assert not check_network_acl(entries, tcp_protocol, check_port)
+        assert not check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_only_ingress_port_with_allow_port(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
 
@@ -86,17 +86,17 @@ class Test_Network_Acls_IPv4_Only:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 100,
             }
         )
 
-        assert check_network_acl(entries, tcp_protocol, check_port)
+        assert check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_only_ingress_port_with_deny_port(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
 
@@ -111,7 +111,7 @@ class Test_Network_Acls_IPv4_Only:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "deny",
                 "RuleNumber": 100,
             }
@@ -120,7 +120,7 @@ class Test_Network_Acls_IPv4_Only:
         # Allow All IPv4
         entries.append(allow_all_entry_ingress_IPv4)
 
-        assert not check_network_acl(entries, tcp_protocol, check_port)
+        assert not check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_only_ingress_port_with_deny_port_in_range(self):
         check_port = 22
@@ -186,7 +186,7 @@ class Test_Network_Acls_IPv4_Only:
 
     def test_check_IPv4_only_ingress_port_with_deny_port_order_incorrect(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
         # Default IPv4 Ingress Deny
@@ -200,7 +200,7 @@ class Test_Network_Acls_IPv4_Only:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "deny",
                 "RuleNumber": 102,
             }
@@ -211,18 +211,17 @@ class Test_Network_Acls_IPv4_Only:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 101,
             }
         )
 
-        assert check_network_acl(entries, tcp_protocol, check_port)
+        assert check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_only_ingress_port_with_deny_port_order_correct(self):
-
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
         # Default IPv4 Ingress Deny
@@ -236,7 +235,7 @@ class Test_Network_Acls_IPv4_Only:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "deny",
                 "RuleNumber": 101,
             }
@@ -247,17 +246,17 @@ class Test_Network_Acls_IPv4_Only:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 102,
             }
         )
 
-        assert not check_network_acl(entries, tcp_protocol, check_port)
+        assert not check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_only_ingress_port_with_allow_port_but_egress(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
 
@@ -272,19 +271,19 @@ class Test_Network_Acls_IPv4_Only:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": True,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 100,
             }
         )
 
-        assert not check_network_acl(entries, tcp_protocol, check_port)
+        assert not check_network_acl(entries, any_protocol, check_port)
 
 
 class Test_Network_Acls_IPv4_IPv6:
     def test_check_IPv4_IPv6_ingress_port_default_entries_deny_both(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
         entries = []
 
         # Default IPv4 Ingress Deny
@@ -299,11 +298,11 @@ class Test_Network_Acls_IPv4_IPv6:
         # Default IPv6 Egress Deny
         entries.append(default_deny_entry_egress_IPv6)
 
-        assert not check_network_acl(entries, tcp_protocol, check_port)
+        assert not check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_IPv6_ingress_port_with_allow_port_IPv4(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
 
@@ -324,17 +323,17 @@ class Test_Network_Acls_IPv4_IPv6:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 100,
             }
         )
 
-        assert check_network_acl(entries, tcp_protocol, check_port)
+        assert check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_IPv6_ingress_port_with_allow_port_IPV6(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
 
@@ -355,17 +354,17 @@ class Test_Network_Acls_IPv4_IPv6:
                 "Ipv6CidrBlock": "::/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 100,
             }
         )
 
-        assert check_network_acl(entries, tcp_protocol, check_port)
+        assert check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_IPv6_ingress_port_with_allow_port_both(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
 
@@ -386,7 +385,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "Ipv6CidrBlock": "::/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 100,
             }
@@ -397,17 +396,17 @@ class Test_Network_Acls_IPv4_IPv6:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 101,
             }
         )
 
-        assert check_network_acl(entries, tcp_protocol, check_port)
+        assert check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_IPv6_ingress_port_with_deny_port_IPv4(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
 
@@ -428,7 +427,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "deny",
                 "RuleNumber": 100,
             }
@@ -440,11 +439,11 @@ class Test_Network_Acls_IPv4_IPv6:
         # Allow All IPv6
         entries.append(allow_all_entry_ingress_IPv6)
 
-        assert check_network_acl(entries, tcp_protocol, check_port)
+        assert check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_IPv6_ingress_port_with_deny_port_IPv6(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
 
@@ -465,7 +464,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "Ipv6CidrBlock": "::/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "deny",
                 "RuleNumber": 100,
             }
@@ -477,11 +476,11 @@ class Test_Network_Acls_IPv4_IPv6:
         # Allow All IPv6
         entries.append(allow_all_entry_ingress_IPv6)
 
-        assert check_network_acl(entries, tcp_protocol, check_port)
+        assert check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_IPv6_ingress_port_with_deny_port_both(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
 
@@ -502,7 +501,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "deny",
                 "RuleNumber": 100,
             }
@@ -513,7 +512,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "Ipv6CidrBlock": "::/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "deny",
                 "RuleNumber": 101,
             }
@@ -525,7 +524,7 @@ class Test_Network_Acls_IPv4_IPv6:
         # Allow All IPv6
         entries.append(allow_all_entry_ingress_IPv6)
 
-        assert not check_network_acl(entries, tcp_protocol, check_port)
+        assert not check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_IPv6_ingress_port_with_deny_port_in_range_IPv4(self):
         check_port = 22
@@ -793,7 +792,7 @@ class Test_Network_Acls_IPv4_IPv6:
 
     def test_check_IPv4_IPv6_ingress_port_with_deny_port_order_incorrect_IPv4(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
         # Default IPv4 Ingress Deny
@@ -813,7 +812,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "deny",
                 "RuleNumber": 102,
             }
@@ -824,17 +823,17 @@ class Test_Network_Acls_IPv4_IPv6:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 101,
             }
         )
 
-        assert check_network_acl(entries, tcp_protocol, check_port)
+        assert check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_IPv6_ingress_port_with_deny_port_order_incorrect_IPv6(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
         # Default IPv4 Ingress Deny
@@ -854,7 +853,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "Ipv6CidrBlock": "::/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "deny",
                 "RuleNumber": 102,
             }
@@ -865,17 +864,17 @@ class Test_Network_Acls_IPv4_IPv6:
                 "Ipv6CidrBlock": "::/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 101,
             }
         )
 
-        assert check_network_acl(entries, tcp_protocol, check_port)
+        assert check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_IPv6_ingress_port_with_deny_port_order_incorrect_both(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
         # Default IPv4 Ingress Deny
@@ -895,7 +894,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "Ipv6CidrBlock": "::/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "deny",
                 "RuleNumber": 102,
             }
@@ -906,7 +905,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "Ipv6CidrBlock": "::/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 101,
             }
@@ -917,7 +916,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "deny",
                 "RuleNumber": 202,
             }
@@ -928,18 +927,17 @@ class Test_Network_Acls_IPv4_IPv6:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 201,
             }
         )
 
-        assert check_network_acl(entries, tcp_protocol, check_port)
+        assert check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_IPv6_ingress_port_with_deny_port_order_correct_IPv4(self):
-
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
         # Default IPv4 Ingress Deny
@@ -959,7 +957,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "deny",
                 "RuleNumber": 101,
             }
@@ -970,18 +968,17 @@ class Test_Network_Acls_IPv4_IPv6:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 102,
             }
         )
 
-        assert not check_network_acl(entries, tcp_protocol, check_port)
+        assert not check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_IPv6_ingress_port_with_deny_port_order_correct_IPv6(self):
-
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
         # Default IPv4 Ingress Deny
@@ -1001,7 +998,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "Ipv6CidrBlock": "::/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "deny",
                 "RuleNumber": 101,
             }
@@ -1012,18 +1009,17 @@ class Test_Network_Acls_IPv4_IPv6:
                 "Ipv6CidrBlock": "::/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 102,
             }
         )
 
-        assert not check_network_acl(entries, tcp_protocol, check_port)
+        assert not check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_IPv6_ingress_port_with_deny_port_order_correct_both(self):
-
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
         # Default IPv4 Ingress Deny
@@ -1043,7 +1039,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "Ipv6CidrBlock": "::/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "deny",
                 "RuleNumber": 101,
             }
@@ -1054,7 +1050,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "Ipv6CidrBlock": "::/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 102,
             }
@@ -1065,7 +1061,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "deny",
                 "RuleNumber": 201,
             }
@@ -1076,16 +1072,16 @@ class Test_Network_Acls_IPv4_IPv6:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": False,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 202,
             }
         )
-        assert not check_network_acl(entries, tcp_protocol, check_port)
+        assert not check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_IPv6_ingress_port_with_allow_port_but_egress_IPv4(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
 
@@ -1106,17 +1102,17 @@ class Test_Network_Acls_IPv4_IPv6:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": True,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 100,
             }
         )
 
-        assert not check_network_acl(entries, tcp_protocol, check_port)
+        assert not check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_IPv6_ingress_port_with_allow_port_but_egress_IPv6(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
 
@@ -1137,17 +1133,17 @@ class Test_Network_Acls_IPv4_IPv6:
                 "Ipv6CidrBlock": "::/0",
                 "Egress": True,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 100,
             }
         )
 
-        assert not check_network_acl(entries, tcp_protocol, check_port)
+        assert not check_network_acl(entries, any_protocol, check_port)
 
     def test_check_IPv4_IPv6_ingress_port_with_allow_port_but_egress_both(self):
         check_port = 22
-        tcp_protocol = "-1"
+        any_protocol = "-1"
 
         entries = []
 
@@ -1168,7 +1164,7 @@ class Test_Network_Acls_IPv4_IPv6:
                 "Ipv6CidrBlock": "::/0",
                 "Egress": True,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 100,
             }
@@ -1179,10 +1175,10 @@ class Test_Network_Acls_IPv4_IPv6:
                 "CidrBlock": "0.0.0.0/0",
                 "Egress": True,
                 "NetworkAclId": "acl-072d520d07e1c1471",
-                "Protocol": tcp_protocol,
+                "Protocol": any_protocol,
                 "RuleAction": "allow",
                 "RuleNumber": 101,
             }
         )
 
-        assert not check_network_acl(entries, tcp_protocol, check_port)
+        assert not check_network_acl(entries, any_protocol, check_port)


### PR DESCRIPTION
### Description

Fix AWS NACLs test:
- Missing `Test` in `Test_ec2_networkacl_allow_ingress_any_port` so the checks were not loaded neither executed.
- Missing `Test` in `Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434` so the checks were not loaded neither executed.
- Fixed tests
- Improved `check_network_acl` docs.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
