### PR TITLE
fix(GuardDuty): only execute checks if GuardDuty enabled

### DIFF
--- a/prowler/providers/aws/services/guardduty/guardduty_centrally_managed/guardduty_centrally_managed.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_centrally_managed/guardduty_centrally_managed.py
@@ -6,7 +6,7 @@ class guardduty_centrally_managed(Check):
     def execute(self):
         findings = []
         for detector in guardduty_client.detectors:
-            if detector.id:
+            if detector.id and detector.enabled_in_account:
                 report = Check_Report_AWS(self.metadata())
                 report.region = detector.region
                 report.resource_id = detector.id

--- a/prowler/providers/aws/services/guardduty/guardduty_no_high_severity_findings/guardduty_no_high_severity_findings.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_no_high_severity_findings/guardduty_no_high_severity_findings.py
@@ -6,7 +6,7 @@ class guardduty_no_high_severity_findings(Check):
     def execute(self):
         findings = []
         for detector in guardduty_client.detectors:
-            if detector.id:
+            if detector.id and detector.enabled_in_account:
                 report = Check_Report_AWS(self.metadata())
                 report.region = detector.region
                 report.resource_id = detector.id

--- a/tests/providers/aws/services/guardduty/guardduty_centrally_managed/guardduty_centrally_managed_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_centrally_managed/guardduty_centrally_managed_test.py
@@ -62,6 +62,31 @@ class Test_guardduty_centrally_managed:
             assert result[0].region == AWS_REGION
             assert result[0].resource_arn == DETECTOR_ARN
 
+    def test_not_enabled_account_detector(self):
+        guardduty_client = mock.MagicMock
+        guardduty_client.detectors = []
+        guardduty_client.detectors.append(
+            Detector(
+                id=AWS_ACCOUNT_NUMBER,
+                region=AWS_REGION,
+                arn=DETECTOR_ARN,
+                enabled_in_account=False,
+            )
+        )
+
+        with mock.patch(
+            "prowler.providers.aws.services.guardduty.guardduty_service.GuardDuty",
+            guardduty_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.guardduty.guardduty_centrally_managed.guardduty_centrally_managed import (
+                guardduty_centrally_managed,
+            )
+
+            check = guardduty_centrally_managed()
+            result = check.execute()
+            assert len(result) == 0
+
     def test_detector_centralized_managed(self):
         guardduty_client = mock.MagicMock
         guardduty_client.detectors = []

--- a/tests/providers/aws/services/guardduty/guardduty_no_high_severity_findings/guardduty_no_high_severity_findings_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_no_high_severity_findings/guardduty_no_high_severity_findings_test.py
@@ -58,6 +58,29 @@ class Test_guardduty_no_high_severity_findings:
             assert result[0].resource_arn == DETECTOR_ARN
             assert result[0].region == AWS_REGION
 
+    def test_not_enabled_account_detector(self):
+        guardduty_client = mock.MagicMock
+        guardduty_client.detectors = []
+        guardduty_client.detectors.append(
+            Detector(
+                id=AWS_ACCOUNT_NUMBER,
+                arn=DETECTOR_ARN,
+                region=AWS_REGION,
+                enabled_in_account=False,
+            )
+        )
+        with mock.patch(
+            "prowler.providers.aws.services.guardduty.guardduty_service.GuardDuty",
+            guardduty_client,
+        ):
+            from prowler.providers.aws.services.guardduty.guardduty_no_high_severity_findings.guardduty_no_high_severity_findings import (
+                guardduty_no_high_severity_findings,
+            )
+
+            check = guardduty_no_high_severity_findings()
+            result = check.execute()
+            assert len(result) == 0
+
     def test_high_findings(self):
         guardduty_client = mock.MagicMock
         guardduty_client.detectors = []


### PR DESCRIPTION
### Description

Only execute checks `guardduty_centrally_managed` and `guardduty_no_high_severity_findings` if GuardDuty is enabled.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
