### PR TITLE
fix(ec2_instance_..._ssm): mock ssm service and client in all the tests

### DIFF
--- a/tests/providers/aws/services/ec2/ec2_instance_managed_by_ssm/ec2_instance_managed_by_ssm_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_managed_by_ssm/ec2_instance_managed_by_ssm_test.py
@@ -50,9 +50,18 @@ class Test_ec2_instance_managed_by_ssm_test:
 
         current_audit_info = self.set_mocked_audit_info()
 
+        ssm_client = mock.MagicMock
+        ssm_client.managed_instances = {}
+
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
+        ), mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_service.SSM",
+            new=ssm_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_client.ssm_client",
+            new=ssm_client,
         ), mock.patch(
             "prowler.providers.aws.services.ec2.ec2_instance_managed_by_ssm.ec2_instance_managed_by_ssm.ec2_client",
             new=EC2(current_audit_info),
@@ -80,6 +89,9 @@ class Test_ec2_instance_managed_by_ssm_test:
             UserData="This is some user_data",
         )[0]
 
+        ssm_client = mock.MagicMock
+        ssm_client.managed_instances = {}
+
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
         current_audit_info = self.set_mocked_audit_info()
@@ -87,6 +99,12 @@ class Test_ec2_instance_managed_by_ssm_test:
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
+        ), mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_service.SSM",
+            new=ssm_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_client.ssm_client",
+            new=ssm_client,
         ), mock.patch(
             "prowler.providers.aws.services.ec2.ec2_instance_managed_by_ssm.ec2_instance_managed_by_ssm.ec2_client",
             new=EC2(current_audit_info),


### PR DESCRIPTION
### Context

In check `ec2_instance_managed_by_ssm` the new tests were not mocking `SSM` service and `ssm_client` in all the cases 


### Description

Mock `SSM` service and `ssm_client` in tests:
- `test_ec2_no_instances`
- `test_ec2_instance_managed_by_ssm_non_compliance_instance`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
