### PR TITLE
fix(clean local output dirs): change function description

### DIFF
--- a/prowler/providers/common/clean.py
+++ b/prowler/providers/common/clean.py
@@ -26,7 +26,7 @@ def clean_provider_local_output_directories(args):
 
 
 def clean_aws_local_output_directories(args):
-    """clean_aws_local_output_directories deletes the output files generated locally in custom directories when output is sent to a remote storage provider for the AWS"""
+    """clean_aws_local_output_directories deletes the output files generated locally in custom directories when output is sent to a remote storage provider for AWS"""
     if args.output_bucket or args.output_bucket_no_assume:
         if args.output_directory != default_output_directory:
             rmtree(args.output_directory)

--- a/prowler/providers/common/clean.py
+++ b/prowler/providers/common/clean.py
@@ -26,7 +26,7 @@ def clean_provider_local_output_directories(args):
 
 
 def clean_aws_local_output_directories(args):
-    """clean_aws_provider_local_output_directories deletes the output files generated locally in custom directories when output is sent to remote provider storage for aws provider"""
+    """clean_aws_local_output_directories deletes the output files generated locally in custom directories when output is sent to a remote storage provider for the AWS"""
     if args.output_bucket or args.output_bucket_no_assume:
         if args.output_directory != default_output_directory:
             rmtree(args.output_directory)

--- a/prowler/providers/common/clean.py
+++ b/prowler/providers/common/clean.py
@@ -8,7 +8,7 @@ from prowler.lib.logger import logger
 
 def clean_provider_local_output_directories(args):
     """
-    clean_provider_local_output_directories cleans deletes local custom dirs when output is sent to remote provider storage
+    clean_provider_local_output_directories deletes the output files generated locally in custom directories when the output is sent to a remote storage provider
     """
     try:
         # import provider cleaning function
@@ -26,7 +26,7 @@ def clean_provider_local_output_directories(args):
 
 
 def clean_aws_local_output_directories(args):
-    """clean_aws_provider_local_output_directories deletes local custom dirs when output is sent to remote provider storage for aws provider"""
+    """clean_aws_provider_local_output_directories deletes the output files generated locally in custom directories when output is sent to remote provider storage for aws provider"""
     if args.output_bucket or args.output_bucket_no_assume:
         if args.output_directory != default_output_directory:
             rmtree(args.output_directory)


### PR DESCRIPTION
### Context

Both `clean_provider_local_output_directories` and `clean_aws_local_output_directories` did not have a good description


### Description

Provide more details in both functions description


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
