### PR TITLE
fix(vpc_different_regions): Handle if there are no VPC

### DIFF
--- a/prowler/providers/aws/services/vpc/vpc_different_regions/vpc_different_regions.py
+++ b/prowler/providers/aws/services/vpc/vpc_different_regions/vpc_different_regions.py
@@ -5,25 +5,23 @@ from prowler.providers.aws.services.vpc.vpc_client import vpc_client
 class vpc_different_regions(Check):
     def execute(self):
         findings = []
-        vpc_regions = set()
-        for vpc in vpc_client.vpcs.values():
-            if not vpc.default:
-                vpc_regions.add(vpc.region)
+        if len(vpc_client.vpcs) > 0:
+            vpc_regions = set()
+            for vpc in vpc_client.vpcs.values():
+                if not vpc.default:
+                    vpc_regions.add(vpc.region)
 
-        report = Check_Report_AWS(self.metadata())
-        # This is a global check under the vpc service: region, resource_id and tags are not relevant here but we keep them for consistency
-        report.region = vpc_client.region
-        report.resource_id = vpc_client.audited_account
-        report.resource_arn = vpc_client.audited_account_arn
-        if len(vpc_regions) == 0:
-            report.status = "INFO"
-            report.status_extended = "No VPCs found."
-        elif len(vpc_regions) == 1:
-            report.status = "FAIL"
-            report.status_extended = "VPCs found only in one region."
-        else:
-            report.status = "PASS"
-            report.status_extended = "VPCs found in more than one region."
-        findings.append(report)
+            report = Check_Report_AWS(self.metadata())
+            report.region = vpc_client.region
+            report.resource_id = vpc_client.audited_account
+            report.resource_arn = vpc_client.audited_account_arn
+
+            if len(vpc_regions) == 1:
+                report.status = "FAIL"
+                report.status_extended = "VPCs found only in one region."
+            else:
+                report.status = "PASS"
+                report.status_extended = "VPCs found in more than one region."
+            findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/vpc/vpc_different_regions/vpc_different_regions.py
+++ b/prowler/providers/aws/services/vpc/vpc_different_regions/vpc_different_regions.py
@@ -16,10 +16,10 @@ class vpc_different_regions(Check):
             report.resource_id = vpc_client.audited_account
             report.resource_arn = vpc_client.audited_account_arn
 
-            if len(vpc_regions) == 1:
-                report.status = "FAIL"
-                report.status_extended = "VPCs found only in one region."
-            else:
+            report.status = "FAIL"
+            report.status_extended = "VPCs found only in one region."
+
+            if len(vpc_regions) > 1:
                 report.status = "PASS"
                 report.status_extended = "VPCs found in more than one region."
             findings.append(report)

--- a/prowler/providers/aws/services/vpc/vpc_different_regions/vpc_different_regions.py
+++ b/prowler/providers/aws/services/vpc/vpc_different_regions/vpc_different_regions.py
@@ -15,12 +15,15 @@ class vpc_different_regions(Check):
         report.region = vpc_client.region
         report.resource_id = vpc_client.audited_account
         report.resource_arn = vpc_client.audited_account_arn
-        report.status = "FAIL"
-        report.status_extended = "VPCs found only in one region."
-        if len(vpc_regions) > 1:
+        if len(vpc_regions) == 0:
+            report.status = "INFO"
+            report.status_extended = "No VPCs found."
+        elif len(vpc_regions) == 1:
+            report.status = "FAIL"
+            report.status_extended = "VPCs found only in one region."
+        else:
             report.status = "PASS"
             report.status_extended = "VPCs found in more than one region."
-
         findings.append(report)
 
         return findings

--- a/tests/providers/aws/services/vpc/vpc_different_regions/vpc_different_regions_test.py
+++ b/tests/providers/aws/services/vpc/vpc_different_regions/vpc_different_regions_test.py
@@ -1,51 +1,51 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_vpc_different_regions:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region="us-east-1",
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
+    @mock_ec2
+    def test_no_vpcs(self):
+        from prowler.providers.aws.services.vpc.vpc_service import VPC
+
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
         )
 
-        return audit_info
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=current_audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.vpc.vpc_different_regions.vpc_different_regions.vpc_client",
+                new=VPC(current_audit_info),
+            ) as vpc_client:
+                # Remove all VPCs
+                vpc_client.vpcs.clear()
+
+                # Test Check
+                from prowler.providers.aws.services.vpc.vpc_different_regions.vpc_different_regions import (
+                    vpc_different_regions,
+                )
+
+                check = vpc_different_regions()
+                result = check.execute()
+
+                assert len(result) == 0
 
     @mock_ec2
     def test_vpc_different_regions(self):
         # VPC Region 1
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         # VPC Region 2
         ec2_client_eu = client("ec2", region_name="eu-west-1")
@@ -53,7 +53,9 @@ class Test_vpc_different_regions:
 
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -78,17 +80,20 @@ class Test_vpc_different_regions:
                     result[0].status_extended == "VPCs found in more than one region."
                 )
                 assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+                assert result[0].resource_arn == AWS_ACCOUNT_ARN
                 assert result[0].resource_tags == []
 
     @mock_ec2
-    def test_vpc_only_one_regions(self):
-        ec2_client = client("ec2", region_name=AWS_REGION)
+    def test_vpc_only_one_region(self):
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         # VPC Region 1
         ec2_client.create_vpc(CidrBlock="172.28.6.0/24", InstanceTenancy="default")
 
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -108,7 +113,8 @@ class Test_vpc_different_regions:
 
                 assert len(result) == 1
                 assert result[0].status == "FAIL"
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].status_extended == "VPCs found only in one region."
                 assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+                assert result[0].resource_arn == AWS_ACCOUNT_ARN
                 assert result[0].resource_tags == []


### PR DESCRIPTION
### Context

Fixes #3080

Issue was laid out in Bug #3080 where having no VPCs resulted in a failure of the `vpc_different_regions.py` check.


### Description

I adjusted the logic a little to return no findings for Zero VPCs, `FAIL` for 1 VPC, and `PASS` for other counts.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
