### PR TITLE
feat(allowlist): allowlist non-default regions configuration

### DIFF
--- a/docs/tutorials/configuration_file.md
+++ b/docs/tutorials/configuration_file.md
@@ -29,6 +29,10 @@ The following list includes all the AWS checks with configurable variables that 
 | `organizations_delegated_administrators`                      | `organizations_trusted_delegated_administrators` | List of Strings |
 | `ecr_repositories_scan_vulnerabilities_in_latest_image`       | `ecr_repository_vulnerability_minimum_severity`  | String          |
 | `trustedadvisor_premium_support_plan_subscribed`              | `verify_premium_support_plans`                   | Boolean         |
+| `config_recorder_all_regions_enabled`                         | `allowlist_non_default_regions`                  | Boolean         |
+| `drs_job_exist`                                               | `allowlist_non_default_regions`                  | Boolean         |
+| `guardduty_is_enabled`                                        | `allowlist_non_default_regions`                  | Boolean         |
+| `securityhub_enabled`                                         | `allowlist_non_default_regions`                  | Boolean         |
 
 ## Azure
 
@@ -44,6 +48,17 @@ The following list includes all the AWS checks with configurable variables that 
 ```yaml title="config.yaml"
 # AWS Configuration
 aws:
+
+  # AWS Global Configuration
+  # aws.allowlist_non_default_regions --> Allowlist Failed Findings in non-default regions for GuardDuty, SecurityHub, DRS and Config
+  allowlist_non_default_regions: False
+
+  # AWS IAM Configuration
+  # aws.iam_user_accesskey_unused --> CIS recommends 45 days
+  max_unused_access_keys_days: 45
+  # aws.iam_user_console_access_unused --> CIS recommends 45 days
+  max_console_access_days: 45
+
   # AWS EC2 Configuration
   # aws.ec2_elastic_ip_shodan
   shodan_api_key: null
@@ -104,6 +119,10 @@ aws:
   # HIGH
   # MEDIUM
   ecr_repository_vulnerability_minimum_severity: "MEDIUM"
+
+  # AWS Trusted Advisor
+  # trustedadvisor_premium_support_plan_subscribed
+  verify_premium_support_plans: True
 
 # Azure Configuration
 azure:

--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -1,5 +1,10 @@
 # AWS Configuration
 aws:
+
+  # AWS Global Configuration
+  # aws.allowlist_non_default_regions --> Allowlist Failed Findings in non-default regions for GuardDuty, SecurityHub, DRS and Config
+  allowlist_non_default_regions: False
+
   # AWS IAM Configuration
   # aws.iam_user_accesskey_unused --> CIS recommends 45 days
   max_unused_access_keys_days: 45

--- a/prowler/providers/aws/services/config/config_recorder_all_regions_enabled/config_recorder_all_regions_enabled.py
+++ b/prowler/providers/aws/services/config/config_recorder_all_regions_enabled/config_recorder_all_regions_enabled.py
@@ -35,6 +35,12 @@ class config_recorder_all_regions_enabled(Check):
                     report.status_extended = (
                         f"AWS Config recorder {recorder.name} is disabled."
                     )
+            if report.status == "FAIL" and (
+                config_client.audit_config.get("allowlist_non_default_regions", False)
+                and not recorder.region == config_client.region
+            ):
+                report.status = "WARNING"
+
             findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/drs/drs_job_exist/drs_job_exist.py
+++ b/prowler/providers/aws/services/drs/drs_job_exist/drs_job_exist.py
@@ -19,6 +19,12 @@ class drs_job_exist(Check):
                     report.status = "PASS"
                     report.status_extended = "DRS is enabled for this region with jobs."
 
+            if report.status == "FAIL" and (
+                drs_client.audit_config.get("allowlist_non_default_regions", False)
+                and not drs.region == drs_client.region
+            ):
+                report.status = "WARNING"
+
             findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled.py
@@ -27,6 +27,14 @@ class guardduty_is_enabled(Check):
                     f"GuardDuty detector {detector.id} configured but suspended."
                 )
 
+            if report.status == "FAIL" and (
+                guardduty_client.audit_config.get(
+                    "allowlist_non_default_regions", False
+                )
+                and not detector.region == guardduty_client.region
+            ):
+                report.status = "WARNING"
+
             findings.append(report)
 
         return findings

--- a/tests/providers/aws/services/config/config_recorder_all_regions_enabled/config_recorder_all_regions_enabled_test.py
+++ b/tests/providers/aws/services/config/config_recorder_all_regions_enabled/config_recorder_all_regions_enabled_test.py
@@ -39,6 +39,7 @@ class Test_config_recorder_all_regions_enabled:
                 completed_checks=0,
                 audit_progress=0,
             ),
+            audit_config={},
         )
 
         return audit_info
@@ -171,7 +172,8 @@ class Test_config_recorder_all_regions_enabled:
         from prowler.providers.aws.services.config.config_service import Config
 
         current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.audited_regions = [AWS_REGION]
+        current_audit_info.profile_region = "eu-south-2"
+        current_audit_info.audited_regions = ["eu-south-2", AWS_REGION]
         current_audit_info.audit_config = {"allowlist_non_default_regions": True}
 
         with mock.patch(
@@ -188,10 +190,10 @@ class Test_config_recorder_all_regions_enabled:
 
             check = config_recorder_all_regions_enabled()
             result = check.execute()
-            assert len(result) == 1
+            assert len(result) == 2
             # Search for the recorder just created
             for recorder in result:
-                if recorder.resource_id:
+                if recorder.region == AWS_REGION:
                     assert recorder.status == "WARNING"
                     assert (
                         recorder.status_extended

--- a/tests/providers/aws/services/config/config_recorder_all_regions_enabled/config_recorder_all_regions_enabled_test.py
+++ b/tests/providers/aws/services/config/config_recorder_all_regions_enabled/config_recorder_all_regions_enabled_test.py
@@ -159,3 +159,44 @@ class Test_config_recorder_all_regions_enabled:
                     assert recorder.resource_id == "default"
                     assert recorder.resource_arn == AWS_ACCOUNT_ARN
                     assert recorder.region == AWS_REGION
+
+    @mock_config
+    def test_config_one_recorder_disabled_allowlisted(self):
+        # Create Config Mocked Resources
+        config_client = client("config", region_name=AWS_REGION)
+        # Create Config Recorder
+        config_client.put_configuration_recorder(
+            ConfigurationRecorder={"name": "default", "roleARN": "somearn"}
+        )
+        from prowler.providers.aws.services.config.config_service import Config
+
+        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info.audited_regions = [AWS_REGION]
+        current_audit_info.audit_config = {"allowlist_non_default_regions": True}
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
+            "prowler.providers.aws.services.config.config_recorder_all_regions_enabled.config_recorder_all_regions_enabled.config_client",
+            new=Config(current_audit_info),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.config.config_recorder_all_regions_enabled.config_recorder_all_regions_enabled import (
+                config_recorder_all_regions_enabled,
+            )
+
+            check = config_recorder_all_regions_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            # Search for the recorder just created
+            for recorder in result:
+                if recorder.resource_id:
+                    assert recorder.status == "WARNING"
+                    assert (
+                        recorder.status_extended
+                        == "AWS Config recorder default is disabled."
+                    )
+                    assert recorder.resource_id == "default"
+                    assert recorder.resource_arn == AWS_ACCOUNT_ARN
+                    assert recorder.region == AWS_REGION

--- a/tests/providers/aws/services/config/config_recorder_all_regions_enabled/config_recorder_all_regions_enabled_test.py
+++ b/tests/providers/aws/services/config/config_recorder_all_regions_enabled/config_recorder_all_regions_enabled_test.py
@@ -167,7 +167,7 @@ class Test_config_recorder_all_regions_enabled:
         config_client = client("config", region_name=AWS_REGION)
         # Create Config Recorder
         config_client.put_configuration_recorder(
-            ConfigurationRecorder={"name": "default", "roleARN": "somearn"}
+            ConfigurationRecorder={"name": AWS_ACCOUNT_NUMBER, "roleARN": "somearn"}
         )
         from prowler.providers.aws.services.config.config_service import Config
 
@@ -197,8 +197,17 @@ class Test_config_recorder_all_regions_enabled:
                     assert recorder.status == "WARNING"
                     assert (
                         recorder.status_extended
-                        == "AWS Config recorder default is disabled."
+                        == f"AWS Config recorder {AWS_ACCOUNT_NUMBER} is disabled."
                     )
-                    assert recorder.resource_id == "default"
+                    assert recorder.resource_id == AWS_ACCOUNT_NUMBER
                     assert recorder.resource_arn == AWS_ACCOUNT_ARN
                     assert recorder.region == AWS_REGION
+                else:
+                    assert recorder.status == "FAIL"
+                    assert (
+                        recorder.status_extended
+                        == f"AWS Config recorder {AWS_ACCOUNT_NUMBER} is disabled."
+                    )
+                    assert recorder.resource_id == AWS_ACCOUNT_NUMBER
+                    assert recorder.resource_arn == AWS_ACCOUNT_ARN
+                    assert recorder.region == "eu-south-2"

--- a/tests/providers/aws/services/drs/drs_job_exist/drs_job_exist_test.py
+++ b/tests/providers/aws/services/drs/drs_job_exist/drs_job_exist_test.py
@@ -125,7 +125,7 @@ class Test_drs_job_exist:
         drs_client.audit_config = {"allowlist_non_default_regions": True}
         drs_client.audited_account = AWS_ACCOUNT_NUMBER
         drs_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-        drs_client.region = AWS_REGION
+        drs_client.region = "eu-west-2"
         drs_client.drs_services = [
             DRSservice(
                 id="DRS",

--- a/tests/providers/aws/services/drs/drs_job_exist/drs_job_exist_test.py
+++ b/tests/providers/aws/services/drs/drs_job_exist/drs_job_exist_test.py
@@ -119,3 +119,37 @@ class Test_drs_job_exist:
             assert result[0].resource_arn == f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
             assert result[0].region == AWS_REGION
             assert result[0].resource_tags == []
+
+    def test_drs_disabled_allowlisted(self):
+        drs_client = mock.MagicMock
+        drs_client.audit_config = {"allowlist_non_default_regions": True}
+        drs_client.audited_account = AWS_ACCOUNT_NUMBER
+        drs_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+        drs_client.region = AWS_REGION
+        drs_client.drs_services = [
+            DRSservice(
+                id="DRS",
+                status="DISABLED",
+                region=AWS_REGION,
+                jobs=[],
+            )
+        ]
+        with mock.patch(
+            "prowler.providers.aws.services.drs.drs_service.DRS",
+            new=drs_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.drs.drs_job_exist.drs_job_exist import (
+                drs_job_exist,
+            )
+
+            check = drs_job_exist()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "WARNING"
+            assert result[0].status_extended == "DRS is not enabled for this region."
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+            assert result[0].region == AWS_REGION
+            assert result[0].resource_tags == []

--- a/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_test.py
@@ -123,3 +123,34 @@ class Test_guardduty_is_enabled:
             assert result[0].resource_id == detector_id
             assert result[0].resource_arn == detector_arn
             assert result[0].region == AWS_REGION
+
+    def test_guardduty_not_configured_allowlisted(self):
+        guardduty_client = mock.MagicMock
+        guardduty_client.audit_config = {"allowlist_non_default_regions": True}
+        guardduty_client.detectors = []
+        guardduty_client.detectors.append(
+            Detector(
+                id=detector_id,
+                arn=detector_arn,
+                region=AWS_REGION,
+            )
+        )
+        with mock.patch(
+            "prowler.providers.aws.services.guardduty.guardduty_service.GuardDuty",
+            guardduty_client,
+        ):
+            from prowler.providers.aws.services.guardduty.guardduty_is_enabled.guardduty_is_enabled import (
+                guardduty_is_enabled,
+            )
+
+            check = guardduty_is_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "WARNING"
+            assert (
+                result[0].status_extended
+                == f"GuardDuty detector {detector_id} not configured."
+            )
+            assert result[0].resource_id == detector_id
+            assert result[0].resource_arn == detector_arn
+            assert result[0].region == AWS_REGION

--- a/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_test.py
@@ -15,6 +15,7 @@ detector_arn = f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_ID}:detector/{detec
 class Test_guardduty_is_enabled:
     def test_no_detectors(self):
         guardduty_client = mock.MagicMock
+        guardduty_client.region = AWS_REGION
         guardduty_client.detectors = []
         guardduty_client.detectors.append(
             Detector(
@@ -71,6 +72,7 @@ class Test_guardduty_is_enabled:
 
     def test_guardduty_configured_but_suspended(self):
         guardduty_client = mock.MagicMock
+        guardduty_client.region = AWS_REGION
         guardduty_client.detectors = []
         guardduty_client.detectors.append(
             Detector(
@@ -100,6 +102,7 @@ class Test_guardduty_is_enabled:
     def test_guardduty_not_configured(self):
         guardduty_client = mock.MagicMock
         guardduty_client.detectors = []
+        guardduty_client.region = AWS_REGION
         guardduty_client.detectors.append(
             Detector(
                 id=detector_id,
@@ -127,6 +130,7 @@ class Test_guardduty_is_enabled:
     def test_guardduty_not_configured_allowlisted(self):
         guardduty_client = mock.MagicMock
         guardduty_client.audit_config = {"allowlist_non_default_regions": True}
+        guardduty_client.region = "eu-south-2"
         guardduty_client.detectors = []
         guardduty_client.detectors.append(
             Detector(

--- a/tests/providers/aws/services/securityhub/securityhub_enabled/securityhub_enabled_test.py
+++ b/tests/providers/aws/services/securityhub/securityhub_enabled/securityhub_enabled_test.py
@@ -12,6 +12,7 @@ AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
 class Test_securityhub_enabled:
     def test_securityhub_hub_inactive(self):
         securityhub_client = mock.MagicMock
+        securityhub_client.region = AWS_REGION
         securityhub_client.securityhubs = [
             SecurityHubHub(
                 arn=AWS_ACCOUNT_ARN,
@@ -114,6 +115,7 @@ class Test_securityhub_enabled:
 
     def test_securityhub_hub_active_without_integrations_or_standards(self):
         securityhub_client = mock.MagicMock
+        securityhub_client.region = AWS_REGION
         securityhub_client.securityhubs = [
             SecurityHubHub(
                 arn="arn:aws:securityhub:us-east-1:0123456789012:hub/default",
@@ -151,6 +153,7 @@ class Test_securityhub_enabled:
     def test_securityhub_hub_active_without_integrations_or_standards_allowlisted(self):
         securityhub_client = mock.MagicMock
         securityhub_client.audit_config = {"allowlist_non_default_regions": True}
+        securityhub_client.region = AWS_REGION
         securityhub_client.securityhubs = [
             SecurityHubHub(
                 arn="arn:aws:securityhub:us-east-1:0123456789012:hub/default",
@@ -158,7 +161,7 @@ class Test_securityhub_enabled:
                 status="ACTIVE",
                 standards="",
                 integrations="",
-                region="eu-west-1",
+                region="eu-south-2",
             )
         ]
         with mock.patch(
@@ -183,4 +186,4 @@ class Test_securityhub_enabled:
                 result[0].resource_arn
                 == "arn:aws:securityhub:us-east-1:0123456789012:hub/default"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == "eu-south-2"


### PR DESCRIPTION
### Description

Add `allowlist_non_default_regions` configuration variable to allowlist failed findings in non-default regions for GuardDuty, SecurityHub, DRS and Config AWS services.

<img width="1095" alt="image" src="https://github.com/prowler-cloud/prowler/assets/38561120/2314aeec-70f4-4ea4-a616-85a92920284a">

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
