### PR TITLE
fix(is_valid_arn): include . into resource name

### DIFF
--- a/prowler/providers/aws/lib/arn/arn.py
+++ b/prowler/providers/aws/lib/arn/arn.py
@@ -55,5 +55,5 @@ def parse_iam_credentials_arn(arn: str) -> ARN:
 
 def is_valid_arn(arn: str) -> bool:
     """is_valid_arn returns True or False whether the given AWS ARN (Amazon Resource Name) is valid or not."""
-    regex = r"^arn:aws(-cn|-us-gov|-iso|-iso-b)?:[a-zA-Z0-9\-]+:([a-z]{2}-[a-z]+-\d{1})?:(\d{12})?:[a-zA-Z0-9\-_\/:]+(:\d+)?$"
+    regex = r"^arn:aws(-cn|-us-gov|-iso|-iso-b)?:[a-zA-Z0-9\-]+:([a-z]{2}-[a-z]+-\d{1})?:(\d{12})?:[a-zA-Z0-9\-_\/:\.]+(:\d+)?$"
     return re.match(regex, arn) is not None

--- a/tests/providers/aws/lib/arn/arn_test.py
+++ b/tests/providers/aws/lib/arn/arn_test.py
@@ -318,6 +318,7 @@ class Test_ARN_Parsing:
         assert is_valid_arn(
             "arn:aws:lambda:eu-west-1:123456789012:function:lambda-function"
         )
+        assert is_valid_arn("arn:aws:sns:eu-west-1:123456789012:test.fifo")
         assert not is_valid_arn("arn:azure:::012345678910:user/test")
         assert not is_valid_arn("arn:aws:iam::account:user/test")
         assert not is_valid_arn("arn:aws:::012345678910:resource")


### PR DESCRIPTION
### Context

When using the flag `--resource-arn` to filter resources that has to be scanned, if the resource name included a `.`
it was returning the error `Invalid ARN ....`

### Description

Include the `.` character into the arn regexp in `is_valid_arn` function


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
