### PR TITLE
fix(send_to_s3_bucket): don't kill exec when fail

### DIFF
--- a/prowler/providers/aws/lib/s3/s3.py
+++ b/prowler/providers/aws/lib/s3/s3.py
@@ -1,5 +1,3 @@
-import sys
-
 from prowler.config.config import (
     csv_file_suffix,
     html_file_suffix,
@@ -41,10 +39,9 @@ def send_to_s3_bucket(
         s3_client.upload_file(file_name, output_bucket_name, object_name)
 
     except Exception as error:
-        logger.critical(
+        logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
         )
-        sys.exit(1)
 
 
 def get_s3_object_path(output_directory: str) -> str:


### PR DESCRIPTION
### Context

When something was going wrong sending outputs to an s3 bucket Prowler was exiting the execution.
Since there are some actions that have are taken after calling `send_to_s3_bucket` we do not want to exit the exec


### Description

- Change `CRITICAL` log to `ERROR` in `send_to_s3_bucket`

- Remove the `sys.exit(1)`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
