### PR TITLE
fix(elbv2_desync_mitigation_mode): improve logic

### DIFF
--- a/prowler/providers/aws/services/elbv2/elbv2_desync_mitigation_mode/elbv2_desync_mitigation_mode.metadata.json
+++ b/prowler/providers/aws/services/elbv2/elbv2_desync_mitigation_mode/elbv2_desync_mitigation_mode.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "elbv2_desync_mitigation_mode",
-  "CheckTitle": "Check whether the Application Load Balancer is configured with defensive or strictest desync mitigation mode, if not check if at least is configured with the drop_invalid_header_fields attribute",
+  "CheckTitle": "Check whether the Application Load Balancer is configured with strictest desync mitigation mode, if not check if at least is configured with the drop_invalid_header_fields attribute",
   "CheckType": [
     "Data Protection"
   ],
@@ -10,9 +10,9 @@
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
   "Severity": "medium",
   "ResourceType": "AwsElasticLoadBalancingV2LoadBalancer",
-  "Description": "Check whether the Application Load Balancer is configured with defensive or strictest desync mitigation mode, if not check if at least is configured with the drop_invalid_header_fields attribute",
+  "Description": "Check whether the Application Load Balancer is configured with strictest desync mitigation mode, if not check if at least is configured with the drop_invalid_header_fields attribute",
   "Risk": "HTTP Desync issues can lead to request smuggling and make your applications vulnerable to request queue or cache poisoning; which could lead to credential hijacking or execution of unauthorized commands.",
-  "RelatedUrl": "",
+  "RelatedUrl": "https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#desync-mitigation-mode",
   "Remediation": {
     "Code": {
       "CLI": "aws elbv2 modify-load-balancer-attributes --load-balancer-arn <alb arn> --attributes Key=routing.http.desync_mitigation_mode,Value=<defensive/strictest>",
@@ -21,7 +21,7 @@
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "Ensure Application Load Balancer is configured with defensive or strictest desync mitigation mode or with the drop_invalid_header_fields attribute enabled",
+      "Text": "Ensure Application Load Balancer is configured with strictest desync mitigation mode or with the drop_invalid_header_fields attribute enabled",
       "Url": "https://aws.amazon.com/about-aws/whats-new/2020/08/application-and-classic-load-balancers-adding-defense-in-depth-with-introduction-of-desync-mitigation-mode/"
     }
   },

--- a/prowler/providers/aws/services/elbv2/elbv2_desync_mitigation_mode/elbv2_desync_mitigation_mode.py
+++ b/prowler/providers/aws/services/elbv2/elbv2_desync_mitigation_mode/elbv2_desync_mitigation_mode.py
@@ -14,12 +14,12 @@ class elbv2_desync_mitigation_mode(Check):
                 report.resource_tags = lb.tags
                 report.status = "PASS"
                 report.status_extended = f"ELBv2 ALB {lb.name} is configured with correct desync mitigation mode."
-                if lb.desync_mitigation_mode == "monitor":
+                if lb.desync_mitigation_mode != "strictest":
                     if lb.drop_invalid_header_fields == "false":
                         report.status = "FAIL"
-                        report.status_extended = f"ELBv2 ALB {lb.name} does not have desync mitigation mode set as defensive or strictest and is not dropping invalid header fields."
+                        report.status_extended = f"ELBv2 ALB {lb.name} does not have desync mitigation mode set as strictest and is not dropping invalid header fields."
                     elif lb.drop_invalid_header_fields == "true":
-                        report.status_extended = f"ELBv2 ALB {lb.name} does not have desync mitigation mode set as defensive or strictest but is dropping invalid header fields."
+                        report.status_extended = f"ELBv2 ALB {lb.name} does not have desync mitigation mode set as strictest but is dropping invalid header fields."
                 findings.append(report)
 
         return findings

--- a/tests/providers/aws/services/elbv2/elbv2_desync_mitigation_mode/elbv2_desync_mitigation_mode_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_desync_mitigation_mode/elbv2_desync_mitigation_mode_test.py
@@ -119,7 +119,7 @@ class Test_elbv2_desync_mitigation_mode:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert search(
-                "does not have desync mitigation mode set as defensive or strictest and is not dropping invalid header fields",
+                "does not have desync mitigation mode set as strictest and is not dropping invalid header fields",
                 result[0].status_extended,
             )
             assert result[0].resource_id == "my-lb"
@@ -180,7 +180,7 @@ class Test_elbv2_desync_mitigation_mode:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert search(
-                "does not have desync mitigation mode set as defensive or strictest but is dropping invalid header fields",
+                "does not have desync mitigation mode set as strictest but is dropping invalid header fields",
                 result[0].status_extended,
             )
             assert result[0].resource_id == "my-lb"


### PR DESCRIPTION
### Description

According to [AWS Documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#desync-mitigation-mode), in order to ensure that your application load balancer receives only requests that comply with [RFC 7230](https://tools.ietf.org/html/rfc7230), it must have the strictest desync mitigation mode.
### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
