### PR TITLE
fix(cloudtrail service): typo in logging info

### DIFF
--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -120,7 +120,7 @@ class Cloudtrail(AWSService):
             )
 
     def __get_insight_selectors__(self):
-        logger.info("Cloudtrail - Getting trail insihgt selectors...")
+        logger.info("Cloudtrail - Getting trail insight selectors...")
 
         try:
             for trail in self.trails:


### PR DESCRIPTION
### Context

There was a typo in a info log message in `cloudtrail` service 


### Description

Fix that typo


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
