### PR TITLE
chore(release): update Prowler Version to 3.11.1

### DIFF
--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -11,7 +11,7 @@ from prowler.lib.logger import logger
 
 timestamp = datetime.today()
 timestamp_utc = datetime.now(timezone.utc).replace(tzinfo=timezone.utc)
-prowler_version = "3.11.0"
+prowler_version = "3.11.1"
 html_logo_url = "https://github.com/prowler-cloud/prowler/"
 html_logo_img = "https://user-images.githubusercontent.com/3985464/113734260-7ba06900-96fb-11eb-82bc-d4f68a1e2710.png"
 square_logo_img = "https://user-images.githubusercontent.com/38561120/235905862-9ece5bd7-9aa3-4e48-807a-3a9035eb8bfb.png"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
   {include = "prowler"}
 ]
 readme = "README.md"
-version = "3.11.0"
+version = "3.11.1"
 
 [tool.poetry.dependencies]
 alive-progress = "3.1.4"


### PR DESCRIPTION
### Description

This PR updates Prowler Version to 3.11.1.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.