### PR TITLE
fix(ec2_instance_imdsv2_enabled ): verify if metadata service is disabled

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled.py
@@ -24,9 +24,7 @@ class ec2_instance_imdsv2_enabled(Check):
                     report.status_extended = (
                         f"EC2 Instance {instance.id} has IMDSv2 enabled and required."
                     )
-                elif (
-                    instance.http_endpoint == "disabled"
-                ):
+                elif instance.http_endpoint == "disabled":
                     report.status = "PASS"
                     report.status_extended = (
                         f"EC2 Instance {instance.id} has metadata service disabled."

--- a/prowler/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled.py
@@ -24,6 +24,13 @@ class ec2_instance_imdsv2_enabled(Check):
                     report.status_extended = (
                         f"EC2 Instance {instance.id} has IMDSv2 enabled and required."
                     )
+                elif (
+                    instance.http_endpoint == "disabled"
+                ):
+                    report.status = "PASS"
+                    report.status_extended = (
+                        f"EC2 Instance {instance.id} has metadata service disabled."
+                    )
 
                 findings.append(report)
 

--- a/tests/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled_test.py
@@ -117,7 +117,7 @@ class Test_ec2_instance_imdsv2_enabled:
             )
 
     @mock_ec2
-    def test_one_uncompliant_ec2(self):
+    def test_one_uncompliant_ec2_metadata_server_disabled(self):
         ec2 = resource("ec2", region_name=AWS_REGION)
         instance = ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID,
@@ -151,13 +151,62 @@ class Test_ec2_instance_imdsv2_enabled:
             result = check.execute()
 
             assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].region == AWS_REGION
+            # Moto fills instance tags with None
+            assert result[0].resource_tags is None
+            assert (
+                result[0].status_extended
+                == f"EC2 Instance {instance.id} has metadata service disabled."
+            )
+            assert result[0].resource_id == instance.id
+            assert (
+                result[0].resource_arn
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+            )
+
+    @mock_ec2
+    def test_one_uncompliant_ec2_metadata_server_enabled(self):
+        ec2 = resource("ec2", region_name=AWS_REGION)
+        instance = ec2.create_instances(
+            ImageId=EXAMPLE_AMI_ID,
+            MinCount=1,
+            MaxCount=1,
+            MetadataOptions={
+                "HttpTokens": "optional",
+                "HttpEndpoint": "enabled",
+            },
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        current_audit_info = self.set_mocked_audit_info()
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_imdsv2_enabled.ec2_instance_imdsv2_enabled.ec2_client",
+            new=EC2(current_audit_info),
+        ) as service_client:
+            from prowler.providers.aws.services.ec2.ec2_instance_imdsv2_enabled.ec2_instance_imdsv2_enabled import (
+                ec2_instance_imdsv2_enabled,
+            )
+
+            service_client.instances[0].http_endpoint = "enabled"
+            service_client.instances[0].http_tokens = "optional"
+
+            check = ec2_instance_imdsv2_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].region == AWS_REGION
             # Moto fills instance tags with None
             assert result[0].resource_tags is None
-            assert search(
-                f"EC2 Instance {instance.id} has IMDSv2 disabled or not required",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == f"EC2 Instance {instance.id} has IMDSv2 disabled or not required."
             )
             assert result[0].resource_id == instance.id
             assert (

--- a/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_test.py
@@ -102,8 +102,8 @@ class Test_guardduty_is_enabled:
         guardduty_client.detectors = []
         guardduty_client.detectors.append(
             Detector(
-                id=detector_id,
-                arn=detector_arn,
+                id=DETECTOR_ID,
+                arn=DETECTOR_ARN,
                 region=AWS_REGION,
             )
         )
@@ -118,8 +118,11 @@ class Test_guardduty_is_enabled:
             check = guardduty_is_enabled()
             result = check.execute()
             assert len(result) == 1
-            assert result[0].status == "FAIL"
-            assert search("not configured", result[0].status_extended)
-            assert result[0].resource_id == detector_id
-            assert result[0].resource_arn == detector_arn
+            assert result[0].status == "WARNING"
+            assert (
+                result[0].status_extended
+                == f"GuardDuty detector {DETECTOR_ID} not configured."
+            )
+            assert result[0].resource_id == DETECTOR_ID
+            assert result[0].resource_arn == DETECTOR_ARN
             assert result[0].region == AWS_REGION


### PR DESCRIPTION
### Context

Hello - I believe the check '**ec2_instance_imdsv2_enabled**' provides inaccurate results when the metadata service is disabled. In my opinion, the result should always be 'PASS' since the HTTP endpoint cannot be queried, regardless of whether IMDSv2 is enabled or not.

Furthermore, the current code will always return 'FAIL' if `http_endpoint == "disabled"`, which leads to a false positive.

Thank you

### Description

I have added an `elif` condition that address this scenario.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
