### PR TITLE
tests(audit_info): refactor trustedadvisor

### DIFF
--- a/tests/providers/aws/services/trustedadvisor/trustedadvisor_errors_and_warnings/trustedadvisor_errors_and_warnings_test.py
+++ b/tests/providers/aws/services/trustedadvisor/trustedadvisor_errors_and_warnings/trustedadvisor_errors_and_warnings_test.py
@@ -4,10 +4,11 @@ from prowler.providers.aws.services.trustedadvisor.trustedadvisor_service import
     Check,
     PremiumSupport,
 )
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+)
 
 CHECK_NAME = "test-check"
 
@@ -19,7 +20,7 @@ class Test_trustedadvisor_errors_and_warnings:
         trustedadvisor_client.premium_support = PremiumSupport(enabled=False)
         trustedadvisor_client.audited_account = AWS_ACCOUNT_NUMBER
         trustedadvisor_client.audited_account_arn = AWS_ACCOUNT_ARN
-        trustedadvisor_client.region = AWS_REGION
+        trustedadvisor_client.region = AWS_REGION_US_EAST_1
         with mock.patch(
             "prowler.providers.aws.services.trustedadvisor.trustedadvisor_service.TrustedAdvisor",
             trustedadvisor_client,
@@ -36,7 +37,7 @@ class Test_trustedadvisor_errors_and_warnings:
                 result[0].status_extended
                 == "Amazon Web Services Premium Support Subscription is required to use this service."
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert result[0].resource_arn == AWS_ACCOUNT_ARN
 
@@ -50,7 +51,7 @@ class Test_trustedadvisor_errors_and_warnings:
             Check(
                 id=CHECK_NAME,
                 name=CHECK_NAME,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 status="ok",
             )
         )
@@ -71,7 +72,7 @@ class Test_trustedadvisor_errors_and_warnings:
                 == f"Trusted Advisor check {CHECK_NAME} is in state ok."
             )
             assert result[0].resource_id == CHECK_NAME
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     def test_trustedadvisor_error_check(self):
         trustedadvisor_client = mock.MagicMock
@@ -83,7 +84,7 @@ class Test_trustedadvisor_errors_and_warnings:
             Check(
                 id=CHECK_NAME,
                 name=CHECK_NAME,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 status="error",
             )
         )
@@ -104,7 +105,7 @@ class Test_trustedadvisor_errors_and_warnings:
                 == f"Trusted Advisor check {CHECK_NAME} is in state error."
             )
             assert result[0].resource_id == CHECK_NAME
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     def test_trustedadvisor_not_available_check(self):
         trustedadvisor_client = mock.MagicMock
@@ -116,7 +117,7 @@ class Test_trustedadvisor_errors_and_warnings:
             Check(
                 id=CHECK_NAME,
                 name=CHECK_NAME,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 status="not_available",
             )
         )

--- a/tests/providers/aws/services/trustedadvisor/trustedadvisor_premium_support_plan_subscribed/trustedadvisor_premium_support_plan_subscribed_test.py
+++ b/tests/providers/aws/services/trustedadvisor/trustedadvisor_premium_support_plan_subscribed/trustedadvisor_premium_support_plan_subscribed_test.py
@@ -3,10 +3,11 @@ from unittest import mock
 from prowler.providers.aws.services.trustedadvisor.trustedadvisor_service import (
     PremiumSupport,
 )
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+)
 
 
 class Test_trustedadvisor_premium_support_plan_subscribed:
@@ -16,7 +17,7 @@ class Test_trustedadvisor_premium_support_plan_subscribed:
         trustedadvisor_client.premium_support = PremiumSupport(enabled=False)
         trustedadvisor_client.audited_account = AWS_ACCOUNT_NUMBER
         trustedadvisor_client.audited_account_arn = AWS_ACCOUNT_ARN
-        trustedadvisor_client.region = AWS_REGION
+        trustedadvisor_client.region = AWS_REGION_US_EAST_1
 
         # Set verify_premium_support_plans config
         trustedadvisor_client.audit_config = {"verify_premium_support_plans": True}
@@ -37,7 +38,7 @@ class Test_trustedadvisor_premium_support_plan_subscribed:
                 result[0].status_extended
                 == "Amazon Web Services Premium Support Plan isn't subscribed."
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert result[0].resource_arn == AWS_ACCOUNT_ARN
 
@@ -47,7 +48,7 @@ class Test_trustedadvisor_premium_support_plan_subscribed:
         trustedadvisor_client.premium_support = PremiumSupport(enabled=True)
         trustedadvisor_client.audited_account = AWS_ACCOUNT_NUMBER
         trustedadvisor_client.audited_account_arn = AWS_ACCOUNT_ARN
-        trustedadvisor_client.region = AWS_REGION
+        trustedadvisor_client.region = AWS_REGION_US_EAST_1
 
         # Set verify_premium_support_plans config
         trustedadvisor_client.audit_config = {"verify_premium_support_plans": True}
@@ -68,6 +69,6 @@ class Test_trustedadvisor_premium_support_plan_subscribed:
                 result[0].status_extended
                 == "Amazon Web Services Premium Support Plan is subscribed."
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert result[0].resource_arn == AWS_ACCOUNT_ARN

--- a/tests/providers/aws/services/trustedadvisor/trustedadvisor_service_test.py
+++ b/tests/providers/aws/services/trustedadvisor/trustedadvisor_service_test.py
@@ -1,17 +1,15 @@
 from unittest.mock import patch
 
 import botocore
-from boto3 import session
 from moto import mock_support
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.trustedadvisor.trustedadvisor_service import (
     TrustedAdvisor,
 )
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -39,60 +37,30 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_TrustedAdvisor_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
 
     # Test TrustedAdvisor Service
     def test_service(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         trustedadvisor = TrustedAdvisor(audit_info)
         assert trustedadvisor.service == "support"
 
     # Test TrustedAdvisor client
     def test_client(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         trustedadvisor = TrustedAdvisor(audit_info)
         assert trustedadvisor.client.__class__.__name__ == "Support"
 
     # Test TrustedAdvisor session
     def test__get_session__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         trustedadvisor = TrustedAdvisor(audit_info)
         assert trustedadvisor.session.__class__.__name__ == "Session"
 
     @mock_support
     # Test TrustedAdvisor session
     def test__describe_trusted_advisor_checks__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         trustedadvisor = TrustedAdvisor(audit_info)
         assert trustedadvisor.premium_support.enabled
         assert len(trustedadvisor.checks) == 104  # Default checks
-        assert trustedadvisor.checks[0].region == AWS_REGION
+        assert trustedadvisor.checks[0].region == AWS_REGION_US_EAST_1


### PR DESCRIPTION
### Description

Refactor Trustedadvisor to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
