### PR TITLE
test(audit_info): refactor directoryservice

### DIFF
--- a/tests/providers/aws/services/directoryservice/directoryservice_service_test.py
+++ b/tests/providers/aws/services/directoryservice/directoryservice_service_test.py
@@ -2,11 +2,8 @@ from datetime import datetime
 from unittest.mock import patch
 
 import botocore
-from boto3 import session
 from moto import mock_ds
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.directoryservice.directoryservice_service import (
     AuthenticationProtocol,
     CertificateState,
@@ -16,12 +13,12 @@ from prowler.providers.aws.services.directoryservice.directoryservice_service im
     EventTopicStatus,
     RadiusStatus,
 )
-from prowler.providers.common.models import Audit_Metadata
-
-# Mock Test Region
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
-
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 # Mocking Access Analyzer Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -69,7 +66,7 @@ def mock_make_api_call(self, operation_name, kwarg):
                 {
                     "DirectoryId": "d-12345a1b2",
                     "TopicName": "test-topic",
-                    "TopicArn": f"arn:aws:sns:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:test-topic",
+                    "TopicArn": f"arn:aws:sns:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:test-topic",
                     "CreatedDateTime": datetime(2022, 1, 1),
                     "Status": "Registered",
                 },
@@ -107,9 +104,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 # Mock generate_regional_clients()
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_EU_WEST_1
+    )
+    regional_client.region = AWS_REGION_EU_WEST_1
+    return {AWS_REGION_EU_WEST_1: regional_client}
 
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
@@ -119,75 +118,54 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_DirectoryService_Service:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     # Test DirectoryService Client
     @mock_ds
     def test__get_client__(self):
-        directoryservice = DirectoryService(self.set_mocked_audit_info())
+        directoryservice = DirectoryService(
+            set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+        )
         assert (
-            directoryservice.regional_clients[AWS_REGION].__class__.__name__
+            directoryservice.regional_clients[AWS_REGION_EU_WEST_1].__class__.__name__
             == "DirectoryService"
         )
 
     # Test DirectoryService Session
     @mock_ds
     def test__get_session__(self):
-        directoryservice = DirectoryService(self.set_mocked_audit_info())
+        directoryservice = DirectoryService(
+            set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+        )
         assert directoryservice.session.__class__.__name__ == "Session"
 
     # Test DirectoryService Service
     @mock_ds
     def test__get_service__(self):
-        directoryservice = DirectoryService(self.set_mocked_audit_info())
+        directoryservice = DirectoryService(
+            set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+        )
         assert directoryservice.service == "ds"
 
     @mock_ds
     def test__describe_directories__(self):
         # Set partition for the service
-        directoryservice = DirectoryService(self.set_mocked_audit_info())
+        directoryservice = DirectoryService(
+            set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+        )
 
         # __describe_directories__
         assert directoryservice.directories["d-12345a1b2"].id == "d-12345a1b2"
         assert (
             directoryservice.directories["d-12345a1b2"].arn
-            == f"arn:aws:ds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:directory/d-12345a1b2"
+            == f"arn:aws:ds:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:directory/d-12345a1b2"
         )
         assert (
             directoryservice.directories["d-12345a1b2"].type
             == DirectoryType.MicrosoftAD
         )
         assert directoryservice.directories["d-12345a1b2"].name == "test-directory"
-        assert directoryservice.directories["d-12345a1b2"].region == AWS_REGION
+        assert (
+            directoryservice.directories["d-12345a1b2"].region == AWS_REGION_EU_WEST_1
+        )
         assert directoryservice.directories["d-12345a1b2"].tags == [
             {"Key": "string", "Value": "string"},
         ]
@@ -222,7 +200,7 @@ class Test_DirectoryService_Service:
         )
         assert (
             directoryservice.directories["d-12345a1b2"].event_topics[0].topic_arn
-            == f"arn:aws:sns:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:test-topic"
+            == f"arn:aws:sns:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:test-topic"
         )
         assert (
             directoryservice.directories["d-12345a1b2"].event_topics[0].status


### PR DESCRIPTION
### Description

Refactor DirectoryService to use the `set_mocked_aws_audit_info`  helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
