### PR TITLE
fix(security group): check if security groups are used by Lambda

### DIFF
--- a/prowler/providers/aws/services/awslambda/awslambda_service.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_service.py
@@ -50,6 +50,9 @@ class Lambda(AWSService):
                         self.functions[lambda_arn] = Function(
                             name=lambda_name,
                             arn=lambda_arn,
+                            security_groups=function.get("VpcConfig", {}).get(
+                                "SecurityGroupIds", []
+                            ),
                             region=regional_client.region,
                         )
                         if "Runtime" in function:
@@ -183,6 +186,7 @@ class URLConfig(BaseModel):
 class Function(BaseModel):
     name: str
     arn: str
+    security_groups: list
     runtime: Optional[str]
     environment: dict = None
     region: str

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used.py
@@ -1,4 +1,5 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.awslambda.awslambda_client import awslambda_client
 from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 
 
@@ -16,7 +17,11 @@ class ec2_securitygroup_not_used(Check):
                 report.resource_tags = security_group.tags
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) it is being used."
-                if len(security_group.network_interfaces) == 0:
+                sg_in_lambda = False
+                for function in awslambda_client.functions.values():
+                    if security_group.id in function.security_groups:
+                        sg_in_lambda = True
+                if len(security_group.network_interfaces) == 0 and not sg_in_lambda:
                     report.status = "FAIL"
                     report.status_extended = f"Security group {security_group.name} ({security_group.id}) it is not being used."
 

--- a/tests/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled_test.py
@@ -100,6 +100,7 @@ class Test_awslambda_function_invoke_api_operations_cloudtrail_logging_enabled:
         lambda_client.functions = {
             function_name: Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,
@@ -164,6 +165,7 @@ class Test_awslambda_function_invoke_api_operations_cloudtrail_logging_enabled:
         lambda_client.functions = {
             function_name: Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,
@@ -240,6 +242,7 @@ class Test_awslambda_function_invoke_api_operations_cloudtrail_logging_enabled:
         lambda_client.functions = {
             function_name: Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,
@@ -317,6 +320,7 @@ class Test_awslambda_function_invoke_api_operations_cloudtrail_logging_enabled:
         lambda_client.functions = {
             function_name: Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,

--- a/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code_test.py
@@ -47,6 +47,7 @@ class Test_awslambda_function_no_secrets_in_code:
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,
@@ -95,6 +96,7 @@ class Test_awslambda_function_no_secrets_in_code:
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,

--- a/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables_test.py
@@ -37,6 +37,7 @@ class Test_awslambda_function_no_secrets_in_variables:
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,
@@ -77,6 +78,7 @@ class Test_awslambda_function_no_secrets_in_variables:
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,
@@ -118,6 +120,7 @@ class Test_awslambda_function_no_secrets_in_variables:
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,

--- a/tests/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible_test.py
@@ -51,6 +51,7 @@ class Test_awslambda_function_not_publicly_accessible:
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,
@@ -106,6 +107,7 @@ class Test_awslambda_function_not_publicly_accessible:
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,
@@ -161,6 +163,7 @@ class Test_awslambda_function_not_publicly_accessible:
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,

--- a/tests/providers/aws/services/awslambda/awslambda_function_url_cors_policy/awslambda_function_url_cors_policy_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_url_cors_policy/awslambda_function_url_cors_policy_test.py
@@ -41,6 +41,7 @@ class Test_awslambda_function_url_cors_policy:
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,
@@ -85,6 +86,7 @@ class Test_awslambda_function_url_cors_policy:
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,
@@ -129,6 +131,7 @@ class Test_awslambda_function_url_cors_policy:
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,

--- a/tests/providers/aws/services/awslambda/awslambda_function_url_public/awslambda_function_url_public_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_url_public/awslambda_function_url_public_test.py
@@ -41,6 +41,7 @@ class Test_awslambda_function_url_public:
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,
@@ -85,6 +86,7 @@ class Test_awslambda_function_url_public:
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,

--- a/tests/providers/aws/services/awslambda/awslambda_function_using_supported_runtimes/awslambda_function_using_supported_runtimes_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_using_supported_runtimes/awslambda_function_using_supported_runtimes_test.py
@@ -36,6 +36,7 @@ class Test_awslambda_function_using_supported_runtimes:
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,
@@ -93,6 +94,7 @@ class Test_awslambda_function_using_supported_runtimes:
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
+                security_groups=[],
                 arn=function_arn,
                 region=AWS_REGION,
                 runtime=function_runtime,
@@ -148,7 +150,10 @@ class Test_awslambda_function_using_supported_runtimes:
         )
         lambda_client.functions = {
             "function_name": Function(
-                name=function_name, arn=function_arn, region=AWS_REGION
+                name=function_name,
+                security_groups=[],
+                arn=function_arn,
+                region=AWS_REGION,
             )
         }
 


### PR DESCRIPTION
### Description

In check `ec2_securitygroup_not_used` verify if security groups are used by any Lambda functions.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
