### PR TITLE
chore: modify latest version msg

### DIFF
--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -70,7 +70,9 @@ def check_current_version():
         if latest_version != prowler_version:
             return f"{prowler_version_string} (latest is {latest_version}, upgrade for the latest features)"
         else:
-            return f"{prowler_version_string} (it is the latest version, yay!)"
+            return (
+                f"{prowler_version_string} (You are running the latest version, yay!)"
+            )
     except requests.RequestException:
         return f"{prowler_version_string}"
     except Exception:

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -63,7 +63,7 @@ class Test_Config:
     def test_check_current_version_with_latest(self):
         assert (
             check_current_version()
-            == f"Prowler {MOCK_PROWLER_VERSION} (it is the latest version, yay!)"
+            == f"Prowler {MOCK_PROWLER_VERSION} (You are running the latest version, yay!)"
         )
 
     @mock.patch(


### PR DESCRIPTION
### Context

This PR updates the latest version message to enhance user engagement and clarity.  
The change from `it is the latest version` to `You are running the latest version` adds a personal touch, making the message feel more user-centric.  
This small adjustment aims to create a more positive and user-friendly experience, reinforcing the idea that the user is in control and up-to-date.


### Description

Safe to merge *PR*: just modified the message for the latest version.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.