### PR TITLE
test(audit_info): refactor documentdb

### DIFF
--- a/tests/providers/aws/services/documentdb/documentdb_service_test.py
+++ b/tests/providers/aws/services/documentdb/documentdb_service_test.py
@@ -1,22 +1,20 @@
 import botocore
-from boto3 import session
 from mock import patch
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.documentdb.documentdb_service import (
     DocumentDB,
     Instance,
 )
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 DOC_DB_CLUSTER_ID = "test-cluster"
 DOC_DB_INSTANCE_NAME = "test-db"
 DOC_DB_INSTANCE_ARN = (
-    f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:{DOC_DB_INSTANCE_NAME}"
+    f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:{DOC_DB_INSTANCE_NAME}"
 )
 DOC_DB_ENGINE_VERSION = "5.0.0"
 
@@ -61,9 +59,11 @@ def mock_make_api_call(self, operation_name, kwargs):
 
 
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_US_EAST_1
+    )
+    regional_client.region = AWS_REGION_US_EAST_1
+    return {AWS_REGION_US_EAST_1: regional_client}
 
 
 @patch(
@@ -73,64 +73,33 @@ def mock_generate_regional_clients(service, audit_info, _):
 # Patch every AWS call using Boto3
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_DocumentDB_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test DocumentDB Service
     def test_service(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         docdb = DocumentDB(audit_info)
         assert docdb.service == "docdb"
 
     # Test DocumentDB Client
     def test_client(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         docdb = DocumentDB(audit_info)
         assert docdb.client.__class__.__name__ == "DocDB"
 
     # Test DocumentDB Session
     def test__get_session__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         docdb = DocumentDB(audit_info)
         assert docdb.session.__class__.__name__ == "Session"
 
     # Test DocumentDB Session
     def test_audited_account(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         docdb = DocumentDB(audit_info)
         assert docdb.audited_account == AWS_ACCOUNT_NUMBER
 
     # Test DocumentDB Get DocumentDB Contacts
     def test_describe_db_instances(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         docdb = DocumentDB(audit_info)
         assert docdb.db_instances == {
             DOC_DB_INSTANCE_ARN: Instance(
@@ -142,7 +111,7 @@ class Test_DocumentDB_Service:
                 public=False,
                 encrypted=False,
                 cluster_id=DOC_DB_CLUSTER_ID,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 tags=[{"Key": "environment", "Value": "test"}],
             )
         }


### PR DESCRIPTION
### Description

Refactor DocumentDB to use the `set_mocked_aws_audit_info`  helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
