### PR TITLE
docs(gcp): update GCP permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,11 +178,7 @@ Prowler will follow the same credentials search as [Google authentication librar
 2. [User credentials set up by using the Google Cloud CLI](https://cloud.google.com/docs/authentication/application-default-credentials#personal)
 3. [The attached service account, returned by the metadata server](https://cloud.google.com/docs/authentication/application-default-credentials#attached-sa)
 
-Those credentials must be associated to a user or service account with proper permissions to do all checks. To make sure, add the following roles to the member associated with the credentials:
-
-  - Viewer
-  - Security Reviewer
-  - Stackdriver Account Viewer
+Those credentials must be associated to a user or service account with proper permissions to do all checks. To make sure, add the `Viewer` role to the member associated with the credentials.
 
 > By default, `prowler` will scan all accessible GCP Projects, use flag `--project-ids` to specify the projects to be scanned.
 

--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -97,10 +97,6 @@ Prowler will follow the same credentials search as [Google authentication librar
 2. [User credentials set up by using the Google Cloud CLI](https://cloud.google.com/docs/authentication/application-default-credentials#personal)
 3. [The attached service account, returned by the metadata server](https://cloud.google.com/docs/authentication/application-default-credentials#attached-sa)
 
-Those credentials must be associated to a user or service account with proper permissions to do all checks. To make sure, add the following roles to the member associated with the credentials:
-
-  - Viewer
-  - Security Reviewer
-  - Stackdriver Account Viewer
+Those credentials must be associated to a user or service account with proper permissions to do all checks. To make sure, add the `Viewer` role to the member associated with the credentials.
 
 > By default, `prowler` will scan all accessible GCP Projects, use flag `--project-ids` to specify the projects to be scanned.

--- a/docs/tutorials/gcp/authentication.md
+++ b/docs/tutorials/gcp/authentication.md
@@ -22,8 +22,4 @@ Prowler will follow the same credentials search as [Google authentication librar
 2. [User credentials set up by using the Google Cloud CLI](https://cloud.google.com/docs/authentication/application-default-credentials#personal)
 3. [The attached service account, returned by the metadata server](https://cloud.google.com/docs/authentication/application-default-credentials#attached-sa)
 
-Those credentials must be associated to a user or service account with proper permissions to do all checks. To make sure, add the following roles to the member associated with the credentials:
-
-  - Viewer
-  - Security Reviewer
-  - Stackdriver Account Viewer
+Those credentials must be associated to a user or service account with proper permissions to do all checks. To make sure, add the `Viewer` role to the member associated with the credentials.


### PR DESCRIPTION
### Description

Update GCP permissions since only `Viewer` role is needed for Prowler.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
