### PR TITLE
feat(unix timestamp): add the --unix-timestamp flag to docs

### DIFF
--- a/docs/tutorials/reporting.md
+++ b/docs/tutorials/reporting.md
@@ -24,6 +24,8 @@ prowler <provider> -M csv json json-asff html -o <custom_report_directory>
 prowler <provider> -M csv json json-asff html \
         -F <custom_report_name> -o <custom_report_directory>
 ```
+## Output timestamp format
+By default, the timestamp format of the output files is ISO 8601. This can be changed with the flag `--unix-timestamp` generating the timestamp fields in pure unix timestamp format.
 
 ## Output Formats
 


### PR DESCRIPTION
### Context

The `--unix-timestamp` flag was added but not included into the docs

### Description

Adds the `--unix-timestamp` flag option to the docs inside the reporting section


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
