### PR TITLE
test(audit_info): refactor wafv2

### DIFF
--- a/tests/providers/aws/services/wafv2/wafv2_service_test.py
+++ b/tests/providers/aws/services/wafv2/wafv2_service_test.py
@@ -1,51 +1,19 @@
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_elbv2, mock_wafv2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_WAFv2_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test WAFv2 Service
     @mock_wafv2
     def test_service(self):
         # WAFv2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         wafv2 = WAFv2(audit_info)
         assert wafv2.service == "wafv2"
 
@@ -53,7 +21,7 @@ class Test_WAFv2_Service:
     @mock_wafv2
     def test_client(self):
         # WAFv2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         wafv2 = WAFv2(audit_info)
         for regional_client in wafv2.regional_clients.values():
             assert regional_client.__class__.__name__ == "WAFV2"
@@ -62,14 +30,14 @@ class Test_WAFv2_Service:
     @mock_wafv2
     def test__get_session__(self):
         # WAFv2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         wafv2 = WAFv2(audit_info)
         assert wafv2.session.__class__.__name__ == "Session"
 
     # Test WAFv2 Describe Web ACLs
     @mock_wafv2
     def test__list_web_acls__(self):
-        wafv2 = client("wafv2", region_name="us-east-1")
+        wafv2 = client("wafv2", region_name=AWS_REGION_EU_WEST_1)
         waf = wafv2.create_web_acl(
             Scope="REGIONAL",
             Name="my-web-acl",
@@ -81,11 +49,11 @@ class Test_WAFv2_Service:
             },
         )["Summary"]
         # WAFv2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         wafv2 = WAFv2(audit_info)
         assert len(wafv2.web_acls) == 1
         assert wafv2.web_acls[0].name == waf["Name"]
-        assert wafv2.web_acls[0].region == AWS_REGION
+        assert wafv2.web_acls[0].region == AWS_REGION_EU_WEST_1
         assert wafv2.web_acls[0].arn == waf["ARN"]
         assert wafv2.web_acls[0].id == waf["Id"]
 
@@ -94,9 +62,9 @@ class Test_WAFv2_Service:
     @mock_elbv2
     @mock_wafv2
     def test__list_resources_for_web_acl__(self):
-        wafv2 = client("wafv2", region_name="us-east-1")
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        wafv2 = client("wafv2", region_name=AWS_REGION_EU_WEST_1)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
         waf = wafv2.create_web_acl(
             Scope="REGIONAL",
             Name="my-web-acl",
@@ -112,10 +80,14 @@ class Test_WAFv2_Service:
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=f"{AWS_REGION_EU_WEST_1}a",
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=f"{AWS_REGION_EU_WEST_1}b",
         )
 
         lb = conn.create_load_balancer(
@@ -128,7 +100,7 @@ class Test_WAFv2_Service:
 
         wafv2.associate_web_acl(WebACLArn=waf["ARN"], ResourceArn=lb["LoadBalancerArn"])
         # WAFv2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         wafv2 = WAFv2(audit_info)
         wafv2.web_acls[0].albs.append(lb["LoadBalancerArn"])
         assert len(wafv2.web_acls) == 1

--- a/tests/providers/aws/services/wafv2/wafv2_webacl_logging_enabled/wafv2_webacl_logging_enabled_test.py
+++ b/tests/providers/aws/services/wafv2/wafv2_webacl_logging_enabled/wafv2_webacl_logging_enabled_test.py
@@ -2,12 +2,14 @@ from unittest import mock
 from uuid import uuid4
 
 from prowler.providers.aws.services.wafv2.wafv2_service import WebAclv2
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
 waf_id = str(uuid4())
 waf_name = "waf-example"
-waf_arn = f"arn:aws:wafv2:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:regional/webacl/{waf_name}/{waf_id}"
+waf_arn = f"arn:aws:wafv2:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:regional/webacl/{waf_name}/{waf_id}"
 
 
 class Test_wafv2_webacl_logging_enabled:
@@ -39,7 +41,7 @@ class Test_wafv2_webacl_logging_enabled:
                 name=waf_name,
                 id=waf_id,
                 albs=[],
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 logging_enabled=True,
             )
         )
@@ -64,7 +66,7 @@ class Test_wafv2_webacl_logging_enabled:
             )
             assert result[0].resource_id == waf_id
             assert result[0].resource_arn == waf_arn
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_wafv2_wb_acl_without_logging(self):
         wafv2_client = mock.MagicMock
@@ -76,7 +78,7 @@ class Test_wafv2_webacl_logging_enabled:
                 name=waf_name,
                 id=waf_id,
                 albs=[],
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 logging_enabled=False,
             )
         )
@@ -101,4 +103,4 @@ class Test_wafv2_webacl_logging_enabled:
             )
             assert result[0].resource_id == waf_id
             assert result[0].resource_arn == waf_arn
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1


### PR DESCRIPTION
### Description

Refactor Wafv2 to use the `set_mocked_aws_audit_info` helper.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
