### PR TITLE
test(audit_info): refactor cloudfront

### DIFF
--- a/tests/providers/aws/services/cloudfront/cloudfront_service_test.py
+++ b/tests/providers/aws/services/cloudfront/cloudfront_service_test.py
@@ -1,20 +1,18 @@
 from unittest.mock import patch
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudfront
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.cloudfront.cloudfront_service import (
     CloudFront,
     GeoRestrictionType,
     ViewerProtocolPolicy,
 )
-from prowler.providers.common.models import Audit_Metadata
-
-# Mock Test Region
-AWS_REGION = "eu-west-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 def example_distribution_config(ref):
@@ -149,65 +147,30 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-# PENDING PR TO GET THE PARAMETERS USING MOTO
-
-
 # Patch every AWS call using Boto3
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_CloudFront_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=DEFAULT_ACCOUNT_ID,
-            audited_account_arn=f"arn:aws:iam::{DEFAULT_ACCOUNT_ID}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test CloudFront Client
     @mock_cloudfront
     def test__get_client__(self):
-        cloudfront = CloudFront(self.set_mocked_audit_info())
+        cloudfront = CloudFront(set_mocked_aws_audit_info())
         assert cloudfront.client.__class__.__name__ == "CloudFront"
 
     # Test CloudFront Session
     @mock_cloudfront
     def test__get_session__(self):
-        cloudfront = CloudFront(self.set_mocked_audit_info())
+        cloudfront = CloudFront(set_mocked_aws_audit_info())
         assert cloudfront.session.__class__.__name__ == "Session"
 
     # Test CloudFront Service
     @mock_cloudfront
     def test__get_service__(self):
-        cloudfront = CloudFront(self.set_mocked_audit_info())
+        cloudfront = CloudFront(set_mocked_aws_audit_info())
         assert cloudfront.service == "cloudfront"
 
     @mock_cloudfront
     def test__list_distributions__zero(self):
-        cloudfront = CloudFront(self.set_mocked_audit_info())
+        cloudfront = CloudFront(set_mocked_aws_audit_info())
 
         assert len(cloudfront.distributions) == 0
 
@@ -218,7 +181,7 @@ class Test_CloudFront_Service:
         response = cloudfront_client.create_distribution(DistributionConfig=config)
         cloudfront_distribution_id = response["Distribution"]["Id"]
         cloudfront_distribution_arn = response["Distribution"]["ARN"]
-        cloudfront = CloudFront(self.set_mocked_audit_info())
+        cloudfront = CloudFront(set_mocked_aws_audit_info())
 
         assert len(cloudfront.distributions) == 1
         assert (
@@ -231,7 +194,7 @@ class Test_CloudFront_Service:
         )
         assert (
             cloudfront.distributions[cloudfront_distribution_id].region
-            == self.set_mocked_audit_info().audit_session.region_name
+            == AWS_REGION_US_EAST_1
         )
         assert (
             cloudfront.distributions[cloudfront_distribution_id].logging_enabled is True


### PR DESCRIPTION
### Description

Refactor CloudFront to use the `set_mocked_aws_audit_info` helper.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
