### PR TITLE
test(audit_info): refactor cloudwatch

### DIFF
--- a/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_acls_alarm_configured/cloudwatch_changes_to_network_acls_alarm_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_acls_alarm_configured/cloudwatch_changes_to_network_acls_alarm_configured_test.py
@@ -1,48 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_changes_to_network_acls_alarm_configured:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
@@ -55,7 +25,9 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -94,15 +66,17 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_no_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         cloudtrail_client.create_trail(Name="test_trail", S3BucketName="test")
 
@@ -114,7 +88,9 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -153,22 +129,24 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
 
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
@@ -179,7 +157,9 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -218,22 +198,24 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -256,7 +238,9 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -296,22 +280,27 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter but no alarms associated."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -345,7 +334,9 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -385,22 +376,27 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_quotes(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -434,7 +430,9 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -474,22 +472,27 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_newlines(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -523,7 +526,9 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -563,3 +568,8 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_gateways_alarm_configured/cloudwatch_changes_to_network_gateways_alarm_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_gateways_alarm_configured/cloudwatch_changes_to_network_gateways_alarm_configured_test.py
@@ -1,48 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
@@ -55,7 +25,9 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -94,15 +66,17 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_no_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         cloudtrail_client.create_trail(Name="test_trail", S3BucketName="test")
 
@@ -114,7 +88,9 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -153,22 +129,24 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
 
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
@@ -179,7 +157,9 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -218,22 +198,24 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -256,7 +238,9 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -296,22 +280,27 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter but no alarms associated."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -345,7 +334,9 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -385,22 +376,27 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_quotes(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -434,7 +430,9 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -474,22 +472,27 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_newlines(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -523,7 +526,9 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -563,3 +568,8 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_route_tables_alarm_configured/cloudwatch_changes_to_network_route_tables_alarm_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_route_tables_alarm_configured/cloudwatch_changes_to_network_route_tables_alarm_configured_test.py
@@ -1,48 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
@@ -55,7 +25,9 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -94,15 +66,17 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_no_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         cloudtrail_client.create_trail(Name="test_trail", S3BucketName="test")
 
@@ -114,7 +88,9 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -153,22 +129,24 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
 
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
@@ -179,7 +157,9 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -218,22 +198,24 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -256,7 +238,9 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -296,22 +280,27 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter but no alarms associated."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -345,7 +334,9 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -385,22 +376,27 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_quotes(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -434,7 +430,9 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -474,22 +472,27 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_newlines(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -523,7 +526,9 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -563,3 +568,8 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_vpcs_alarm_configured/cloudwatch_changes_to_vpcs_alarm_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_vpcs_alarm_configured/cloudwatch_changes_to_vpcs_alarm_configured_test.py
@@ -1,48 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_changes_to_vpcs_alarm_configured:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
@@ -55,7 +25,9 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -94,15 +66,17 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_no_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         cloudtrail_client.create_trail(Name="test_trail", S3BucketName="test")
 
@@ -114,7 +88,9 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -153,22 +129,24 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
 
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
@@ -179,7 +157,9 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -218,22 +198,24 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -256,7 +238,9 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -296,22 +280,27 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter but no alarms associated."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -345,7 +334,9 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -385,22 +376,27 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_quotes(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -434,7 +430,9 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -474,22 +472,27 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_newlines(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -523,7 +526,9 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -563,3 +568,8 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_cross_account_sharing_disabled/cloudwatch_cross_account_sharing_disabled_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_cross_account_sharing_disabled/cloudwatch_cross_account_sharing_disabled_test.py
@@ -1,52 +1,24 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_iam
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_cross_account_sharing_disabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_iam
     def test_cloudwatch_without_cross_account_role(self):
         from prowler.providers.aws.services.iam.iam_service import IAM
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -84,14 +56,16 @@ class Test_cloudwatch_cross_account_sharing_disabled:
     @mock_iam
     def test_cloudwatch_log_group_with_cross_account_role(self):
         # Generate Logs Client
-        iam_client = client("iam", region_name=AWS_REGION)
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
         # Request Logs group
         iam_client.create_role(
             RoleName="CloudWatch-CrossAccountSharingRole", AssumeRolePolicyDocument="{}"
         )
         from prowler.providers.aws.services.iam.iam_service import IAM
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_kms_encryption_enabled/cloudwatch_log_group_kms_encryption_enabled_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_kms_encryption_enabled/cloudwatch_log_group_kms_encryption_enabled_test.py
@@ -1,51 +1,22 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_logs
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_log_group_kms_encryption_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     def test_cloudwatch_no_log_groups(self):
         from prowler.providers.aws.services.cloudwatch.cloudwatch_service import Logs
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -77,7 +48,7 @@ class Test_cloudwatch_log_group_kms_encryption_enabled:
     @mock_logs
     def test_cloudwatch_log_group_without_kms_key(self):
         # Generate Logs Client
-        logs_client = client("logs", region_name=AWS_REGION)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
         # Request Logs group
         logs_client.create_log_group(
             logGroupName="test",
@@ -85,7 +56,9 @@ class Test_cloudwatch_log_group_kms_encryption_enabled:
 
         from prowler.providers.aws.services.cloudwatch.cloudwatch_service import Logs
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -123,13 +96,15 @@ class Test_cloudwatch_log_group_kms_encryption_enabled:
     @mock_logs
     def test_cloudwatch_log_group_with_kms_key(self):
         # Generate Logs Client
-        logs_client = client("logs", region_name=AWS_REGION)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
         # Request Logs group
         logs_client.create_log_group(logGroupName="test", kmsKeyId="test_kms_id")
 
         from prowler.providers.aws.services.cloudwatch.cloudwatch_service import Logs
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_no_secrets_in_logs/cloudwatch_log_group_no_secrets_in_logs_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_no_secrets_in_logs/cloudwatch_log_group_no_secrets_in_logs_test.py
@@ -1,53 +1,24 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_logs
 from moto.core.utils import unix_time_millis
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_log_group_no_secrets_in_logs:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     def test_cloudwatch_no_log_groups(self):
         from prowler.providers.aws.services.cloudwatch.cloudwatch_service import Logs
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -79,7 +50,7 @@ class Test_cloudwatch_log_group_no_secrets_in_logs:
     @mock_logs
     def test_cloudwatch_log_group_without_secrets(self):
         # Generate Logs Client
-        logs_client = client("logs", region_name=AWS_REGION)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
         # Request Logs group
         logs_client.create_log_group(logGroupName="test")
         logs_client.create_log_stream(logGroupName="test", logStreamName="test stream")
@@ -95,7 +66,9 @@ class Test_cloudwatch_log_group_no_secrets_in_logs:
         )
         from prowler.providers.aws.services.cloudwatch.cloudwatch_service import Logs
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -130,7 +103,7 @@ class Test_cloudwatch_log_group_no_secrets_in_logs:
     @mock_logs
     def test_cloudwatch_log_group_with_secrets(self):
         # Generate Logs Client
-        logs_client = client("logs", region_name=AWS_REGION)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
         # Request Logs group
         logs_client.create_log_group(logGroupName="test")
         logs_client.create_log_stream(logGroupName="test", logStreamName="test stream")
@@ -146,7 +119,9 @@ class Test_cloudwatch_log_group_no_secrets_in_logs:
         )
         from prowler.providers.aws.services.cloudwatch.cloudwatch_service import Logs
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled_test.py
@@ -1,48 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
@@ -55,7 +25,9 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -96,15 +68,17 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_no_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         cloudtrail_client.create_trail(Name="test_trail", S3BucketName="test")
 
@@ -116,7 +90,9 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -157,22 +133,24 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
 
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
@@ -183,7 +161,9 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -224,22 +204,24 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -262,7 +244,9 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -304,22 +288,27 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
                 == "CloudWatch log group /log-group/test found with metric filter test-filter but no alarms associated."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -353,7 +342,9 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -395,22 +386,27 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_quotes(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -444,7 +440,9 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -486,22 +484,27 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_newlines(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -535,7 +538,9 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -577,3 +582,8 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled_test.py
@@ -1,48 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
@@ -55,7 +25,9 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -96,15 +68,17 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_no_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         cloudtrail_client.create_trail(Name="test_trail", S3BucketName="test")
 
@@ -116,7 +90,9 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -157,22 +133,24 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
 
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
@@ -183,7 +161,9 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -224,22 +204,24 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -262,7 +244,9 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -304,22 +288,27 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
                 == "CloudWatch log group /log-group/test found with metric filter test-filter but no alarms associated."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -353,7 +342,9 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -395,22 +386,27 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_quotes(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -444,7 +440,9 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -486,22 +484,27 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_newlines(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -535,7 +538,9 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -577,3 +582,8 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_authentication_failures/cloudwatch_log_metric_filter_authentication_failures_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_authentication_failures/cloudwatch_log_metric_filter_authentication_failures_test.py
@@ -1,48 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_log_metric_filter_authentication_failures:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
@@ -55,7 +25,9 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -94,15 +66,17 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_no_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         cloudtrail_client.create_trail(Name="test_trail", S3BucketName="test")
 
@@ -114,7 +88,9 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -153,22 +129,24 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
 
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
@@ -179,7 +157,9 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -218,22 +198,24 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -256,7 +238,9 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -296,22 +280,27 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter but no alarms associated."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -345,7 +334,9 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -385,22 +376,27 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_quotes(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -434,7 +430,9 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -474,22 +472,27 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_newlines(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -523,7 +526,9 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -563,3 +568,8 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_aws_organizations_changes/cloudwatch_log_metric_filter_aws_organizations_changes_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_aws_organizations_changes/cloudwatch_log_metric_filter_aws_organizations_changes_test.py
@@ -1,48 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
@@ -55,7 +25,9 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -94,15 +66,17 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_no_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         cloudtrail_client.create_trail(Name="test_trail", S3BucketName="test")
 
@@ -114,7 +88,9 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -153,22 +129,24 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
 
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
@@ -179,7 +157,9 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -218,22 +198,24 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -256,7 +238,9 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -296,22 +280,27 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter but no alarms associated."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -345,7 +334,9 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -385,22 +376,27 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_quotes(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -434,7 +430,9 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -474,22 +472,27 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_newlines(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -523,7 +526,9 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -563,3 +568,8 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes_test.py
@@ -1,48 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
@@ -55,7 +25,9 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -94,15 +66,17 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_no_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         cloudtrail_client.create_trail(Name="test_trail", S3BucketName="test")
 
@@ -114,7 +88,9 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -153,22 +129,24 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
 
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
@@ -179,7 +157,9 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -218,22 +198,24 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -256,7 +238,9 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -296,22 +280,27 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter but no alarms associated."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -345,7 +334,9 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -385,22 +376,27 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_quotes(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -434,7 +430,9 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -474,22 +472,27 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_newlines(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -523,7 +526,9 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -563,3 +568,8 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_policy_changes/cloudwatch_log_metric_filter_policy_changes_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_policy_changes/cloudwatch_log_metric_filter_policy_changes_test.py
@@ -1,48 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
@@ -55,7 +25,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -94,15 +66,17 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_no_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         cloudtrail_client.create_trail(Name="test_trail", S3BucketName="test")
 
@@ -114,7 +88,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -153,22 +129,24 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
 
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
@@ -179,7 +157,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -218,22 +198,24 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -256,7 +238,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -296,22 +280,27 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter but no alarms associated."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -345,7 +334,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -385,22 +376,27 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_quotes(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -434,7 +430,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -474,22 +472,27 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_newlines(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -523,7 +526,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -563,3 +568,8 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_root_usage/cloudwatch_log_metric_filter_root_usage_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_root_usage/cloudwatch_log_metric_filter_root_usage_test.py
@@ -1,48 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_log_metric_filter_root_usage:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
@@ -55,7 +25,9 @@ class Test_cloudwatch_log_metric_filter_root_usage:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -94,15 +66,17 @@ class Test_cloudwatch_log_metric_filter_root_usage:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_no_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         cloudtrail_client.create_trail(Name="test_trail", S3BucketName="test")
 
@@ -114,7 +88,9 @@ class Test_cloudwatch_log_metric_filter_root_usage:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -153,22 +129,24 @@ class Test_cloudwatch_log_metric_filter_root_usage:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
 
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
@@ -179,7 +157,9 @@ class Test_cloudwatch_log_metric_filter_root_usage:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -218,22 +198,24 @@ class Test_cloudwatch_log_metric_filter_root_usage:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -256,7 +238,9 @@ class Test_cloudwatch_log_metric_filter_root_usage:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -296,22 +280,27 @@ class Test_cloudwatch_log_metric_filter_root_usage:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter but no alarms associated."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -345,7 +334,9 @@ class Test_cloudwatch_log_metric_filter_root_usage:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -385,22 +376,27 @@ class Test_cloudwatch_log_metric_filter_root_usage:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_quotes(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -434,7 +430,9 @@ class Test_cloudwatch_log_metric_filter_root_usage:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -474,22 +472,27 @@ class Test_cloudwatch_log_metric_filter_root_usage:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_newlines(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -523,7 +526,9 @@ class Test_cloudwatch_log_metric_filter_root_usage:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -563,3 +568,8 @@ class Test_cloudwatch_log_metric_filter_root_usage:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_security_group_changes/cloudwatch_log_metric_filter_security_group_changes_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_security_group_changes/cloudwatch_log_metric_filter_security_group_changes_test.py
@@ -1,48 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
@@ -55,7 +25,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -94,15 +66,17 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_no_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         cloudtrail_client.create_trail(Name="test_trail", S3BucketName="test")
 
@@ -114,7 +88,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -153,22 +129,24 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
 
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
@@ -179,7 +157,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -218,22 +198,24 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -256,7 +238,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -296,22 +280,27 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter but no alarms associated."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -345,7 +334,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -385,22 +376,27 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_quotes(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -434,7 +430,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -474,22 +472,27 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_newlines(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -523,7 +526,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -563,3 +568,8 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_sign_in_without_mfa/cloudwatch_log_metric_filter_sign_in_without_mfa_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_sign_in_without_mfa/cloudwatch_log_metric_filter_sign_in_without_mfa_test.py
@@ -1,48 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
@@ -55,7 +25,9 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -94,15 +66,17 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_no_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         cloudtrail_client.create_trail(Name="test_trail", S3BucketName="test")
 
@@ -114,7 +88,9 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -153,22 +129,24 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
 
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
@@ -179,7 +157,9 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -218,22 +198,24 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -256,7 +238,9 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -296,22 +280,27 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter but no alarms associated."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -345,7 +334,9 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -385,22 +376,27 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_quotes(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -434,7 +430,9 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -474,22 +472,27 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_newlines(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -523,7 +526,9 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -563,3 +568,8 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_unauthorized_api_calls/cloudwatch_log_metric_filter_unauthorized_api_calls_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_unauthorized_api_calls/cloudwatch_log_metric_filter_unauthorized_api_calls_test.py
@@ -1,48 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudtrail, mock_cloudwatch, mock_logs, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
@@ -55,7 +25,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -94,15 +66,17 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_no_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         cloudtrail_client.create_trail(Name="test_trail", S3BucketName="test")
 
@@ -114,7 +88,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -153,22 +129,24 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
 
         from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
@@ -179,7 +157,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -218,22 +198,24 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 result[0].status_extended
                 == "No CloudWatch log groups found with metric filters or alarms associated."
             )
-            assert result[0].resource_id == current_audit_info.audited_account
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -256,7 +238,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -296,22 +280,27 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter but no alarms associated."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -345,7 +334,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -385,22 +376,27 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_quotes(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -434,7 +430,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -474,22 +472,27 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_logs
     @mock_cloudtrail
     @mock_cloudwatch
     @mock_s3
     def test_cloudwatch_trail_with_log_group_with_metric_and_alarm_with_newlines(self):
-        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION)
-        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION)
-        logs_client = client("logs", region_name=AWS_REGION)
-        s3_client = client("s3", region_name=AWS_REGION)
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         s3_client.create_bucket(Bucket="test")
         logs_client.create_log_group(logGroupName="/log-group/test")
         cloudtrail_client.create_trail(
             Name="test_trail",
             S3BucketName="test",
-            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:/log-group/test:*",
+            CloudWatchLogsLogGroupArn=f"arn:aws:logs:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test:*",
         )
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
@@ -523,7 +526,9 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
             Logs,
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         from prowler.providers.common.models import Audit_Metadata
 
@@ -563,3 +568,8 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
                 == "CloudWatch log group /log-group/test found with metric filter test-filter and alarms set."
             )
             assert result[0].resource_id == "/log-group/test"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:metric-filter/test-filter"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_service_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_service_test.py
@@ -1,55 +1,25 @@
-from boto3 import client, session
+from boto3 import client
 from moto import mock_cloudwatch, mock_logs
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.cloudwatch.cloudwatch_service import (
     CloudWatch,
     Logs,
 )
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_CloudWatch_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                # We need to set this check to call __describe_log_groups__
-                expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test CloudWatch Service
     @mock_cloudwatch
     def test_service(self):
         # CloudWatch client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            expected_checks=["cloudwatch_log_group_no_secrets_in_logs"]
+        )
         cloudwatch = CloudWatch(audit_info)
         assert cloudwatch.service == "cloudwatch"
 
@@ -57,7 +27,9 @@ class Test_CloudWatch_Service:
     @mock_cloudwatch
     def test_client(self):
         # CloudWatch client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            expected_checks=["cloudwatch_log_group_no_secrets_in_logs"]
+        )
         cloudwatch = CloudWatch(audit_info)
         for client_ in cloudwatch.regional_clients.values():
             assert client_.__class__.__name__ == "CloudWatch"
@@ -66,7 +38,9 @@ class Test_CloudWatch_Service:
     @mock_cloudwatch
     def test__get_session__(self):
         # CloudWatch client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            expected_checks=["cloudwatch_log_group_no_secrets_in_logs"]
+        )
         cloudwatch = CloudWatch(audit_info)
         assert cloudwatch.session.__class__.__name__ == "Session"
 
@@ -74,7 +48,9 @@ class Test_CloudWatch_Service:
     @mock_cloudwatch
     def test_audited_account(self):
         # CloudWatch client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            expected_checks=["cloudwatch_log_group_no_secrets_in_logs"]
+        )
         cloudwatch = CloudWatch(audit_info)
         assert cloudwatch.audited_account == AWS_ACCOUNT_NUMBER
 
@@ -82,7 +58,9 @@ class Test_CloudWatch_Service:
     @mock_logs
     def test_logs_service(self):
         # Logs client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            expected_checks=["cloudwatch_log_group_no_secrets_in_logs"]
+        )
         logs = Logs(audit_info)
         assert logs.service == "logs"
 
@@ -90,7 +68,9 @@ class Test_CloudWatch_Service:
     @mock_logs
     def test_logs_client(self):
         # Logs client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            expected_checks=["cloudwatch_log_group_no_secrets_in_logs"]
+        )
         logs = Logs(audit_info)
         for client_ in logs.regional_clients.values():
             assert client_.__class__.__name__ == "CloudWatchLogs"
@@ -99,7 +79,9 @@ class Test_CloudWatch_Service:
     @mock_logs
     def test__logs_get_session__(self):
         # Logs client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            expected_checks=["cloudwatch_log_group_no_secrets_in_logs"]
+        )
         logs = Logs(audit_info)
         assert logs.session.__class__.__name__ == "Session"
 
@@ -107,7 +89,9 @@ class Test_CloudWatch_Service:
     @mock_logs
     def test_logs_audited_account(self):
         # Logs client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            expected_checks=["cloudwatch_log_group_no_secrets_in_logs"]
+        )
         logs = Logs(audit_info)
         assert logs.audited_account == AWS_ACCOUNT_NUMBER
 
@@ -115,7 +99,7 @@ class Test_CloudWatch_Service:
     @mock_cloudwatch
     def test__describe_alarms__(self):
         # CloudWatch client for this test class
-        cw_client = client("cloudwatch", region_name=AWS_REGION)
+        cw_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
         cw_client.put_metric_alarm(
             AlarmActions=["arn:alarm"],
             AlarmDescription="A test",
@@ -133,17 +117,19 @@ class Test_CloudWatch_Service:
             Unit="Seconds",
             Tags=[{"Key": "key-1", "Value": "value-1"}],
         )
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            expected_checks=["cloudwatch_log_group_no_secrets_in_logs"]
+        )
         cloudwatch = CloudWatch(audit_info)
         assert len(cloudwatch.metric_alarms) == 1
         assert (
             cloudwatch.metric_alarms[0].arn
-            == f"arn:aws:cloudwatch:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:alarm:test"
+            == f"arn:aws:cloudwatch:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:alarm:test"
         )
         assert cloudwatch.metric_alarms[0].name == "test"
         assert cloudwatch.metric_alarms[0].metric == "test_metric"
         assert cloudwatch.metric_alarms[0].name_space == "test_namespace"
-        assert cloudwatch.metric_alarms[0].region == AWS_REGION
+        assert cloudwatch.metric_alarms[0].region == AWS_REGION_US_EAST_1
         assert cloudwatch.metric_alarms[0].tags == [
             {"Key": "key-1", "Value": "value-1"}
         ]
@@ -152,7 +138,7 @@ class Test_CloudWatch_Service:
     @mock_logs
     def test__describe_metric_filters__(self):
         # Logs client for this test class
-        logs_client = client("logs", region_name=AWS_REGION)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
         logs_client.put_metric_filter(
             logGroupName="/log-group/test",
             filterName="test-filter",
@@ -165,20 +151,22 @@ class Test_CloudWatch_Service:
                 }
             ],
         )
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            expected_checks=["cloudwatch_log_group_no_secrets_in_logs"]
+        )
         logs = Logs(audit_info)
         assert len(logs.metric_filters) == 1
         assert logs.metric_filters[0].log_group == "/log-group/test"
         assert logs.metric_filters[0].name == "test-filter"
         assert logs.metric_filters[0].metric == "my-metric"
         assert logs.metric_filters[0].pattern == "test-pattern"
-        assert logs.metric_filters[0].region == AWS_REGION
+        assert logs.metric_filters[0].region == AWS_REGION_US_EAST_1
 
     # Test Logs Filters
     @mock_logs
     def test__describe_log_groups__(self):
         # Logs client for this test class
-        logs_client = client("logs", region_name=AWS_REGION)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
         logs_client.create_log_group(
             logGroupName="/log-group/test",
             kmsKeyId="test_kms_id",
@@ -187,18 +175,20 @@ class Test_CloudWatch_Service:
         logs_client.put_retention_policy(
             logGroupName="/log-group/test", retentionInDays=400
         )
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            expected_checks=["cloudwatch_log_group_no_secrets_in_logs"]
+        )
         logs = Logs(audit_info)
         assert len(logs.log_groups) == 1
         assert (
             logs.log_groups[0].arn
-            == f"arn:aws:logs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test"
+            == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test"
         )
         assert logs.log_groups[0].name == "/log-group/test"
         assert logs.log_groups[0].retention_days == 400
         assert logs.log_groups[0].kms_id == "test_kms_id"
         assert not logs.log_groups[0].never_expire
-        assert logs.log_groups[0].region == AWS_REGION
+        assert logs.log_groups[0].region == AWS_REGION_US_EAST_1
         assert logs.log_groups[0].tags == [
             {"tag_key_1": "tag_value_1", "tag_key_2": "tag_value_2"}
         ]
@@ -206,26 +196,28 @@ class Test_CloudWatch_Service:
     @mock_logs
     def test__describe_log_groups__never_expire(self):
         # Logs client for this test class
-        logs_client = client("logs", region_name=AWS_REGION)
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
         logs_client.create_log_group(
             logGroupName="/log-group/test",
             kmsKeyId="test_kms_id",
             tags={"tag_key_1": "tag_value_1", "tag_key_2": "tag_value_2"},
         )
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            expected_checks=["cloudwatch_log_group_no_secrets_in_logs"]
+        )
         logs = Logs(audit_info)
         assert len(logs.log_groups) == 1
         assert (
             logs.log_groups[0].arn
-            == f"arn:aws:logs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test"
+            == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:/log-group/test"
         )
         assert logs.log_groups[0].name == "/log-group/test"
         assert logs.log_groups[0].never_expire
         # Since it never expires we don't use the retention_days
         assert logs.log_groups[0].retention_days == 9999
         assert logs.log_groups[0].kms_id == "test_kms_id"
-        assert logs.log_groups[0].region == AWS_REGION
+        assert logs.log_groups[0].region == AWS_REGION_US_EAST_1
         assert logs.log_groups[0].tags == [
             {"tag_key_1": "tag_value_1", "tag_key_2": "tag_value_2"}
         ]


### PR DESCRIPTION
### Description

Refactor CloudWatch to use the `set_mocked_aws_audit_info`  helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
