### PR TITLE
test(audit_info): refactor apigatewayv2

### DIFF
--- a/tests/providers/aws/services/apigatewayv2/apigatewayv2_access_logging_enabled/apigatewayv2_access_logging_enabled_test.py
+++ b/tests/providers/aws/services/apigatewayv2/apigatewayv2_access_logging_enabled/apigatewayv2_access_logging_enabled_test.py
@@ -1,15 +1,14 @@
 from unittest import mock
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from mock import patch
 from moto import mock_apigatewayv2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 # Mocking ApiGatewayV2 Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -40,44 +39,15 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_apigatewayv2_api_access_logging_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_apigatewayv2
     def test_apigateway_no_apis(self):
         from prowler.providers.aws.services.apigatewayv2.apigatewayv2_service import (
             ApiGatewayV2,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -99,7 +69,7 @@ class Test_apigatewayv2_api_access_logging_enabled:
     @mock_apigatewayv2
     def test_apigateway_one_api_with_logging_in_stage(self):
         # Create ApiGatewayV2 Mocked Resources
-        apigatewayv2_client = client("apigatewayv2", region_name=AWS_REGION)
+        apigatewayv2_client = client("apigatewayv2", region_name=AWS_REGION_US_EAST_1)
         # Create ApiGatewayV2 API
         api = apigatewayv2_client.create_api(Name="test-api", ProtocolType="HTTP")
         # Get stages mock with stage with logging
@@ -107,7 +77,9 @@ class Test_apigatewayv2_api_access_logging_enabled:
             ApiGatewayV2,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -124,8 +96,8 @@ class Test_apigatewayv2_api_access_logging_enabled:
             check = apigatewayv2_api_access_logging_enabled()
             result = check.execute()
 
-            assert result[0].status == "PASS"
             assert len(result) == 1
+            assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
                 == f"API Gateway V2 test-api ID {api['ApiId']} in stage test-stage has access logging enabled."
@@ -134,7 +106,7 @@ class Test_apigatewayv2_api_access_logging_enabled:
             assert result[0].resource_id == "test-api"
             assert (
                 result[0].resource_arn
-                == f"arn:aws:apigateway:{AWS_REGION}::apis/{api['ApiId']}"
+                == f"arn:aws:apigateway:{AWS_REGION_US_EAST_1}::apis/{api['ApiId']}"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [{}]

--- a/tests/providers/aws/services/apigatewayv2/apigatewayv2_authorizers_enabled/apigatewayv2_authorizers_enabled_test.py
+++ b/tests/providers/aws/services/apigatewayv2/apigatewayv2_authorizers_enabled/apigatewayv2_authorizers_enabled_test.py
@@ -1,15 +1,14 @@
 from unittest import mock
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from mock import patch
 from moto import mock_apigatewayv2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 # Mocking ApiGatewayV2 Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -40,44 +39,15 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_apigatewayv2_api_authorizers_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_apigatewayv2
     def test_apigateway_no_apis(self):
         from prowler.providers.aws.services.apigatewayv2.apigatewayv2_service import (
             ApiGatewayV2,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -99,7 +69,7 @@ class Test_apigatewayv2_api_authorizers_enabled:
     @mock_apigatewayv2
     def test_apigateway_one_api_with_authorizer(self):
         # Create ApiGatewayV2 Mocked Resources
-        apigatewayv2_client = client("apigatewayv2", region_name=AWS_REGION)
+        apigatewayv2_client = client("apigatewayv2", region_name=AWS_REGION_US_EAST_1)
         # Create ApiGatewayV2 API
         api = apigatewayv2_client.create_api(Name="test-api", ProtocolType="HTTP")
         apigatewayv2_client.create_authorizer(
@@ -113,7 +83,9 @@ class Test_apigatewayv2_api_authorizers_enabled:
             ApiGatewayV2,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -130,8 +102,8 @@ class Test_apigatewayv2_api_authorizers_enabled:
             check = apigatewayv2_api_authorizers_enabled()
             result = check.execute()
 
-            assert result[0].status == "PASS"
             assert len(result) == 1
+            assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
                 == f"API Gateway V2 test-api ID {api['ApiId']} has an authorizer configured."
@@ -139,7 +111,7 @@ class Test_apigatewayv2_api_authorizers_enabled:
             assert result[0].resource_id == "test-api"
             assert (
                 result[0].resource_arn
-                == f"arn:aws:apigateway:{AWS_REGION}::apis/{api['ApiId']}"
+                == f"arn:aws:apigateway:{AWS_REGION_US_EAST_1}::apis/{api['ApiId']}"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [{}]

--- a/tests/providers/aws/services/apigatewayv2/apigatewayv2_service_test.py
+++ b/tests/providers/aws/services/apigatewayv2/apigatewayv2_service_test.py
@@ -1,16 +1,16 @@
 import botocore
-from boto3 import client, session
+from boto3 import client
 from mock import patch
 from moto import mock_apigatewayv2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.apigatewayv2.apigatewayv2_service import (
     ApiGatewayV2,
 )
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 # Mocking ApiGatewayV2 Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -41,42 +41,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_ApiGatewayV2_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test ApiGatewayV2 Service
     @mock_apigatewayv2
     def test_service(self):
         # ApiGatewayV2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         apigatewayv2 = ApiGatewayV2(audit_info)
         assert apigatewayv2.service == "apigatewayv2"
 
@@ -84,7 +53,7 @@ class Test_ApiGatewayV2_Service:
     @mock_apigatewayv2
     def test_client(self):
         # ApiGatewayV2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         apigatewayv2 = ApiGatewayV2(audit_info)
         for regional_client in apigatewayv2.regional_clients.values():
             assert regional_client.__class__.__name__ == "ApiGatewayV2"
@@ -93,7 +62,7 @@ class Test_ApiGatewayV2_Service:
     @mock_apigatewayv2
     def test__get_session__(self):
         # ApiGatewayV2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         apigatewayv2 = ApiGatewayV2(audit_info)
         assert apigatewayv2.session.__class__.__name__ == "Session"
 
@@ -101,7 +70,7 @@ class Test_ApiGatewayV2_Service:
     @mock_apigatewayv2
     def test_audited_account(self):
         # ApiGatewayV2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         apigatewayv2 = ApiGatewayV2(audit_info)
         assert apigatewayv2.audited_account == AWS_ACCOUNT_NUMBER
 
@@ -109,13 +78,13 @@ class Test_ApiGatewayV2_Service:
     @mock_apigatewayv2
     def test__get_apis__(self):
         # Generate ApiGatewayV2 Client
-        apigatewayv2_client = client("apigatewayv2", region_name=AWS_REGION)
+        apigatewayv2_client = client("apigatewayv2", region_name=AWS_REGION_US_EAST_1)
         # Create ApiGatewayV2 API
         apigatewayv2_client.create_api(
             Name="test-api", ProtocolType="HTTP", Tags={"test": "test"}
         )
         # ApiGatewayV2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         apigatewayv2 = ApiGatewayV2(audit_info)
         assert len(apigatewayv2.apis) == len(apigatewayv2_client.get_apis()["Items"])
         assert apigatewayv2.apis[0].tags == [{"test": "test"}]
@@ -124,7 +93,7 @@ class Test_ApiGatewayV2_Service:
     @mock_apigatewayv2
     def test__get_authorizers__(self):
         # Generate ApiGatewayV2 Client
-        apigatewayv2_client = client("apigatewayv2", region_name=AWS_REGION)
+        apigatewayv2_client = client("apigatewayv2", region_name=AWS_REGION_US_EAST_1)
         # Create ApiGatewayV2 Rest API
         api = apigatewayv2_client.create_api(Name="test-api", ProtocolType="HTTP")
         # Create authorizer
@@ -136,7 +105,7 @@ class Test_ApiGatewayV2_Service:
             AuthorizerPayloadFormatVersion="2.0",
         )
         # ApiGatewayV2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         apigatewayv2 = ApiGatewayV2(audit_info)
         assert apigatewayv2.apis[0].authorizer is True
 
@@ -144,10 +113,10 @@ class Test_ApiGatewayV2_Service:
     @mock_apigatewayv2
     def test__get_stages__(self):
         # Generate ApiGatewayV2 Client
-        apigatewayv2_client = client("apigatewayv2", region_name=AWS_REGION)
+        apigatewayv2_client = client("apigatewayv2", region_name=AWS_REGION_US_EAST_1)
         # Create ApiGatewayV2 Rest API and a deployment stage
         apigatewayv2_client.create_api(Name="test-api", ProtocolType="HTTP")
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         apigatewayv2 = ApiGatewayV2(audit_info)
         assert apigatewayv2.apis[0].stages[0].logging is True


### PR DESCRIPTION
### Description

Refactor API Gateway v2 to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
