### PR TITLE
test(audit_info): refactor appstream

### DIFF
--- a/tests/providers/aws/services/appstream/appstream_service_test.py
+++ b/tests/providers/aws/services/appstream/appstream_service_test.py
@@ -1,12 +1,13 @@
 from unittest.mock import patch
 
 import botocore
-from boto3 import session
 from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.appstream.appstream_service import AppStream
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
@@ -64,55 +65,24 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_AppStream_Service:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     # Test AppStream Client
     def test__get_client__(self):
-        appstream = AppStream(self.set_mocked_audit_info())
+        appstream = AppStream(set_mocked_aws_audit_info([AWS_REGION_US_EAST_1]))
         assert appstream.regional_clients[AWS_REGION].__class__.__name__ == "AppStream"
 
     # Test AppStream Session
     def test__get_session__(self):
-        appstream = AppStream(self.set_mocked_audit_info())
+        appstream = AppStream(set_mocked_aws_audit_info([AWS_REGION_US_EAST_1]))
         assert appstream.session.__class__.__name__ == "Session"
 
     # Test AppStream Session
     def test__get_service__(self):
-        appstream = AppStream(self.set_mocked_audit_info())
+        appstream = AppStream(set_mocked_aws_audit_info([AWS_REGION_US_EAST_1]))
         assert appstream.service == "appstream"
 
     def test__describe_fleets__(self):
         # Set partition for the service
-        appstream = AppStream(self.set_mocked_audit_info())
+        appstream = AppStream(set_mocked_aws_audit_info([AWS_REGION_US_EAST_1]))
         assert len(appstream.fleets) == 2
 
         assert (
@@ -139,7 +109,7 @@ class Test_AppStream_Service:
 
     def test__list_tags_for_resource__(self):
         # Set partition for the service
-        appstream = AppStream(self.set_mocked_audit_info())
+        appstream = AppStream(set_mocked_aws_audit_info([AWS_REGION_US_EAST_1]))
         assert len(appstream.fleets) == 2
 
         assert appstream.fleets[0].tags == [{"test": "test"}]


### PR DESCRIPTION
### Description

Refactor AppStream to use the `set_mocked_aws_audit_info` helper.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
