### PR TITLE
fix(iam): Handle NoSuchEntity when calling list_role_policies

### DIFF
--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -504,6 +504,16 @@ class IAM(AWSService):
 
                 role.inline_policies = inline_role_policies
 
+            except ClientError as error:
+                if error.response["Error"]["Code"] == "NoSuchEntity":
+                    logger.warning(
+                        f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
+                else:
+                    logger.error(
+                        f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
+
             except Exception as error:
                 logger.error(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"


### PR DESCRIPTION
### Description

Fix the following error: `NoSuchEntityException[466]: An error occurred (NoSuchEntity) when calling the ListRolePolicies operation: The role with name cannot be found.`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
