### PR TITLE
fix(ec2_securitygroup_not_used): Mock Lambda service

### DIFF
--- a/tests/providers/aws/audit_info_utils.py
+++ b/tests/providers/aws/audit_info_utils.py
@@ -1,0 +1,45 @@
+from boto3 import session
+
+from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.common.models import Audit_Metadata
+
+AWS_REGION_US_EAST_1 = "us-east-1"
+AWS_PARTITION = "aws"
+AWS_ACCOUNT_NUMBER = "123456789012"
+AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+
+
+# Mocked AWS Audit Info
+def set_mocked_aws_audit_info(
+    audited_regions: [str] = [],
+    audited_account: str = AWS_ACCOUNT_NUMBER,
+    audited_account_arn: str = AWS_ACCOUNT_ARN,
+):
+    audit_info = AWS_Audit_Info(
+        session_config=None,
+        original_session=None,
+        audit_session=session.Session(
+            profile_name=None,
+            botocore_session=None,
+        ),
+        audited_account=audited_account,
+        audited_account_arn=audited_account_arn,
+        audited_user_id=None,
+        audited_partition=AWS_PARTITION,
+        audited_identity_arn=None,
+        profile=None,
+        profile_region=None,
+        credentials=None,
+        assumed_role_info=None,
+        audited_regions=audited_regions,
+        organizations_metadata=None,
+        audit_resources=None,
+        mfa_enabled=False,
+        audit_metadata=Audit_Metadata(
+            services_scanned=0,
+            expected_checks=[],
+            completed_checks=0,
+            audit_progress=0,
+        ),
+    )
+    return audit_info

--- a/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code_test.py
@@ -8,8 +8,10 @@ from prowler.providers.aws.services.awslambda.awslambda_service import (
     Function,
     LambdaCode,
 )
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_awslambda_function_no_secrets_in_code:
@@ -18,7 +20,10 @@ class Test_awslambda_function_no_secrets_in_code:
         lambda_client.functions = {}
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_no_secrets_in_code.awslambda_function_no_secrets_in_code.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -35,9 +40,7 @@ class Test_awslambda_function_no_secrets_in_code:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
         code_with_secrets = """
         def lambda_handler(event, context):
                 db_password = "test-password"
@@ -49,7 +52,7 @@ class Test_awslambda_function_no_secrets_in_code:
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 runtime=function_runtime,
                 code=LambdaCode(
                     location="",
@@ -59,7 +62,10 @@ class Test_awslambda_function_no_secrets_in_code:
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_no_secrets_in_code.awslambda_function_no_secrets_in_code.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -71,7 +77,7 @@ class Test_awslambda_function_no_secrets_in_code:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn
             assert result[0].status == "FAIL"
@@ -85,9 +91,7 @@ class Test_awslambda_function_no_secrets_in_code:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
         code_with_secrets = """
         def lambda_handler(event, context):
                 print("custom log event")
@@ -98,7 +102,7 @@ class Test_awslambda_function_no_secrets_in_code:
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 runtime=function_runtime,
                 code=LambdaCode(
                     location="",
@@ -108,7 +112,10 @@ class Test_awslambda_function_no_secrets_in_code:
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_no_secrets_in_code.awslambda_function_no_secrets_in_code.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -120,7 +127,7 @@ class Test_awslambda_function_no_secrets_in_code:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn
             assert result[0].status == "PASS"

--- a/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables_test.py
@@ -3,8 +3,10 @@ from unittest import mock
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.awslambda.awslambda_service import Function
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_awslambda_function_no_secrets_in_variables:
@@ -13,7 +15,10 @@ class Test_awslambda_function_no_secrets_in_variables:
         lambda_client.functions = {}
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_no_secrets_in_variables.awslambda_function_no_secrets_in_variables.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -30,22 +35,23 @@ class Test_awslambda_function_no_secrets_in_variables:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
 
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 runtime=function_runtime,
             )
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_no_secrets_in_variables.awslambda_function_no_secrets_in_variables.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -57,7 +63,7 @@ class Test_awslambda_function_no_secrets_in_variables:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn
             assert result[0].status == "PASS"
@@ -71,23 +77,24 @@ class Test_awslambda_function_no_secrets_in_variables:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
 
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 runtime=function_runtime,
                 environment={"db_password": "test-password"},
             )
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_no_secrets_in_variables.awslambda_function_no_secrets_in_variables.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -99,7 +106,7 @@ class Test_awslambda_function_no_secrets_in_variables:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn
             assert result[0].status == "FAIL"
@@ -113,23 +120,24 @@ class Test_awslambda_function_no_secrets_in_variables:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
 
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 runtime=function_runtime,
                 environment={"db_username": "test-user"},
             )
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_no_secrets_in_variables.awslambda_function_no_secrets_in_variables.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -141,7 +149,7 @@ class Test_awslambda_function_no_secrets_in_variables:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn
             assert result[0].status == "PASS"

--- a/tests/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible_test.py
@@ -3,8 +3,10 @@ from unittest import mock
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.awslambda.awslambda_service import Function
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_awslambda_function_not_publicly_accessible:
@@ -13,7 +15,10 @@ class Test_awslambda_function_not_publicly_accessible:
         lambda_client.functions = {}
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_not_publicly_accessible.awslambda_function_not_publicly_accessible.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -30,9 +35,7 @@ class Test_awslambda_function_not_publicly_accessible:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
         lambda_policy = {
             "Version": "2012-10-17",
             "Statement": [
@@ -53,14 +56,17 @@ class Test_awslambda_function_not_publicly_accessible:
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 runtime=function_runtime,
                 policy=lambda_policy,
             )
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_not_publicly_accessible.awslambda_function_not_publicly_accessible.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -72,7 +78,7 @@ class Test_awslambda_function_not_publicly_accessible:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn
             assert result[0].status == "FAIL"
@@ -86,9 +92,7 @@ class Test_awslambda_function_not_publicly_accessible:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
         lambda_policy = {
             "Version": "2012-10-17",
             "Statement": [
@@ -109,14 +113,17 @@ class Test_awslambda_function_not_publicly_accessible:
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 runtime=function_runtime,
                 policy=lambda_policy,
             )
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_not_publicly_accessible.awslambda_function_not_publicly_accessible.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -128,7 +135,7 @@ class Test_awslambda_function_not_publicly_accessible:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn
             assert result[0].status == "PASS"
@@ -142,9 +149,7 @@ class Test_awslambda_function_not_publicly_accessible:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
         lambda_policy = {
             "Version": "2012-10-17",
             "Statement": [
@@ -165,14 +170,17 @@ class Test_awslambda_function_not_publicly_accessible:
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 runtime=function_runtime,
                 policy=lambda_policy,
             )
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_not_publicly_accessible.awslambda_function_not_publicly_accessible.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -184,7 +192,7 @@ class Test_awslambda_function_not_publicly_accessible:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn
             assert result[0].status == "FAIL"

--- a/tests/providers/aws/services/awslambda/awslambda_function_url_cors_policy/awslambda_function_url_cors_policy_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_url_cors_policy/awslambda_function_url_cors_policy_test.py
@@ -8,8 +8,10 @@ from prowler.providers.aws.services.awslambda.awslambda_service import (
     URLConfig,
     URLConfigCORS,
 )
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_awslambda_function_url_cors_policy:
@@ -18,7 +20,10 @@ class Test_awslambda_function_url_cors_policy:
         lambda_client.functions = {}
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_url_cors_policy.awslambda_function_url_cors_policy.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -35,15 +40,13 @@ class Test_awslambda_function_url_cors_policy:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 runtime=function_runtime,
                 url_config=URLConfig(
                     auth_type=AuthType.NONE,
@@ -54,7 +57,10 @@ class Test_awslambda_function_url_cors_policy:
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_url_cors_policy.awslambda_function_url_cors_policy.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -66,7 +72,7 @@ class Test_awslambda_function_url_cors_policy:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn
             assert result[0].status == "FAIL"
@@ -80,15 +86,13 @@ class Test_awslambda_function_url_cors_policy:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "python3.9"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 runtime=function_runtime,
                 url_config=URLConfig(
                     auth_type=AuthType.AWS_IAM,
@@ -99,7 +103,10 @@ class Test_awslambda_function_url_cors_policy:
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_url_cors_policy.awslambda_function_url_cors_policy.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -111,7 +118,7 @@ class Test_awslambda_function_url_cors_policy:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn
             assert result[0].status == "PASS"
@@ -125,15 +132,13 @@ class Test_awslambda_function_url_cors_policy:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "python3.9"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 runtime=function_runtime,
                 url_config=URLConfig(
                     auth_type=AuthType.AWS_IAM,
@@ -146,7 +151,10 @@ class Test_awslambda_function_url_cors_policy:
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_url_cors_policy.awslambda_function_url_cors_policy.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -158,7 +166,7 @@ class Test_awslambda_function_url_cors_policy:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn
             assert result[0].status == "FAIL"

--- a/tests/providers/aws/services/awslambda/awslambda_function_url_public/awslambda_function_url_public_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_url_public/awslambda_function_url_public_test.py
@@ -8,8 +8,10 @@ from prowler.providers.aws.services.awslambda.awslambda_service import (
     URLConfig,
     URLConfigCORS,
 )
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_awslambda_function_url_public:
@@ -18,7 +20,10 @@ class Test_awslambda_function_url_public:
         lambda_client.functions = {}
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_url_public.awslambda_function_url_public.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -35,15 +40,13 @@ class Test_awslambda_function_url_public:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 runtime=function_runtime,
                 url_config=URLConfig(
                     auth_type=AuthType.NONE,
@@ -54,7 +57,10 @@ class Test_awslambda_function_url_public:
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_url_public.awslambda_function_url_public.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -66,7 +72,7 @@ class Test_awslambda_function_url_public:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn
             assert result[0].status == "FAIL"
@@ -80,15 +86,13 @@ class Test_awslambda_function_url_public:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "python3.9"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 runtime=function_runtime,
                 url_config=URLConfig(
                     auth_type=AuthType.AWS_IAM,
@@ -99,7 +103,10 @@ class Test_awslambda_function_url_public:
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_url_public.awslambda_function_url_public.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -111,7 +118,7 @@ class Test_awslambda_function_url_public:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn
             assert result[0].status == "PASS"

--- a/tests/providers/aws/services/awslambda/awslambda_function_using_supported_runtimes/awslambda_function_using_supported_runtimes_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_using_supported_runtimes/awslambda_function_using_supported_runtimes_test.py
@@ -3,8 +3,10 @@ from unittest import mock
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.awslambda.awslambda_service import Function
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_awslambda_function_using_supported_runtimes:
@@ -13,7 +15,10 @@ class Test_awslambda_function_using_supported_runtimes:
         lambda_client.functions = {}
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_using_supported_runtimes.awslambda_function_using_supported_runtimes.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -30,15 +35,13 @@ class Test_awslambda_function_using_supported_runtimes:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 runtime=function_runtime,
             )
         }
@@ -62,7 +65,10 @@ class Test_awslambda_function_using_supported_runtimes:
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_using_supported_runtimes.awslambda_function_using_supported_runtimes.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -74,7 +80,7 @@ class Test_awslambda_function_using_supported_runtimes:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn
             assert result[0].status == "FAIL"
@@ -88,15 +94,13 @@ class Test_awslambda_function_using_supported_runtimes:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "python3.9"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 runtime=function_runtime,
             )
         }
@@ -120,7 +124,10 @@ class Test_awslambda_function_using_supported_runtimes:
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_using_supported_runtimes.awslambda_function_using_supported_runtimes.awslambda_client",
             new=lambda_client,
         ):
             # Test Check
@@ -132,7 +139,7 @@ class Test_awslambda_function_using_supported_runtimes:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn
             assert result[0].status == "PASS"
@@ -145,15 +152,13 @@ class Test_awslambda_function_using_supported_runtimes:
     def test_function_no_runtime(self):
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
-        function_arn = (
-            f"arn:aws:lambda:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
-        )
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
                 security_groups=[],
                 arn=function_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         }
 
@@ -176,7 +181,10 @@ class Test_awslambda_function_using_supported_runtimes:
         }
 
         with mock.patch(
-            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            set_mocked_aws_audit_info(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_using_supported_runtimes.awslambda_function_using_supported_runtimes.awslambda_client",
             new=lambda_client,
         ):
             # Test Check

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used_test.py
@@ -45,11 +45,13 @@ class Test_ec2_securitygroup_not_used:
         return audit_info
 
     @mock_ec2
+    @mock_lambda
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
+        from prowler.providers.aws.services.awslambda.awslambda_service import Lambda
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
         current_audit_info = self.set_mocked_audit_info()
@@ -60,6 +62,9 @@ class Test_ec2_securitygroup_not_used:
         ), mock.patch(
             "prowler.providers.aws.services.ec2.ec2_securitygroup_not_used.ec2_securitygroup_not_used.ec2_client",
             new=EC2(current_audit_info),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            new=Lambda(current_audit_info),
         ):
             # Test Check
             from prowler.providers.aws.services.ec2.ec2_securitygroup_not_used.ec2_securitygroup_not_used import (
@@ -73,6 +78,7 @@ class Test_ec2_securitygroup_not_used:
             assert len(result) == 0
 
     @mock_ec2
+    @mock_lambda
     def test_ec2_unused_sg(self):
         # Create EC2 Mocked Resources
         ec2 = resource("ec2", AWS_REGION)
@@ -83,6 +89,7 @@ class Test_ec2_securitygroup_not_used:
             GroupName=sg_name, Description="test", VpcId=vpc_id
         )
 
+        from prowler.providers.aws.services.awslambda.awslambda_service import Lambda
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
         current_audit_info = self.set_mocked_audit_info()
@@ -93,6 +100,9 @@ class Test_ec2_securitygroup_not_used:
         ), mock.patch(
             "prowler.providers.aws.services.ec2.ec2_securitygroup_not_used.ec2_securitygroup_not_used.ec2_client",
             new=EC2(current_audit_info),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            new=Lambda(current_audit_info),
         ):
             # Test Check
             from prowler.providers.aws.services.ec2.ec2_securitygroup_not_used.ec2_securitygroup_not_used import (
@@ -119,6 +129,7 @@ class Test_ec2_securitygroup_not_used:
             assert result[0].resource_tags == []
 
     @mock_ec2
+    @mock_lambda
     def test_ec2_used_default_sg(self):
         # Create EC2 Mocked Resources
         ec2 = resource("ec2", AWS_REGION)
@@ -131,6 +142,7 @@ class Test_ec2_securitygroup_not_used:
         subnet = ec2.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/18")
         subnet.create_network_interface(Groups=[sg.id])
 
+        from prowler.providers.aws.services.awslambda.awslambda_service import Lambda
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
         current_audit_info = self.set_mocked_audit_info()
@@ -141,6 +153,9 @@ class Test_ec2_securitygroup_not_used:
         ), mock.patch(
             "prowler.providers.aws.services.ec2.ec2_securitygroup_not_used.ec2_securitygroup_not_used.ec2_client",
             new=EC2(current_audit_info),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            new=Lambda(current_audit_info),
         ):
             # Test Check
             from prowler.providers.aws.services.ec2.ec2_securitygroup_not_used.ec2_securitygroup_not_used import (
@@ -209,6 +224,7 @@ class Test_ec2_securitygroup_not_used:
             },
         )
 
+        from prowler.providers.aws.services.awslambda.awslambda_service import Lambda
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
         current_audit_info = self.set_mocked_audit_info()
@@ -219,6 +235,9 @@ class Test_ec2_securitygroup_not_used:
         ), mock.patch(
             "prowler.providers.aws.services.ec2.ec2_securitygroup_not_used.ec2_securitygroup_not_used.ec2_client",
             new=EC2(current_audit_info),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_service.Lambda",
+            new=Lambda(current_audit_info),
         ):
             # Test Check
             from prowler.providers.aws.services.ec2.ec2_securitygroup_not_used.ec2_securitygroup_not_used import (


### PR DESCRIPTION
### Description

The check `ec2_securitygroup_not_used` now uses a `Lambda` service client (https://github.com/prowler-cloud/prowler/pull/2944) so we need to mock that service client in the check's tests.

I fixed all the `Lambda` mocks using the same way with the check `awslambda_client` and created a `utils` lib with some code that is always present in the tests.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
