### PR TITLE
fix(sqs_queues_not_publicly_accessible): Improve status extended

### DIFF
--- a/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible.py
@@ -31,16 +31,17 @@ class sqs_queues_not_publicly_accessible(Check):
                                 and "*" in statement["Principal"]["CanonicalUser"]
                             )
                         ):
-                            if (
-                                "Condition" in statement
-                                and is_account_only_allowed_in_condition(
+                            if "Condition" in statement:
+                                if is_account_only_allowed_in_condition(
                                     statement["Condition"], sqs_client.audited_account
-                                )
-                            ):
-                                report.status_extended = f"SQS queue {queue.id} is not public because its policy only allows access from the same account."
+                                ):
+                                    report.status_extended = f"SQS queue {queue.id} is not public because its policy only allows access from the same account."
+                                else:
+                                    report.status = "FAIL"
+                                    report.status_extended = f"SQS queue {queue.id} is public because its policy allows public access, and the condition does not limit access to resources within the same account."
                             else:
                                 report.status = "FAIL"
-                                report.status_extended = f"SQS queue {queue.id} is public because its policy allows public access, and the condition does not limit access to resources within the same account."
+                                report.status_extended = f"SQS queue {queue.id} is public because its policy allows public access."
             findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible.py
@@ -40,7 +40,7 @@ class sqs_queues_not_publicly_accessible(Check):
                                 report.status_extended = f"SQS queue {queue.id} is not public because its policy only allows access from the same account."
                             else:
                                 report.status = "FAIL"
-                                report.status_extended = f"SQS queue {queue.id} is public because its policy allows public access."
+                                report.status_extended = f"SQS queue {queue.id} is public because its policy allows public access, and the condition does not limit access to resources within the same account."
             findings.append(report)
 
         return findings


### PR DESCRIPTION

### Context

Came across some SQS queues that failed the check, but had conditions that used the `ArnEquals` and `aws:SourceArn` keys, but the resources were a list of SNS topics in another account.

This change is to make it more clear that there is a condition that may be limiting access, but the check has still failed because it does not restrict access to resources within the same account


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
