### PR TITLE
fix(trustedadvisor): handle missing dict key

### DIFF
--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
@@ -34,9 +34,9 @@ class TrustedAdvisor(AWSService):
     def __describe_trusted_advisor_checks__(self):
         logger.info("TrustedAdvisor - Describing Checks...")
         try:
-            for check in self.client.describe_trusted_advisor_checks(language="en")[
-                "checks"
-            ]:
+            for check in self.client.describe_trusted_advisor_checks(language="en").get(
+                "checks", []
+            ):
                 self.checks.append(
                     Check(
                         id=check["id"],


### PR DESCRIPTION
### Context

In `trustedadvisor` service we were not handling if there were no checks


### Description

Include a `.get()` method when looking for `checks`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
