### PR TITLE
fix(ec2 tests): add tags and region non sg checks

### DIFF
--- a/tests/providers/aws/services/ec2/ec2_ami_public/ec2_ami_public_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ami_public/ec2_ami_public_test.py
@@ -68,7 +68,7 @@ class Test_ec2_ami_public:
 
     @mock_ec2
     def test_one_private_ami(self):
-        ec2 = client("ec2", region_name="us-east-1")
+        ec2 = client("ec2", region_name=AWS_REGION)
 
         reservation = ec2.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
         instance = reservation["Instances"][0]
@@ -104,10 +104,12 @@ class Test_ec2_ami_public:
                 result[0].resource_arn
                 == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:image/{image_id}"
             )
+            assert result[0].region == AWS_REGION
+            assert result[0].resource_tags == []
 
     @mock_ec2
     def test_one_public_ami(self):
-        ec2 = client("ec2", region_name="us-east-1")
+        ec2 = client("ec2", region_name=AWS_REGION)
 
         reservation = ec2.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
         instance = reservation["Instances"][0]
@@ -154,3 +156,5 @@ class Test_ec2_ami_public:
                 result[0].resource_arn
                 == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:image/{image_id}"
             )
+            assert result[0].region == AWS_REGION
+            assert result[0].resource_tags == []

--- a/tests/providers/aws/services/ec2/ec2_ebs_default_encryption/ec2_ebs_default_encryption_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ebs_default_encryption/ec2_ebs_default_encryption_test.py
@@ -1,4 +1,3 @@
-from re import search
 from unittest import mock
 
 from boto3 import client, session
@@ -74,9 +73,12 @@ class Test_ec2_ebs_default_encryption:
             for result in results:
                 if result.region == AWS_REGION:
                     assert result.status == "PASS"
-                    assert search(
-                        "EBS Default Encryption is activated",
-                        result.status_extended,
+                    assert (
+                        result.status_extended == "EBS Default Encryption is activated."
+                    )
+                    assert result.resource_id == AWS_ACCOUNT_NUMBER
+                    assert (
+                        result.resource_arn == f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
                     )
 
     @mock_ec2
@@ -103,7 +105,8 @@ class Test_ec2_ebs_default_encryption:
             # One result per region
             assert len(result) == 2
             assert result[0].status == "FAIL"
-            assert search(
-                "EBS Default Encryption is not activated",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended == "EBS Default Encryption is not activated."
             )
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"

--- a/tests/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot_test.py
@@ -115,6 +115,8 @@ class Test_ec2_ebs_public_snapshot:
 
             for snap in results:
                 if snap.resource_id == snapshot.id:
+                    assert snap.region == AWS_REGION
+                    assert snap.resource_tags == []
                     assert snap.status == "FAIL"
                     assert (
                         snap.status_extended
@@ -158,6 +160,8 @@ class Test_ec2_ebs_public_snapshot:
 
             for snap in results:
                 if snap.resource_id == snapshot.id:
+                    assert snap.region == AWS_REGION
+                    assert snap.resource_tags == []
                     assert snap.status == "PASS"
                     assert (
                         snap.status_extended

--- a/tests/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted_test.py
@@ -108,6 +108,8 @@ class Test_ec2_ebs_snapshots_encrypted:
 
             for snap in results:
                 if snap.resource_id == snapshot.id:
+                    assert snap.region == AWS_REGION
+                    assert snap.resource_tags == []
                     assert snap.status == "FAIL"
                     assert (
                         snap.status_extended
@@ -151,6 +153,8 @@ class Test_ec2_ebs_snapshots_encrypted:
 
             for snap in results:
                 if snap.resource_id == snapshot.id:
+                    assert snap.region == AWS_REGION
+                    assert snap.resource_tags == []
                     assert snap.status == "PASS"
                     assert (
                         snap.status_extended

--- a/tests/providers/aws/services/ec2/ec2_ebs_volume_encryption/ec2_ebs_volume_encryption_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ebs_volume_encryption/ec2_ebs_volume_encryption_test.py
@@ -93,6 +93,9 @@ class Test_ec2_ebs_volume_encryption:
             assert len(result) == 1
 
             assert result[0].status == "FAIL"
+            assert result[0].region == AWS_REGION
+            # Moto creates the volume with None in the tags attribute
+            assert result[0].resource_tags is None
             assert (
                 result[0].status_extended == f"EBS Snapshot {volume.id} is unencrypted."
             )
@@ -131,6 +134,9 @@ class Test_ec2_ebs_volume_encryption:
             assert len(result) == 1
 
             assert result[0].status == "PASS"
+            assert result[0].region == AWS_REGION
+            # Moto creates the volume with None in the tags attribute
+            assert result[0].resource_tags is None
             assert (
                 result[0].status_extended == f"EBS Snapshot {volume.id} is encrypted."
             )

--- a/tests/providers/aws/services/ec2/ec2_elastic_ip_unassgined/ec2_elastic_ip_unassgined_test.py
+++ b/tests/providers/aws/services/ec2/ec2_elastic_ip_unassgined/ec2_elastic_ip_unassgined_test.py
@@ -96,6 +96,8 @@ class Test_ec2_elastic_ip_unassgined:
 
             assert len(results) == 1
             assert results[0].status == "FAIL"
+            assert results[0].region == AWS_REGION
+            assert results[0].resource_tags == []
             assert search(
                 "is not associated",
                 results[0].status_extended,
@@ -145,6 +147,8 @@ class Test_ec2_elastic_ip_unassgined:
 
             assert len(results) == 1
             assert results[0].status == "PASS"
+            assert results[0].region == AWS_REGION
+            assert results[0].resource_tags == []
             assert search(
                 "is associated",
                 results[0].status_extended,

--- a/tests/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled_test.py
@@ -103,6 +103,9 @@ class Test_ec2_instance_imdsv2_enabled:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
+            assert result[0].region == AWS_REGION
+            # Moto fills instance tags with None
+            assert result[0].resource_tags is None
             assert search(
                 f"EC2 Instance {instance.id} has IMDSv2 enabled and required",
                 result[0].status_extended,
@@ -149,6 +152,9 @@ class Test_ec2_instance_imdsv2_enabled:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
+            assert result[0].region == AWS_REGION
+            # Moto fills instance tags with None
+            assert result[0].resource_tags is None
             assert search(
                 f"EC2 Instance {instance.id} has IMDSv2 disabled or not required",
                 result[0].status_extended,

--- a/tests/providers/aws/services/ec2/ec2_instance_internet_facing_with_instance_profile/ec2_instance_internet_facing_with_instance_profile_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_internet_facing_with_instance_profile/ec2_instance_internet_facing_with_instance_profile_test.py
@@ -112,9 +112,10 @@ class Test_ec2_instance_internet_facing_with_instance_profile:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert search(
-                f"EC2 Instance {instance.id} is not internet facing with an instance profile",
-                result[0].status_extended,
+            assert result[0].region == AWS_REGION
+            assert result[0].resource_tags is None
+            assert result[0].status_extended == (
+                f"EC2 Instance {instance.id} is not internet facing with an instance profile."
             )
             assert result[0].resource_id == instance.id
             assert (
@@ -167,6 +168,8 @@ class Test_ec2_instance_internet_facing_with_instance_profile:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
+            assert result[0].region == AWS_REGION
+            assert result[0].resource_tags is None
             assert search(
                 "is internet-facing with Instance Profile", result[0].status_extended
             )

--- a/tests/providers/aws/services/ec2/ec2_instance_older_than_specific_days/ec2_instance_older_than_specific_days_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_older_than_specific_days/ec2_instance_older_than_specific_days_test.py
@@ -101,6 +101,8 @@ class Test_ec2_instance_older_than_specific_days:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
+            assert result[0].region == AWS_REGION
+            assert result[0].resource_tags is None
             assert search(
                 f"EC2 Instance {instance.id} is not older", result[0].status_extended
             )
@@ -145,6 +147,8 @@ class Test_ec2_instance_older_than_specific_days:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
+            assert result[0].region == AWS_REGION
+            assert result[0].resource_tags is None
             assert search(
                 f"EC2 Instance {instance.id} is older", result[0].status_extended
             )

--- a/tests/providers/aws/services/ec2/ec2_instance_profile_attached/ec2_instance_profile_attached_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_profile_attached/ec2_instance_profile_attached_test.py
@@ -112,6 +112,8 @@ class Test_ec2_instance_profile_attached:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
+            assert result[0].region == AWS_REGION
+            assert result[0].resource_tags is None
             assert search(
                 "associated with Instance Profile Role",
                 result[0].status_extended,
@@ -160,6 +162,8 @@ class Test_ec2_instance_profile_attached:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
+            assert result[0].region == AWS_REGION
+            assert result[0].resource_tags is None
             assert search(
                 "not associated with an Instance Profile", result[0].status_extended
             )

--- a/tests/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip_test.py
@@ -105,6 +105,8 @@ class Test_ec2_instance_public_ip:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
+            assert result[0].region == AWS_REGION
+            assert result[0].resource_tags is None
             assert search(
                 f"EC2 Instance {instance.id} does not have a Public IP.",
                 result[0].status_extended,
@@ -153,6 +155,8 @@ class Test_ec2_instance_public_ip:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
+            assert result[0].region == AWS_REGION
+            assert result[0].resource_tags is None
             assert search(
                 f"EC2 Instance {instance.id} has a Public IP.",
                 result[0].status_extended,

--- a/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_any_port/ec2_networkacl_allow_ingress_any_port_test.py
+++ b/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_any_port/ec2_networkacl_allow_ingress_any_port_test.py
@@ -92,6 +92,8 @@ class Test_ec2_networkacl_allow_ingress_any_port:
 
             # by default nacls are public
             assert result[0].status == "FAIL"
+            assert result[0].region in (AWS_REGION, "eu-west-1")
+            assert result[0].resource_tags == []
             assert (
                 result[0].status_extended
                 == f"Network ACL {result[0].resource_id} has every port open to the Internet."
@@ -139,6 +141,8 @@ class Test_ec2_networkacl_allow_ingress_any_port:
             for nacl in result:
                 if nacl.resource_id == nacl_id:
                     assert nacl.status == "FAIL"
+                    assert result[0].region in (AWS_REGION, "eu-west-1")
+                    assert result[0].resource_tags == []
                     assert (
                         nacl.status_extended
                         == f"Network ACL {nacl_id} has every port open to the Internet."
@@ -190,6 +194,8 @@ class Test_ec2_networkacl_allow_ingress_any_port:
             for nacl in result:
                 if nacl.resource_id == nacl_id:
                     assert nacl.status == "PASS"
+                    assert result[0].region in (AWS_REGION, "eu-west-1")
+                    assert result[0].resource_tags == []
                     assert (
                         nacl.status_extended
                         == f"Network ACL {nacl_id} does not have every port open to the Internet."

--- a/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22_test.py
+++ b/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22_test.py
@@ -92,6 +92,8 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
 
             # by default nacls are public
             assert result[0].status == "FAIL"
+            assert result[0].region in (AWS_REGION, "eu-west-1")
+            assert result[0].resource_tags == []
             assert (
                 result[0].status_extended
                 == f"Network ACL {result[0].resource_id} has SSH port 22 open to the Internet."
@@ -140,6 +142,8 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
             for nacl in result:
                 if nacl.resource_id == nacl_id:
                     assert nacl.status == "FAIL"
+                    assert result[0].region in (AWS_REGION, "eu-west-1")
+                    assert result[0].resource_tags == []
                     assert (
                         nacl.status_extended
                         == f"Network ACL {nacl_id} has SSH port 22 open to the Internet."
@@ -192,6 +196,8 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
             for nacl in result:
                 if nacl.resource_id == nacl_id:
                     assert nacl.status == "PASS"
+                    assert result[0].region in (AWS_REGION, "eu-west-1")
+                    assert result[0].resource_tags == []
                     assert (
                         nacl.status_extended
                         == f"Network ACL {nacl_id} does not have SSH port 22 open to the Internet."

--- a/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389_test.py
+++ b/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389_test.py
@@ -92,6 +92,8 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
 
             # by default nacls are public
             assert result[0].status == "FAIL"
+            assert result[0].region in (AWS_REGION, "eu-west-1")
+            assert result[0].resource_tags == []
             assert (
                 result[0].status_extended
                 == f"Network ACL {result[0].resource_id} has Microsoft RDP port 3389 open to the Internet."
@@ -140,6 +142,8 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
             for nacl in result:
                 if nacl.resource_id == nacl_id:
                     assert nacl.status == "FAIL"
+                    assert result[0].region in (AWS_REGION, "eu-west-1")
+                    assert result[0].resource_tags == []
                     assert (
                         nacl.status_extended
                         == f"Network ACL {nacl_id} has Microsoft RDP port 3389 open to the Internet."
@@ -192,6 +196,8 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
             for nacl in result:
                 if nacl.resource_id == nacl_id:
                     assert nacl.status == "PASS"
+                    assert result[0].region in (AWS_REGION, "eu-west-1")
+                    assert result[0].resource_tags == []
                     assert (
                         nacl.status_extended
                         == f"Network ACL {nacl_id} does not have Microsoft RDP port 3389 open to the Internet."


### PR DESCRIPTION
### Context

Some `ec2` service tests were not covering the assertion of the fields `region` and `resource_tags`


### Description

Cover those two fields in ec2 tests part 1 (not sg tests)


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
