### PR TITLE
chore(permissions): add DLM permissions

### DIFF
--- a/permissions/prowler-additions-policy.json
+++ b/permissions/prowler-additions-policy.json
@@ -10,6 +10,7 @@
         "cloudtrail:GetInsightSelectors",
         "codeartifact:List*",
         "codebuild:BatchGet*",
+        "dlm:Get*",
         "drs:Describe*",
         "ds:Get*",
         "ds:Describe*",


### PR DESCRIPTION
### Description

Add `dlm:Get*` permission for the new Amazon Data Lifecycle Manager checks.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
