### PR TITLE
tests(audit_info): refactor vpc

### DIFF
--- a/tests/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries_test.py
+++ b/tests/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries_test.py
@@ -1,55 +1,25 @@
 import json
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
 TRUSTED_AWS_ACCOUNT_NUMBER = "111122223333"
 NON_TRUSTED_AWS_ACCOUNT_NUMBER = "000011112222"
 
 
 class Test_vpc_endpoint_connections_trust_boundaries:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_vpc_no_endpoints(self):
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         # Set config variable
         current_audit_info.audit_config = {"trusted_account_ids": []}
 
@@ -74,7 +44,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
     @mock_ec2
     def test_vpc_aws_endpoint(self):
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
@@ -88,7 +58,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
 
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         # Set config variable
         current_audit_info.audit_config = {"trusted_account_ids": []}
 
@@ -113,7 +83,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
     @mock_ec2
     def test_vpc_endpoint_with_full_access(self):
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
@@ -139,7 +109,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
 
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         # Set config variable
         current_audit_info.audit_config = {"trusted_account_ids": []}
 
@@ -169,12 +139,12 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     result[0].resource_id
                     == vpc_endpoint["VpcEndpoint"]["VpcEndpointId"]
                 )
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_ec2
     def test_vpc_endpoint_with_trusted_account_arn(self):
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
@@ -201,7 +171,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
         )
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         # Set config variable
         current_audit_info.audit_config = {"trusted_account_ids": []}
 
@@ -231,12 +201,12 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     result[0].resource_id
                     == vpc_endpoint["VpcEndpoint"]["VpcEndpointId"]
                 )
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_ec2
     def test_vpc_endpoint_with_trusted_account_id(self):
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
@@ -261,7 +231,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
         )
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         # Set config variable
         current_audit_info.audit_config = {"trusted_account_ids": []}
 
@@ -291,12 +261,12 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     result[0].resource_id
                     == vpc_endpoint["VpcEndpoint"]["VpcEndpointId"]
                 )
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_ec2
     def test_vpc_endpoint_with_untrusted_account(self):
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
@@ -324,7 +294,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
 
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         # Set config variable
         current_audit_info.audit_config = {"trusted_account_ids": []}
 
@@ -358,7 +328,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
     @mock_ec2
     def test_vpc_endpoint_with_config_trusted_account_with_arn(self):
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
@@ -385,7 +355,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
         )
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         # Set config variable
         current_audit_info.audit_config = {
@@ -418,12 +388,12 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     result[0].resource_id
                     == vpc_endpoint["VpcEndpoint"]["VpcEndpointId"]
                 )
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_ec2
     def test_vpc_endpoint_with_config_trusted_account(self):
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
@@ -448,7 +418,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
         )
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         # Set config variable
         current_audit_info.audit_config = {
@@ -481,12 +451,12 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     result[0].resource_id
                     == vpc_endpoint["VpcEndpoint"]["VpcEndpointId"]
                 )
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_ec2
     def test_vpc_endpoint_with_two_account_ids_one_trusted_one_not(self):
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
@@ -516,7 +486,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
         )
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         # Set config variable
         current_audit_info.audit_config = {"trusted_account_ids": []}
 
@@ -546,12 +516,12 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     result[0].resource_id
                     == vpc_endpoint["VpcEndpoint"]["VpcEndpointId"]
                 )
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_ec2
     def test_vpc_endpoint_with_aws_principal_all(self):
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
@@ -576,7 +546,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
         )
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         # Set config variable
         current_audit_info.audit_config = {"trusted_account_ids": []}
 
@@ -606,14 +576,14 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     result[0].resource_id
                     == vpc_endpoint["VpcEndpoint"]["VpcEndpointId"]
                 )
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_ec2
     def test_vpc_endpoint_with_aws_principal_all_but_restricted_condition_with_SourceAccount(
         self,
     ):
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
@@ -643,7 +613,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
         )
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         # Set config variable
         current_audit_info.audit_config = {"trusted_account_ids": []}
 
@@ -673,14 +643,14 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     result[0].resource_id
                     == vpc_endpoint["VpcEndpoint"]["VpcEndpointId"]
                 )
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_ec2
     def test_vpc_endpoint_with_aws_principal_all_but_restricted_condition_with_PrincipalAccount(
         self,
     ):
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
@@ -710,7 +680,7 @@ class Test_vpc_endpoint_connections_trust_boundaries:
         )
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         # Set config variable
         current_audit_info.audit_config = {"trusted_account_ids": []}
 
@@ -740,4 +710,4 @@ class Test_vpc_endpoint_connections_trust_boundaries:
                     result[0].resource_id
                     == vpc_endpoint["VpcEndpoint"]["VpcEndpointId"]
                 )
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/vpc/vpc_endpoint_services_allowed_principals_trust_boundaries/vpc_endpoint_services_allowed_principals_trust_boundaries_test.py
+++ b/tests/providers/aws/services/vpc/vpc_endpoint_services_allowed_principals_trust_boundaries/vpc_endpoint_services_allowed_principals_trust_boundaries_test.py
@@ -4,11 +4,11 @@ from boto3 import client
 from moto import mock_ec2, mock_elbv2
 
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_audit_info,
 )
 
-AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
 AWS_ACCOUNT_NUMBER_2 = "111122223333"
 AWS_ACCOUNT_ARN_2 = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER_2}:root"

--- a/tests/providers/aws/services/vpc/vpc_flow_logs_enabled/vpc_flow_logs_enabled_test.py
+++ b/tests/providers/aws/services/vpc/vpc_flow_logs_enabled/vpc_flow_logs_enabled_test.py
@@ -1,51 +1,24 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_vpc_flow_logs_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_ec2
     def test_vpc_only_default_vpcs(self):
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -69,7 +42,7 @@ class Test_vpc_flow_logs_enabled:
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         vpc = ec2_client.create_vpc(
             CidrBlock="10.0.0.0/16",
@@ -94,7 +67,9 @@ class Test_vpc_flow_logs_enabled:
             + ":role/test-role",
         )
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -125,11 +100,13 @@ class Test_vpc_flow_logs_enabled:
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -161,11 +138,13 @@ class Test_vpc_flow_logs_enabled:
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         current_audit_info.ignore_unused_services = True
 
         with mock.patch(
@@ -190,12 +169,14 @@ class Test_vpc_flow_logs_enabled:
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
         # Create VPC Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
 
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         current_audit_info.ignore_unused_services = True
 
         with mock.patch(

--- a/tests/providers/aws/services/vpc/vpc_peering_routing_tables_with_least_privilege/vpc_peering_routing_tables_with_least_privilege_test.py
+++ b/tests/providers/aws/services/vpc/vpc_peering_routing_tables_with_least_privilege/vpc_peering_routing_tables_with_least_privilege_test.py
@@ -1,52 +1,20 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_vpc_peering_routing_tables_with_least_privilege:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_vpc_no_peering_connections(self):
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -69,8 +37,8 @@ class Test_vpc_peering_routing_tables_with_least_privilege:
     @mock_ec2
     def test_vpc_comply_peering_connection_(self):
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
-        ec2_resource = resource("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
 
         # Create VPCs peers as well as a comply route
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
@@ -96,7 +64,7 @@ class Test_vpc_peering_routing_tables_with_least_privilege:
 
         from prowler.providers.aws.services.vpc.vpc_service import VPC, Route
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -131,13 +99,13 @@ class Test_vpc_peering_routing_tables_with_least_privilege:
                     == f"VPC Peering Connection {vpc_pcx_id} comply with least privilege access."
                 )
                 assert result[0].resource_id == vpc_pcx_id
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_ec2
     def test_vpc_comply_peering_connection_edge_case(self):
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
-        ec2_resource = resource("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
 
         # Create VPCs peers as well as a comply route
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
@@ -161,7 +129,7 @@ class Test_vpc_peering_routing_tables_with_least_privilege:
 
         from prowler.providers.aws.services.vpc.vpc_service import VPC, Route
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -196,13 +164,13 @@ class Test_vpc_peering_routing_tables_with_least_privilege:
                     == f"VPC Peering Connection {vpc_pcx_id} comply with least privilege access."
                 )
                 assert result[0].resource_id == vpc_pcx_id
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_ec2
     def test_vpc_not_comply_peering_connection_(self):
         # Create VPC Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
-        ec2_resource = resource("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
 
         # Create VPCs peers as well as a comply route
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
@@ -228,7 +196,7 @@ class Test_vpc_peering_routing_tables_with_least_privilege:
 
         from prowler.providers.aws.services.vpc.vpc_service import VPC, Route
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -263,4 +231,4 @@ class Test_vpc_peering_routing_tables_with_least_privilege:
                     == f"VPC Peering Connection {vpc_pcx_id} does not comply with least privilege access since it accepts whole VPCs CIDR in its route tables."
                 )
                 assert result[0].resource_id == vpc_pcx_id
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/vpc/vpc_service_test.py
+++ b/tests/providers/aws/services/vpc/vpc_service_test.py
@@ -1,53 +1,26 @@
 import json
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_elbv2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC, Route
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_VPC_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["eu-west-1", "us-east-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
 
     # Test VPC Service
     @mock_ec2
     def test_service(self):
         # VPC client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         vpc = VPC(audit_info)
         assert vpc.service == "ec2"
 
@@ -55,7 +28,9 @@ class Test_VPC_Service:
     @mock_ec2
     def test_client(self):
         # VPC client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         vpc = VPC(audit_info)
         for regional_client in vpc.regional_clients.values():
             assert regional_client.__class__.__name__ == "EC2"
@@ -64,7 +39,9 @@ class Test_VPC_Service:
     @mock_ec2
     def test__get_session__(self):
         # VPC client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         vpc = VPC(audit_info)
         assert vpc.session.__class__.__name__ == "Session"
 
@@ -72,7 +49,9 @@ class Test_VPC_Service:
     @mock_ec2
     def test_audited_account(self):
         # VPC client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         vpc = VPC(audit_info)
         assert vpc.audited_account == AWS_ACCOUNT_NUMBER
 
@@ -80,7 +59,7 @@ class Test_VPC_Service:
     @mock_ec2
     def test__describe_vpcs__(self):
         # Generate VPC Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create VPC
         vpc = ec2_client.create_vpc(
             CidrBlock="10.0.0.0/16",
@@ -94,7 +73,9 @@ class Test_VPC_Service:
             ],
         )["Vpc"]
         # VPC client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         vpc = VPC(audit_info)
         assert (
             len(vpc.vpcs) == 3
@@ -109,7 +90,7 @@ class Test_VPC_Service:
     @mock_ec2
     def test__describe_flow_logs__(self):
         # Generate VPC Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         new_vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
         # Create VPC Flow log
         ec2_client.create_flow_logs(
@@ -123,7 +104,9 @@ class Test_VPC_Service:
             + ":role/test-role",
         )
         # VPC client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         vpc = VPC(audit_info)
         # Search created VPC among default ones
         for vpc_iter in vpc.vpcs.values():
@@ -134,7 +117,7 @@ class Test_VPC_Service:
     @mock_ec2
     def test__describe_vpc_peering_connections__(self):
         # Generate VPC Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create VPCs peers
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         peer_vpc = ec2_client.create_vpc(CidrBlock="11.0.0.0/16")
@@ -156,7 +139,9 @@ class Test_VPC_Service:
             VpcPeeringConnectionId=vpc_pcx_id
         )
         # VPC client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         vpc = VPC(audit_info)
         assert len(vpc.vpc_peering_connections) == 1
         assert vpc.vpc_peering_connections[0].id == vpc_pcx_id
@@ -168,8 +153,8 @@ class Test_VPC_Service:
     @mock_ec2
     def test__describe_route_tables__(self):
         # Generate VPC Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
-        _ = resource("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        _ = resource("ec2", region_name=AWS_REGION_US_EAST_1)
 
         # Create VPCs peers as well as a route
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
@@ -195,7 +180,9 @@ class Test_VPC_Service:
         # )
 
         # VPC client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         vpc = VPC(audit_info)
         vpc.vpc_peering_connections[0].route_tables = [
             Route(
@@ -210,7 +197,7 @@ class Test_VPC_Service:
     @mock_ec2
     def test__describe_vpc_endpoints__(self):
         # Generate VPC Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create VPC endpoint
         vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
@@ -242,7 +229,9 @@ class Test_VPC_Service:
             ],
         )["VpcEndpoint"]["VpcEndpointId"]
         # VPC client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         vpc = VPC(audit_info)
         assert len(vpc.vpc_endpoints) == 1
         assert vpc.vpc_endpoints[0].id == endpoint
@@ -255,8 +244,8 @@ class Test_VPC_Service:
     @mock_elbv2
     def test__describe_vpc_endpoint_services__(self):
         # Generate VPC Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
-        elbv2_client = client("elbv2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        elbv2_client = client("elbv2", region_name=AWS_REGION_US_EAST_1)
 
         vpc = ec2_client.create_vpc(
             CidrBlock="172.28.7.0/24", InstanceTenancy="default"
@@ -264,7 +253,7 @@ class Test_VPC_Service:
         subnet = ec2_client.create_subnet(
             VpcId=vpc["Vpc"]["VpcId"],
             CidrBlock="172.28.7.192/26",
-            AvailabilityZone=f"{AWS_REGION}a",
+            AvailabilityZone=f"{AWS_REGION_US_EAST_1}a",
         )
         lb_name = "lb_vpce-test"
         lb_arn = elbv2_client.create_load_balancer(
@@ -286,11 +275,13 @@ class Test_VPC_Service:
             ],
         )
         endpoint_id = endpoint["ServiceConfiguration"]["ServiceId"]
-        endpoint_arn = f"arn:aws:ec2:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:vpc-endpoint-service/{endpoint_id}"
+        endpoint_arn = f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:vpc-endpoint-service/{endpoint_id}"
         endpoint_service = endpoint["ServiceConfiguration"]["ServiceName"]
 
         # VPC client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         vpc = VPC(audit_info)
 
         for vpce in vpc.vpc_endpoint_services:
@@ -299,14 +290,14 @@ class Test_VPC_Service:
             assert vpce.service == endpoint_service
             assert vpce.owner_id == AWS_ACCOUNT_NUMBER
             assert vpce.allowed_principals == []
-            assert vpce.region == AWS_REGION
+            assert vpce.region == AWS_REGION_US_EAST_1
             assert vpce.tags == []
 
     # Test VPC Describe VPC Subnets
     @mock_ec2
     def test__describe_vpc_subnets__(self):
         # Generate VPC Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create VPC
         vpc = ec2_client.create_vpc(
             CidrBlock="172.28.7.0/24", InstanceTenancy="default"
@@ -314,10 +305,12 @@ class Test_VPC_Service:
         subnet = ec2_client.create_subnet(
             VpcId=vpc["Vpc"]["VpcId"],
             CidrBlock="172.28.7.192/26",
-            AvailabilityZone=f"{AWS_REGION}a",
+            AvailabilityZone=f"{AWS_REGION_US_EAST_1}a",
         )
         # VPC client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
         vpc = VPC(audit_info)
         assert (
             len(vpc.vpcs) == 3
@@ -328,8 +321,8 @@ class Test_VPC_Service:
                 assert vpc.subnets[0].default is False
                 assert vpc.subnets[0].vpc_id == vpc.id
                 assert vpc.subnets[0].cidr_block == "172.28.7.192/26"
-                assert vpc.subnets[0].availability_zone == f"{AWS_REGION}a"
+                assert vpc.subnets[0].availability_zone == f"{AWS_REGION_US_EAST_1}a"
                 assert vpc.subnets[0].public is False
                 assert vpc.subnets[0].nat_gateway is False
-                assert vpc.subnets[0].region == AWS_REGION
+                assert vpc.subnets[0].region == AWS_REGION_US_EAST_1
                 assert vpc.subnets[0].tags is None

--- a/tests/providers/aws/services/vpc/vpc_subnet_different_az/vpc_subnet_different_az_test.py
+++ b/tests/providers/aws/services/vpc/vpc_subnet_different_az/vpc_subnet_different_az_test.py
@@ -1,50 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_vpc_subnet_different_az:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_vpc_subnet_different_az(self):
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2_client.create_vpc(
             CidrBlock="172.28.7.0/24",
             InstanceTenancy="default",
@@ -61,19 +29,19 @@ class Test_vpc_subnet_different_az:
         ec2_client.create_subnet(
             VpcId=vpc["Vpc"]["VpcId"],
             CidrBlock="172.28.7.192/26",
-            AvailabilityZone=f"{AWS_REGION}a",
+            AvailabilityZone=f"{AWS_REGION_US_EAST_1}a",
         )
 
         # VPC AZ 2
         ec2_client.create_subnet(
             VpcId=vpc["Vpc"]["VpcId"],
             CidrBlock="172.28.7.0/26",
-            AvailabilityZone=f"{AWS_REGION}b",
+            AvailabilityZone=f"{AWS_REGION_US_EAST_1}b",
         )
 
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -103,13 +71,13 @@ class Test_vpc_subnet_different_az:
                         assert result.resource_tags == [
                             {"Key": "Name", "Value": "vpc_name"}
                         ]
-                        assert result.region == AWS_REGION
+                        assert result.region == AWS_REGION_US_EAST_1
                 if not found:
                     assert False
 
     @mock_ec2
     def test_vpc_subnet_same_az(self):
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2_client.create_vpc(
             CidrBlock="172.28.7.0/24", InstanceTenancy="default"
         )
@@ -117,19 +85,19 @@ class Test_vpc_subnet_different_az:
         ec2_client.create_subnet(
             VpcId=vpc["Vpc"]["VpcId"],
             CidrBlock="172.28.7.192/26",
-            AvailabilityZone=f"{AWS_REGION}a",
+            AvailabilityZone=f"{AWS_REGION_US_EAST_1}a",
         )
 
         # VPC AZ 2
         ec2_client.create_subnet(
             VpcId=vpc["Vpc"]["VpcId"],
             CidrBlock="172.28.7.0/26",
-            AvailabilityZone=f"{AWS_REGION}a",
+            AvailabilityZone=f"{AWS_REGION_US_EAST_1}a",
         )
 
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -153,24 +121,24 @@ class Test_vpc_subnet_different_az:
                         assert result.status == "FAIL"
                         assert (
                             result.status_extended
-                            == f"VPC {vpc['Vpc']['VpcId']} has only subnets in {AWS_REGION}a."
+                            == f"VPC {vpc['Vpc']['VpcId']} has only subnets in {AWS_REGION_US_EAST_1}a."
                         )
                         assert result.resource_id == vpc["Vpc"]["VpcId"]
                         assert result.resource_tags == []
-                        assert result.region == AWS_REGION
+                        assert result.region == AWS_REGION_US_EAST_1
                 if not found:
                     assert False
 
     @mock_ec2
     def test_vpc_no_subnets(self):
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2_client.create_vpc(
             CidrBlock="172.28.7.0/24", InstanceTenancy="default"
         )
 
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -198,6 +166,6 @@ class Test_vpc_subnet_different_az:
                         )
                         assert result.resource_id == vpc["Vpc"]["VpcId"]
                         assert result.resource_tags == []
-                        assert result.region == AWS_REGION
+                        assert result.region == AWS_REGION_US_EAST_1
                 if not found:
                     assert False

--- a/tests/providers/aws/services/vpc/vpc_subnet_separate_private_public/vpc_subnet_separate_private_public_test.py
+++ b/tests/providers/aws/services/vpc/vpc_subnet_separate_private_public/vpc_subnet_separate_private_public_test.py
@@ -1,50 +1,18 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_vpc_subnet_separate_private_public:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_vpc_subnet_only_private(self):
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2_client.create_vpc(
             CidrBlock="172.28.7.0/24",
             InstanceTenancy="default",
@@ -61,7 +29,7 @@ class Test_vpc_subnet_separate_private_public:
         subnet_private = ec2_client.create_subnet(
             VpcId=vpc["Vpc"]["VpcId"],
             CidrBlock="172.28.7.192/26",
-            AvailabilityZone=f"{AWS_REGION}a",
+            AvailabilityZone=f"{AWS_REGION_US_EAST_1}a",
         )
         route_table_private = ec2_client.create_route_table(
             VpcId=vpc["Vpc"]["VpcId"],
@@ -77,7 +45,7 @@ class Test_vpc_subnet_separate_private_public:
 
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -107,13 +75,13 @@ class Test_vpc_subnet_separate_private_public:
                         assert result.resource_tags == [
                             {"Key": "Name", "Value": "vpc_name"}
                         ]
-                        assert result.region == AWS_REGION
+                        assert result.region == AWS_REGION_US_EAST_1
                 if not found:
                     assert False
 
     @mock_ec2
     def test_vpc_subnet_only_public(self):
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2_client.create_vpc(
             CidrBlock="172.28.7.0/24", InstanceTenancy="default"
         )
@@ -121,7 +89,7 @@ class Test_vpc_subnet_separate_private_public:
         subnet_public = ec2_client.create_subnet(
             VpcId=vpc["Vpc"]["VpcId"],
             CidrBlock="172.28.7.192/26",
-            AvailabilityZone=f"{AWS_REGION}a",
+            AvailabilityZone=f"{AWS_REGION_US_EAST_1}a",
         )
         route_table_public = ec2_client.create_route_table(
             VpcId=vpc["Vpc"]["VpcId"],
@@ -139,7 +107,7 @@ class Test_vpc_subnet_separate_private_public:
 
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -167,13 +135,13 @@ class Test_vpc_subnet_separate_private_public:
                         )
                         assert result.resource_id == vpc["Vpc"]["VpcId"]
                         assert result.resource_tags == []
-                        assert result.region == AWS_REGION
+                        assert result.region == AWS_REGION_US_EAST_1
                 if not found:
                     assert False
 
     @mock_ec2
     def test_vpc_subnet_private_and_public(self):
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2_client.create_vpc(
             CidrBlock="172.28.7.0/24", InstanceTenancy="default"
         )
@@ -181,7 +149,7 @@ class Test_vpc_subnet_separate_private_public:
         subnet_private = ec2_client.create_subnet(
             VpcId=vpc["Vpc"]["VpcId"],
             CidrBlock="172.28.7.192/26",
-            AvailabilityZone=f"{AWS_REGION}a",
+            AvailabilityZone=f"{AWS_REGION_US_EAST_1}a",
         )
         route_table_private = ec2_client.create_route_table(
             VpcId=vpc["Vpc"]["VpcId"],
@@ -198,7 +166,7 @@ class Test_vpc_subnet_separate_private_public:
         subnet_public = ec2_client.create_subnet(
             VpcId=vpc["Vpc"]["VpcId"],
             CidrBlock="172.28.7.0/26",
-            AvailabilityZone=f"{AWS_REGION}a",
+            AvailabilityZone=f"{AWS_REGION_US_EAST_1}a",
         )
         route_table_public = ec2_client.create_route_table(
             VpcId=vpc["Vpc"]["VpcId"],
@@ -216,7 +184,7 @@ class Test_vpc_subnet_separate_private_public:
 
         from prowler.providers.aws.services.vpc.vpc_service import VPC
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -244,6 +212,6 @@ class Test_vpc_subnet_separate_private_public:
                         )
                         assert result.resource_id == vpc["Vpc"]["VpcId"]
                         assert result.resource_tags == []
-                        assert result.region == AWS_REGION
+                        assert result.region == AWS_REGION_US_EAST_1
                 if not found:
                     assert False


### PR DESCRIPTION
### Description

Refactor VPC to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
