### PR TITLE
test(audit_info): refactor sns

### DIFF
--- a/tests/providers/aws/services/sns/sns_service_test.py
+++ b/tests/providers/aws/services/sns/sns_service_test.py
@@ -3,15 +3,15 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_sns
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.sns.sns_service import SNS
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "eu-west-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
 topic_name = "test-topic"
 test_policy = {
@@ -20,7 +20,7 @@ test_policy = {
             "Effect": "Allow",
             "Principal": {"AWS": f"{AWS_ACCOUNT_NUMBER}"},
             "Action": ["sns:Publish"],
-            "Resource": f"arn:aws:sns:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:{topic_name}",
+            "Resource": f"arn:aws:sns:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:{topic_name}",
         }
     ]
 }
@@ -38,9 +38,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_EU_WEST_1
+    )
+    regional_client.region = AWS_REGION_EU_WEST_1
+    return {AWS_REGION_EU_WEST_1: regional_client}
 
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
@@ -49,60 +51,30 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_SNS_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
 
     # Test SNS Service
     def test_service(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         sns = SNS(audit_info)
         assert sns.service == "sns"
 
     # Test SNS client
     def test_client(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         sns = SNS(audit_info)
         for reg_client in sns.regional_clients.values():
             assert reg_client.__class__.__name__ == "SNS"
 
     # Test SNS session
     def test__get_session__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         sns = SNS(audit_info)
         assert sns.session.__class__.__name__ == "Session"
 
     @mock_sns
     # Test SNS session
     def test__list_topics__(self):
-        sns_client = client("sns", region_name=AWS_REGION)
+        sns_client = client("sns", region_name=AWS_REGION_EU_WEST_1)
         sns_client.create_topic(
             Name=topic_name,
             Tags=[
@@ -110,16 +82,16 @@ class Test_SNS_Service:
             ],
         )
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         sns = SNS(audit_info)
 
         assert len(sns.topics) == 1
         assert sns.topics[0].name == topic_name
         assert (
             sns.topics[0].arn
-            == f"arn:aws:sns:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:{topic_name}"
+            == f"arn:aws:sns:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:{topic_name}"
         )
-        assert sns.topics[0].region == AWS_REGION
+        assert sns.topics[0].region == AWS_REGION_EU_WEST_1
         assert sns.topics[0].tags == [
             {"Key": "test", "Value": "test"},
         ]
@@ -127,17 +99,17 @@ class Test_SNS_Service:
     @mock_sns
     # Test SNS session
     def test__get_topic_attributes__(self):
-        sns_client = client("sns", region_name=AWS_REGION)
+        sns_client = client("sns", region_name=AWS_REGION_EU_WEST_1)
         sns_client.create_topic(Name=topic_name)
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         sns = SNS(audit_info)
 
         assert len(sns.topics) == 1
         assert (
             sns.topics[0].arn
-            == f"arn:aws:sns:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:{topic_name}"
+            == f"arn:aws:sns:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:{topic_name}"
         )
-        assert sns.topics[0].region == AWS_REGION
+        assert sns.topics[0].region == AWS_REGION_EU_WEST_1
         assert sns.topics[0].policy
         assert sns.topics[0].kms_master_key_id == kms_key_id

--- a/tests/providers/aws/services/sns/sns_topics_kms_encryption_at_rest_enabled/sns_topics_kms_encryption_at_rest_enabled_test.py
+++ b/tests/providers/aws/services/sns/sns_topics_kms_encryption_at_rest_enabled/sns_topics_kms_encryption_at_rest_enabled_test.py
@@ -3,13 +3,14 @@ from unittest import mock
 from uuid import uuid4
 
 from prowler.providers.aws.services.sns.sns_service import Topic
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 kms_key_id = str(uuid4())
 topic_name = "test-topic"
-topic_arn = f"arn:aws:sns:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:{topic_name}"
+topic_arn = f"arn:aws:sns:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:{topic_name}"
 
 
 class Test_sns_topics_kms_encryption_at_rest_enabled:
@@ -36,7 +37,7 @@ class Test_sns_topics_kms_encryption_at_rest_enabled:
                 arn=topic_arn,
                 name=topic_name,
                 kms_master_key_id=kms_key_id,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
             )
         )
         with mock.patch(
@@ -59,7 +60,7 @@ class Test_sns_topics_kms_encryption_at_rest_enabled:
         sns_client = mock.MagicMock
         sns_client.topics = []
         sns_client.topics.append(
-            Topic(arn=topic_arn, name=topic_name, region=AWS_REGION)
+            Topic(arn=topic_arn, name=topic_name, region=AWS_REGION_EU_WEST_1)
         )
         with mock.patch(
             "prowler.providers.aws.services.sns.sns_service.SNS",

--- a/tests/providers/aws/services/sns/sns_topics_not_publicly_accessible/sns_topics_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/sns/sns_topics_not_publicly_accessible/sns_topics_not_publicly_accessible_test.py
@@ -2,20 +2,21 @@ from unittest import mock
 from uuid import uuid4
 
 from prowler.providers.aws.services.sns.sns_service import Topic
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 kms_key_id = str(uuid4())
 topic_name = "test-topic"
-topic_arn = f"arn:aws:sns:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:{topic_name}"
+topic_arn = f"arn:aws:sns:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:{topic_name}"
 test_policy_restricted = {
     "Statement": [
         {
             "Effect": "Allow",
             "Principal": {"AWS": f"{AWS_ACCOUNT_NUMBER}"},
             "Action": ["sns:Publish"],
-            "Resource": f"arn:aws:sns:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:{topic_name}",
+            "Resource": f"arn:aws:sns:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:{topic_name}",
         }
     ]
 }
@@ -26,7 +27,7 @@ test_policy_restricted_condition = {
             "Effect": "Allow",
             "Principal": {"AWS": "*"},
             "Action": ["sns:Publish"],
-            "Resource": f"arn:aws:sns:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:{topic_name}",
+            "Resource": f"arn:aws:sns:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:{topic_name}",
             "Condition": {"StringEquals": {"aws:SourceAccount": AWS_ACCOUNT_NUMBER}},
         }
     ]
@@ -38,7 +39,7 @@ test_policy_restricted_default_condition = {
             "Effect": "Allow",
             "Principal": {"AWS": "*"},
             "Action": ["sns:Publish"],
-            "Resource": f"arn:aws:sns:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:{topic_name}",
+            "Resource": f"arn:aws:sns:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:{topic_name}",
             "Condition": {"StringEquals": {"aws:SourceOwner": AWS_ACCOUNT_NUMBER}},
         }
     ]
@@ -50,7 +51,7 @@ test_policy_not_restricted = {
             "Effect": "Allow",
             "Principal": {"AWS": "*"},
             "Action": ["sns:Publish"],
-            "Resource": f"arn:aws:sns:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:{topic_name}",
+            "Resource": f"arn:aws:sns:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:{topic_name}",
         }
     ]
 }
@@ -80,7 +81,7 @@ class Test_sns_topics_not_publicly_accessible:
                 arn=topic_arn,
                 name=topic_name,
                 policy=test_policy_restricted,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
             )
         )
         with mock.patch(
@@ -101,14 +102,14 @@ class Test_sns_topics_not_publicly_accessible:
             )
             assert result[0].resource_id == topic_name
             assert result[0].resource_arn == topic_arn
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
             assert result[0].resource_tags == []
 
     def test_topic_no_policy(self):
         sns_client = mock.MagicMock
         sns_client.topics = []
         sns_client.topics.append(
-            Topic(arn=topic_arn, name=topic_name, region=AWS_REGION)
+            Topic(arn=topic_arn, name=topic_name, region=AWS_REGION_EU_WEST_1)
         )
         with mock.patch(
             "prowler.providers.aws.services.sns.sns_service.SNS",
@@ -128,7 +129,7 @@ class Test_sns_topics_not_publicly_accessible:
             )
             assert result[0].resource_id == topic_name
             assert result[0].resource_arn == topic_arn
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
             assert result[0].resource_tags == []
 
     def test_topic_public_with_condition(self):
@@ -140,7 +141,7 @@ class Test_sns_topics_not_publicly_accessible:
                 arn=topic_arn,
                 name=topic_name,
                 policy=test_policy_restricted_condition,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
             )
         )
         with mock.patch(
@@ -161,7 +162,7 @@ class Test_sns_topics_not_publicly_accessible:
             )
             assert result[0].resource_id == topic_name
             assert result[0].resource_arn == topic_arn
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
             assert result[0].resource_tags == []
 
     def test_topic_public_with_default_condition(self):
@@ -173,7 +174,7 @@ class Test_sns_topics_not_publicly_accessible:
                 arn=topic_arn,
                 name=topic_name,
                 policy=test_policy_restricted_default_condition,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
             )
         )
         with mock.patch(
@@ -194,7 +195,7 @@ class Test_sns_topics_not_publicly_accessible:
             )
             assert result[0].resource_id == topic_name
             assert result[0].resource_arn == topic_arn
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
             assert result[0].resource_tags == []
 
     def test_topic_public(self):
@@ -204,7 +205,7 @@ class Test_sns_topics_not_publicly_accessible:
             Topic(
                 arn=topic_arn,
                 name=topic_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 policy=test_policy_not_restricted,
             )
         )
@@ -226,5 +227,5 @@ class Test_sns_topics_not_publicly_accessible:
             )
             assert result[0].resource_id == topic_name
             assert result[0].resource_arn == topic_arn
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
             assert result[0].resource_tags == []


### PR DESCRIPTION
### Description

Refactor SNS to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
