### PR TITLE
[bugfix] check122 has to check not only string but also array values of the Action field

### DIFF
--- a/checks/check122
+++ b/checks/check122
@@ -32,7 +32,7 @@ check122(){
     for policy in $LIST_CUSTOM_POLICIES; do
       POLICY_ARN=$(awk 'BEGIN{FS=OFS=","}{NF--; print}' <<< "${policy}")
       POLICY_VERSION=$(awk -F ',' '{print $(NF)}' <<< "${policy}")
-      POLICY_WITH_FULL=$($AWSCLI iam get-policy-version --output text --policy-arn $POLICY_ARN --version-id $POLICY_VERSION --query "[PolicyVersion.Document.Statement] | [] | [?Action!=null] | [?Effect == 'Allow' && Resource == '*' && Action == '*']" $PROFILE_OPT --region $REGION)
+      POLICY_WITH_FULL=$($AWSCLI iam get-policy-version --output text --policy-arn $POLICY_ARN --version-id $POLICY_VERSION --query "[PolicyVersion.Document.Statement] | [] | [?Action!=null] | [?Effect == 'Allow' && Resource == '*' && contains(Action, '*')]" $PROFILE_OPT --region $REGION)
       if [[ $POLICY_WITH_FULL ]]; then
         POLICIES_ALLOW_LIST="$POLICIES_ALLOW_LIST $POLICY_ARN"
       else


### PR DESCRIPTION
### Context

The `check122` tested only `string` but not `array` values of the `Action` field. Therefore `check122` did not find IAM policies where a star `*` value of the `Action` field is an `array` element. 

Example of a policy that `check122` did **not** find **before** the bugfix:
```
{
    "Statement": [
        {
            "Action": [
                "*"
            ],
            "Effect": "Allow",
            "Resource": "*"
        }
    ],
    "Version": "2012-10-17"
}
```
**Before** this bugfix, `check122` did find IAM policies only like this:
```
{
    "Statement": [
        {
            "Action": "*",
            "Effect": "Allow",
            "Resource": "*",
            "Sid": ""
        }
    ],
    "Version": "2012-10-17"
}
```

### Description

I changed the code `Action == '*'`, which tests only `string` values, to `contains(Action, '*')`, which now also tests `array` values. Therefore `check122` will now find both types of the above shown IAM policy examples.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
