### PR TITLE
fix(SQS): fix invalid SQS ARNs

### DIFF
--- a/prowler/providers/aws/services/sqs/sqs_service.py
+++ b/prowler/providers/aws/services/sqs/sqs_service.py
@@ -23,7 +23,11 @@ class SQS(AWSService):
         logger.info("SQS - describing queues...")
         try:
             list_queues_paginator = regional_client.get_paginator("list_queues")
-            for page in list_queues_paginator.paginate():
+            # The SQS API uses nonstandard pagination
+            # you must specify a PageSize if there are more than 1000 queues
+            for page in list_queues_paginator.paginate(
+                PaginationConfig={"PageSize": 1000}
+            ):
                 if "QueueUrls" in page:
                     for queue in page["QueueUrls"]:
                         # the queue name is the last path segment of the url

--- a/prowler/providers/aws/services/sqs/sqs_service.py
+++ b/prowler/providers/aws/services/sqs/sqs_service.py
@@ -26,13 +26,16 @@ class SQS(AWSService):
             for page in list_queues_paginator.paginate():
                 if "QueueUrls" in page:
                     for queue in page["QueueUrls"]:
-                        arn = f"arn:{self.audited_partition}:sqs:{regional_client.region}:{self.audited_account}:{queue}"
+                        # the queue name is the last path segment of the url
+                        queue_name = queue.split("/")[-1]
+                        arn = f"arn:{self.audited_partition}:sqs:{regional_client.region}:{self.audited_account}:{queue_name}"
                         if not self.audit_resources or (
                             is_resource_filtered(arn, self.audit_resources)
                         ):
                             self.queues.append(
                                 Queue(
                                     arn=arn,
+                                    name=queue_name,
                                     id=queue,
                                     region=regional_client.region,
                                 )
@@ -122,6 +125,7 @@ class SQS(AWSService):
 
 class Queue(BaseModel):
     id: str
+    name: str
     arn: str
     region: str
     policy: dict = None

--- a/tests/providers/aws/services/sqs/sqs_queues_server_side_encryption_enabled/sqs_queues_server_side_encryption_enabled_test.py
+++ b/tests/providers/aws/services/sqs/sqs_queues_server_side_encryption_enabled/sqs_queues_server_side_encryption_enabled_test.py
@@ -8,8 +8,11 @@ AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 
 test_kms_key_id = str(uuid4())
-queue_id = str(uuid4())
-topic_arn = f"arn:aws:sqs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:{queue_id}"
+test_queue_name = str(uuid4())
+test_queue_url = (
+    f"https://sqs.{AWS_REGION}.amazonaws.com/{AWS_ACCOUNT_NUMBER}/{test_queue_name}"
+)
+test_queue_arn = f"arn:aws:sqs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:{test_queue_name}"
 
 
 class Test_sqs_queues_server_side_encryption_enabled:
@@ -33,10 +36,11 @@ class Test_sqs_queues_server_side_encryption_enabled:
         sqs_client.queues = []
         sqs_client.queues.append(
             Queue(
-                id=queue_id,
+                id=test_queue_url,
+                name=test_queue_name,
                 region=AWS_REGION,
                 kms_key_id=test_kms_key_id,
-                arn="arn_test",
+                arn=test_queue_arn,
             )
         )
         with mock.patch(
@@ -52,17 +56,18 @@ class Test_sqs_queues_server_side_encryption_enabled:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert search("is using Server Side Encryption", result[0].status_extended)
-            assert result[0].resource_id == queue_id
-            assert result[0].resource_arn == "arn_test"
+            assert result[0].resource_id == test_queue_url
+            assert result[0].resource_arn == test_queue_arn
 
     def test_queues_no_encryption(self):
         sqs_client = mock.MagicMock
         sqs_client.queues = []
         sqs_client.queues.append(
             Queue(
-                id=queue_id,
+                id=test_queue_url,
+                name=test_queue_name,
                 region=AWS_REGION,
-                arn="arn_test",
+                arn=test_queue_arn,
             )
         )
         with mock.patch(
@@ -80,5 +85,5 @@ class Test_sqs_queues_server_side_encryption_enabled:
             assert search(
                 "is not using Server Side Encryption", result[0].status_extended
             )
-            assert result[0].resource_id == queue_id
-            assert result[0].resource_arn == "arn_test"
+            assert result[0].resource_id == test_queue_url
+            assert result[0].resource_arn == test_queue_arn

--- a/tests/providers/aws/services/sqs/sqs_service_test.py
+++ b/tests/providers/aws/services/sqs/sqs_service_test.py
@@ -110,6 +110,10 @@ class Test_SQS_Service:
         sqs = SQS(audit_info)
         assert len(sqs.queues) == 1
         assert sqs.queues[0].id == queue["QueueUrl"]
+        assert sqs.queues[0].name == test_queue
+        assert sqs.queues[0].name == sqs.queues[0].arn.split(":")[-1]
+        assert sqs.queues[0].name == sqs.queues[0].id.split("/")[-1]
+        assert sqs.queues[0].arn == test_queue_arn
         assert sqs.queues[0].region == AWS_REGION
         assert sqs.queues[0].tags == [{"test": "test"}]
 

--- a/tests/providers/aws/services/sqs/sqs_service_test.py
+++ b/tests/providers/aws/services/sqs/sqs_service_test.py
@@ -117,6 +117,18 @@ class Test_SQS_Service:
         assert sqs.queues[0].region == AWS_REGION
         assert sqs.queues[0].tags == [{"test": "test"}]
 
+    # moto does not properly mock this and is hardcoded to return 1000 queues
+    # so this test currently always fails
+    # @mock_sqs
+    # # Test SQS list queues for over 1000 queues
+    # def test__list_queues__pagination_over_a_thousand(self):
+    #     sqs_client = client("sqs", region_name=AWS_REGION)
+    #     for i in range(0,1050):
+    #         sqs_client.create_queue(QueueName=f"{test_queue}-{i}", tags={"test": "test"})
+    #     audit_info = self.set_mocked_audit_info()
+    #     sqs = SQS(audit_info)
+    #     assert len(sqs.queues) > 1000
+
     @mock_sqs
     # Test SQS list queues
     def test__get_queue_attributes__(self):


### PR DESCRIPTION
### Context

Prowler is currently generating invalid ARNs for SQS queues.  Instead of parsing the queue name from the queue URL to be the resource id of the ARN, it is using the entire queue URL.  So for instance a queue named `test-queue` should have an ARN like `arn:aws:sqs:eu-west-1:123456789012:test-queue` but prowler is instead generating the invalid ARN `arn:aws:sqs:eu-west-1:123456789012:https://sqs.eu-west-1.amazonaws.com/123456789012/test-queue` and this is what is being reported to Security Hub.


### Description

The sqs_service has been fixed to parse the last path segment of the queue as the queue name, and use that instead of the queue URL when generating the ARN.  The tests for the sqs_service and existing checks have been strengthened to more accurately simulate AWS API responses and to check that the SQS ARNs generated by Prowler are correct.  All tests are passing.

I left the queue id as the full URL, as the URL is guaranteed to be unique and the queue name can collide between regions and accounts.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
