### PR TITLE
fix(outputs_unix_timestamp): Remove subsecond

### DIFF
--- a/prowler/lib/utils/utils.py
+++ b/prowler/lib/utils/utils.py
@@ -94,7 +94,7 @@ def validate_ip_address(ip_string):
 
 def outputs_unix_timestamp(is_unix_timestamp: bool, timestamp: datetime):
     if is_unix_timestamp:
-        timestamp = mktime(timestamp.timetuple())
+        timestamp = int(mktime(timestamp.timetuple()))
     else:
         timestamp = timestamp.isoformat()
     return timestamp

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -1192,9 +1192,9 @@ class Test_Outputs:
                 provider="aws",
                 project_uid="",
             ),
-            time=mktime(timestamp.timetuple()),
+            time=int(mktime(timestamp.timetuple())),
             metadata=Metadata(
-                original_time=mktime(timestamp.timetuple()),
+                original_time=int(mktime(timestamp.timetuple())),
                 profiles=["default"],
                 product=Product(
                     language="en",


### PR DESCRIPTION
### Context

Improves #2805 

### Description

Remove the subsecond part from the epoch when using unix timestamp.

@ramses999 could you please test it?

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
