### PR TITLE
fix(codeartifact): solve dependency confusion check

### DIFF
--- a/prowler/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled.py
@@ -15,8 +15,8 @@ class codeartifact_packages_external_public_publishing_disabled(Check):
             for package in repository.packages:
                 report = Check_Report_AWS(self.metadata())
                 report.region = repository.region
-                report.resource_id = f"{repository.arn}/{package.namespace + ':' if package.namespace else ''}{package.name}"
-                report.resource_arn = repository.arn
+                report.resource_id = package.name
+                report.resource_arn = f"{repository.arn}/{package.namespace + ':' if package.namespace else ''}{package.name}"
                 report.resource_tags = repository.tags
 
                 if package.latest_version.origin.origin_type in (

--- a/prowler/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled.py
@@ -15,7 +15,7 @@ class codeartifact_packages_external_public_publishing_disabled(Check):
             for package in repository.packages:
                 report = Check_Report_AWS(self.metadata())
                 report.region = repository.region
-                report.resource_id = package.name
+                report.resource_id = f"{repository.arn}/{package.namespace + ':' if package.namespace else ''}{package.name}"
                 report.resource_arn = repository.arn
                 report.resource_tags = repository.tags
 

--- a/prowler/providers/aws/services/codeartifact/codeartifact_service.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_service.py
@@ -148,8 +148,6 @@ class CodeArtifact(AWSService):
                             )
                     # Save all the packages information
                     self.repositories[repository].packages = packages
-                    if self.repositories[repository].name == "cfn":
-                        print(packages)
 
             except ClientError as error:
                 if error.response["Error"]["Code"] == "ResourceNotFoundException":

--- a/prowler/providers/aws/services/codeartifact/codeartifact_service.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_service.py
@@ -86,7 +86,9 @@ class CodeArtifact(AWSService):
                             if package_namespace:
                                 latest_version_information = (
                                     regional_client.list_package_versions(
-                                        domain=self.repositories[repository].domain_name,
+                                        domain=self.repositories[
+                                            repository
+                                        ].domain_name,
                                         domainOwner=self.repositories[
                                             repository
                                         ].domain_owner,
@@ -100,7 +102,9 @@ class CodeArtifact(AWSService):
                             else:
                                 latest_version_information = (
                                     regional_client.list_package_versions(
-                                        domain=self.repositories[repository].domain_name,
+                                        domain=self.repositories[
+                                            repository
+                                        ].domain_name,
                                         domainOwner=self.repositories[
                                             repository
                                         ].domain_owner,

--- a/prowler/providers/aws/services/codeartifact/codeartifact_service.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_service.py
@@ -63,7 +63,7 @@ class CodeArtifact(AWSService):
                     list_packages_parameters = {
                         "domain": self.repositories[repository].domain_name,
                         "domainOwner": self.repositories[repository].domain_owner,
-                        "repository": repository,
+                        "repository": self.repositories[repository].name,
                     }
                     packages = []
                     for page in list_packages_paginator.paginate(
@@ -83,18 +83,33 @@ class CodeArtifact(AWSService):
                                 ]
                             )
                             # Get Latest Package Version
-                            latest_version_information = (
-                                regional_client.list_package_versions(
-                                    domain=self.repositories[repository].domain_name,
-                                    domainOwner=self.repositories[
-                                        repository
-                                    ].domain_owner,
-                                    repository=repository,
-                                    format=package_format,
-                                    package=package_name,
-                                    sortBy="PUBLISHED_TIME",
+                            if package_namespace:
+                                latest_version_information = (
+                                    regional_client.list_package_versions(
+                                        domain=self.repositories[repository].domain_name,
+                                        domainOwner=self.repositories[
+                                            repository
+                                        ].domain_owner,
+                                        repository=self.repositories[repository].name,
+                                        format=package_format,
+                                        namespace=package_namespace,
+                                        package=package_name,
+                                        sortBy="PUBLISHED_TIME",
+                                    )
                                 )
-                            )
+                            else:
+                                latest_version_information = (
+                                    regional_client.list_package_versions(
+                                        domain=self.repositories[repository].domain_name,
+                                        domainOwner=self.repositories[
+                                            repository
+                                        ].domain_owner,
+                                        repository=self.repositories[repository].name,
+                                        format=package_format,
+                                        package=package_name,
+                                        sortBy="PUBLISHED_TIME",
+                                    )
+                                )
                             latest_version = ""
                             latest_origin_type = "UNKNOWN"
                             latest_status = "Published"
@@ -133,6 +148,8 @@ class CodeArtifact(AWSService):
                             )
                     # Save all the packages information
                     self.repositories[repository].packages = packages
+                    if self.repositories[repository].name == "cfn":
+                        print(packages)
 
             except ClientError as error:
                 if error.response["Error"]["Code"] == "ResourceNotFoundException":

--- a/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_test.py
+++ b/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_test.py
@@ -110,7 +110,10 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
             assert len(result) == 1
             assert result[0].region == AWS_REGION
             assert result[0].resource_id == "test-package"
-            assert result[0].resource_arn == repository_arn
+            assert (
+                result[0].resource_arn
+                == repository_arn + "/" + package_namespace + ":" + package_name
+            )
             assert result[0].resource_tags == []
             assert result[0].status == "FAIL"
             assert (
@@ -167,7 +170,10 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
             assert len(result) == 1
             assert result[0].region == AWS_REGION
             assert result[0].resource_id == "test-package"
-            assert result[0].resource_arn == repository_arn
+            assert (
+                result[0].resource_arn
+                == repository_arn + "/" + package_namespace + ":" + package_name
+            )
             assert result[0].resource_tags == []
             assert result[0].status == "PASS"
             assert (


### PR DESCRIPTION
### Context

While testing some Code Artifact repositories for dependency confusion I realised when this check was ported from bash to python it broke.


### Description

Fix the data gathering step of the check. Before not all the needed data was getting collected causing the check to miss findings.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
