### PR TITLE
fix(policy_condition_parser): add StringEquals aws:SourceArn condition

### DIFF
--- a/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
+++ b/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
@@ -25,6 +25,7 @@ def is_account_only_allowed_in_condition(
             "s3:resourceaccount",
             "aws:principalaccount",
             "aws:resourceaccount",
+            "aws:sourcearn",
         ],
         "StringLike": [
             "aws:sourceaccount",

--- a/tests/providers/aws/lib/policy_condition_parser/policy_condition_parser_test.py
+++ b/tests/providers/aws/lib/policy_condition_parser/policy_condition_parser_test.py
@@ -230,6 +230,26 @@ class Test_policy_condition_parser:
             condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
         )
 
+    def test_condition_parser_string_equals_aws_SourceArn_str(self):
+        condition_statement = {
+            "StringEquals": {
+                "aws:SourceArn": f"arn:aws:cloudtrail:*:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*"
+            }
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_string_equals_aws_SourceArn_str_not_valid(self):
+        condition_statement = {
+            "StringEquals": {
+                "aws:SourceArn": f"arn:aws:cloudtrail:*:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*"
+            }
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
     def test_condition_parser_string_like_aws_PrincipalAccount_list(self):
         condition_statement = {
             "StringLike": {"aws:PrincipalAccount": [TRUSTED_AWS_ACCOUNT_NUMBER]}


### PR DESCRIPTION
### Context

Solves #2792 

When testing valid condition options for policies we do not have included the following config
```
{
    "StringEquals": {
          "aws:SourceArn":  ARN"
    }
```

### Description

Include that option into the `is_account_only_allowed_in_condition` function and its tests


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
