### PR TITLE
fix(vpc): ignore com.amazonaws.vpce endpoints

### DIFF
--- a/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
+++ b/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
@@ -15,8 +15,11 @@ class vpc_endpoint_connections_trust_boundaries(Check):
         # Always include the same account as trusted
         trusted_account_ids.append(vpc_client.audited_account)
         for endpoint in vpc_client.vpc_endpoints:
-            # Check VPC endpoint policy
-            if endpoint.policy_document:
+            # Check VPC endpoint policy and  avoid "com.amazonaws.vpce" endpoints since the policy cannot be modified
+            if (
+                endpoint.policy_document
+                and "com.amazonaws.vpce." not in endpoint.service_name
+            ):
                 access_from_trusted_accounts = True
                 for statement in endpoint.policy_document["Statement"]:
                     # If one policy allows access from a non-trusted account

--- a/prowler/providers/aws/services/vpc/vpc_service.py
+++ b/prowler/providers/aws/services/vpc/vpc_service.py
@@ -163,6 +163,7 @@ class VPC(AWSService):
                                 arn=arn,
                                 id=endpoint["VpcEndpointId"],
                                 vpc_id=endpoint["VpcId"],
+                                service_name=endpoint["ServiceName"],
                                 state=endpoint["State"],
                                 policy_document=endpoint_policy,
                                 owner_id=endpoint["OwnerId"],
@@ -352,6 +353,7 @@ class VpcEndpoint(BaseModel):
     arn: str
     id: str
     vpc_id: str
+    service_name: str
     state: str
     policy_document: Optional[dict]
     owner_id: str

--- a/tests/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries_test.py
+++ b/tests/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries_test.py
@@ -72,6 +72,45 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                 assert len(result) == 0
 
     @mock_ec2
+    def test_vpc_aws_endpoint(self):
+        # Create VPC Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION)
+
+        vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
+
+        route_table = ec2_client.create_route_table(VpcId=vpc["VpcId"])["RouteTable"]
+        ec2_client.create_vpc_endpoint(
+            VpcId=vpc["VpcId"],
+            ServiceName="com.amazonaws.vpce.us-east-1.s3",
+            RouteTableIds=[route_table["RouteTableId"]],
+            VpcEndpointType="Interface",
+        )
+
+        from prowler.providers.aws.services.vpc.vpc_service import VPC
+
+        current_audit_info = self.set_mocked_audit_info()
+        # Set config variable
+        current_audit_info.audit_config = {"trusted_account_ids": []}
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.vpc.vpc_endpoint_connections_trust_boundaries.vpc_endpoint_connections_trust_boundaries.vpc_client",
+                new=VPC(current_audit_info),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.vpc.vpc_endpoint_connections_trust_boundaries.vpc_endpoint_connections_trust_boundaries import (
+                    vpc_endpoint_connections_trust_boundaries,
+                )
+
+                check = vpc_endpoint_connections_trust_boundaries()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    @mock_ec2
     def test_vpc_endpoint_with_full_access(self):
         # Create VPC Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION)


### PR DESCRIPTION
### Description

Ignore com.amazonaws.vpce endpoints in `vpc_endpoint_connections_trust_boundaries` check since their policy cannot be modified.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
