### PR TITLE
fix(eks_control_plane_endpoint_access_restricted): handle endpoint private access

### DIFF
--- a/prowler/providers/aws/services/eks/eks_control_plane_endpoint_access_restricted/eks_control_plane_endpoint_access_restricted.py
+++ b/prowler/providers/aws/services/eks/eks_control_plane_endpoint_access_restricted/eks_control_plane_endpoint_access_restricted.py
@@ -15,7 +15,7 @@ class eks_control_plane_endpoint_access_restricted(Check):
             report.status_extended = (
                 f"Cluster endpoint access is private for EKS cluster {cluster.name}."
             )
-            if cluster.endpoint_public_access and not cluster.endpoint_private_access:
+            if cluster.endpoint_public_access:
                 if "0.0.0.0/0" in cluster.public_access_cidrs:
                     report.status = "FAIL"
                     report.status_extended = f"Cluster control plane access is not restricted for EKS cluster {cluster.name}."

--- a/tests/providers/aws/services/eks/eks_control_plane_endpoint_access_restricted/eks_control_plane_endpoint_access_restricted_test.py
+++ b/tests/providers/aws/services/eks/eks_control_plane_endpoint_access_restricted/eks_control_plane_endpoint_access_restricted_test.py
@@ -26,7 +26,7 @@ class Test_eks_control_plane_endpoint_access_restricted:
             result = check.execute()
             assert len(result) == 0
 
-    def test_control_plane_private(self):
+    def test_control_plane_access_private(self):
         eks_client = mock.MagicMock
         eks_client.clusters = []
         eks_client.clusters.append(
@@ -94,7 +94,7 @@ class Test_eks_control_plane_endpoint_access_restricted:
             assert result[0].resource_id == cluster_name
             assert result[0].resource_arn == cluster_arn
 
-    def test_control_plane_not_restricted(self):
+    def test_control_plane_public(self):
         eks_client = mock.MagicMock
         eks_client.clusters = []
         eks_client.clusters.append(
@@ -105,6 +105,40 @@ class Test_eks_control_plane_endpoint_access_restricted:
                 logging=None,
                 endpoint_public_access=True,
                 endpoint_private_access=False,
+                public_access_cidrs=["123.123.123.123/32", "0.0.0.0/0"],
+            )
+        )
+
+        with mock.patch(
+            "prowler.providers.aws.services.eks.eks_service.EKS",
+            eks_client,
+        ):
+            from prowler.providers.aws.services.eks.eks_control_plane_endpoint_access_restricted.eks_control_plane_endpoint_access_restricted import (
+                eks_control_plane_endpoint_access_restricted,
+            )
+
+            check = eks_control_plane_endpoint_access_restricted()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert search(
+                "Cluster control plane access is not restricted for EKS cluster",
+                result[0].status_extended,
+            )
+            assert result[0].resource_id == cluster_name
+            assert result[0].resource_arn == cluster_arn
+
+    def test_control_plane_public_and_private(self):
+        eks_client = mock.MagicMock
+        eks_client.clusters = []
+        eks_client.clusters.append(
+            EKSCluster(
+                name=cluster_name,
+                arn=cluster_arn,
+                region=AWS_REGION,
+                logging=None,
+                endpoint_public_access=True,
+                endpoint_private_access=True,
                 public_access_cidrs=["123.123.123.123/32", "0.0.0.0/0"],
             )
         )

--- a/tests/providers/aws/services/eks/eks_control_plane_endpoint_access_restricted/eks_control_plane_endpoint_access_restricted_test.py
+++ b/tests/providers/aws/services/eks/eks_control_plane_endpoint_access_restricted/eks_control_plane_endpoint_access_restricted_test.py
@@ -59,6 +59,8 @@ class Test_eks_control_plane_endpoint_access_restricted:
             )
             assert result[0].resource_id == cluster_name
             assert result[0].resource_arn == cluster_arn
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION
 
     def test_control_plane_access_restricted(self):
         eks_client = mock.MagicMock
@@ -93,6 +95,8 @@ class Test_eks_control_plane_endpoint_access_restricted:
             )
             assert result[0].resource_id == cluster_name
             assert result[0].resource_arn == cluster_arn
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION
 
     def test_control_plane_public(self):
         eks_client = mock.MagicMock
@@ -127,6 +131,8 @@ class Test_eks_control_plane_endpoint_access_restricted:
             )
             assert result[0].resource_id == cluster_name
             assert result[0].resource_arn == cluster_arn
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION
 
     def test_control_plane_public_and_private(self):
         eks_client = mock.MagicMock
@@ -161,3 +167,5 @@ class Test_eks_control_plane_endpoint_access_restricted:
             )
             assert result[0].resource_id == cluster_name
             assert result[0].resource_arn == cluster_arn
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION


### PR DESCRIPTION
### Context
This check would create false-negatives when the EKS API endpoint was set to "Public and private" and the Public access source allowlist was set to "0.0.0.0/0(open to all traffic)"

This change fixed this issue


### Description

An EKS cluster could have cluster.endpoint_public_access and cluster.endpoint_private_access set to True. This would result in the AND bool operator failing, and the check would pass, when it should fail.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
