### PR TITLE
fix(vpc_peering_routing_tables_with_least_privilege): check only peering routes

### DIFF
--- a/prowler/providers/aws/services/vpc/vpc_peering_routing_tables_with_least_privilege/vpc_peering_routing_tables_with_least_privilege.metadata.json
+++ b/prowler/providers/aws/services/vpc/vpc_peering_routing_tables_with_least_privilege/vpc_peering_routing_tables_with_least_privilege.metadata.json
@@ -17,7 +17,7 @@
     "Code": {
       "CLI": "https://docs.bridgecrew.io/docs/networking_5#cli-command",
       "NativeIaC": "",
-      "Other": "",
+      "Other": "https://www.trendmicro.com/cloudoneconformity-staging/knowledge-base/aws/VPC/vpc-peering-access.html#",
       "Terraform": ""
     },
     "Recommendation": {

--- a/prowler/providers/aws/services/vpc/vpc_service.py
+++ b/prowler/providers/aws/services/vpc/vpc_service.py
@@ -103,7 +103,10 @@ class VPC(AWSService):
                         if (
                             route["Origin"] != "CreateRouteTable"
                         ):  # avoid default route table
-                            if "DestinationCidrBlock" in route:
+                            if (
+                                "DestinationCidrBlock" in route
+                                and "VpcPeeringConnectionId" in route
+                            ):
                                 destination_cidrs.append(route["DestinationCidrBlock"])
                     conn.route_tables.append(
                         Route(


### PR DESCRIPTION
### Description

Check only VpcPeeringConnection routes in `vpc_peering_routing_tables_with_least_privilege`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
