### PR TITLE
test(audit_info): refactor ssm

### DIFF
--- a/tests/providers/aws/services/ssm/ssm_document_secrets/ssm_document_secrets_test.py
+++ b/tests/providers/aws/services/ssm/ssm_document_secrets/ssm_document_secrets_test.py
@@ -3,8 +3,7 @@ from unittest import mock
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.ssm.ssm_service import Document
-
-AWS_REGION = "eu-west-1"
+from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
 
 
 class Test_ssm_documents_secrets:
@@ -28,15 +27,13 @@ class Test_ssm_documents_secrets:
     def test_document_with_secrets(self):
         ssm_client = mock.MagicMock
         document_name = "test-document"
-        document_arn = (
-            f"arn:aws:ssm:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:document/{document_name}"
-        )
+        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:document/{document_name}"
         ssm_client.audited_account = DEFAULT_ACCOUNT_ID
         ssm_client.documents = {
             document_name: Document(
                 arn=document_arn,
                 name=document_name,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 content={"db_password": "test-password"},
                 account_owners=[],
             )
@@ -54,7 +51,7 @@ class Test_ssm_documents_secrets:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == document_name
             assert result[0].resource_arn == document_arn
             assert result[0].status == "FAIL"
@@ -66,15 +63,13 @@ class Test_ssm_documents_secrets:
     def test_document_no_secrets(self):
         ssm_client = mock.MagicMock
         document_name = "test-document"
-        document_arn = (
-            f"arn:aws:ssm:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:document/{document_name}"
-        )
+        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:document/{document_name}"
         ssm_client.audited_account = DEFAULT_ACCOUNT_ID
         ssm_client.documents = {
             document_name: Document(
                 arn=document_arn,
                 name=document_name,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 content={"profile": "test"},
                 account_owners=[],
             )
@@ -92,7 +87,7 @@ class Test_ssm_documents_secrets:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == document_name
             assert result[0].resource_arn == document_arn
             assert result[0].status == "PASS"

--- a/tests/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public_test.py
+++ b/tests/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public_test.py
@@ -3,8 +3,7 @@ from unittest import mock
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.ssm.ssm_service import Document
-
-AWS_REGION = "eu-west-1"
+from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
 
 
 class Test_ssm_documents_set_as_public:
@@ -28,15 +27,13 @@ class Test_ssm_documents_set_as_public:
     def test_document_public(self):
         ssm_client = mock.MagicMock
         document_name = "test-document"
-        document_arn = (
-            f"arn:aws:ssm:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:document/{document_name}"
-        )
+        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:document/{document_name}"
         ssm_client.audited_account = DEFAULT_ACCOUNT_ID
         ssm_client.documents = {
             document_name: Document(
                 arn=document_arn,
                 name=document_name,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 content="",
                 account_owners=["111111111111", "111111222222"],
             )
@@ -54,7 +51,7 @@ class Test_ssm_documents_set_as_public:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == document_name
             assert result[0].resource_arn == document_arn
             assert result[0].status == "FAIL"
@@ -65,15 +62,13 @@ class Test_ssm_documents_set_as_public:
     def test_document_not_public(self):
         ssm_client = mock.MagicMock
         document_name = "test-document"
-        document_arn = (
-            f"arn:aws:ssm:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:document/{document_name}"
-        )
+        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:document/{document_name}"
         ssm_client.audited_account = DEFAULT_ACCOUNT_ID
         ssm_client.documents = {
             document_name: Document(
                 arn=document_arn,
                 name=document_name,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 content="",
                 account_owners=[],
             )
@@ -91,7 +86,7 @@ class Test_ssm_documents_set_as_public:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == document_name
             assert result[0].resource_arn == document_arn
             assert result[0].status == "PASS"

--- a/tests/providers/aws/services/ssm/ssm_managed_compliant_patching/ssm_managed_compliant_patching_test.py
+++ b/tests/providers/aws/services/ssm/ssm_managed_compliant_patching/ssm_managed_compliant_patching_test.py
@@ -6,8 +6,7 @@ from prowler.providers.aws.services.ssm.ssm_service import (
     ComplianceResource,
     ResourceStatus,
 )
-
-AWS_REGION = "eu-west-1"
+from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
 
 
 class Test_ssm_managed_compliant_patching:
@@ -35,7 +34,7 @@ class Test_ssm_managed_compliant_patching:
         ssm_client.compliance_resources = {
             instance_id: ComplianceResource(
                 id="i-1234567890abcdef0",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 status=ResourceStatus.COMPLIANT,
             )
         }
@@ -53,7 +52,7 @@ class Test_ssm_managed_compliant_patching:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == instance_id
             assert result[0].status == "PASS"
             assert (
@@ -68,7 +67,7 @@ class Test_ssm_managed_compliant_patching:
         ssm_client.compliance_resources = {
             instance_id: ComplianceResource(
                 id="i-1234567890abcdef0",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 status=ResourceStatus.NON_COMPLIANT,
             )
         }
@@ -86,7 +85,7 @@ class Test_ssm_managed_compliant_patching:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == instance_id
             assert result[0].status == "FAIL"
             assert (

--- a/tests/providers/aws/services/ssm/ssm_service_test.py
+++ b/tests/providers/aws/services/ssm/ssm_service_test.py
@@ -2,16 +2,15 @@ from unittest.mock import patch
 
 import botocore
 import yaml
-from boto3 import client, session
+from boto3 import client
 from moto import mock_ssm
 from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.ssm.ssm_service import SSM, ResourceStatus
-from prowler.providers.common.models import Audit_Metadata
-
-# Mock Test Region
-AWS_REGION = "eu-west-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 # Mocking Access Analyzer Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -68,9 +67,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 # Mock generate_regional_clients()
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_US_EAST_1
+    )
+    regional_client.region = AWS_REGION_US_EAST_1
+    return {AWS_REGION_US_EAST_1: regional_client}
 
 
 # SSM Document YAML Template
@@ -132,59 +133,28 @@ mainSteps:
     new=mock_generate_regional_clients,
 )
 class Test_SSM_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=DEFAULT_ACCOUNT_ID,
-            audited_account_arn=f"arn:aws:iam::{DEFAULT_ACCOUNT_ID}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test SSM Client
     @mock_ssm
     def test__get_client__(self):
-        ssm = SSM(self.set_mocked_audit_info())
-        assert ssm.regional_clients[AWS_REGION].__class__.__name__ == "SSM"
+        ssm = SSM(set_mocked_aws_audit_info([AWS_REGION_US_EAST_1]))
+        assert ssm.regional_clients[AWS_REGION_US_EAST_1].__class__.__name__ == "SSM"
 
     # Test SSM Session
     @mock_ssm
     def test__get_session__(self):
-        ssm = SSM(self.set_mocked_audit_info())
+        ssm = SSM(set_mocked_aws_audit_info([AWS_REGION_US_EAST_1]))
         assert ssm.session.__class__.__name__ == "Session"
 
     # Test SSM Service
     @mock_ssm
     def test__get_service__(self):
-        ssm = SSM(self.set_mocked_audit_info())
+        ssm = SSM(set_mocked_aws_audit_info([AWS_REGION_US_EAST_1]))
         assert ssm.service == "ssm"
 
     @mock_ssm
     def test__list_documents__(self):
         # Create SSM Document
-        ssm_client = client("ssm", region_name=AWS_REGION)
+        ssm_client = client("ssm", region_name=AWS_REGION_US_EAST_1)
         ssm_document_name = "test-document"
         _ = ssm_client.create_document(
             Content=ssm_document_yaml,
@@ -202,16 +172,16 @@ class Test_SSM_Service:
             AccountIdsToAdd=[DEFAULT_ACCOUNT_ID],
         )
 
-        ssm = SSM(self.set_mocked_audit_info())
+        ssm = SSM(set_mocked_aws_audit_info([AWS_REGION_US_EAST_1]))
 
-        document_arn = f"arn:aws:ssm:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:document/{ssm_document_name}"
+        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:document/{ssm_document_name}"
 
         assert len(ssm.documents) == 1
         assert ssm.documents
         assert ssm.documents[document_arn]
         assert ssm.documents[document_arn].arn == document_arn
         assert ssm.documents[document_arn].name == ssm_document_name
-        assert ssm.documents[document_arn].region == AWS_REGION
+        assert ssm.documents[document_arn].region == AWS_REGION_US_EAST_1
         assert ssm.documents[document_arn].tags == [
             {"Key": "test", "Value": "test"},
         ]
@@ -220,11 +190,11 @@ class Test_SSM_Service:
 
     @mock_ssm
     def test__list_resource_compliance_summaries__(self):
-        ssm = SSM(self.set_mocked_audit_info())
+        ssm = SSM(set_mocked_aws_audit_info([AWS_REGION_US_EAST_1]))
         instance_id = "i-1234567890abcdef0"
         assert len(ssm.compliance_resources) == 1
         assert ssm.compliance_resources
         assert ssm.compliance_resources[instance_id]
         assert ssm.compliance_resources[instance_id].id == instance_id
-        assert ssm.compliance_resources[instance_id].region == AWS_REGION
+        assert ssm.compliance_resources[instance_id].region == AWS_REGION_US_EAST_1
         assert ssm.compliance_resources[instance_id].status == ResourceStatus.COMPLIANT


### PR DESCRIPTION
### Description

Refactor SSM to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
