### PR TITLE
fix(eks_endpoints_not_publicly_accessible): handle endpoint private access

### DIFF
--- a/prowler/providers/aws/services/eks/eks_endpoints_not_publicly_accessible/eks_endpoints_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/eks/eks_endpoints_not_publicly_accessible/eks_endpoints_not_publicly_accessible.py
@@ -15,7 +15,7 @@ class eks_endpoints_not_publicly_accessible(Check):
             report.status_extended = (
                 f"Cluster endpoint access is private for EKS cluster {cluster.name}."
             )
-            if cluster.endpoint_public_access and not cluster.endpoint_private_access:
+            if cluster.endpoint_public_access:
                 report.status = "FAIL"
                 report.status_extended = (
                     f"Cluster endpoint access is public for EKS cluster {cluster.name}."

--- a/tests/providers/aws/services/eks/eks_endpoints_not_publicly_accessible/eks_endpoints_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/eks/eks_endpoints_not_publicly_accessible/eks_endpoints_not_publicly_accessible_test.py
@@ -58,6 +58,8 @@ class Test_eks_endpoints_not_publicly_accessible:
             )
             assert result[0].resource_id == cluster_name
             assert result[0].resource_arn == cluster_arn
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION
 
     def test_endpoint_not_public_access(self):
         eks_client = mock.MagicMock
@@ -91,3 +93,5 @@ class Test_eks_endpoints_not_publicly_accessible:
             )
             assert result[0].resource_id == cluster_name
             assert result[0].resource_arn == cluster_arn
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION


### PR DESCRIPTION
### Context
This check would create false-negatives when the EKS API endpoint was set to "Public and private" and the Public access source allowlist was set to "0.0.0.0/0(open to all traffic)"

This change fixed this issue


### Description

An EKS cluster could have cluster.endpoint_public_access and cluster.endpoint_private_access set to True. This would result in the AND bool operator failing, and the check would pass, when it should fail.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
