### PR TITLE
fix(iam-sqs): Handle exceptions for non-existent resources

### DIFF
--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -371,7 +371,7 @@ class IAM(AWSService):
 
                     role.attached_policies = attached_role_policies
                 except ClientError as error:
-                    if error.response["Error"]["Code"] == "NoSuchEntityException":
+                    if error.response["Error"]["Code"] == "NoSuchEntity":
                         logger.warning(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
@@ -639,7 +639,7 @@ class IAM(AWSService):
                     response = self.client.list_role_tags(RoleName=role.name)["Tags"]
                     role.tags = response
                 except ClientError as error:
-                    if error.response["Error"]["Code"] == "NoSuchEntityException":
+                    if error.response["Error"]["Code"] == "NoSuchEntity":
                         role.tags = []
 
         except Exception as error:
@@ -653,7 +653,7 @@ class IAM(AWSService):
                     response = self.client.list_user_tags(UserName=user.name)["Tags"]
                     user.tags = response
                 except ClientError as error:
-                    if error.response["Error"]["Code"] == "NoSuchEntityException":
+                    if error.response["Error"]["Code"] == "NoSuchEntity":
                         user.tags = []
 
         except Exception as error:
@@ -669,7 +669,7 @@ class IAM(AWSService):
                     ]
                     policy.tags = response
                 except ClientError as error:
-                    if error.response["Error"]["Code"] == "NoSuchEntityException":
+                    if error.response["Error"]["Code"] == "NoSuchEntity":
                         policy.tags = []
 
         except Exception as error:
@@ -697,7 +697,7 @@ class IAM(AWSService):
                     ]
 
                 except ClientError as error:
-                    logger.error(
+                    logger.warning(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
@@ -717,7 +717,7 @@ class IAM(AWSService):
                             "AccessKeyMetadata"
                         ]
                 except ClientError as error:
-                    logger.error(
+                    logger.warning(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -139,7 +139,10 @@ class IAM(AWSService):
                 logger.warning(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
-
+            else:
+                logger.error(
+                    f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
         except Exception as error:
             logger.error(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -208,14 +211,24 @@ class IAM(AWSService):
                 reuse_prevention=reuse_prevention,
                 hard_expiry=hard_expiry,
             )
-        except Exception as error:
-            if "NoSuchEntity" in str(error):
+
+        except ClientError as error:
+            if error.response["Error"]["Code"] == "NoSuchEntity":
                 # Password policy does not exist
                 stored_password_policy = None
+                logger.warning(
+                    f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
             else:
                 logger.error(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
+
+        except Exception as error:
+            logger.error(
+                f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
         finally:
             return stored_password_policy
 
@@ -268,17 +281,22 @@ class IAM(AWSService):
         logger.info("IAM - List Attached Group Policies...")
         try:
             for group in self.groups:
-                list_attached_group_policies_paginator = self.client.get_paginator(
-                    "list_attached_group_policies"
-                )
-                attached_group_policies = []
-                for page in list_attached_group_policies_paginator.paginate(
-                    GroupName=group.name
-                ):
-                    for attached_group_policy in page["AttachedPolicies"]:
-                        attached_group_policies.append(attached_group_policy)
+                try:
+                    list_attached_group_policies_paginator = self.client.get_paginator(
+                        "list_attached_group_policies"
+                    )
+                    attached_group_policies = []
+                    for page in list_attached_group_policies_paginator.paginate(
+                        GroupName=group.name
+                    ):
+                        for attached_group_policy in page["AttachedPolicies"]:
+                            attached_group_policies.append(attached_group_policy)
 
-                group.attached_policies = attached_group_policies
+                    group.attached_policies = attached_group_policies
+                except Exception as error:
+                    logger.error(
+                        f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
         except Exception as error:
             logger.error(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -337,18 +355,33 @@ class IAM(AWSService):
         logger.info("IAM - List Attached User Policies...")
         try:
             for user in self.users:
-                attached_user_policies = []
-                get_user_attached_policies_paginator = self.client.get_paginator(
-                    "list_attached_user_policies"
-                )
-                for page in get_user_attached_policies_paginator.paginate(
-                    UserName=user.name
-                ):
-                    for policy in page["AttachedPolicies"]:
-                        attached_user_policies.append(policy)
+                try:
+                    attached_user_policies = []
+                    get_user_attached_policies_paginator = self.client.get_paginator(
+                        "list_attached_user_policies"
+                    )
+                    for page in get_user_attached_policies_paginator.paginate(
+                        UserName=user.name
+                    ):
+                        for policy in page["AttachedPolicies"]:
+                            attached_user_policies.append(policy)
 
-                user.attached_policies = attached_user_policies
+                    user.attached_policies = attached_user_policies
 
+                except ClientError as error:
+                    if error.response["Error"]["Code"] == "NoSuchEntity":
+                        logger.warning(
+                            f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
+                    else:
+                        logger.error(
+                            f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
+
+                except Exception as error:
+                    logger.error(
+                        f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
         except Exception as error:
             logger.error(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -375,6 +408,15 @@ class IAM(AWSService):
                         logger.warning(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
+                    else:
+                        logger.error(
+                            f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
+
+                except Exception as error:
+                    logger.error(
+                        f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
 
         except Exception as error:
             logger.error(
@@ -641,6 +683,10 @@ class IAM(AWSService):
                 except ClientError as error:
                     if error.response["Error"]["Code"] == "NoSuchEntity":
                         role.tags = []
+                    else:
+                        logger.error(
+                            f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
 
         except Exception as error:
             logger.error(
@@ -655,6 +701,10 @@ class IAM(AWSService):
                 except ClientError as error:
                     if error.response["Error"]["Code"] == "NoSuchEntity":
                         user.tags = []
+                    else:
+                        logger.error(
+                            f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
 
         except Exception as error:
             logger.error(
@@ -671,6 +721,10 @@ class IAM(AWSService):
                 except ClientError as error:
                     if error.response["Error"]["Code"] == "NoSuchEntity":
                         policy.tags = []
+                    else:
+                        logger.error(
+                            f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
 
         except Exception as error:
             logger.error(

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -687,6 +687,10 @@ class IAM(AWSService):
                         logger.error(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
+                except Exception as error:
+                    logger.error(
+                        f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
 
         except Exception as error:
             logger.error(
@@ -725,6 +729,10 @@ class IAM(AWSService):
                         logger.error(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
+                except Exception as error:
+                    logger.error(
+                        f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
 
         except Exception as error:
             logger.error(

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -697,9 +697,19 @@ class IAM(AWSService):
                     ]
 
                 except ClientError as error:
-                    logger.warning(
+                    if error.response["Error"]["Code"] == "NoSuchEntity":
+                        logger.warning(
+                            f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
+                    else:
+                        logger.error(
+                            f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
+                except Exception as error:
+                    logger.error(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
+
         except Exception as error:
             logger.error(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -717,7 +727,16 @@ class IAM(AWSService):
                             "AccessKeyMetadata"
                         ]
                 except ClientError as error:
-                    logger.warning(
+                    if error.response["Error"]["Code"] == "NoSuchEntity":
+                        logger.warning(
+                            f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
+                    else:
+                        logger.error(
+                            f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
+                except Exception as error:
+                    logger.error(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:

--- a/prowler/providers/aws/services/sqs/sqs_service.py
+++ b/prowler/providers/aws/services/sqs/sqs_service.py
@@ -74,6 +74,14 @@ class SQS(AWSService):
                         logger.warning(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
+                    else:
+                        logger.error(
+                            f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
+                except Exception as error:
+                    logger.error(
+                        f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
         except Exception as error:
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -97,6 +105,14 @@ class SQS(AWSService):
                         logger.warning(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
+                    else:
+                        logger.error(
+                            f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
+                except Exception as error:
+                    logger.error(
+                        f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
 
         except Exception as error:
             logger.error(

--- a/prowler/providers/aws/services/sqs/sqs_service.py
+++ b/prowler/providers/aws/services/sqs/sqs_service.py
@@ -16,7 +16,7 @@ class SQS(AWSService):
         super().__init__(__class__.__name__, audit_info)
         self.queues = []
         self.__threading_call__(self.__list_queues__)
-        self.__get_queue_attributes__(self.regional_clients)
+        self.__get_queue_attributes__()
         self.__list_queue_tags__()
 
     def __list_queues__(self, regional_client):
@@ -42,28 +42,38 @@ class SQS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_queue_attributes__(self, regional_clients):
+    def __get_queue_attributes__(self):
         try:
             logger.info("SQS - describing queue attributes...")
             for queue in self.queues:
-                regional_client = regional_clients[queue.region]
-                queue_attributes = regional_client.get_queue_attributes(
-                    QueueUrl=queue.id, AttributeNames=["All"]
-                )
-                if "Attributes" in queue_attributes:
-                    if "Policy" in queue_attributes["Attributes"]:
-                        queue.policy = loads(queue_attributes["Attributes"]["Policy"])
-                    if "KmsMasterKeyId" in queue_attributes["Attributes"]:
-                        queue.kms_key_id = queue_attributes["Attributes"][
-                            "KmsMasterKeyId"
-                        ]
-                    if "SqsManagedSseEnabled" in queue_attributes["Attributes"]:
-                        if (
-                            queue_attributes["Attributes"]["SqsManagedSseEnabled"]
-                            == "true"
-                        ):
-                            queue.kms_key_id = "SqsManagedSseEnabled"
-
+                try:
+                    regional_client = self.regional_clients[queue.region]
+                    queue_attributes = regional_client.get_queue_attributes(
+                        QueueUrl=queue.id, AttributeNames=["All"]
+                    )
+                    if "Attributes" in queue_attributes:
+                        if "Policy" in queue_attributes["Attributes"]:
+                            queue.policy = loads(
+                                queue_attributes["Attributes"]["Policy"]
+                            )
+                        if "KmsMasterKeyId" in queue_attributes["Attributes"]:
+                            queue.kms_key_id = queue_attributes["Attributes"][
+                                "KmsMasterKeyId"
+                            ]
+                        if "SqsManagedSseEnabled" in queue_attributes["Attributes"]:
+                            if (
+                                queue_attributes["Attributes"]["SqsManagedSseEnabled"]
+                                == "true"
+                            ):
+                                queue.kms_key_id = "SqsManagedSseEnabled"
+                except ClientError as error:
+                    if (
+                        error.response["Error"]["Code"]
+                        == "AWS.SimpleQueueService.NonExistentQueue"
+                    ):
+                        logger.warning(
+                            f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
         except Exception as error:
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"


### PR DESCRIPTION
### Description

- SQS: Handle `AWS.SimpleQueueService.NonExistentQueue` errors
- IAM: Handle `NoSuchEntity` and warnings. I've changed `NoSuchEntityException` to `NoSuchEntity` since the `error.response["Error"]["Code"]` contains just the `NoSuchEntity`.

The IAM change can be tested with this code:
```python
from boto3 import client
from botocore.client import ClientError

iam_client = client("iam", "eu-west-1")
arn = "arn:aws:iam::123456789012:policy/test-policy"

try:
    iam_client.list_policy_tags(PolicyArn=arn)
except ClientError as error:
    print(error.response["Error"]["Code"])
```


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
