### PR TITLE
fix(iam_inline_policy_no_administrative_privileges): set resource id as the entity name

### DIFF
--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges.py
@@ -10,7 +10,7 @@ class iam_inline_policy_no_administrative_privileges(Check):
                 report = Check_Report_AWS(self.metadata())
                 report.region = iam_client.region
                 report.resource_arn = policy.arn
-                report.resource_id = policy.name
+                report.resource_id = policy.entity
                 report.resource_tags = policy.tags
                 report.status = "PASS"
                 report.status_extended = f"{policy.type} policy {policy.name} for IAM identity {policy.arn} does not allow '*:*' administrative privileges."

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -398,6 +398,7 @@ class IAM(AWSService):
                                 Policy(
                                     name=policy,
                                     arn=user.arn,
+                                    entity=user.name,
                                     type="Inline",
                                     attached=True,
                                     version_id="v1",
@@ -438,6 +439,7 @@ class IAM(AWSService):
                                 Policy(
                                     name=policy,
                                     arn=group.arn,
+                                    entity=group.name,
                                     type="Inline",
                                     attached=True,
                                     version_id="v1",
@@ -478,6 +480,7 @@ class IAM(AWSService):
                                 Policy(
                                     name=policy,
                                     arn=role.arn,
+                                    entity=role.name,
                                     type="Inline",
                                     attached=True,
                                     version_id="v1",
@@ -526,6 +529,7 @@ class IAM(AWSService):
                             Policy(
                                 name=policy["PolicyName"],
                                 arn=policy["Arn"],
+                                entity=policy["PolicyId"],
                                 version_id=policy["DefaultVersionId"],
                                 type="Custom" if scope == "Local" else "AWS",
                                 attached=True
@@ -704,6 +708,7 @@ class Certificate(BaseModel):
 class Policy(BaseModel):
     name: str
     arn: str
+    entity: str
     version_id: str
     type: str
     attached: bool

--- a/tests/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges_test.py
+++ b/tests/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges_test.py
@@ -128,7 +128,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert len(results) == 1
             assert results[0].region == AWS_REGION
             assert results[0].resource_arn == group_arn
-            assert results[0].resource_id == policy_name
+            assert results[0].resource_id == group_name
             assert results[0].resource_tags == []
             assert results[0].status == "FAIL"
             assert (
@@ -172,7 +172,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert len(results) == 1
             assert results[0].region == AWS_REGION
             assert results[0].resource_arn == group_arn
-            assert results[0].resource_id == policy_name
+            assert results[0].resource_id == group_name
             assert results[0].resource_tags == []
             assert results[0].status == "PASS"
             assert (
@@ -316,7 +316,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert len(results) == 1
             assert results[0].region == AWS_REGION
             assert results[0].resource_arn == role_arn
-            assert results[0].resource_id == policy_name
+            assert results[0].resource_id == role_name
             assert results[0].resource_tags == []
             assert results[0].status == "FAIL"
             assert (
@@ -363,7 +363,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert len(results) == 1
             assert results[0].region == AWS_REGION
             assert results[0].resource_arn == role_arn
-            assert results[0].resource_id == policy_name
+            assert results[0].resource_id == role_name
             assert results[0].resource_tags == []
             assert results[0].status == "PASS"
             assert (
@@ -507,7 +507,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert len(results) == 1
             assert results[0].region == AWS_REGION
             assert results[0].resource_arn == user_arn
-            assert results[0].resource_id == policy_name
+            assert results[0].resource_id == user_name
             assert results[0].resource_tags == []
             assert results[0].status == "FAIL"
             assert (
@@ -553,7 +553,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert len(results) == 1
             assert results[0].region == AWS_REGION
             assert results[0].resource_arn == user_arn
-            assert results[0].resource_id == policy_name
+            assert results[0].resource_id == user_name
             assert results[0].resource_tags == []
             assert results[0].status == "PASS"
             assert (

--- a/tests/providers/aws/services/iam/iam_service_test.py
+++ b/tests/providers/aws/services/iam/iam_service_test.py
@@ -818,6 +818,7 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
                     type="Inline",
                     attached=True,
                     document=INLINE_POLICY_NOT_ADMIN,
+                    entity=user_name,
                 )
 
     # Test IAM Group Inline Policy
@@ -861,6 +862,7 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
                     type="Inline",
                     attached=True,
                     document=INLINE_POLICY_NOT_ADMIN,
+                    entity=group_name,
                 )
 
     # Test IAM Role Inline Policy
@@ -906,4 +908,5 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
                     type="Inline",
                     attached=True,
                     document=INLINE_POLICY_NOT_ADMIN,
+                    entity=role_name,
                 )


### PR DESCRIPTION
### Description

Set resource id as the entity name.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
