### PR TITLE
fix(Dockerfile): Update to python:3.11-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.11-alpine
 
 LABEL maintainer="https://github.com/prowler-cloud/prowler"
 


### PR DESCRIPTION
### Context

We need to update base container since it includes insecure packages


### Description

Update base image from `python:3.9-alpine` to `python:3.11-alpine`
 

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
