### PR TITLE
fix(dockerfile): Use latest curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM python:3.9-alpine
 LABEL maintainer="https://github.com/prowler-cloud/prowler"
 
 # Update system dependencies
-RUN apk --no-cache upgrade && apk --no-cache add curl=8.2.1-r0
+#hadolint ignore=DL3018
+RUN apk --no-cache upgrade && apk --no-cache add curl
 
 # Create nonroot user
 RUN mkdir -p /home/prowler && \


### PR DESCRIPTION
### Context

Currently the pipeline to build the container is broken:
```
------
 > [2/9] RUN apk --no-cache upgrade && apk --no-cache add curl=8.2.1-r0:
#0 0.191 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
#0 0.709 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
#0 1.307 OK: 16 MiB in 38 packages
#0 1.419 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
#0 1.890 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
#0 2.482 ERROR: unable to select packages:
#0 2.485   curl-8.3.0-r0:
#0 2.485     breaks: world[curl=8.2.1-r0]
------
Dockerfile:6
--------------------
   4 |     
   5 |     # Update system dependencies
   6 | >>> RUN apk --no-cache upgrade && apk --no-cache add curl=8.2.1-r0
   7 |     
   8 |     # Create nonroot user
--------------------
ERROR: failed to solve: process "/bin/sh -c apk --no-cache upgrade && apk --no-cache add curl=8.2.1-r0" did not complete successfully: exit code: 1
```

### Description

Do not pin `curl` version.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
