### PR TITLE
fix(ec2_elastic_ip_unassigned): rename check

### DIFF
--- a/docs/tutorials/aws/v2_to_v3_checks_mapping.md
+++ b/docs/tutorials/aws/v2_to_v3_checks_mapping.md
@@ -84,7 +84,7 @@ checks_v3_to_v2_mapping = {
     "ec2_ebs_snapshots_encrypted": "extra740",
     "ec2_ebs_volume_encryption": "extra729",
     "ec2_elastic_ip_shodan": "extra7102",
-    "ec2_elastic_ip_unassgined": "extra7146",
+    "ec2_elastic_ip_unassigned": "extra7146",
     "ec2_instance_imdsv2_enabled": "extra786",
     "ec2_instance_internet_facing_with_instance_profile": "extra770",
     "ec2_instance_managed_by_ssm": "extra7124",

--- a/prowler/compliance/aws/aws_well_architected_framework_security_pillar_aws.json
+++ b/prowler/compliance/aws/aws_well_architected_framework_security_pillar_aws.json
@@ -435,7 +435,7 @@
         "appstream_fleet_session_idle_disconnect_timeout",
         "cloudwatch_log_group_retention_policy_specific_days_enabled",
         "codebuild_project_older_90_days",
-        "ec2_elastic_ip_unassgined",
+        "ec2_elastic_ip_unassigned",
         "ecr_repositories_lifecycle_policy_enabled",
         "elbv2_listeners_underneath",
         "iam_password_policy_expires_passwords_within_90_days_or_less"

--- a/prowler/compliance/aws/cisa_aws.json
+++ b/prowler/compliance/aws/cisa_aws.json
@@ -19,7 +19,7 @@
         "ec2_instance_managed_by_ssm",
         "ec2_instance_older_than_specific_days",
         "ssm_managed_compliant_patching",
-        "ec2_elastic_ip_unassgined"
+        "ec2_elastic_ip_unassigned"
       ]
     },
     {
@@ -148,7 +148,7 @@
         }
       ],
       "Checks": [
-        "ec2_elastic_ip_unassgined",
+        "ec2_elastic_ip_unassigned",
         "vpc_flow_logs_enabled"
       ]
     },

--- a/prowler/compliance/aws/ffiec_aws.json
+++ b/prowler/compliance/aws/ffiec_aws.json
@@ -19,7 +19,7 @@
       "Checks": [
         "ec2_instance_managed_by_ssm",
         "ec2_instance_older_than_specific_days",
-        "ec2_elastic_ip_unassgined"
+        "ec2_elastic_ip_unassigned"
       ]
     },
     {

--- a/prowler/compliance/aws/nist_800_171_revision_2_aws.json
+++ b/prowler/compliance/aws/nist_800_171_revision_2_aws.json
@@ -425,7 +425,7 @@
         "ec2_instance_older_than_specific_days",
         "elbv2_deletion_protection",
         "ssm_managed_compliant_patching",
-        "ec2_elastic_ip_unassgined",
+        "ec2_elastic_ip_unassigned",
         "ec2_networkacl_allow_ingress_any_port"
       ]
     },

--- a/prowler/compliance/aws/nist_csf_1.1_aws.json
+++ b/prowler/compliance/aws/nist_csf_1.1_aws.json
@@ -761,7 +761,7 @@
       "Checks": [
         "ec2_instance_managed_by_ssm",
         "ssm_managed_compliant_patching",
-        "ec2_elastic_ip_unassgined"
+        "ec2_elastic_ip_unassigned"
       ]
     },
     {

--- a/prowler/compliance/aws/pci_3.2.1_aws.json
+++ b/prowler/compliance/aws/pci_3.2.1_aws.json
@@ -98,7 +98,7 @@
       "Checks": [
         "ec2_ebs_public_snapshot",
         "ec2_securitygroup_default_restrict_traffic",
-        "ec2_elastic_ip_unassgined",
+        "ec2_elastic_ip_unassigned",
         "ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22",
         "ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389",
         "vpc_flow_logs_enabled"

--- a/prowler/providers/aws/services/ec2/ec2_elastic_ip_unassigned/ec2_elastic_ip_unassigned.metadata.json
+++ b/prowler/providers/aws/services/ec2/ec2_elastic_ip_unassigned/ec2_elastic_ip_unassigned.metadata.json
@@ -1,6 +1,6 @@
 {
   "Provider": "aws",
-  "CheckID": "ec2_elastic_ip_unassgined",
+  "CheckID": "ec2_elastic_ip_unassigned",
   "CheckTitle": "Check if there is any unassigned Elastic IP.",
   "CheckType": [
     "Infrastructure Security"

--- a/prowler/providers/aws/services/ec2/ec2_elastic_ip_unassigned/ec2_elastic_ip_unassigned.py
+++ b/prowler/providers/aws/services/ec2/ec2_elastic_ip_unassigned/ec2_elastic_ip_unassigned.py
@@ -2,7 +2,7 @@ from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 
 
-class ec2_elastic_ip_unassgined(Check):
+class ec2_elastic_ip_unassigned(Check):
     def execute(self):
         findings = []
         for eip in ec2_client.elastic_ips:

--- a/tests/providers/aws/services/ec2/ec2_elastic_ip_unassigned/ec2_elastic_ip_unassigned_test.py
+++ b/tests/providers/aws/services/ec2/ec2_elastic_ip_unassigned/ec2_elastic_ip_unassigned_test.py
@@ -12,7 +12,7 @@ EXAMPLE_AMI_ID = "ami-12c6146b"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 
-class Test_ec2_elastic_ip_unassgined:
+class Test_ec2_elastic_ip_unassigned:
     def set_mocked_audit_info(self):
         audit_info = AWS_Audit_Info(
             session_config=None,
@@ -54,15 +54,15 @@ class Test_ec2_elastic_ip_unassgined:
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_elastic_ip_unassgined.ec2_elastic_ip_unassgined.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_elastic_ip_unassigned.ec2_elastic_ip_unassigned.ec2_client",
             new=EC2(current_audit_info),
         ):
             # Test Check
-            from prowler.providers.aws.services.ec2.ec2_elastic_ip_unassgined.ec2_elastic_ip_unassgined import (
-                ec2_elastic_ip_unassgined,
+            from prowler.providers.aws.services.ec2.ec2_elastic_ip_unassigned.ec2_elastic_ip_unassigned import (
+                ec2_elastic_ip_unassigned,
             )
 
-            check = ec2_elastic_ip_unassgined()
+            check = ec2_elastic_ip_unassigned()
             result = check.execute()
 
             assert len(result) == 0
@@ -83,15 +83,15 @@ class Test_ec2_elastic_ip_unassgined:
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_elastic_ip_unassgined.ec2_elastic_ip_unassgined.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_elastic_ip_unassigned.ec2_elastic_ip_unassigned.ec2_client",
             new=EC2(current_audit_info),
         ):
             # Test Check
-            from prowler.providers.aws.services.ec2.ec2_elastic_ip_unassgined.ec2_elastic_ip_unassgined import (
-                ec2_elastic_ip_unassgined,
+            from prowler.providers.aws.services.ec2.ec2_elastic_ip_unassigned.ec2_elastic_ip_unassigned import (
+                ec2_elastic_ip_unassigned,
             )
 
-            check = ec2_elastic_ip_unassgined()
+            check = ec2_elastic_ip_unassigned()
             results = check.execute()
 
             assert len(results) == 1
@@ -134,15 +134,15 @@ class Test_ec2_elastic_ip_unassgined:
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=current_audit_info,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_elastic_ip_unassgined.ec2_elastic_ip_unassgined.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_elastic_ip_unassigned.ec2_elastic_ip_unassigned.ec2_client",
             new=EC2(current_audit_info),
         ):
             # Test Check
-            from prowler.providers.aws.services.ec2.ec2_elastic_ip_unassgined.ec2_elastic_ip_unassgined import (
-                ec2_elastic_ip_unassgined,
+            from prowler.providers.aws.services.ec2.ec2_elastic_ip_unassigned.ec2_elastic_ip_unassigned import (
+                ec2_elastic_ip_unassigned,
             )
 
-            check = ec2_elastic_ip_unassgined()
+            check = ec2_elastic_ip_unassigned()
             results = check.execute()
 
             assert len(results) == 1


### PR DESCRIPTION
### Context

Check `ec2_elastic_ip_unassgined` had a typo  in its name


### Description

Rename the check and all its references to `ec2_elastic_ip_unassigned`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
