### PR TITLE
fix(s3_bucket_policy_public_write_access): Handle S3 Policy without Principal

### DIFF
--- a/prowler/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access.py
@@ -41,7 +41,10 @@ class s3_bucket_policy_public_write_access(Check):
                     if (
                         statement["Effect"] == "Allow"
                         and "Condition" not in statement
-                        and "*" in str(statement["Principal"])
+                        and (
+                            "Principal" in statement
+                            and "*" in str(statement["Principal"])
+                        )
                         and (
                             "s3:PutObject" in statement["Action"]
                             or "*" in statement["Action"]


### PR DESCRIPTION
### Description

Fix the following error: `s3_bucket_policy_public_write_access -- KeyError[44]: 'Principal'`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
