### PR TITLE
fix(pipeline): launch linters with file changes

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - "master"
+    paths:
+      - '**.py'
+      - './Dockerfile'
   pull_request:
     branches:
       - "master"
+    paths:
+      - '**.py'
+      - './Dockerfile'
 
 jobs:
   build:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,16 +4,15 @@ on:
   push:
     branches:
       - "master"
-    paths:
-      - '**.py'
-      - './Dockerfile'
+    paths-ignore:
+      - 'docs/**'
+      - './README.md'
   pull_request:
     branches:
       - "master"
-    paths:
-      - '**.py'
-      - './Dockerfile'
-
+    paths-ignore:
+      - 'docs/**'
+      - './README.md'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Context

We were launching tests and linters in the PRs and `main` pushes even if no python/Dockerfile files were involved


### Description

Launch linters only when source code files are involved


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
