### PR TITLE
test(audit_info): refactor cloudtrail

### DIFF
--- a/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete_test.py
@@ -2,54 +2,27 @@ from unittest import mock
 from unittest.mock import patch
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_iam, mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.cloudtrail.cloudtrail_service import Cloudtrail
 from prowler.providers.aws.services.s3.s3_service import S3
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 # Mocking Backup Calls
 make_api_call = botocore.client.BaseClient._make_api_call
 
 
 class Test_cloudtrail_bucket_requires_mfa_delete:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_cloudtrail
     def test_no_trails(self):
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -70,10 +43,14 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
     @mock_cloudtrail
     @mock_s3
     def test_trails_with_no_mfa_bucket(self):
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us_with_no_mfa_bucket"
         bucket_name_us = "bucket_test_us_with_no_mfa"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -107,7 +84,7 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
                 == f"Trail {trail_name_us} bucket ({bucket_name_us}) does not have MFA delete enabled."
             )
             assert result[0].resource_id == trail_name_us
-            assert result[0].region == "us-east-1"
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_arn == trail_us["TrailARN"]
             assert result[0].resource_tags == []
 
@@ -131,10 +108,14 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
         new=mock_make_api_call_getbucketversioning_mfadelete_enabled,
     )
     def test_trails_with_mfa_bucket(self):
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us_with_mfa_bucket"
         bucket_name_us = "bucket_test_us_with_mfa"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -168,17 +149,21 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
                 == f"Trail {trail_name_us} bucket ({bucket_name_us}) has MFA delete enabled."
             )
             assert result[0].resource_id == trail_name_us
-            assert result[0].region == "us-east-1"
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_arn == trail_us["TrailARN"]
             assert result[0].resource_tags == []
 
     @mock_cloudtrail
     @mock_s3
     def test_trails_with_no_mfa_bucket_cross(self):
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us_with_no_mfa_bucket"
         bucket_name_us = "bucket_test_us_with_no_mfa"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -215,7 +200,7 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
                 == f"Trail {trail_name_us} bucket ({bucket_name_us}) is a cross-account bucket in another account out of Prowler's permissions scope, please check it manually."
             )
             assert result[0].resource_id == trail_name_us
-            assert result[0].region == "us-east-1"
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_arn == trail_us["TrailARN"]
             assert result[0].resource_tags == []
 
@@ -228,10 +213,14 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
         new=mock_make_api_call_getbucketversioning_mfadelete_enabled,
     )
     def test_trails_with_mfa_bucket_cross(self):
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us_with_mfa_bucket"
         bucket_name_us = "bucket_test_us_with_mfa"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -268,6 +257,6 @@ class Test_cloudtrail_bucket_requires_mfa_delete:
                 == f"Trail {trail_name_us} bucket ({bucket_name_us}) is a cross-account bucket in another account out of Prowler's permissions scope, please check it manually."
             )
             assert result[0].resource_id == trail_name_us
-            assert result[0].region == "us-east-1"
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_arn == trail_us["TrailARN"]
             assert result[0].resource_tags == []

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_cloudwatch_logging_enabled/cloudtrail_cloudwatch_logging_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_cloudwatch_logging_enabled/cloudtrail_cloudwatch_logging_enabled_test.py
@@ -2,50 +2,23 @@ from datetime import datetime, timedelta, timezone
 from re import search
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudtrail_cloudwatch_logging_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_cloudtrail
     @mock_s3
     def test_no_trails(self):
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
             Cloudtrail,
@@ -71,10 +44,14 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
     @mock_cloudtrail
     @mock_s3
     def test_trails_sending_logs_during_and_not_last_day(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
-        cloudtrail_client_eu_west_1 = client("cloudtrail", region_name="eu-west-1")
-        s3_client_eu_west_1 = client("s3", region_name="eu-west-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        cloudtrail_client_eu_west_1 = client(
+            "cloudtrail", region_name=AWS_REGION_EU_WEST_1
+        )
+        s3_client_eu_west_1 = client("s3", region_name=AWS_REGION_EU_WEST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         trail_name_eu = "trail_test_eu"
@@ -82,7 +59,7 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
         s3_client_eu_west_1.create_bucket(
             Bucket=bucket_name_eu,
-            CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+            CreateBucketConfiguration={"LocationConstraint": AWS_REGION_EU_WEST_1},
         )
         trail_us = cloudtrail_client_us_east_1.create_trail(
             Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=False
@@ -97,11 +74,15 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]),
         ):
             with mock.patch(
                 "prowler.providers.aws.services.cloudtrail.cloudtrail_cloudwatch_logging_enabled.cloudtrail_cloudwatch_logging_enabled.cloudtrail_client",
-                new=Cloudtrail(self.set_mocked_audit_info()),
+                new=Cloudtrail(
+                    set_mocked_aws_audit_info(
+                        [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+                    )
+                ),
             ) as service_client:
                 # Test Check
                 from prowler.providers.aws.services.cloudtrail.cloudtrail_cloudwatch_logging_enabled.cloudtrail_cloudwatch_logging_enabled import (
@@ -136,7 +117,7 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
                             f"Single region trail {trail_name_us} has been logging the last 24h.",
                         )
                         assert report.resource_tags == []
-                        assert report.region == "us-east-1"
+                        assert report.region == AWS_REGION_US_EAST_1
                     if report.resource_id == trail_name_eu:
                         assert report.resource_id == trail_name_eu
                         assert report.resource_arn == trail_eu["TrailARN"]
@@ -146,15 +127,19 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
                             f"Single region trail {trail_name_eu} is not logging in the last 24h.",
                         )
                         assert report.resource_tags == []
-                        assert report.region == "eu-west-1"
+                        assert report.region == AWS_REGION_EU_WEST_1
 
     @mock_cloudtrail
     @mock_s3
     def test_multi_region_and_single_region_logging_and_not(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
-        cloudtrail_client_eu_west_1 = client("cloudtrail", region_name="eu-west-1")
-        s3_client_eu_west_1 = client("s3", region_name="eu-west-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        cloudtrail_client_eu_west_1 = client(
+            "cloudtrail", region_name=AWS_REGION_EU_WEST_1
+        )
+        s3_client_eu_west_1 = client("s3", region_name=AWS_REGION_EU_WEST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         trail_name_eu = "trail_test_eu"
@@ -162,7 +147,7 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
         s3_client_eu_west_1.create_bucket(
             Bucket=bucket_name_eu,
-            CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+            CreateBucketConfiguration={"LocationConstraint": AWS_REGION_EU_WEST_1},
         )
         trail_us = cloudtrail_client_us_east_1.create_trail(
             Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=True
@@ -177,11 +162,15 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]),
         ):
             with mock.patch(
                 "prowler.providers.aws.services.cloudtrail.cloudtrail_cloudwatch_logging_enabled.cloudtrail_cloudwatch_logging_enabled.cloudtrail_client",
-                new=Cloudtrail(self.set_mocked_audit_info()),
+                new=Cloudtrail(
+                    set_mocked_aws_audit_info(
+                        [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+                    )
+                ),
             ) as service_client:
                 # Test Check
                 from prowler.providers.aws.services.cloudtrail.cloudtrail_cloudwatch_logging_enabled.cloudtrail_cloudwatch_logging_enabled import (
@@ -218,7 +207,7 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
                         assert report.resource_tags == []
                     if (
                         report.resource_id == trail_name_eu
-                        and report.region == "eu-west-1"
+                        and report.region == AWS_REGION_EU_WEST_1
                     ):
                         assert report.resource_id == trail_name_eu
                         assert report.resource_arn == trail_eu["TrailARN"]
@@ -232,10 +221,14 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
     @mock_cloudtrail
     @mock_s3
     def test_trails_sending_and_not_sending_logs(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
-        cloudtrail_client_eu_west_1 = client("cloudtrail", region_name="eu-west-1")
-        s3_client_eu_west_1 = client("s3", region_name="eu-west-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        cloudtrail_client_eu_west_1 = client(
+            "cloudtrail", region_name=AWS_REGION_EU_WEST_1
+        )
+        s3_client_eu_west_1 = client("s3", region_name=AWS_REGION_EU_WEST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         trail_name_eu = "trail_test_eu"
@@ -243,7 +236,7 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
         s3_client_eu_west_1.create_bucket(
             Bucket=bucket_name_eu,
-            CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+            CreateBucketConfiguration={"LocationConstraint": AWS_REGION_EU_WEST_1},
         )
         trail_us = cloudtrail_client_us_east_1.create_trail(
             Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=False
@@ -258,11 +251,15 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]),
         ):
             with mock.patch(
                 "prowler.providers.aws.services.cloudtrail.cloudtrail_cloudwatch_logging_enabled.cloudtrail_cloudwatch_logging_enabled.cloudtrail_client",
-                new=Cloudtrail(self.set_mocked_audit_info()),
+                new=Cloudtrail(
+                    set_mocked_aws_audit_info(
+                        [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+                    )
+                ),
             ) as service_client:
                 # Test Check
                 from prowler.providers.aws.services.cloudtrail.cloudtrail_cloudwatch_logging_enabled.cloudtrail_cloudwatch_logging_enabled import (

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_insights_exist/cloudtrail_insights_exist_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_insights_exist/cloudtrail_insights_exist_test.py
@@ -1,49 +1,22 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.cloudtrail.cloudtrail_service import Cloudtrail
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudtrail_insights_exist:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_cloudtrail
     def test_no_trails(self):
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -65,10 +38,14 @@ class Test_cloudtrail_insights_exist:
     @mock_cloudtrail
     @mock_s3
     def test_trails_with_no_insight_selector(self):
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us_with_no_insight_selector"
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -100,17 +77,21 @@ class Test_cloudtrail_insights_exist:
                     == f"Trail {trail_name_us} does not have insight selectors and it is logging."
                 )
                 assert result[0].resource_id == trail_name_us
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].resource_arn == trail_us["TrailARN"]
                 assert result[0].resource_tags == []
 
     @mock_cloudtrail
     @mock_s3
     def test_trails_with_insight_selector(self):
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us_with_insight_selector"
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -146,6 +127,6 @@ class Test_cloudtrail_insights_exist:
                     == f"Trail {trail_name_us} has insight selectors and it is logging."
                 )
                 assert result[0].resource_id == trail_name_us
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].resource_arn == trail_us["TrailARN"]
                 assert result[0].resource_tags == []

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_kms_encryption_enabled/cloudtrail_kms_encryption_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_kms_encryption_enabled/cloudtrail_kms_encryption_enabled_test.py
@@ -1,46 +1,17 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_kms, mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudtrail_kms_encryption_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_cloudtrail
     @mock_s3
     def test_no_trails(self):
@@ -50,10 +21,12 @@ class Test_cloudtrail_kms_encryption_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_kms_encryption_enabled.cloudtrail_kms_encryption_enabled.cloudtrail_client",
-            new=Cloudtrail(self.set_mocked_audit_info()),
+            new=Cloudtrail(
+                set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.cloudtrail.cloudtrail_kms_encryption_enabled.cloudtrail_kms_encryption_enabled import (
@@ -68,8 +41,10 @@ class Test_cloudtrail_kms_encryption_enabled:
     @mock_cloudtrail
     @mock_s3
     def test_trail_no_kms(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -83,10 +58,12 @@ class Test_cloudtrail_kms_encryption_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_kms_encryption_enabled.cloudtrail_kms_encryption_enabled.cloudtrail_client",
-            new=Cloudtrail(self.set_mocked_audit_info()),
+            new=Cloudtrail(
+                set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.cloudtrail.cloudtrail_kms_encryption_enabled.cloudtrail_kms_encryption_enabled import (
@@ -105,15 +82,17 @@ class Test_cloudtrail_kms_encryption_enabled:
             assert result[0].resource_id == trail_name_us
             assert result[0].resource_arn == trail_us["TrailARN"]
             assert result[0].resource_tags == []
-            assert result[0].region == "us-east-1"
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_cloudtrail
     @mock_s3
     @mock_kms
     def test_trail_kms(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
-        kms_client = client("kms", region_name="us-east-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -131,10 +110,12 @@ class Test_cloudtrail_kms_encryption_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_kms_encryption_enabled.cloudtrail_kms_encryption_enabled.cloudtrail_client",
-            new=Cloudtrail(self.set_mocked_audit_info()),
+            new=Cloudtrail(
+                set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.cloudtrail.cloudtrail_kms_encryption_enabled.cloudtrail_kms_encryption_enabled import (
@@ -153,4 +134,4 @@ class Test_cloudtrail_kms_encryption_enabled:
             assert result[0].resource_id == trail_name_us
             assert result[0].resource_arn == trail_us["TrailARN"]
             assert result[0].resource_tags == []
-            assert result[0].region == "us-east-1"
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_log_file_validation_enabled/cloudtrail_log_file_validation_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_log_file_validation_enabled/cloudtrail_log_file_validation_enabled_test.py
@@ -1,46 +1,17 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudtrail_log_file_validation_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_cloudtrail
     @mock_s3
     def test_no_trails(self):
@@ -50,10 +21,12 @@ class Test_cloudtrail_log_file_validation_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_log_file_validation_enabled.cloudtrail_log_file_validation_enabled.cloudtrail_client",
-            new=Cloudtrail(self.set_mocked_audit_info()),
+            new=Cloudtrail(
+                set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.cloudtrail.cloudtrail_log_file_validation_enabled.cloudtrail_log_file_validation_enabled import (
@@ -68,8 +41,10 @@ class Test_cloudtrail_log_file_validation_enabled:
     @mock_cloudtrail
     @mock_s3
     def test_no_logging_validation(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -82,10 +57,12 @@ class Test_cloudtrail_log_file_validation_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_log_file_validation_enabled.cloudtrail_log_file_validation_enabled.cloudtrail_client",
-            new=Cloudtrail(self.set_mocked_audit_info()),
+            new=Cloudtrail(
+                set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.cloudtrail.cloudtrail_log_file_validation_enabled.cloudtrail_log_file_validation_enabled import (
@@ -101,15 +78,19 @@ class Test_cloudtrail_log_file_validation_enabled:
             assert result[0].resource_id == trail_name_us
             assert result[0].resource_arn == trail_us["TrailARN"]
             assert result[0].resource_tags == []
-            assert result[0].region == "us-east-1"
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_cloudtrail
     @mock_s3
     def test_various_trails_with_and_without_logging_validation(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
-        cloudtrail_client_eu_west_1 = client("cloudtrail", region_name="eu-west-1")
-        s3_client_eu_west_1 = client("s3", region_name="eu-west-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        cloudtrail_client_eu_west_1 = client(
+            "cloudtrail", region_name=AWS_REGION_EU_WEST_1
+        )
+        s3_client_eu_west_1 = client("s3", region_name=AWS_REGION_EU_WEST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         trail_name_eu = "trail_test_eu"
@@ -117,7 +98,7 @@ class Test_cloudtrail_log_file_validation_enabled:
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
         s3_client_eu_west_1.create_bucket(
             Bucket=bucket_name_eu,
-            CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+            CreateBucketConfiguration={"LocationConstraint": AWS_REGION_EU_WEST_1},
         )
         trail_us = cloudtrail_client_us_east_1.create_trail(
             Name=trail_name_us,
@@ -135,10 +116,12 @@ class Test_cloudtrail_log_file_validation_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_log_file_validation_enabled.cloudtrail_log_file_validation_enabled.cloudtrail_client",
-            new=Cloudtrail(self.set_mocked_audit_info()),
+            new=Cloudtrail(
+                set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1])
+            ),
         ) as service_client:
             # Test Check
             from prowler.providers.aws.services.cloudtrail.cloudtrail_log_file_validation_enabled.cloudtrail_log_file_validation_enabled import (
@@ -159,7 +142,7 @@ class Test_cloudtrail_log_file_validation_enabled:
                     assert report.resource_id == trail_name_us
                     assert report.resource_arn == trail_us["TrailARN"]
                     assert report.resource_tags == []
-                    assert report.region == "us-east-1"
+                    assert report.region == AWS_REGION_US_EAST_1
                 elif report.resource_id == trail_name_eu:
                     assert report.status == "FAIL"
                     assert search(
@@ -168,4 +151,4 @@ class Test_cloudtrail_log_file_validation_enabled:
                     assert report.resource_id == trail_name_eu
                     assert report.resource_arn == trail_eu["TrailARN"]
                     assert report.resource_tags == []
-                    assert report.region == "eu-west-1"
+                    assert report.region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_access_logging_enabled/cloudtrail_logs_s3_bucket_access_logging_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_access_logging_enabled/cloudtrail_logs_s3_bucket_access_logging_enabled_test.py
@@ -1,46 +1,17 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudtrail_logs_s3_bucket_access_logging_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_cloudtrail
     @mock_s3
     def test_no_trails(self):
@@ -51,13 +22,17 @@ class Test_cloudtrail_logs_s3_bucket_access_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_client",
-            new=Cloudtrail(self.set_mocked_audit_info()),
+            new=Cloudtrail(
+                set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1])
+            ),
         ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_logs_s3_bucket_access_logging_enabled.s3_client",
-            new=S3(self.set_mocked_audit_info()),
+            new=S3(
+                set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_logs_s3_bucket_access_logging_enabled import (
@@ -72,8 +47,10 @@ class Test_cloudtrail_logs_s3_bucket_access_logging_enabled:
     @mock_cloudtrail
     @mock_s3
     def test_bucket_not_logging(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -88,13 +65,17 @@ class Test_cloudtrail_logs_s3_bucket_access_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_client",
-            new=Cloudtrail(self.set_mocked_audit_info()),
+            new=Cloudtrail(
+                set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1])
+            ),
         ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_logs_s3_bucket_access_logging_enabled.s3_client",
-            new=S3(self.set_mocked_audit_info()),
+            new=S3(
+                set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_logs_s3_bucket_access_logging_enabled import (
@@ -113,13 +94,15 @@ class Test_cloudtrail_logs_s3_bucket_access_logging_enabled:
             assert result[0].resource_id == trail_name_us
             assert result[0].resource_arn == trail_us["TrailARN"]
             assert result[0].resource_tags == []
-            assert result[0].region == "us-east-1"
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_cloudtrail
     @mock_s3
     def test_bucket_logging(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         logging_bucket = "logging"
@@ -154,13 +137,17 @@ class Test_cloudtrail_logs_s3_bucket_access_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_client",
-            new=Cloudtrail(self.set_mocked_audit_info()),
+            new=Cloudtrail(
+                set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1])
+            ),
         ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_logs_s3_bucket_access_logging_enabled.s3_client",
-            new=S3(self.set_mocked_audit_info()),
+            new=S3(
+                set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_logs_s3_bucket_access_logging_enabled import (
@@ -179,13 +166,15 @@ class Test_cloudtrail_logs_s3_bucket_access_logging_enabled:
             assert result[0].resource_id == trail_name_us
             assert result[0].resource_arn == trail_us["TrailARN"]
             assert result[0].resource_tags == []
-            assert result[0].region == "us-east-1"
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_cloudtrail
     @mock_s3
     def test_bucket_cross_account(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -200,13 +189,17 @@ class Test_cloudtrail_logs_s3_bucket_access_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_client",
-            new=Cloudtrail(self.set_mocked_audit_info()),
+            new=Cloudtrail(
+                set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1])
+            ),
         ), mock.patch(
             "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_logs_s3_bucket_access_logging_enabled.s3_client",
-            new=S3(self.set_mocked_audit_info()),
+            new=S3(
+                set_mocked_aws_audit_info([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1])
+            ),
         ) as s3_client:
             # Test Check
             from prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_access_logging_enabled.cloudtrail_logs_s3_bucket_access_logging_enabled import (
@@ -228,4 +221,4 @@ class Test_cloudtrail_logs_s3_bucket_access_logging_enabled:
             assert result[0].resource_id == trail_name_us
             assert result[0].resource_arn == trail_us["TrailARN"]
             assert result[0].resource_tags == []
-            assert result[0].region == "us-east-1"
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_test.py
@@ -1,55 +1,27 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION_US_EAST_1 = "us-east-1"
-AWS_REGION_EU_WEST_1 = "eu-west-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudtrail_multi_region_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=[AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_cloudtrail
     def test_no_trails(self):
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
             Cloudtrail,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -124,7 +96,9 @@ class Test_cloudtrail_multi_region_enabled:
             Cloudtrail,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -201,7 +175,9 @@ class Test_cloudtrail_multi_region_enabled:
             Cloudtrail,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -277,7 +253,9 @@ class Test_cloudtrail_multi_region_enabled:
             Cloudtrail,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled_logging_management_events/cloudtrail_multi_region_enabled_logging_management_events_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled_logging_management_events/cloudtrail_multi_region_enabled_logging_management_events_test.py
@@ -6,7 +6,6 @@ from moto import mock_cloudtrail, mock_s3
 from tests.providers.aws.audit_info_utils import (
     AWS_ACCOUNT_ARN,
     AWS_ACCOUNT_NUMBER,
-    AWS_REGION_EU_WEST_1,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_audit_info,
 )
@@ -19,9 +18,7 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
             Cloudtrail,
         )
 
-        current_audit_info = set_mocked_aws_audit_info(
-            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
-        )
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -78,9 +75,7 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
             Cloudtrail,
         )
 
-        current_audit_info = set_mocked_aws_audit_info(
-            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
-        )
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -138,9 +133,7 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
             Cloudtrail,
         )
 
-        current_audit_info = set_mocked_aws_audit_info(
-            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
-        )
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -195,9 +188,7 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
             Cloudtrail,
         )
 
-        current_audit_info = set_mocked_aws_audit_info(
-            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
-        )
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -253,9 +244,7 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
             Cloudtrail,
         )
 
-        current_audit_info = set_mocked_aws_audit_info(
-            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
-        )
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled_logging_management_events/cloudtrail_multi_region_enabled_logging_management_events_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled_logging_management_events/cloudtrail_multi_region_enabled_logging_management_events_test.py
@@ -1,54 +1,27 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudtrail_multi_region_enabled_logging_management_events:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=[AWS_REGION],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_cloudtrail
     def test_no_trails(self):
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
             Cloudtrail,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -68,7 +41,7 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
                 assert len(result) == 1
                 assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                 assert result[0].resource_arn == AWS_ACCOUNT_ARN
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
@@ -78,8 +51,10 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
     @mock_cloudtrail
     @mock_s3
     def test_compliant_trail_advanced_event_selector(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name=AWS_REGION)
-        s3_client_us_east_1 = client("s3", region_name=AWS_REGION)
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -103,7 +78,9 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
             Cloudtrail,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -123,18 +100,20 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
                 assert len(result) == 1
                 assert result[0].resource_id == trail_name_us
                 assert result[0].resource_arn == trail_us["TrailARN"]
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == f"Trail {trail_name_us} from home region {AWS_REGION} is multi-region, is logging and have management events enabled."
+                    == f"Trail {trail_name_us} from home region {AWS_REGION_US_EAST_1} is multi-region, is logging and have management events enabled."
                 )
 
     @mock_cloudtrail
     @mock_s3
     def test_non_compliant_trail_advanced_event_selector(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name=AWS_REGION)
-        s3_client_us_east_1 = client("s3", region_name=AWS_REGION)
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -159,7 +138,9 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
             Cloudtrail,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -178,7 +159,7 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
                 result = check.execute()
                 assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                 assert result[0].resource_arn == AWS_ACCOUNT_ARN
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
@@ -188,8 +169,10 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
     @mock_cloudtrail
     @mock_s3
     def test_compliant_trail_classic_event_selector(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name=AWS_REGION)
-        s3_client_us_east_1 = client("s3", region_name=AWS_REGION)
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -212,7 +195,9 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
             Cloudtrail,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -232,18 +217,20 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
                 assert len(result) == 1
                 assert result[0].resource_id == trail_name_us
                 assert result[0].resource_arn == trail_us["TrailARN"]
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == f"Trail {trail_name_us} from home region {AWS_REGION} is multi-region, is logging and have management events enabled."
+                    == f"Trail {trail_name_us} from home region {AWS_REGION_US_EAST_1} is multi-region, is logging and have management events enabled."
                 )
 
     @mock_cloudtrail
     @mock_s3
     def test_non_compliant_trail_classic_event_selector(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name=AWS_REGION)
-        s3_client_us_east_1 = client("s3", region_name=AWS_REGION)
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -266,7 +253,9 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
             Cloudtrail,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -285,7 +274,7 @@ class Test_cloudtrail_multi_region_enabled_logging_management_events:
                 result = check.execute()
                 assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                 assert result[0].resource_arn == AWS_ACCOUNT_ARN
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_service_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_service_test.py
@@ -1,56 +1,31 @@
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.cloudtrail.cloudtrail_service import Cloudtrail
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_Cloudtrail_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["eu-west-1", "us-east-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test Cloudtrail Service
     @mock_cloudtrail
     def test_service(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         cloudtrail = Cloudtrail(audit_info)
         assert cloudtrail.service == "cloudtrail"
 
     # Test Cloudtrail client
     @mock_cloudtrail
     def test_client(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         cloudtrail = Cloudtrail(audit_info)
         for regional_client in cloudtrail.regional_clients.values():
             assert regional_client.__class__.__name__ == "CloudTrail"
@@ -58,24 +33,32 @@ class Test_Cloudtrail_Service:
     # Test Cloudtrail session
     @mock_cloudtrail
     def test__get_session__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         cloudtrail = Cloudtrail(audit_info)
         assert cloudtrail.session.__class__.__name__ == "Session"
 
     # Test Cloudtrail Session
     @mock_cloudtrail
     def test_audited_account(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         cloudtrail = Cloudtrail(audit_info)
         assert cloudtrail.audited_account == AWS_ACCOUNT_NUMBER
 
     @mock_cloudtrail
     @mock_s3
     def test_describe_trails(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
-        cloudtrail_client_eu_west_1 = client("cloudtrail", region_name="eu-west-1")
-        s3_client_eu_west_1 = client("s3", region_name="eu-west-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        cloudtrail_client_eu_west_1 = client(
+            "cloudtrail", region_name=AWS_REGION_EU_WEST_1
+        )
+        s3_client_eu_west_1 = client("s3", region_name=AWS_REGION_EU_WEST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         trail_name_eu = "trail_test_eu"
@@ -83,7 +66,7 @@ class Test_Cloudtrail_Service:
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
         s3_client_eu_west_1.create_bucket(
             Bucket=bucket_name_eu,
-            CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+            CreateBucketConfiguration={"LocationConstraint": AWS_REGION_EU_WEST_1},
         )
         cloudtrail_client_us_east_1.create_trail(
             Name=trail_name_us,
@@ -101,7 +84,9 @@ class Test_Cloudtrail_Service:
                 {"Key": "test", "Value": "test"},
             ],
         )
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         cloudtrail = Cloudtrail(audit_info)
         assert len(cloudtrail.trails) == 2
         for trail in cloudtrail.trails:
@@ -109,9 +94,13 @@ class Test_Cloudtrail_Service:
                 assert trail.name == trail_name_us or trail.name == trail_name_eu
                 assert not trail.is_multiregion
                 assert (
-                    trail.home_region == "us-east-1" or trail.home_region == "eu-west-1"
+                    trail.home_region == AWS_REGION_US_EAST_1
+                    or trail.home_region == AWS_REGION_EU_WEST_1
                 )
-                assert trail.region == "us-east-1" or trail.region == "eu-west-1"
+                assert (
+                    trail.region == AWS_REGION_US_EAST_1
+                    or trail.region == AWS_REGION_EU_WEST_1
+                )
                 assert not trail.is_logging
                 assert not trail.log_file_validation_enabled
                 assert not trail.latest_cloudwatch_delivery_time
@@ -126,10 +115,14 @@ class Test_Cloudtrail_Service:
     @mock_cloudtrail
     @mock_s3
     def test_status_trails(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
-        cloudtrail_client_eu_west_1 = client("cloudtrail", region_name="eu-west-1")
-        s3_client_eu_west_1 = client("s3", region_name="eu-west-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        cloudtrail_client_eu_west_1 = client(
+            "cloudtrail", region_name=AWS_REGION_EU_WEST_1
+        )
+        s3_client_eu_west_1 = client("s3", region_name=AWS_REGION_EU_WEST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         trail_name_eu = "trail_test_eu"
@@ -137,7 +130,7 @@ class Test_Cloudtrail_Service:
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
         s3_client_eu_west_1.create_bucket(
             Bucket=bucket_name_eu,
-            CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+            CreateBucketConfiguration={"LocationConstraint": AWS_REGION_EU_WEST_1},
         )
         cloudtrail_client_us_east_1.create_trail(
             Name=trail_name_us,
@@ -149,15 +142,17 @@ class Test_Cloudtrail_Service:
         cloudtrail_client_eu_west_1.create_trail(
             Name=trail_name_eu, S3BucketName=bucket_name_eu, IsMultiRegionTrail=False
         )
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         cloudtrail = Cloudtrail(audit_info)
         assert len(cloudtrail.trails) == len(audit_info.audited_regions)
         for trail in cloudtrail.trails:
             if trail.name:
                 if trail.name == trail_name_us:
                     assert not trail.is_multiregion
-                    assert trail.home_region == "us-east-1"
-                    assert trail.region == "us-east-1"
+                    assert trail.home_region == AWS_REGION_US_EAST_1
+                    assert trail.region == AWS_REGION_US_EAST_1
                     assert trail.is_logging
                     assert trail.log_file_validation_enabled
                     assert not trail.latest_cloudwatch_delivery_time
@@ -166,8 +161,10 @@ class Test_Cloudtrail_Service:
     @mock_cloudtrail
     @mock_s3
     def test_get_classic_event_selectors(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -190,15 +187,17 @@ class Test_Cloudtrail_Service:
                 }
             ],
         )["EventSelectors"]
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         cloudtrail = Cloudtrail(audit_info)
         assert len(cloudtrail.trails) == len(audit_info.audited_regions)
         for trail in cloudtrail.trails:
             if trail.name:
                 if trail.name == trail_name_us:
                     assert not trail.is_multiregion
-                    assert trail.home_region == "us-east-1"
-                    assert trail.region == "us-east-1"
+                    assert trail.home_region == AWS_REGION_US_EAST_1
+                    assert trail.region == AWS_REGION_US_EAST_1
                     assert trail.is_logging
                     assert trail.log_file_validation_enabled
                     assert not trail.latest_cloudwatch_delivery_time
@@ -211,8 +210,10 @@ class Test_Cloudtrail_Service:
     @mock_cloudtrail
     @mock_s3
     def test_get_advanced_event_selectors(self):
-        cloudtrail_client_us_east_1 = client("cloudtrail", region_name="us-east-1")
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        cloudtrail_client_us_east_1 = client(
+            "cloudtrail", region_name=AWS_REGION_US_EAST_1
+        )
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         trail_name_us = "trail_test_us"
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
@@ -235,15 +236,17 @@ class Test_Cloudtrail_Service:
                 },
             ],
         )["AdvancedEventSelectors"]
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         cloudtrail = Cloudtrail(audit_info)
         assert len(cloudtrail.trails) == len(audit_info.audited_regions)
         for trail in cloudtrail.trails:
             if trail.name:
                 if trail.name == trail_name_us:
                     assert not trail.is_multiregion
-                    assert trail.home_region == "us-east-1"
-                    assert trail.region == "us-east-1"
+                    assert trail.home_region == AWS_REGION_US_EAST_1
+                    assert trail.region == AWS_REGION_US_EAST_1
                     assert trail.is_logging
                     assert trail.log_file_validation_enabled
                     assert not trail.latest_cloudwatch_delivery_time


### PR DESCRIPTION
### Description

Refactor CloudTrail to use the `set_mocked_aws_audit_info` helper.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
