### PR TITLE
fix(s3 race condition): catch error if a bucket does not exist any longer

### DIFF
--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -44,9 +44,9 @@ class S3(AWSService):
             list_buckets = self.client.list_buckets()
             for bucket in list_buckets["Buckets"]:
                 try:
-                    bucket_region = self.client.get_bucket_location(Bucket=bucket["Name"])[
-                        "LocationConstraint"
-                    ]
+                    bucket_region = self.client.get_bucket_location(
+                        Bucket=bucket["Name"]
+                    )["LocationConstraint"]
                     if bucket_region == "EU":  # If EU, bucket_region is eu-west-1
                         bucket_region = "eu-west-1"
                     if not bucket_region:  # If None, bucket_region is us-east-1
@@ -62,12 +62,16 @@ class S3(AWSService):
                             if bucket_region in audit_info.audited_regions:
                                 buckets.append(
                                     Bucket(
-                                        name=bucket["Name"], arn=arn, region=bucket_region
+                                        name=bucket["Name"],
+                                        arn=arn,
+                                        region=bucket_region,
                                     )
                                 )
                         else:
                             buckets.append(
-                                Bucket(name=bucket["Name"], arn=arn, region=bucket_region)
+                                Bucket(
+                                    name=bucket["Name"], arn=arn, region=bucket_region
+                                )
                             )
                 except ClientError as error:
                     if error.response["Error"]["Code"] == "NoSuchBucket":


### PR DESCRIPTION
### Context

In AWS accounts with a huge amount of volatile s3 buckets, it may happen that s3 buckets got already deleted during the inspection of the s3 bucket because the list of all s3 buckets was retrieved earlier when the s3 bucket still existed.
In such a case, prowler catched the error `NoSuchBucket` but did not continue iterating the remaining s3 buckets. Instead, prowler returned an **empty** list of s3 buckets and as such could not find potential security issues for **any** s3 buckets in this AWS account.

By the way, **prowler v2** also has this issue. All checks that iterate of an earlier retrieved list of s3 buckets will throw an error if a s3 bucket got deleted because of the unexpected AWS response format. By throwing such an error, the prowler csv report gets broken and is unusable for further automatic processing. Just for completeness, these are the related prowler v2 checks:

- extra73
- extra7172
- extra718
- extra725
- extra734
- extra763
- extra764
- extra771

### Description

I fixed the `s3_service.py` by adding a `try:catch` statement **within** the loop that is iterating over each bucket. If an error is thrown within the loop, it will be catched without exiting the loop. Therefore, all s3 buckets that are still present can now  be checked for possible security issues.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
