### PR TITLE
fix(custom checks): fix import from s3

### DIFF
--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -134,11 +134,13 @@ def parse_checks_from_folder(audit_info, input_folder: str, provider: str) -> in
         ):
             bucket = input_folder.split("/")[2]
             key = ("/").join(input_folder.split("/")[3:])
-            s3_reource = audit_info.audit_session.resource("s3")
-            bucket = s3_reource.Bucket(bucket)
+            s3_resource = audit_info.audit_session.resource("s3")
+            bucket = s3_resource.Bucket(bucket)
             for obj in bucket.objects.filter(Prefix=key):
                 if not os.path.exists(os.path.dirname(obj.key)):
                     os.makedirs(os.path.dirname(obj.key))
+                if obj.key[-1] == "/":
+                    continue
                 bucket.download_file(obj.key, obj.key)
             input_folder = key
         # Import custom checks by moving the checks folders to the corresponding services


### PR DESCRIPTION
### Context

When importing custom checks from a s3 bucket there are problems when the bucket folders are created from the web console.

https://aws.amazon.com/premiumsupport/knowledge-center/s3-prefix-nested-folders-difference/

### Description

Process the files inside the s3 bucket when they are not directories

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
