### PR TITLE
test(audit_info): refactor cloudformation

### DIFF
--- a/tests/providers/aws/services/cloudformation/cloudformation_service_test.py
+++ b/tests/providers/aws/services/cloudformation/cloudformation_service_test.py
@@ -4,19 +4,17 @@ from unittest.mock import patch
 
 import boto3
 import botocore
-from boto3 import session
 from dateutil.tz import tzutc
 from moto import mock_cloudformation
 from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.cloudformation.cloudformation_service import (
     CloudFormation,
 )
-from prowler.providers.common.models import Audit_Metadata
-
-# Mock Test Region
-AWS_REGION = "eu-west-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
 # Dummy CloudFormation Template
 dummy_template = {
@@ -122,9 +120,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 # Mock generate_regional_clients()
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_EU_WEST_1
+    )
+    regional_client.region = AWS_REGION_EU_WEST_1
+    return {AWS_REGION_EU_WEST_1: regional_client}
 
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
@@ -134,64 +134,41 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_CloudFormation_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=None,
-            audited_account_arn=None,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test CloudFormation Client
     @mock_cloudformation
     def test__get_client__(self):
-        cloudformation = CloudFormation(self.set_mocked_audit_info())
+        cloudformation = CloudFormation(
+            set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        )
         assert (
-            cloudformation.regional_clients[AWS_REGION].__class__.__name__
+            cloudformation.regional_clients[AWS_REGION_EU_WEST_1].__class__.__name__
             == "CloudFormation"
         )
 
     # Test CloudFormation Service
     @mock_cloudformation
     def test__get_service__(self):
-        cloudformation = CloudFormation(self.set_mocked_audit_info())
+        cloudformation = CloudFormation(
+            set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        )
         assert (
-            cloudformation.regional_clients[AWS_REGION].__class__.__name__
+            cloudformation.regional_clients[AWS_REGION_EU_WEST_1].__class__.__name__
             == "CloudFormation"
         )
 
     # Test CloudFormation Session
     @mock_cloudformation
     def test__get_session__(self):
-        cloudformation = CloudFormation(self.set_mocked_audit_info())
+        cloudformation = CloudFormation(
+            set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        )
         assert cloudformation.session.__class__.__name__ == "Session"
 
     @mock_cloudformation
     def test__describe_stacks__(self):
-        cloudformation_client = boto3.client("cloudformation", region_name=AWS_REGION)
+        cloudformation_client = boto3.client(
+            "cloudformation", region_name=AWS_REGION_EU_WEST_1
+        )
         stack_arn = cloudformation_client.create_stack(
             StackName="Test-Stack",
             TemplateBody=json.dumps(dummy_template),
@@ -210,7 +187,9 @@ class Test_CloudFormation_Service:
             ],
         )
 
-        cloudformation = CloudFormation(self.set_mocked_audit_info())
+        cloudformation = CloudFormation(
+            set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        )
         assert len(cloudformation.stacks) == 1
         assert cloudformation.stacks[0].arn == stack_arn["StackId"]
         assert cloudformation.stacks[0].name == "Test-Stack"
@@ -218,7 +197,7 @@ class Test_CloudFormation_Service:
         assert cloudformation.stacks[0].enable_termination_protection is True
         assert cloudformation.stacks[0].is_nested_stack is False
         assert cloudformation.stacks[0].root_nested_stack == ""
-        assert cloudformation.stacks[0].region == AWS_REGION
+        assert cloudformation.stacks[0].region == AWS_REGION_EU_WEST_1
         assert cloudformation.stacks[0].tags == [
             {"Key": "Tag1", "Value": "Value1"},
             {"Key": "Tag2", "Value": "Value2"},


### PR DESCRIPTION
### Description

Refactor CloudFormation to use the `set_mocked_aws_audit_info` helper.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
