### PR TITLE
refactor(severities): Define it in one place

### DIFF
--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -22,6 +22,9 @@ gcp_logo = "https://user-images.githubusercontent.com/38561120/235928332-eb4accd
 orange_color = "\033[38;5;208m"
 banner_color = "\033[1;92m"
 
+# Severities
+valid_severities = ["critical", "high", "medium", "low", "informational"]
+
 # Compliance
 actual_directory = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
 

--- a/prowler/lib/check/checks_loader.py
+++ b/prowler/lib/check/checks_loader.py
@@ -1,5 +1,6 @@
 from colorama import Fore, Style
 
+from prowler.config.config import valid_severities
 from prowler.lib.check.check import (
     parse_checks_from_compliance_framework,
     parse_checks_from_file,
@@ -10,7 +11,6 @@ from prowler.lib.logger import logger
 
 
 # Generate the list of checks to execute
-# PENDING Test for this function
 def load_checks_to_execute(
     bulk_checks_metadata: dict,
     bulk_compliance_frameworks: dict,
@@ -27,13 +27,7 @@ def load_checks_to_execute(
         # Local subsets
         checks_to_execute = set()
         check_aliases = {}
-        check_severities = {
-            "critical": [],
-            "high": [],
-            "medium": [],
-            "low": [],
-            "informational": [],
-        }
+        check_severities = {key: [] for key in valid_severities}
         check_categories = {}
 
         # First, loop over the bulk_checks_metadata to extract the needed subsets

--- a/prowler/lib/check/custom_checks_metadata.py
+++ b/prowler/lib/check/custom_checks_metadata.py
@@ -3,9 +3,9 @@ import sys
 import yaml
 from jsonschema import validate
 
+from prowler.config.config import valid_severities
 from prowler.lib.logger import logger
 
-valid_severities = ["critical", "high", "medium", "low", "informational"]
 custom_checks_metadata_schema = {
     "type": "object",
     "properties": {

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -7,6 +7,7 @@ from prowler.config.config import (
     check_current_version,
     default_config_file_path,
     default_output_directory,
+    valid_severities,
 )
 from prowler.providers.common.arguments import (
     init_providers_parser,
@@ -224,8 +225,8 @@ Detailed documentation at https://docs.prowler.cloud
         common_checks_parser.add_argument(
             "--severity",
             nargs="+",
-            help="List of severities to be executed [informational, low, medium, high, critical]",
-            choices=["informational", "low", "medium", "high", "critical"],
+            help=f"List of severities to be executed {valid_severities}",
+            choices=valid_severities,
         )
         group.add_argument(
             "--compliance",


### PR DESCRIPTION
### Context

We had several definitions of a list of severities instead of one global to be used across the codebase.

Origin -> https://github.com/prowler-cloud/prowler/pull/3066#discussion_r1410716365


### Description

Create a `valid_severities` in the `config.py` and use it.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
