### PR TITLE
fix(aws): check all conditions in IAM policy parser

### DIFF
--- a/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
+++ b/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
@@ -56,11 +56,13 @@ def is_account_only_allowed_in_condition(
                     ):
                         # if there is an arn/account without the source account -> we do not consider it safe
                         # here by default we assume is true and look for false entries
-                        is_condition_valid = True
+                        is_condition_key_restrictive = True
                         for item in condition_statement[condition_operator][value]:
                             if source_account not in item:
-                                is_condition_valid = False
+                                is_condition_key_restrictive = False
                                 break
+                        if is_condition_key_restrictive:
+                            is_condition_valid = True
 
                     # value is a string
                     elif isinstance(

--- a/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
+++ b/prowler/providers/aws/lib/policy_condition_parser/policy_condition_parser.py
@@ -61,6 +61,7 @@ def is_account_only_allowed_in_condition(
                             if source_account not in item:
                                 is_condition_key_restrictive = False
                                 break
+
                         if is_condition_key_restrictive:
                             is_condition_valid = True
 

--- a/tests/providers/aws/lib/policy_condition_parser/policy_condition_parser_test.py
+++ b/tests/providers/aws/lib/policy_condition_parser/policy_condition_parser_test.py
@@ -1282,3 +1282,76 @@ class Test_policy_condition_parser:
         assert not is_account_only_allowed_in_condition(
             condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
         )
+
+    def test_condition_parser_two_lists_unrestrictive(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:ResourceAccount": [
+                    TRUSTED_AWS_ACCOUNT_NUMBER,
+                    NON_TRUSTED_AWS_ACCOUNT_NUMBER, 
+                ]
+            },
+            "ArnLike": {
+                "AWS:SourceArn": [
+                    f"arn:aws:cloudtrail:*:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*",
+                    f"arn:aws:cloudtrail:*:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*",
+                ]
+            },
+        }
+        assert not is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_two_lists_both_restrictive(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:ResourceAccount": [
+                    TRUSTED_AWS_ACCOUNT_NUMBER,
+                ]
+            },
+            "ArnLike": {
+                "AWS:SourceArn": [
+                    f"arn:aws:cloudtrail:*:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*",
+                ]
+            },
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_two_lists_first_restrictive(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:ResourceAccount": [
+                    TRUSTED_AWS_ACCOUNT_NUMBER,
+                ]
+            },
+            "ArnLike": {
+                "AWS:SourceArn": [
+                    f"arn:aws:cloudtrail:*:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*",
+                    f"arn:aws:cloudtrail:*:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*",
+                ]
+            },
+
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )
+
+    def test_condition_parser_two_lists_second_restrictive(self):
+        condition_statement = {
+            "StringLike": {
+                "AWS:ResourceAccount": [
+                    TRUSTED_AWS_ACCOUNT_NUMBER,
+                    NON_TRUSTED_AWS_ACCOUNT_NUMBER, 
+                ]
+            },
+            "ArnLike": {
+                "AWS:SourceArn": [
+                    f"arn:aws:cloudtrail:*:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*",
+                ]
+            },
+        }
+        assert is_account_only_allowed_in_condition(
+            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
+        )

--- a/tests/providers/aws/lib/policy_condition_parser/policy_condition_parser_test.py
+++ b/tests/providers/aws/lib/policy_condition_parser/policy_condition_parser_test.py
@@ -1288,7 +1288,7 @@ class Test_policy_condition_parser:
             "StringLike": {
                 "AWS:ResourceAccount": [
                     TRUSTED_AWS_ACCOUNT_NUMBER,
-                    NON_TRUSTED_AWS_ACCOUNT_NUMBER, 
+                    NON_TRUSTED_AWS_ACCOUNT_NUMBER,
                 ]
             },
             "ArnLike": {
@@ -1332,7 +1332,6 @@ class Test_policy_condition_parser:
                     f"arn:aws:cloudtrail:*:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*",
                 ]
             },
-
         }
         assert is_account_only_allowed_in_condition(
             condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
@@ -1343,7 +1342,7 @@ class Test_policy_condition_parser:
             "StringLike": {
                 "AWS:ResourceAccount": [
                     TRUSTED_AWS_ACCOUNT_NUMBER,
-                    NON_TRUSTED_AWS_ACCOUNT_NUMBER, 
+                    NON_TRUSTED_AWS_ACCOUNT_NUMBER,
                 ]
             },
             "ArnLike": {


### PR DESCRIPTION
### Context

There's a bug in the aws policy_condition_parser that treats compound policy conditions differently depending on order when there are multiple condition keys with list values.  Currently, the last condition key value list evaluated is the only one that can pass the check.

This test will fail:
```
    def test_condition_parser_two_lists_first_restrictive(self):
        condition_statement = {
            "StringLike": {
                "AWS:ResourceAccount": [
                    TRUSTED_AWS_ACCOUNT_NUMBER,
                ]
            },
            "ArnLike": {
                "AWS:SourceArn": [
                    f"arn:aws:cloudtrail:*:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*",
                    f"arn:aws:cloudtrail:*:{NON_TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*",
                ]
            },

        }
        assert is_account_only_allowed_in_condition(
            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
        )
```

And this test will succeed:
```
    def test_condition_parser_two_lists_second_restrictive(self):
        condition_statement = {
            "StringLike": {
                "AWS:ResourceAccount": [
                    TRUSTED_AWS_ACCOUNT_NUMBER,
                    NON_TRUSTED_AWS_ACCOUNT_NUMBER, 
                ]
            },
            "ArnLike": {
                "AWS:SourceArn": [
                    f"arn:aws:cloudtrail:*:{TRUSTED_AWS_ACCOUNT_NUMBER}:trail/*",
                ]
            },
        }
        assert is_account_only_allowed_in_condition(
            condition_statement, TRUSTED_AWS_ACCOUNT_NUMBER
        )
```

Both tests should succeed, as the condition is a boolean AND and any condition that restricts to only the trusted account is always enforced.

### Description

I added four additional tests for compound statements and made a small change to the logic so that each condition key is fully evaluated in a separate scope before changing the global is_condition_valid flag.  All existing tests pass on Python 3.11 as well as the four new ones.

I'm also testing a patch for my environment that adds an additional parser function that tests for broad unrestricted access (eg account wildcards) instead of testing that access is solely limited to the resource account.  In a large environment with hundreds of accounts we need to be able to fail unrestricted/public access to resources like SNS/SQS while still passing least-privilege cross-account IAM in resource policies.  Is that something you'd be interested in for this PR or should I make a separate one?


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
