### PR TITLE
test(audit_info): refactor codebuild

### DIFF
--- a/tests/providers/aws/services/codebuild/codebuild_service_test.py
+++ b/tests/providers/aws/services/codebuild/codebuild_service_test.py
@@ -2,15 +2,12 @@ from datetime import datetime, timedelta
 from unittest.mock import patch
 
 import botocore
-from boto3 import session
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.codebuild.codebuild_service import Codebuild
-from prowler.providers.common.models import Audit_Metadata
-
-# Mock Test Region
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
 # last time invoked time
 last_invoked_time = datetime.now() - timedelta(days=2)
@@ -42,9 +39,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 # Mock generate_regional_clients()
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_EU_WEST_1
+    )
+    regional_client.region = AWS_REGION_EU_WEST_1
+    return {AWS_REGION_EU_WEST_1: regional_client}
 
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
@@ -53,57 +52,27 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_Codebuild_Service:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test Codebuild Session
     def test__get_session__(self):
-        codebuild = Codebuild(self.set_mocked_audit_info())
+        codebuild = Codebuild(set_mocked_aws_audit_info())
         assert codebuild.session.__class__.__name__ == "Session"
 
     # Test Codebuild Service
     def test__get_service__(self):
-        codebuild = Codebuild(self.set_mocked_audit_info())
+        codebuild = Codebuild(set_mocked_aws_audit_info())
         assert codebuild.service == "codebuild"
 
     def test__list_projects__(self):
-        codebuild = Codebuild(self.set_mocked_audit_info())
+        codebuild = Codebuild(set_mocked_aws_audit_info())
         assert len(codebuild.projects) == 1
         assert codebuild.projects[0].name == "test"
-        assert codebuild.projects[0].region == AWS_REGION
+        assert codebuild.projects[0].region == AWS_REGION_EU_WEST_1
 
     def test__list_builds_for_project__(self):
-        codebuild = Codebuild(self.set_mocked_audit_info())
+        codebuild = Codebuild(set_mocked_aws_audit_info())
         assert len(codebuild.projects) == 1
         assert codebuild.projects[0].name == "test"
-        assert codebuild.projects[0].region == AWS_REGION
+        assert codebuild.projects[0].region == AWS_REGION_EU_WEST_1
         assert codebuild.projects[0].last_invoked_time == last_invoked_time
         assert (
             codebuild.projects[0].buildspec


### PR DESCRIPTION
### Description

Refactor CodeBuild to use the `set_mocked_aws_audit_info`  helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
