### PR TITLE
test(audit_info): refactor config

### DIFF
--- a/tests/providers/aws/audit_info_utils.py
+++ b/tests/providers/aws/audit_info_utils.py
@@ -6,6 +6,7 @@ from prowler.providers.common.models import Audit_Metadata
 AWS_REGION_US_EAST_1 = "us-east-1"
 AWS_REGION_EU_WEST_1 = "eu-west-1"
 AWS_REGION_EU_WEST_2 = "eu-west-2"
+AWS_REGION_EU_SOUTH_2 = "eu-south-2"
 AWS_PARTITION = "aws"
 AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
@@ -18,6 +19,8 @@ def set_mocked_aws_audit_info(
     audited_account: str = AWS_ACCOUNT_NUMBER,
     audited_account_arn: str = AWS_ACCOUNT_ARN,
     expected_checks: [str] = [],
+    profile_region: str = None,
+    audit_config: dict = {},
 ):
     audit_info = AWS_Audit_Info(
         session_config=None,
@@ -32,7 +35,7 @@ def set_mocked_aws_audit_info(
         audited_partition=AWS_PARTITION,
         audited_identity_arn=None,
         profile=None,
-        profile_region=None,
+        profile_region=profile_region,
         credentials=None,
         assumed_role_info=None,
         audited_regions=audited_regions,
@@ -45,5 +48,6 @@ def set_mocked_aws_audit_info(
             completed_checks=0,
             audit_progress=0,
         ),
+        audit_config=audit_config,
     )
     return audit_info


### PR DESCRIPTION
### Description

Refactor Config to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
