### PR TITLE
fix(set_azure_audit_info): assign correct logging when no auth

### DIFF
--- a/prowler/providers/azure/lib/exception/exception.py
+++ b/prowler/providers/azure/lib/exception/exception.py
@@ -1,0 +1,11 @@
+class AzureException(Exception):
+    """
+    Exception raised when dealing with Azure Provider/Azure audit info instance
+
+    Attributes:
+        message -- message to be displayed
+    """
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)

--- a/prowler/providers/common/audit_info.py
+++ b/prowler/providers/common/audit_info.py
@@ -30,6 +30,7 @@ from prowler.providers.azure.lib.audit_info.models import (
     Azure_Audit_Info,
     Azure_Region_Config,
 )
+from prowler.providers.azure.lib.exception.exception import AzureException
 from prowler.providers.gcp.gcp_provider import GCP_Provider
 from prowler.providers.gcp.lib.audit_info.audit_info import gcp_audit_info
 from prowler.providers.gcp.lib.audit_info.models import GCP_Audit_Info
@@ -295,15 +296,13 @@ Azure Identity Type: {Fore.YELLOW}[{audit_info.identity.identity_type}]{Style.RE
             and not browser_auth
             and not managed_entity_auth
         ):
-            logger.critical(
+            raise AzureException(
                 "Azure provider requires at least one authentication method set: [--az-cli-auth | --sp-env-auth | --browser-auth | --managed-identity-auth]"
             )
-            sys.exit(1)
         if (not browser_auth and tenant_id) or (browser_auth and not tenant_id):
-            logger.critical(
+            raise AzureException(
                 "Azure Tenant ID (--tenant-id) is required only for browser authentication mode"
             )
-            sys.exit(1)
 
         azure_provider = Azure_Provider(
             az_cli_auth,

--- a/prowler/providers/common/audit_info.py
+++ b/prowler/providers/common/audit_info.py
@@ -295,13 +295,15 @@ Azure Identity Type: {Fore.YELLOW}[{audit_info.identity.identity_type}]{Style.RE
             and not browser_auth
             and not managed_entity_auth
         ):
-            raise Exception(
+            logger.critical(
                 "Azure provider requires at least one authentication method set: [--az-cli-auth | --sp-env-auth | --browser-auth | --managed-identity-auth]"
             )
+            sys.exit(1)
         if (not browser_auth and tenant_id) or (browser_auth and not tenant_id):
-            raise Exception(
+            logger.critical(
                 "Azure Tenant ID (--tenant-id) is required only for browser authentication mode"
             )
+            sys.exit(1)
 
         azure_provider = Azure_Provider(
             az_cli_auth,


### PR DESCRIPTION
### Context

In azure audit info, when we are not getting required env variables we are exiting using
```
raise Exception
```
Instead of 
```
logger.critical()
sys.exit(1)
```
That must be unified


### Description

Replace `raise Exception` for the common logging critical path in `prowler/providers/common/audit_info.py`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
