### PR TITLE
fix(GuardDuty): Add `enabled_in_account` parameter

### DIFF
--- a/prowler/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled.py
@@ -13,7 +13,8 @@ class guardduty_is_enabled(Check):
             report.resource_tags = detector.tags
             report.status = "PASS"
             report.status_extended = f"GuardDuty detector {detector.id} enabled."
-            if detector.arn == guardduty_client.audited_account_arn:
+
+            if not detector.enabled_in_account:
                 report.status = "FAIL"
                 report.status_extended = "GuardDuty is not enabled."
             elif detector.status is None:

--- a/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_test.py
@@ -1,4 +1,3 @@
-from re import search
 from unittest import mock
 from uuid import uuid4
 
@@ -8,11 +7,11 @@ AWS_REGION = "us-east-1"
 AWS_ACCOUNT_ID = "123456789012"
 AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
 
-detector_id = str(uuid4())
-detector_arn = f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_ID}:detector/{detector_id}"
+DETECTOR_ID = str(uuid4())
+DETECTOR_ARN = f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_ID}:detector/{DETECTOR_ID}"
 
 
-class Test_guardduty_is_enabled:
+class Test_:
     def test_no_detectors(self):
         guardduty_client = mock.MagicMock
         guardduty_client.detectors = []
@@ -21,6 +20,7 @@ class Test_guardduty_is_enabled:
                 id=AWS_ACCOUNT_ID,
                 region=AWS_REGION,
                 arn=AWS_ACCOUNT_ARN,
+                enabled_in_account=False,
             )
         )
         guardduty_client.audited_account_arn = AWS_ACCOUNT_ARN
@@ -36,7 +36,7 @@ class Test_guardduty_is_enabled:
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert search("is not enabled", result[0].status_extended)
+            assert result[0].status_extended == "GuardDuty is not enabled."
             assert result[0].resource_id == AWS_ACCOUNT_ID
             assert result[0].resource_arn == AWS_ACCOUNT_ARN
             assert result[0].region == AWS_REGION
@@ -46,9 +46,9 @@ class Test_guardduty_is_enabled:
         guardduty_client.detectors = []
         guardduty_client.detectors.append(
             Detector(
-                id=detector_id,
+                id=DETECTOR_ID,
                 region=AWS_REGION,
-                arn=detector_arn,
+                arn=DETECTOR_ARN,
                 status=True,
             )
         )
@@ -64,9 +64,12 @@ class Test_guardduty_is_enabled:
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert search("enabled", result[0].status_extended)
-            assert result[0].resource_id == detector_id
-            assert result[0].resource_arn == detector_arn
+            assert (
+                result[0].status_extended
+                == f"GuardDuty detector {DETECTOR_ID} enabled."
+            )
+            assert result[0].resource_id == DETECTOR_ID
+            assert result[0].resource_arn == DETECTOR_ARN
             assert result[0].region == AWS_REGION
 
     def test_guardduty_configured_but_suspended(self):
@@ -74,8 +77,8 @@ class Test_guardduty_is_enabled:
         guardduty_client.detectors = []
         guardduty_client.detectors.append(
             Detector(
-                id=detector_id,
-                arn=detector_arn,
+                id=DETECTOR_ID,
+                arn=DETECTOR_ARN,
                 region=AWS_REGION,
                 status=False,
             )
@@ -92,9 +95,12 @@ class Test_guardduty_is_enabled:
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert search("configured but suspended", result[0].status_extended)
-            assert result[0].resource_id == detector_id
-            assert result[0].resource_arn == detector_arn
+            assert (
+                result[0].status_extended
+                == f"GuardDuty detector {DETECTOR_ID} configured but suspended."
+            )
+            assert result[0].resource_id == DETECTOR_ID
+            assert result[0].resource_arn == DETECTOR_ARN
             assert result[0].region == AWS_REGION
 
     def test_guardduty_not_configured(self):
@@ -102,8 +108,8 @@ class Test_guardduty_is_enabled:
         guardduty_client.detectors = []
         guardduty_client.detectors.append(
             Detector(
-                id=detector_id,
-                arn=detector_arn,
+                id=DETECTOR_ID,
+                arn=DETECTOR_ARN,
                 region=AWS_REGION,
             )
         )
@@ -119,7 +125,10 @@ class Test_guardduty_is_enabled:
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert search("not configured", result[0].status_extended)
-            assert result[0].resource_id == detector_id
-            assert result[0].resource_arn == detector_arn
+            assert (
+                result[0].status_extended
+                == f"GuardDuty detector {DETECTOR_ID} not configured."
+            )
+            assert result[0].resource_id == DETECTOR_ID
+            assert result[0].resource_arn == DETECTOR_ARN
             assert result[0].region == AWS_REGION

--- a/tests/providers/aws/services/guardduty/guardduty_service_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_service_test.py
@@ -121,6 +121,14 @@ class Test_GuardDuty_Service:
 
         assert len(guardduty.detectors) == 1
         assert guardduty.detectors[0].id == response["DetectorId"]
+        assert (
+            guardduty.detectors[0].arn
+            == f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:detector/{response['DetectorId']}"
+        )
+        assert guardduty.detectors[0].enabled_in_account
+        assert len(guardduty.detectors[0].findings) == 1
+        assert guardduty.detectors[0].member_accounts == ["123456789012"]
+        assert guardduty.detectors[0].administrator_account == "123456789013"
         assert guardduty.detectors[0].region == AWS_REGION
         assert guardduty.detectors[0].tags == [{"test": "test"}]
 
@@ -135,8 +143,16 @@ class Test_GuardDuty_Service:
 
         assert len(guardduty.detectors) == 1
         assert guardduty.detectors[0].id == response["DetectorId"]
+        assert (
+            guardduty.detectors[0].arn
+            == f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:detector/{response['DetectorId']}"
+        )
+        assert guardduty.detectors[0].enabled_in_account
+        assert len(guardduty.detectors[0].findings) == 1
+        assert guardduty.detectors[0].member_accounts == ["123456789012"]
+        assert guardduty.detectors[0].administrator_account == "123456789013"
         assert guardduty.detectors[0].region == AWS_REGION
-        assert guardduty.detectors[0].status
+        assert guardduty.detectors[0].tags == [{"test": "test"}]
 
     @mock_guardduty
     # Test GuardDuty session
@@ -149,9 +165,16 @@ class Test_GuardDuty_Service:
 
         assert len(guardduty.detectors) == 1
         assert guardduty.detectors[0].id == response["DetectorId"]
-        assert guardduty.detectors[0].region == AWS_REGION
-        assert guardduty.detectors[0].status
+        assert (
+            guardduty.detectors[0].arn
+            == f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:detector/{response['DetectorId']}"
+        )
+        assert guardduty.detectors[0].enabled_in_account
         assert len(guardduty.detectors[0].findings) == 1
+        assert guardduty.detectors[0].member_accounts == ["123456789012"]
+        assert guardduty.detectors[0].administrator_account == "123456789013"
+        assert guardduty.detectors[0].region == AWS_REGION
+        assert guardduty.detectors[0].tags == [{"test": "test"}]
 
     @mock_guardduty
     def test__list_members__(self):
@@ -163,9 +186,16 @@ class Test_GuardDuty_Service:
 
         assert len(guardduty.detectors) == 1
         assert guardduty.detectors[0].id == response["DetectorId"]
+        assert (
+            guardduty.detectors[0].arn
+            == f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:detector/{response['DetectorId']}"
+        )
+        assert guardduty.detectors[0].enabled_in_account
+        assert len(guardduty.detectors[0].findings) == 1
+        assert guardduty.detectors[0].member_accounts == ["123456789012"]
+        assert guardduty.detectors[0].administrator_account == "123456789013"
         assert guardduty.detectors[0].region == AWS_REGION
-        assert guardduty.detectors[0].status
-        assert len(guardduty.detectors[0].member_accounts) == 1
+        assert guardduty.detectors[0].tags == [{"test": "test"}]
 
     @mock_guardduty
     # Test GuardDuty session
@@ -178,6 +208,13 @@ class Test_GuardDuty_Service:
 
         assert len(guardduty.detectors) == 1
         assert guardduty.detectors[0].id == response["DetectorId"]
+        assert (
+            guardduty.detectors[0].arn
+            == f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:detector/{response['DetectorId']}"
+        )
+        assert guardduty.detectors[0].enabled_in_account
+        assert len(guardduty.detectors[0].findings) == 1
+        assert guardduty.detectors[0].member_accounts == ["123456789012"]
+        assert guardduty.detectors[0].administrator_account == "123456789013"
         assert guardduty.detectors[0].region == AWS_REGION
-        assert guardduty.detectors[0].status
-        assert guardduty.detectors[0].administrator_account == AWS_ACCOUNT_NUMBER_ADMIN
+        assert guardduty.detectors[0].tags == [{"test": "test"}]


### PR DESCRIPTION
### Description

Add `enabled_in_account` parameter to raise a `FAIL` if the account has not configured GuardDuty in the audited region.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
