### PR TITLE
fix(build-lint-push pipeline): pass pipeline when ignored files

### DIFF
--- a/.github/workflows/build-lint-push-containers.yml
+++ b/.github/workflows/build-lint-push-containers.yml
@@ -34,30 +34,41 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Test if changes are in filtered paths
+        id: are-non-changed-filtered-paths
+        uses: tj-actions/changed-files@v39
+        with:
+          files_ignore: |
+            .github/**
+            README.md
+            docs/**
+
       - name: Setup python (release)
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies (release)
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           pipx install poetry
           pipx inject poetry poetry-bumpversion
 
       - name: Update Prowler version (release)
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           poetry version ${{ github.event.release.tag_name }}
 
       - name: Login to DockerHub
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to Public ECR
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         uses: docker/login-action@v2
         with:
           registry: public.ecr.aws
@@ -67,10 +78,11 @@ jobs:
           AWS_REGION: ${{ env.AWS_REGION }}
 
       - name: Set up Docker Buildx
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         uses: docker/setup-buildx-action@v2
 
       - name: Build and push container image (latest)
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         uses: docker/build-push-action@v2
         with:
           push: true
@@ -82,7 +94,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push container image (release)
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         uses: docker/build-push-action@v2
         with:
           # Use local context to get changes
@@ -103,15 +115,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest commit info
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           LATEST_COMMIT_HASH=$(echo ${{ github.event.after }} | cut -b -7)
           echo "LATEST_COMMIT_HASH=${LATEST_COMMIT_HASH}" >> $GITHUB_ENV
       - name: Dispatch event for latest
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           curl https://api.github.com/repos/${{ secrets.DISPATCH_OWNER }}/${{ secrets.DISPATCH_REPO }}/dispatches -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.ACCESS_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" --data '{"event_type":"dispatch","client_payload":{"version":"latest", "tag": "${{ env.LATEST_COMMIT_HASH }}"}}'
       - name: Dispatch event for release
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           curl https://api.github.com/repos/${{ secrets.DISPATCH_OWNER }}/${{ secrets.DISPATCH_REPO }}/dispatches -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.ACCESS_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" --data '{"event_type":"dispatch","client_payload":{"version":"release", "tag":"${{ github.event.release.tag_name }}"}}'

--- a/.github/workflows/build-lint-push-containers.yml
+++ b/.github/workflows/build-lint-push-containers.yml
@@ -34,41 +34,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Test if changes are in filtered paths
-        id: are-non-changed-filtered-paths
-        uses: tj-actions/changed-files@v39
-        with:
-          files_ignore: |
-            .github/**
-            README.md
-            docs/**
-
       - name: Setup python (release)
-        if: github.event_name == 'release' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: github.event_name == 'release'
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies (release)
-        if: github.event_name == 'release' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: github.event_name == 'release'
         run: |
           pipx install poetry
           pipx inject poetry poetry-bumpversion
 
       - name: Update Prowler version (release)
-        if: github.event_name == 'release' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: github.event_name == 'release'
         run: |
           poetry version ${{ github.event.release.tag_name }}
 
       - name: Login to DockerHub
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to Public ECR
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         uses: docker/login-action@v2
         with:
           registry: public.ecr.aws
@@ -78,11 +67,10 @@ jobs:
           AWS_REGION: ${{ env.AWS_REGION }}
 
       - name: Set up Docker Buildx
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         uses: docker/setup-buildx-action@v2
 
       - name: Build and push container image (latest)
-        if: github.event_name == 'push' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v2
         with:
           push: true
@@ -94,7 +82,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push container image (release)
-        if: github.event_name == 'release' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: github.event_name == 'release'
         uses: docker/build-push-action@v2
         with:
           # Use local context to get changes
@@ -115,15 +103,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get latest commit info
-        if: github.event_name == 'push' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: github.event_name == 'push'
         run: |
           LATEST_COMMIT_HASH=$(echo ${{ github.event.after }} | cut -b -7)
           echo "LATEST_COMMIT_HASH=${LATEST_COMMIT_HASH}" >> $GITHUB_ENV
       - name: Dispatch event for latest
-        if: github.event_name == 'push' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: github.event_name == 'push'
         run: |
           curl https://api.github.com/repos/${{ secrets.DISPATCH_OWNER }}/${{ secrets.DISPATCH_REPO }}/dispatches -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.ACCESS_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" --data '{"event_type":"dispatch","client_payload":{"version":"latest", "tag": "${{ env.LATEST_COMMIT_HASH }}"}}'
       - name: Dispatch event for release
-        if: github.event_name == 'release' && steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: github.event_name == 'release'
         run: |
           curl https://api.github.com/repos/${{ secrets.DISPATCH_OWNER }}/${{ secrets.DISPATCH_REPO }}/dispatches -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.ACCESS_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" --data '{"event_type":"dispatch","client_payload":{"version":"release", "tag":"${{ github.event.release.tag_name }}"}}'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Test if changes are in filtered paths
-        id: are-non-changed-filtered-paths
+        id: are-non-filtered-paths-changed
         uses: tj-actions/changed-files@v39
         with:
           files_ignore: |
@@ -31,18 +31,18 @@ jobs:
             README.md
             docs/**
       - name: Install poetry
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
         run: |
           python -m pip install --upgrade pip
           pipx install poetry
       - name: Set up Python ${{ matrix.python-version }}
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
       - name: Install dependencies
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
         run: |
           poetry install
           poetry run pip list
@@ -52,43 +52,43 @@ jobs:
             ) && curl -L -o /tmp/hadolint "https://github.com/hadolint/hadolint/releases/download/v${VERSION}/hadolint-Linux-x86_64" \
             && chmod +x /tmp/hadolint
       - name: Poetry check
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
         run: |
           poetry lock --check
       - name: Lint with flake8
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
         run: |
           poetry run flake8 . --ignore=E266,W503,E203,E501,W605,E128 --exclude contrib
       - name: Checking format with black
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
         run: |
           poetry run black --check .
       - name: Lint with pylint
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
         run: |
           poetry run pylint --disable=W,C,R,E -j 0 -rn -sn prowler/
       - name: Bandit
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
         run: |
           poetry run bandit -q -lll -x '*_test.py,./contrib/' -r .
       - name: Safety
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
         run: |
           poetry run safety check
       - name: Vulture
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
         run: |
           poetry run vulture --exclude "contrib" --min-confidence 100 .
       - name: Hadolint
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
         run: |
           /tmp/hadolint Dockerfile --ignore=DL3013
       - name: Test with pytest
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
         run: |
           poetry run pytest -n auto --cov=./prowler --cov-report=xml tests
       - name: Upload coverage reports to Codecov
-        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
+        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,16 +22,27 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Test if changes are in filtered paths
+        id: are-non-changed-filtered-paths
+        uses: tj-actions/changed-files@v39
+        with:
+          files_ignore: |
+            .github/**
+            README.md
+            docs/**
       - name: Install poetry
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           python -m pip install --upgrade pip
           pipx install poetry
       - name: Set up Python ${{ matrix.python-version }}
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
       - name: Install dependencies
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           poetry install
           poetry run pip list
@@ -41,33 +52,43 @@ jobs:
             ) && curl -L -o /tmp/hadolint "https://github.com/hadolint/hadolint/releases/download/v${VERSION}/hadolint-Linux-x86_64" \
             && chmod +x /tmp/hadolint
       - name: Poetry check
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           poetry lock --check
       - name: Lint with flake8
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           poetry run flake8 . --ignore=E266,W503,E203,E501,W605,E128 --exclude contrib
       - name: Checking format with black
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           poetry run black --check .
       - name: Lint with pylint
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           poetry run pylint --disable=W,C,R,E -j 0 -rn -sn prowler/
       - name: Bandit
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           poetry run bandit -q -lll -x '*_test.py,./contrib/' -r .
       - name: Safety
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           poetry run safety check
       - name: Vulture
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           poetry run vulture --exclude "contrib" --min-confidence 100 .
       - name: Hadolint
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           /tmp/hadolint Dockerfile --ignore=DL3013
       - name: Test with pytest
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         run: |
           poetry run pytest -n auto --cov=./prowler --cov-report=xml tests
       - name: Upload coverage reports to Codecov
+        if: steps.are-non-changed-filtered-paths.outputs.test_any_changed == true
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Test if changes are in filtered paths
+      - name: Test if changes are in not ignored paths
         id: are-non-ignored-files-changed
         uses: tj-actions/changed-files@v39
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,15 +4,9 @@ on:
   push:
     branches:
       - "master"
-    paths-ignore:
-      - 'docs/**'
-      - './README.md'
   pull_request:
     branches:
       - "master"
-    paths-ignore:
-      - 'docs/**'
-      - './README.md'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Test if changes are in filtered paths
-        id: are-non-filtered-paths-changed
+        id: are-non-ignored-files-changed
         uses: tj-actions/changed-files@v39
         with:
           files_ignore: |
@@ -25,18 +25,18 @@ jobs:
             README.md
             docs/**
       - name: Install poetry
-        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
+        if: steps.are-non-ignored-files-changed.outputs.test_any_changed == true
         run: |
           python -m pip install --upgrade pip
           pipx install poetry
       - name: Set up Python ${{ matrix.python-version }}
-        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
+        if: steps.are-non-ignored-files-changed.outputs.test_any_changed == true
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
       - name: Install dependencies
-        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
+        if: steps.are-non-ignored-files-changed.outputs.test_any_changed == true
         run: |
           poetry install
           poetry run pip list
@@ -46,43 +46,43 @@ jobs:
             ) && curl -L -o /tmp/hadolint "https://github.com/hadolint/hadolint/releases/download/v${VERSION}/hadolint-Linux-x86_64" \
             && chmod +x /tmp/hadolint
       - name: Poetry check
-        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
+        if: steps.are-non-ignored-files-changed.outputs.test_any_changed == true
         run: |
           poetry lock --check
       - name: Lint with flake8
-        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
+        if: steps.are-non-ignored-files-changed.outputs.test_any_changed == true
         run: |
           poetry run flake8 . --ignore=E266,W503,E203,E501,W605,E128 --exclude contrib
       - name: Checking format with black
-        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
+        if: steps.are-non-ignored-files-changed.outputs.test_any_changed == true
         run: |
           poetry run black --check .
       - name: Lint with pylint
-        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
+        if: steps.are-non-ignored-files-changed.outputs.test_any_changed == true
         run: |
           poetry run pylint --disable=W,C,R,E -j 0 -rn -sn prowler/
       - name: Bandit
-        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
+        if: steps.are-non-ignored-files-changed.outputs.test_any_changed == true
         run: |
           poetry run bandit -q -lll -x '*_test.py,./contrib/' -r .
       - name: Safety
-        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
+        if: steps.are-non-ignored-files-changed.outputs.test_any_changed == true
         run: |
           poetry run safety check
       - name: Vulture
-        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
+        if: steps.are-non-ignored-files-changed.outputs.test_any_changed == true
         run: |
           poetry run vulture --exclude "contrib" --min-confidence 100 .
       - name: Hadolint
-        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
+        if: steps.are-non-ignored-files-changed.outputs.test_any_changed == true
         run: |
           /tmp/hadolint Dockerfile --ignore=DL3013
       - name: Test with pytest
-        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
+        if: steps.are-non-ignored-files-changed.outputs.test_any_changed == true
         run: |
           poetry run pytest -n auto --cov=./prowler --cov-report=xml tests
       - name: Upload coverage reports to Codecov
-        if: steps.are-non-filtered-paths-changed.outputs.test_any_changed == true
+        if: steps.are-non-ignored-files-changed.outputs.test_any_changed == true
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Context

Right now, due to branch protection rules, pipeline `build-lint-push` is not being passed if the PR contains only files from ignored paths. This disallow PRs to be merged


### Description

Use the action `tj-actions/changed-files` to test if there are changes in the non filtered paths


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
