### PR TITLE
chore(clean output dirs): clean local output dirs with flag

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -325,7 +325,8 @@ def prowler():
         remove_custom_checks_module(checks_folder, provider)
 
     # clean local directories
-    clean_provider_local_output_directories(args)
+    if args.clean_local_output_directories:
+        clean_provider_local_output_directories(args)
 
     # If there are failed findings exit code 3, except if -z is input
     if not args.ignore_exit_code_3 and stats["total_fail"] > 0:

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -166,6 +166,12 @@ Detailed documentation at https://docs.prowler.cloud
             default=False,
             help="Set the output timestamp format as unix timestamps instead of iso format timestamps (default mode).",
         )
+        common_outputs_parser.add_argument(
+            "--clean-local-output-directories",
+            action="store_true",
+            default=False,
+            help="Deletes local output directories when output reports are sent to external entities (i.e. S3 bucket)",
+        )
 
     def __init_logging_parser__(self):
         # Logging Options

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -78,6 +78,7 @@ class Test_Parser:
         assert not parsed.allowlist_file
         assert not parsed.resource_tags
         assert not parsed.ignore_unused_services
+        assert not parsed.clean_local_output_directories
 
     def test_default_parser_no_arguments_azure(self):
         provider = "azure"
@@ -297,6 +298,11 @@ class Test_Parser:
         command = [prowler_command, "--unix-timestamp"]
         parsed = self.parser.parse(command)
         assert parsed.unix_timestamp
+
+    def test_root_parser_clean_local_output_directories(self):
+        command = [prowler_command, "--clean-local-output-directories"]
+        parsed = self.parser.parse(command)
+        assert parsed.clean_local_output_directories
 
     def test_logging_parser_only_logs_set(self):
         command = [prowler_command, "--only-logs"]


### PR DESCRIPTION
### Context

Cleaning output local directories when sending outputs to external entities could not be always useful, since it deletes original files


### Description

Only delete that information when including `--clean-local-output-directories`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
