### PR TITLE
fix(html): unroll regions set prior concat

### DIFF
--- a/prowler/lib/outputs/html.py
+++ b/prowler/lib/outputs/html.py
@@ -345,7 +345,7 @@ def get_aws_html_assessment_summary(audit_info):
             elif not audit_info.audited_regions:
                 audited_regions = "All Regions"
             else:
-                audited_regions = audit_info.audited_regions
+                audited_regions = ", ".join(audit_info.audited_regions)
             return (
                 """
             <div class="col-md-2">


### PR DESCRIPTION
### Context

When launching Prowler with the flag `--resource-arn` the `html` file was not being generated because it was trying to concat a `set` of regions to `str` fields


### Description

Unroll the `set` of regions in `get_aws_html_assessment_summary` and transform it into `str`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
