### PR TITLE
fix(iam): do not list tags for inline policies

### DIFF
--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -718,10 +718,11 @@ class IAM(AWSService):
         try:
             for policy in self.policies:
                 try:
-                    response = self.client.list_policy_tags(PolicyArn=policy.arn)[
-                        "Tags"
-                    ]
-                    policy.tags = response
+                    if policy.type != "Inline":
+                        response = self.client.list_policy_tags(PolicyArn=policy.arn)[
+                            "Tags"
+                        ]
+                        policy.tags = response
                 except ClientError as error:
                     if error.response["Error"]["Code"] == "NoSuchEntity":
                         policy.tags = []


### PR DESCRIPTION
### Description

Do not list tags for inline policies in IAM Service.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
