### PR TITLE
fix(ec2 nacl checks):unify logic

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_any_port/ec2_networkacl_allow_ingress_any_port.py
+++ b/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_any_port/ec2_networkacl_allow_ingress_any_port.py
@@ -14,11 +14,10 @@ class ec2_networkacl_allow_ingress_any_port(Check):
             report.resource_id = network_acl.id
             report.resource_arn = network_acl.arn
             report.resource_tags = network_acl.tags
+            report.status = "PASS"
+            report.status_extended = f"Network ACL {network_acl.id} does not have every port open to the Internet."
             # If some entry allows it, that ACL is not securely configured
-            if not check_network_acl(network_acl.entries, tcp_protocol, check_port):
-                report.status = "PASS"
-                report.status_extended = f"Network ACL {network_acl.id} does not have every port open to the Internet."
-            else:
+            if check_network_acl(network_acl.entries, tcp_protocol, check_port):
                 report.status = "FAIL"
                 report.status_extended = (
                     f"Network ACL {network_acl.id} has every port open to the Internet."

--- a/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22.py
+++ b/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22.py
@@ -13,15 +13,13 @@ class ec2_networkacl_allow_ingress_tcp_port_22(Check):
             report.region = network_acl.region
             report.resource_arn = network_acl.arn
             report.resource_tags = network_acl.tags
+            report.status = "PASS"
+            report.status_extended = f"Network ACL {network_acl.id} does not have SSH port 22 open to the Internet."
+            report.resource_id = network_acl.id
             # If some entry allows it, that ACL is not securely configured
-            if not check_network_acl(network_acl.entries, tcp_protocol, check_port):
-                report.status = "PASS"
-                report.status_extended = f"Network ACL {network_acl.id} does not have SSH port 22 open to the Internet."
-                report.resource_id = network_acl.id
-            else:
+            if check_network_acl(network_acl.entries, tcp_protocol, check_port):
                 report.status = "FAIL"
                 report.status_extended = f"Network ACL {network_acl.id} has SSH port 22 open to the Internet."
-                report.resource_id = network_acl.id
             findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389.py
+++ b/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389.py
@@ -13,15 +13,13 @@ class ec2_networkacl_allow_ingress_tcp_port_3389(Check):
             report.region = network_acl.region
             report.resource_arn = network_acl.arn
             report.resource_tags = network_acl.tags
+            report.status = "PASS"
+            report.status_extended = f"Network ACL {network_acl.id} does not have Microsoft RDP port 3389 open to the Internet."
+            report.resource_id = network_acl.id
             # If some entry allows it, that ACL is not securely configured
-            if not check_network_acl(network_acl.entries, tcp_protocol, check_port):
-                report.status = "PASS"
-                report.status_extended = f"Network ACL {network_acl.id} does not have Microsoft RDP port 3389 open to the Internet."
-                report.resource_id = network_acl.id
-            else:
+            if check_network_acl(network_acl.entries, tcp_protocol, check_port):
                 report.status = "FAIL"
                 report.status_extended = f"Network ACL {network_acl.id} has Microsoft RDP port 3389 open to the Internet."
-                report.resource_id = network_acl.id
             findings.append(report)
 
         return findings


### PR DESCRIPTION
### Context

Nacl checks from `ec2` service were not following default check logic


### Description

Reformat check logic from checks:
- `ec2_networkacl_allow_ingress_any_port`
- `ec2_networkacl_allow_ingress_tcp_port_22`
- `ec2_networkacl_allow_ingress_tcp_port_3389`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
