### PR TITLE
fix(ec2 ebs/instance checks): unify checks logic

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot.py
@@ -10,16 +10,14 @@ class ec2_ebs_public_snapshot(Check):
             report.region = snapshot.region
             report.resource_arn = snapshot.arn
             report.resource_tags = snapshot.tags
-            if not snapshot.public:
-                report.status = "PASS"
-                report.status_extended = f"EBS Snapshot {snapshot.id} is not Public."
-                report.resource_id = snapshot.id
-            else:
+            report.status = "PASS"
+            report.status_extended = f"EBS Snapshot {snapshot.id} is not Public."
+            report.resource_id = snapshot.id
+            if snapshot.public:
                 report.status = "FAIL"
                 report.status_extended = (
                     f"EBS Snapshot {snapshot.id} is currently Public."
                 )
-                report.resource_id = snapshot.id
             findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted.py
@@ -10,11 +10,10 @@ class ec2_ebs_snapshots_encrypted(Check):
             report.region = snapshot.region
             report.resource_arn = snapshot.arn
             report.resource_tags = snapshot.tags
-            if snapshot.encrypted:
-                report.status = "PASS"
-                report.status_extended = f"EBS Snapshot {snapshot.id} is encrypted."
-                report.resource_id = snapshot.id
-            else:
+            report.status = "PASS"
+            report.status_extended = f"EBS Snapshot {snapshot.id} is encrypted."
+            report.resource_id = snapshot.id
+            if not snapshot.encrypted:
                 report.status = "FAIL"
                 report.status_extended = f"EBS Snapshot {snapshot.id} is unencrypted."
                 report.resource_id = snapshot.id

--- a/prowler/providers/aws/services/ec2/ec2_ebs_volume_encryption/ec2_ebs_volume_encryption.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_volume_encryption/ec2_ebs_volume_encryption.py
@@ -11,10 +11,9 @@ class ec2_ebs_volume_encryption(Check):
             report.resource_id = volume.id
             report.resource_arn = volume.arn
             report.resource_tags = volume.tags
-            if volume.encrypted:
-                report.status = "PASS"
-                report.status_extended = f"EBS Snapshot {volume.id} is encrypted."
-            else:
+            report.status = "PASS"
+            report.status_extended = f"EBS Snapshot {volume.id} is encrypted."
+            if not volume.encrypted:
                 report.status = "FAIL"
                 report.status_extended = f"EBS Snapshot {volume.id} is unencrypted."
             findings.append(report)

--- a/prowler/providers/aws/services/ec2/ec2_instance_managed_by_ssm/ec2_instance_managed_by_ssm.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_managed_by_ssm/ec2_instance_managed_by_ssm.py
@@ -12,18 +12,16 @@ class ec2_instance_managed_by_ssm(Check):
                 report.region = instance.region
                 report.resource_arn = instance.arn
                 report.resource_tags = instance.tags
+                report.status = "PASS"
+                report.status_extended = (
+                    f"EC2 Instance {instance.id} is managed by Systems Manager."
+                )
+                report.resource_id = instance.id
                 if not ssm_client.managed_instances.get(instance.id):
                     report.status = "FAIL"
                     report.status_extended = (
                         f"EC2 Instance {instance.id} is not managed by Systems Manager."
                     )
-                    report.resource_id = instance.id
-                else:
-                    report.status = "PASS"
-                    report.status_extended = (
-                        f"EC2 Instance {instance.id} is managed by Systems Manager."
-                    )
-                    report.resource_id = instance.id
                 findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip.py
@@ -11,16 +11,16 @@ class ec2_instance_public_ip(Check):
                 report.region = instance.region
                 report.resource_arn = instance.arn
                 report.resource_tags = instance.tags
+                report.status = "PASS"
+                report.status_extended = (
+                    f"EC2 Instance {instance.id} does not have a Public IP."
+                )
+                report.resource_id = instance.id
                 if instance.public_ip:
                     report.status = "FAIL"
                     report.status_extended = f"EC2 Instance {instance.id} has a Public IP: {instance.public_ip} ({instance.public_dns})."
                     report.resource_id = instance.id
-                else:
-                    report.status = "PASS"
-                    report.status_extended = (
-                        f"EC2 Instance {instance.id} does not have a Public IP."
-                    )
-                    report.resource_id = instance.id
+
                 findings.append(report)
 
         return findings


### PR DESCRIPTION
### Context

In `ec2` service there were checks not following the same logic we use for all the checks when assigning the status to the findings 


### Description

Change logic for checks:
- `ec2_ebs_public_snapshot`
- `ec2_ebs_snapshots_encrypted`
- `ec2_ebs_volume_encryption`
- `ec2_instance_managed_by_ssm`
- `ec2_instance_public_ip`



### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
