### PR TITLE
fix(clean local output dirs): clean dirs when output to s3

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -34,6 +34,7 @@ from prowler.lib.outputs.json import close_json
 from prowler.lib.outputs.outputs import extract_findings_statistics
 from prowler.lib.outputs.slack import send_slack_message
 from prowler.lib.outputs.summary_table import display_summary_table
+from prowler.lib.utils.utils import clean_local_output_directories
 from prowler.providers.aws.aws_provider import get_available_aws_service_regions
 from prowler.providers.aws.lib.s3.s3 import send_to_s3_bucket
 from prowler.providers.aws.lib.security_hub.security_hub import (
@@ -300,6 +301,9 @@ def prowler():
     # If custom checks were passed, remove the modules
     if checks_folder:
         remove_custom_checks_module(checks_folder, provider)
+
+    # clean local directories
+    clean_local_output_directories(args)
 
     # If there are failed findings exit code 3, except if -z is input
     if not args.ignore_exit_code_3 and stats["total_fail"] > 0:

--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -34,7 +34,6 @@ from prowler.lib.outputs.json import close_json
 from prowler.lib.outputs.outputs import extract_findings_statistics
 from prowler.lib.outputs.slack import send_slack_message
 from prowler.lib.outputs.summary_table import display_summary_table
-from prowler.lib.utils.utils import clean_local_output_directories
 from prowler.providers.aws.aws_provider import get_available_aws_service_regions
 from prowler.providers.aws.lib.s3.s3 import send_to_s3_bucket
 from prowler.providers.aws.lib.security_hub.security_hub import (
@@ -48,6 +47,7 @@ from prowler.providers.common.audit_info import (
     set_provider_audit_info,
     set_provider_execution_parameters,
 )
+from prowler.providers.common.clean import clean_provider_local_output_directories
 from prowler.providers.common.outputs import set_provider_output_options
 from prowler.providers.common.quick_inventory import run_provider_quick_inventory
 
@@ -303,7 +303,7 @@ def prowler():
         remove_custom_checks_module(checks_folder, provider)
 
     # clean local directories
-    clean_local_output_directories(args)
+    clean_provider_local_output_directories(args)
 
     # If there are failed findings exit code 3, except if -z is input
     if not args.ignore_exit_code_3 and stats["total_fail"] > 0:

--- a/prowler/lib/utils/utils.py
+++ b/prowler/lib/utils/utils.py
@@ -7,13 +7,11 @@ from hashlib import sha512
 from io import TextIOWrapper
 from ipaddress import ip_address
 from os.path import exists
-from shutil import rmtree
 from time import mktime
 
 from detect_secrets import SecretsCollection
 from detect_secrets.settings import default_settings
 
-from prowler.config.config import default_output_directory
 from prowler.lib.logger import logger
 
 
@@ -104,10 +102,3 @@ def outputs_unix_timestamp(is_unix_timestamp: bool, timestamp: datetime):
     else:
         timestamp = timestamp.isoformat()
     return timestamp
-
-
-def clean_local_output_directories(args: dict):
-    """clean_local_output_directories deletes local custom dirs when output is sent to remote provider storage"""
-    if args.provider == "aws" and (args.output_bucket or args.output_bucket_no_assume):
-        if args.output_directory != default_output_directory:
-            rmtree(args.output_directory)

--- a/prowler/lib/utils/utils.py
+++ b/prowler/lib/utils/utils.py
@@ -7,11 +7,13 @@ from hashlib import sha512
 from io import TextIOWrapper
 from ipaddress import ip_address
 from os.path import exists
+from shutil import rmtree
 from time import mktime
 
 from detect_secrets import SecretsCollection
 from detect_secrets.settings import default_settings
 
+from prowler.config.config import default_output_directory
 from prowler.lib.logger import logger
 
 
@@ -102,3 +104,10 @@ def outputs_unix_timestamp(is_unix_timestamp: bool, timestamp: datetime):
     else:
         timestamp = timestamp.isoformat()
     return timestamp
+
+
+def clean_local_output_directories(args: dict):
+    """clean_local_output_directories deletes local custom dirs when output is sent to remote provider storage"""
+    if args.provider == "aws" and (args.output_bucket or args.output_bucket_no_assume):
+        if args.output_directory != default_output_directory:
+            rmtree(args.output_directory)

--- a/prowler/providers/common/clean.py
+++ b/prowler/providers/common/clean.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+from shutil import rmtree
+
+from prowler.config.config import default_output_directory
+from prowler.lib.logger import logger
+
+
+def clean_provider_local_output_directories(args):
+    """
+    clean_provider_local_output_directories cleans deletes local custom dirs when output is sent to remote provider storage
+    """
+    try:
+        # import provider cleaning function
+        provider_clean_function = f"clean_{args.provider}_local_output_directories"
+        getattr(importlib.import_module(__name__), provider_clean_function)(args)
+    except Exception as error:
+        logger.critical(
+            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        sys.exit(1)
+
+
+def clean_aws_local_output_directories(args):
+    """clean_aws_provider_local_output_directories deletes local custom dirs when output is sent to remote provider storage for aws provider"""
+    if args.output_bucket or args.output_bucket_no_assume:
+        if args.output_directory != default_output_directory:
+            rmtree(args.output_directory)

--- a/prowler/providers/common/clean.py
+++ b/prowler/providers/common/clean.py
@@ -14,6 +14,10 @@ def clean_provider_local_output_directories(args):
         # import provider cleaning function
         provider_clean_function = f"clean_{args.provider}_local_output_directories"
         getattr(importlib.import_module(__name__), provider_clean_function)(args)
+    except AttributeError as attribute_exception:
+        logger.info(
+            f"Cleaning local output directories not initialized for provider {args.provider}: {attribute_exception}"
+        )
     except Exception as error:
         logger.critical(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"

--- a/tests/providers/common/clean_test.py
+++ b/tests/providers/common/clean_test.py
@@ -1,0 +1,86 @@
+import importlib
+import tempfile
+from argparse import Namespace
+from os import path
+
+import pytest
+from mock import patch
+
+from prowler.providers.common.clean import clean_provider_local_output_directories
+
+
+class Test_Common_Clean:
+    def set_provider_input_args(self, provider):
+        set_args_function = f"set_{provider}_input_args"
+        args = getattr(
+            getattr(importlib.import_module(__name__), __class__.__name__),
+            set_args_function,
+        )(self)
+        return args
+
+    def set_aws_input_args(self):
+        args = Namespace()
+        args.provider = "aws"
+        args.output_bucket = "test-bucket"
+        args.output_bucket_no_assume = None
+        return args
+
+    def set_azure_input_args(self):
+        args = Namespace()
+        args.provider = "azure"
+        return args
+
+    def test_clean_provider_local_output_directories_non_initialized(self):
+        provider = "azure"
+        input_args = self.set_provider_input_args(provider)
+
+        with pytest.raises(SystemExit) as exception:
+            _ = clean_provider_local_output_directories(input_args)
+
+        assert isinstance(exception, pytest.ExceptionInfo)
+
+    def test_clean_aws_local_output_directories_non_default_dir_output_bucket(self):
+        provider = "aws"
+        input_args = self.set_provider_input_args(provider)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_args.output_directory = temp_dir
+            clean_provider_local_output_directories(input_args)
+            assert not path.exists(input_args.output_directory)
+
+    def test_clean_aws_local_output_directories_non_default_dir_output_bucket_no_assume(
+        self,
+    ):
+        provider = "aws"
+        input_args = self.set_provider_input_args(provider)
+        input_args.output_bucket = None
+        input_args.output_bucket_no_assume = "test"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_args.output_directory = temp_dir
+            clean_provider_local_output_directories(input_args)
+            assert not path.exists(input_args.output_directory)
+
+    def test_clean_aws_local_output_directories_default_dir_output_bucket(self):
+        provider = "aws"
+        input_args = self.set_provider_input_args(provider)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch(
+                "prowler.providers.common.clean.default_output_directory", new=temp_dir
+            ):
+                input_args.output_directory = temp_dir
+                clean_provider_local_output_directories(input_args)
+                assert path.exists(input_args.output_directory)
+
+    def test_clean_aws_local_output_directories_default_dir_output_bucket_no_assume(
+        self,
+    ):
+        provider = "aws"
+        input_args = self.set_provider_input_args(provider)
+        input_args.output_bucket_no_assume = "test"
+        input_args.ouput_bucket = None
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch(
+                "prowler.providers.common.clean.default_output_directory", new=temp_dir
+            ):
+                input_args.output_directory = temp_dir
+                clean_provider_local_output_directories(input_args)
+                assert path.exists(input_args.output_directory)

--- a/tests/providers/common/clean_test.py
+++ b/tests/providers/common/clean_test.py
@@ -1,9 +1,9 @@
 import importlib
+import logging
 import tempfile
 from argparse import Namespace
 from os import path
 
-import pytest
 from mock import patch
 
 from prowler.providers.common.clean import clean_provider_local_output_directories
@@ -30,14 +30,15 @@ class Test_Common_Clean:
         args.provider = "azure"
         return args
 
-    def test_clean_provider_local_output_directories_non_initialized(self):
+    def test_clean_provider_local_output_directories_non_initialized(self, caplog):
         provider = "azure"
         input_args = self.set_provider_input_args(provider)
-
-        with pytest.raises(SystemExit) as exception:
-            _ = clean_provider_local_output_directories(input_args)
-
-        assert isinstance(exception, pytest.ExceptionInfo)
+        caplog.set_level(logging.INFO)
+        clean_provider_local_output_directories(input_args)
+        assert (
+            f"Cleaning local output directories not initialized for provider {provider}:"
+            in caplog.text
+        )
 
     def test_clean_aws_local_output_directories_non_default_dir_output_bucket(self):
         provider = "aws"


### PR DESCRIPTION
### Context

When sending output to s3 bucket with a custom output directory we were not deleting that local output directory


### Description

When options `output_bucket` or `output_bucket_no_assume` are set with `output_directory` and that directory is not the default one -> delete it


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
