### PR TITLE
test(audit_info): refactor apigateway

### DIFF
--- a/tests/providers/aws/services/apigateway/apigateway_authorizers_enabled/apigateway_authorizers_enabled_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_authorizers_enabled/apigateway_authorizers_enabled_test.py
@@ -1,55 +1,26 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_apigateway, mock_iam, mock_lambda
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_apigateway_restapi_authorizers_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_apigateway
     def test_apigateway_no_rest_apis(self):
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -73,8 +44,8 @@ class Test_apigateway_restapi_authorizers_enabled:
     @mock_lambda
     def test_apigateway_one_rest_api_with_lambda_authorizer(self):
         # Create APIGateway Mocked Resources
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
-        lambda_client = client("lambda", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
+        lambda_client = client("lambda", region_name=AWS_REGION_US_EAST_1)
         iam_client = client("iam")
         # Create APIGateway Rest API
         role_arn = iam_client.create_role(
@@ -103,7 +74,9 @@ class Test_apigateway_restapi_authorizers_enabled:
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -129,15 +102,15 @@ class Test_apigateway_restapi_authorizers_enabled:
             assert result[0].resource_id == "test-rest-api"
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION}::/restapis/{rest_api['id']}"
+                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION_US_EAST_1}::/restapis/{rest_api['id']}"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [{}]
 
     @mock_apigateway
     def test_apigateway_one_rest_api_without_lambda_authorizer(self):
         # Create APIGateway Mocked Resources
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Rest API
         rest_api = apigateway_client.create_rest_api(
             name="test-rest-api",
@@ -146,7 +119,9 @@ class Test_apigateway_restapi_authorizers_enabled:
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -172,7 +147,7 @@ class Test_apigateway_restapi_authorizers_enabled:
             assert result[0].resource_id == "test-rest-api"
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION}::/restapis/{rest_api['id']}"
+                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION_US_EAST_1}::/restapis/{rest_api['id']}"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [{}]

--- a/tests/providers/aws/services/apigateway/apigateway_client_certificate_enabled/apigateway_client_certificate_enabled_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_client_certificate_enabled/apigateway_client_certificate_enabled_test.py
@@ -1,52 +1,21 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_apigateway
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.apigateway.apigateway_service import Stage
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_apigateway_restapi_client_certificate_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_apigateway
     def test_apigateway_no_stages(self):
         # Create APIGateway Mocked Resources
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Rest API
         apigateway_client.create_rest_api(
             name="test-rest-api",
@@ -55,7 +24,9 @@ class Test_apigateway_restapi_client_certificate_enabled:
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -77,7 +48,7 @@ class Test_apigateway_restapi_client_certificate_enabled:
     @mock_apigateway
     def test_apigateway_one_stage_without_certificate(self):
         # Create APIGateway Mocked Resources
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Deployment Stage
         rest_api = apigateway_client.create_rest_api(
             name="test-rest-api",
@@ -113,7 +84,9 @@ class Test_apigateway_restapi_client_certificate_enabled:
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -139,15 +112,15 @@ class Test_apigateway_restapi_client_certificate_enabled:
             assert result[0].resource_id == "test-rest-api"
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION}::/restapis/{rest_api['id']}/stages/test"
+                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION_US_EAST_1}::/restapis/{rest_api['id']}/stages/test"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [None]
 
     @mock_apigateway
     def test_apigateway_one_stage_with_certificate(self):
         # Create APIGateway Mocked Resources
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Deployment Stage
         rest_api = apigateway_client.create_rest_api(
             name="test-rest-api",
@@ -156,7 +129,9 @@ class Test_apigateway_restapi_client_certificate_enabled:
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -173,7 +148,7 @@ class Test_apigateway_restapi_client_certificate_enabled:
             service_client.rest_apis[0].stages.append(
                 Stage(
                     name="test",
-                    arn=f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION}::/restapis/test-rest-api/stages/test",
+                    arn=f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION_US_EAST_1}::/restapis/test-rest-api/stages/test",
                     logging=True,
                     client_certificate=True,
                     waf=True,
@@ -192,7 +167,7 @@ class Test_apigateway_restapi_client_certificate_enabled:
             assert result[0].resource_id == "test-rest-api"
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION}::/restapis/test-rest-api/stages/test"
+                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION_US_EAST_1}::/restapis/test-rest-api/stages/test"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []

--- a/tests/providers/aws/services/apigateway/apigateway_endpoint_public/apigateway_endpoint_public_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_endpoint_public/apigateway_endpoint_public_test.py
@@ -1,54 +1,25 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_apigateway
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_apigateway_restapi_public:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_apigateway
     def test_apigateway_no_rest_apis(self):
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -70,7 +41,7 @@ class Test_apigateway_restapi_public:
     @mock_apigateway
     def test_apigateway_one_private_rest_api(self):
         # Create APIGateway Mocked Resources
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Deployment Stage
         rest_api = apigateway_client.create_rest_api(
             name="test-rest-api",
@@ -84,7 +55,9 @@ class Test_apigateway_restapi_public:
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -110,15 +83,15 @@ class Test_apigateway_restapi_public:
             assert result[0].resource_id == "test-rest-api"
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION}::/restapis/{rest_api['id']}"
+                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION_US_EAST_1}::/restapis/{rest_api['id']}"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [{}]
 
     @mock_apigateway
     def test_apigateway_one_public_rest_api(self):
         # Create APIGateway Mocked Resources
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Deployment Stage
         rest_api = apigateway_client.create_rest_api(
             name="test-rest-api",
@@ -132,7 +105,9 @@ class Test_apigateway_restapi_public:
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -158,7 +133,7 @@ class Test_apigateway_restapi_public:
             assert result[0].resource_id == "test-rest-api"
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION}::/restapis/{rest_api['id']}"
+                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION_US_EAST_1}::/restapis/{rest_api['id']}"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [{}]

--- a/tests/providers/aws/services/apigateway/apigateway_endpoint_public_without_authorizer/apigateway_endpoint_public_without_authorizer_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_endpoint_public_without_authorizer/apigateway_endpoint_public_without_authorizer_test.py
@@ -1,56 +1,27 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_apigateway
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 API_GW_NAME = "test-rest-api"
 
 
 class Test_apigateway_restapi_public_with_authorizer:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_apigateway
     def test_apigateway_no_rest_apis(self):
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -72,7 +43,7 @@ class Test_apigateway_restapi_public_with_authorizer:
     @mock_apigateway
     def test_apigateway_one_public_rest_api_without_authorizer(self):
         # Create APIGateway Mocked Resources
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Deployment Stage
         rest_api = apigateway_client.create_rest_api(
             name=API_GW_NAME,
@@ -86,7 +57,9 @@ class Test_apigateway_restapi_public_with_authorizer:
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -112,15 +85,15 @@ class Test_apigateway_restapi_public_with_authorizer:
             assert result[0].resource_id == API_GW_NAME
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION}::/restapis/{rest_api['id']}"
+                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION_US_EAST_1}::/restapis/{rest_api['id']}"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [{}]
 
     @mock_apigateway
     def test_apigateway_one_public_rest_api_with_authorizer(self):
         # Create APIGateway Mocked Resources
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Deployment Stage
         rest_api = apigateway_client.create_rest_api(
             name="test-rest-api",
@@ -137,7 +110,9 @@ class Test_apigateway_restapi_public_with_authorizer:
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -163,7 +138,7 @@ class Test_apigateway_restapi_public_with_authorizer:
             assert result[0].resource_id == API_GW_NAME
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION}::/restapis/{rest_api['id']}"
+                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION_US_EAST_1}::/restapis/{rest_api['id']}"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [{}]

--- a/tests/providers/aws/services/apigateway/apigateway_logging_enabled/apigateway_logging_enabled_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_logging_enabled/apigateway_logging_enabled_test.py
@@ -1,54 +1,25 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_apigateway
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_apigateway_restapi_logging_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_apigateway
     def test_apigateway_no_rest_apis(self):
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -70,7 +41,7 @@ class Test_apigateway_restapi_logging_enabled:
     @mock_apigateway
     def test_apigateway_one_rest_api_with_logging(self):
         # Create APIGateway Mocked Resources
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         rest_api = apigateway_client.create_rest_api(
             name="test-rest-api",
         )
@@ -116,7 +87,9 @@ class Test_apigateway_restapi_logging_enabled:
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -142,15 +115,15 @@ class Test_apigateway_restapi_logging_enabled:
             assert result[0].resource_id == "test-rest-api"
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION}::/restapis/{rest_api['id']}/stages/test"
+                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION_US_EAST_1}::/restapis/{rest_api['id']}/stages/test"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [None]
 
     @mock_apigateway
     def test_apigateway_one_rest_api_without_logging(self):
         # Create APIGateway Mocked Resources
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Rest API
         rest_api = apigateway_client.create_rest_api(
             name="test-rest-api",
@@ -187,7 +160,9 @@ class Test_apigateway_restapi_logging_enabled:
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -213,7 +188,7 @@ class Test_apigateway_restapi_logging_enabled:
             assert result[0].resource_id == "test-rest-api"
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION}::/restapis/{rest_api['id']}/stages/test"
+                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION_US_EAST_1}::/restapis/{rest_api['id']}/stages/test"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [None]

--- a/tests/providers/aws/services/apigateway/apigateway_service_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_service_test.py
@@ -1,51 +1,20 @@
-from boto3 import client, session
+from boto3 import client
 from moto import mock_apigateway
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.apigateway.apigateway_service import APIGateway
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_APIGateway_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test APIGateway Service
     @mock_apigateway
     def test_service(self):
         # APIGateway client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         apigateway = APIGateway(audit_info)
         assert apigateway.service == "apigateway"
 
@@ -53,7 +22,7 @@ class Test_APIGateway_Service:
     @mock_apigateway
     def test_client(self):
         # APIGateway client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         apigateway = APIGateway(audit_info)
         for regional_client in apigateway.regional_clients.values():
             assert regional_client.__class__.__name__ == "APIGateway"
@@ -62,7 +31,7 @@ class Test_APIGateway_Service:
     @mock_apigateway
     def test__get_session__(self):
         # APIGateway client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         apigateway = APIGateway(audit_info)
         assert apigateway.session.__class__.__name__ == "Session"
 
@@ -70,7 +39,7 @@ class Test_APIGateway_Service:
     @mock_apigateway
     def test_audited_account(self):
         # APIGateway client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         apigateway = APIGateway(audit_info)
         assert apigateway.audited_account == AWS_ACCOUNT_NUMBER
 
@@ -78,13 +47,13 @@ class Test_APIGateway_Service:
     @mock_apigateway
     def test__get_rest_apis__(self):
         # Generate APIGateway Client
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Rest API
         apigateway_client.create_rest_api(
             name="test-rest-api",
         )
         # APIGateway client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         apigateway = APIGateway(audit_info)
         assert len(apigateway.rest_apis) == len(
             apigateway_client.get_rest_apis()["items"]
@@ -94,7 +63,7 @@ class Test_APIGateway_Service:
     @mock_apigateway
     def test__get_authorizers__(self):
         # Generate APIGateway Client
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Rest API
         rest_api = apigateway_client.create_rest_api(
             name="test-rest-api",
@@ -106,7 +75,7 @@ class Test_APIGateway_Service:
             type="TOKEN",
         )
         # APIGateway client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         apigateway = APIGateway(audit_info)
         assert apigateway.rest_apis[0].authorizer is True
 
@@ -114,7 +83,7 @@ class Test_APIGateway_Service:
     @mock_apigateway
     def test__get_rest_api__(self):
         # Generate APIGateway Client
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create private APIGateway Rest API
         apigateway_client.create_rest_api(
             name="test-rest-api",
@@ -122,7 +91,7 @@ class Test_APIGateway_Service:
             tags={"test": "test"},
         )
         # APIGateway client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         apigateway = APIGateway(audit_info)
         assert apigateway.rest_apis[0].public_endpoint is False
         assert apigateway.rest_apis[0].tags == [{"test": "test"}]
@@ -131,7 +100,7 @@ class Test_APIGateway_Service:
     @mock_apigateway
     def test__get_stages__(self):
         # Generate APIGateway Client
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Rest API and a deployment stage
         rest_api = apigateway_client.create_rest_api(
             name="test-rest-api",
@@ -174,6 +143,6 @@ class Test_APIGateway_Service:
                 },
             ],
         )
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         apigateway = APIGateway(audit_info)
         assert apigateway.rest_apis[0].stages[0].logging is True

--- a/tests/providers/aws/services/apigateway/apigateway_waf_acl_attached/apigateway_waf_acl_attached_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_waf_acl_attached/apigateway_waf_acl_attached_test.py
@@ -1,54 +1,25 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_apigateway, mock_wafv2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_apigateway_restapi_waf_acl_attached:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_apigateway
     def test_apigateway_no_rest_apis(self):
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -71,8 +42,8 @@ class Test_apigateway_restapi_waf_acl_attached:
     @mock_wafv2
     def test_apigateway_one_rest_api_with_waf(self):
         # Create APIGateway Mocked Resources
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
-        waf_client = client("wafv2", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
+        waf_client = client("wafv2", region_name=AWS_REGION_US_EAST_1)
         rest_api = apigateway_client.create_rest_api(
             name="test-rest-api",
         )
@@ -122,7 +93,9 @@ class Test_apigateway_restapi_waf_acl_attached:
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -148,15 +121,15 @@ class Test_apigateway_restapi_waf_acl_attached:
             assert result[0].resource_id == "test-rest-api"
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION}::/restapis/{rest_api['id']}/stages/test"
+                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION_US_EAST_1}::/restapis/{rest_api['id']}/stages/test"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [None]
 
     @mock_apigateway
     def test_apigateway_one_rest_api_without_waf(self):
         # Create APIGateway Mocked Resources
-        apigateway_client = client("apigateway", region_name=AWS_REGION)
+        apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Rest API
         rest_api = apigateway_client.create_rest_api(
             name="test-rest-api",
@@ -193,7 +166,9 @@ class Test_apigateway_restapi_waf_acl_attached:
             APIGateway,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -219,7 +194,7 @@ class Test_apigateway_restapi_waf_acl_attached:
             assert result[0].resource_id == "test-rest-api"
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION}::/restapis/{rest_api['id']}/stages/test"
+                == f"arn:{current_audit_info.audited_partition}:apigateway:{AWS_REGION_US_EAST_1}::/restapis/{rest_api['id']}/stages/test"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [None]


### PR DESCRIPTION
### Description

Refactor API Gateway to use the `set_mocked_aws_audit_info` helper.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
