### PR TITLE
fix(sts): force v2 STS tokens

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -131,7 +131,11 @@ def assume_role(
         if sts_endpoint_region is None:
             sts_endpoint_region = AWS_STS_GLOBAL_ENDPOINT_REGION
 
-        sts_client = session.client("sts", sts_endpoint_region)
+        sts_client = session.client(
+            "sts",
+            sts_endpoint_region,
+            endpoint_url=f"https://sts.{sts_endpoint_region}.amazonaws.com",
+        )
         assumed_credentials = sts_client.assume_role(**assume_role_arguments)
     except Exception as error:
         logger.critical(

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -12,6 +12,7 @@ from prowler.lib.logger import logger
 from prowler.lib.utils.utils import open_file, parse_json_file
 from prowler.providers.aws.config import AWS_STS_GLOBAL_ENDPOINT_REGION
 from prowler.providers.aws.lib.audit_info.models import AWS_Assume_Role, AWS_Audit_Info
+from prowler.providers.aws.lib.credentials.credentials import create_sts_session
 
 
 ################## AWS PROVIDER
@@ -131,11 +132,7 @@ def assume_role(
         if sts_endpoint_region is None:
             sts_endpoint_region = AWS_STS_GLOBAL_ENDPOINT_REGION
 
-        sts_client = session.client(
-            "sts",
-            sts_endpoint_region,
-            endpoint_url=f"https://sts.{sts_endpoint_region}.amazonaws.com",
-        )
+        sts_client = create_sts_session(session, sts_endpoint_region)
         assumed_credentials = sts_client.assume_role(**assume_role_arguments)
     except Exception as error:
         logger.critical(

--- a/prowler/providers/aws/lib/credentials/credentials.py
+++ b/prowler/providers/aws/lib/credentials/credentials.py
@@ -29,9 +29,7 @@ def validate_aws_credentials(
             # Get the first region passed to the -f/--region
             aws_region = input_regions[0]
 
-        validate_credentials_client = session.client(
-            "sts", aws_region, endpoint_url=f"https://sts.{aws_region}.amazonaws.com"
-        )
+        validate_credentials_client = create_sts_session(session, aws_region)
         caller_identity = validate_credentials_client.get_caller_identity()
         # Include the region where the caller_identity has validated the credentials
         caller_identity["region"] = aws_region
@@ -66,3 +64,11 @@ Caller Identity ARN: {Fore.YELLOW}[{audit_info.audited_identity_arn}]{Style.RESE
         report += f"""Assumed Role ARN: {Fore.YELLOW}[{audit_info.assumed_role_info.role_arn}]{Style.RESET_ALL}
 """
     print(report)
+
+
+def create_sts_session(
+    session: session.Session, aws_region: str
+) -> session.Session.client:
+    return session.client(
+        "sts", aws_region, endpoint_url=f"https://sts.{aws_region}.amazonaws.com"
+    )

--- a/prowler/providers/aws/lib/credentials/credentials.py
+++ b/prowler/providers/aws/lib/credentials/credentials.py
@@ -29,7 +29,9 @@ def validate_aws_credentials(
             # Get the first region passed to the -f/--region
             aws_region = input_regions[0]
 
-        validate_credentials_client = session.client("sts", aws_region)
+        validate_credentials_client = session.client(
+            "sts", aws_region, endpoint_url=f"https://sts.{aws_region}.amazonaws.com"
+        )
         caller_identity = validate_credentials_client.get_caller_identity()
         # Include the region where the caller_identity has validated the credentials
         caller_identity["region"] = aws_region


### PR DESCRIPTION
### Description

Set a regional STS endpoint URLs in STS sessions since these always return v2 tokens so they always work with any region.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
