### PR TITLE
chore(github): ignore permissions path in GitHub actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,6 +25,7 @@ jobs:
             .github/**
             README.md
             docs/**
+            permissions/**
       - name: Install poetry
         if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
         run: |


### PR DESCRIPTION
### Description

Ignore `permissions` path in GitHub actions.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
