### PR TITLE
test(audit_info): refactor ec2

### DIFF
--- a/tests/providers/aws/audit_info_utils.py
+++ b/tests/providers/aws/audit_info_utils.py
@@ -4,6 +4,7 @@ from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION_US_EAST_1 = "us-east-1"
+AWS_REGION_US_EAST_1_AZA = "us-east-1a"
 AWS_REGION_EU_WEST_1 = "eu-west-1"
 AWS_REGION_EU_WEST_2 = "eu-west-2"
 AWS_REGION_EU_SOUTH_2 = "eu-south-2"
@@ -21,6 +22,7 @@ def set_mocked_aws_audit_info(
     expected_checks: [str] = [],
     profile_region: str = None,
     audit_config: dict = {},
+    ignore_unused_services: bool = False,
 ):
     audit_info = AWS_Audit_Info(
         session_config=None,
@@ -49,5 +51,6 @@ def set_mocked_aws_audit_info(
             audit_progress=0,
         ),
         audit_config=audit_config,
+        ignore_unused_services=ignore_unused_services,
     )
     return audit_info

--- a/tests/providers/aws/services/ec2/ec2_ami_public/ec2_ami_public_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ami_public/ec2_ami_public_test.py
@@ -1,53 +1,25 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
 EXAMPLE_AMI_ID = "ami-12c6146b"
-AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_ec2_ami_public:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_no_amis(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -68,7 +40,7 @@ class Test_ec2_ami_public:
 
     @mock_ec2
     def test_one_private_ami(self):
-        ec2 = client("ec2", region_name=AWS_REGION)
+        ec2 = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         reservation = ec2.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
         instance = reservation["Instances"][0]
@@ -80,7 +52,9 @@ class Test_ec2_ami_public:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -102,14 +76,14 @@ class Test_ec2_ami_public:
             assert result[0].resource_id == image_id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:image/{image_id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:image/{image_id}"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
 
     @mock_ec2
     def test_one_public_ami(self):
-        ec2 = client("ec2", region_name=AWS_REGION)
+        ec2 = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         reservation = ec2.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
         instance = reservation["Instances"][0]
@@ -130,7 +104,9 @@ class Test_ec2_ami_public:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -154,7 +130,7 @@ class Test_ec2_ami_public:
             assert result[0].resource_id == image_id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:image/{image_id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:image/{image_id}"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []

--- a/tests/providers/aws/services/ec2/ec2_ebs_default_encryption/ec2_ebs_default_encryption_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ebs_default_encryption/ec2_ebs_default_encryption_test.py
@@ -1,57 +1,30 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
 EXAMPLE_AMI_ID = "ami-12c6146b"
-AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_ec2_ebs_default_encryption:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_ebs_encryption_enabled(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.enable_ebs_encryption_by_default()
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -71,7 +44,7 @@ class Test_ec2_ebs_default_encryption:
             # One result per region
             assert len(results) == 2
             for result in results:
-                if result.region == AWS_REGION:
+                if result.region == AWS_REGION_US_EAST_1:
                     assert result.status == "PASS"
                     assert (
                         result.status_extended == "EBS Default Encryption is activated."
@@ -85,7 +58,9 @@ class Test_ec2_ebs_default_encryption:
     def test_ec2_ebs_encryption_disabled(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -115,8 +90,10 @@ class Test_ec2_ebs_default_encryption:
     def test_ec2_ebs_encryption_disabled_ignored(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -139,12 +116,14 @@ class Test_ec2_ebs_default_encryption:
     @mock_ec2
     def test_ec2_ebs_encryption_disabled_ignoring_with_volumes(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
-        ec2.create_volume(Size=36, AvailabilityZone=f"{AWS_REGION}a")
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2.create_volume(Size=36, AvailabilityZone=f"{AWS_REGION_US_EAST_1}a")
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -163,7 +142,7 @@ class Test_ec2_ebs_default_encryption:
 
             # One result per region
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended == "EBS Default Encryption is not activated."

--- a/tests/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot_test.py
@@ -1,20 +1,22 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from mock import patch
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_US_EAST_1
+    )
+    regional_client.region = AWS_REGION_US_EAST_1
+    return {AWS_REGION_US_EAST_1: regional_client}
 
 
 @patch(
@@ -22,42 +24,13 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_ec2_ebs_public_snapshot:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_snapshots(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -80,9 +53,9 @@ class Test_ec2_ebs_public_snapshot:
     @mock_ec2
     def test_ec2_public_snapshot(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
-        ec2_client = client("ec2", region_name=AWS_REGION)
-        volume = ec2.create_volume(Size=80, AvailabilityZone=f"{AWS_REGION}a")
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        volume = ec2.create_volume(Size=80, AvailabilityZone=f"{AWS_REGION_US_EAST_1}a")
         snapshot = volume.create_snapshot(Description="testsnap")
         ec2_client.modify_snapshot_attribute(
             SnapshotId=snapshot.id,
@@ -93,7 +66,9 @@ class Test_ec2_ebs_public_snapshot:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -115,7 +90,7 @@ class Test_ec2_ebs_public_snapshot:
 
             for snap in results:
                 if snap.resource_id == snapshot.id:
-                    assert snap.region == AWS_REGION
+                    assert snap.region == AWS_REGION_US_EAST_1
                     assert snap.resource_tags == []
                     assert snap.status == "FAIL"
                     assert (
@@ -124,21 +99,23 @@ class Test_ec2_ebs_public_snapshot:
                     )
                     assert (
                         snap.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:snapshot/{snapshot.id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:snapshot/{snapshot.id}"
                     )
 
     @mock_ec2
     def test_ec2_private_snapshot(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         snapshot = volume = ec2.create_volume(
-            Size=80, AvailabilityZone=f"{AWS_REGION}a", Encrypted=True
+            Size=80, AvailabilityZone=f"{AWS_REGION_US_EAST_1}a", Encrypted=True
         )
         snapshot = volume.create_snapshot(Description="testsnap")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -160,7 +137,7 @@ class Test_ec2_ebs_public_snapshot:
 
             for snap in results:
                 if snap.resource_id == snapshot.id:
-                    assert snap.region == AWS_REGION
+                    assert snap.region == AWS_REGION_US_EAST_1
                     assert snap.resource_tags == []
                     assert snap.status == "PASS"
                     assert (
@@ -169,5 +146,5 @@ class Test_ec2_ebs_public_snapshot:
                     )
                     assert (
                         snap.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:snapshot/{snapshot.id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:snapshot/{snapshot.id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_ebs_volume_encryption/ec2_ebs_volume_encryption_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ebs_volume_encryption/ec2_ebs_volume_encryption_test.py
@@ -1,52 +1,23 @@
 from unittest import mock
 
-from boto3 import resource, session
+from boto3 import resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_ebs_volume_encryption:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_no_volumes(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -68,12 +39,14 @@ class Test_ec2_ebs_volume_encryption:
     @mock_ec2
     def test_ec2_unencrypted_volume(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
-        volume = ec2.create_volume(Size=80, AvailabilityZone=f"{AWS_REGION}a")
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        volume = ec2.create_volume(Size=80, AvailabilityZone=f"{AWS_REGION_US_EAST_1}a")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -93,7 +66,7 @@ class Test_ec2_ebs_volume_encryption:
             assert len(result) == 1
 
             assert result[0].status == "FAIL"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             # Moto creates the volume with None in the tags attribute
             assert result[0].resource_tags is None
             assert (
@@ -101,20 +74,22 @@ class Test_ec2_ebs_volume_encryption:
             )
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:volume/{volume.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:volume/{volume.id}"
             )
 
     @mock_ec2
     def test_ec2_encrypted_volume(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         volume = ec2.create_volume(
-            Size=80, AvailabilityZone=f"{AWS_REGION}a", Encrypted=True
+            Size=80, AvailabilityZone=f"{AWS_REGION_US_EAST_1}a", Encrypted=True
         )
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -134,7 +109,7 @@ class Test_ec2_ebs_volume_encryption:
             assert len(result) == 1
 
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             # Moto creates the volume with None in the tags attribute
             assert result[0].resource_tags is None
             assert (
@@ -142,5 +117,5 @@ class Test_ec2_ebs_volume_encryption:
             )
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:volume/{volume.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:volume/{volume.id}"
             )

--- a/tests/providers/aws/services/ec2/ec2_elastic_ip_shodan/ec2_elastic_ip_shodan_test.py
+++ b/tests/providers/aws/services/ec2/ec2_elastic_ip_shodan/ec2_elastic_ip_shodan_test.py
@@ -1,59 +1,32 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 EXAMPLE_AMI_ID = "ami-12c6146b"
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "eu-west-1"
 
 
 class Test_ec2_elastic_ip_shodan:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-            audit_config={"shodan_api_key": ""},
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_one_instances_no_public_ip(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", AWS_REGION)
+        ec2_client = client("ec2", AWS_REGION_US_EAST_1)
         # Create EC2 Instance
         ec2_client.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            audit_config={"shodan_api_key": ""},
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -75,13 +48,16 @@ class Test_ec2_elastic_ip_shodan:
     @mock_ec2
     def test_ec2_one_unattached_eip(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", AWS_REGION)
+        ec2_client = client("ec2", AWS_REGION_US_EAST_1)
         # Create EC2 Instance
         ec2_client.allocate_address(Domain="vpc")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            audit_config={"shodan_api_key": ""},
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -103,7 +79,7 @@ class Test_ec2_elastic_ip_shodan:
     @mock_ec2
     def test_ec2_one_attached_eip_no_shodan_api_key(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", AWS_REGION)
+        ec2_client = client("ec2", AWS_REGION_US_EAST_1)
         # Create EC2 Instance
         instance = ec2_client.run_instances(
             ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
@@ -116,7 +92,10 @@ class Test_ec2_elastic_ip_shodan:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            audit_config={"shodan_api_key": ""},
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -138,7 +117,7 @@ class Test_ec2_elastic_ip_shodan:
     @mock_ec2
     def test_ec2_one_attached_eip_shodan_api_key(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", AWS_REGION)
+        ec2_client = client("ec2", AWS_REGION_US_EAST_1)
         # Create EC2 Instance
         instance = ec2_client.run_instances(
             ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
@@ -154,8 +133,10 @@ class Test_ec2_elastic_ip_shodan:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.audit_config = {"shodan_api_key": "XXXXXXX"}
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            audit_config={"shodan_api_key": "XXXXXXX"},
+        )
 
         ports = ["22", "443"]
         isp = "test-isp"
@@ -183,9 +164,9 @@ class Test_ec2_elastic_ip_shodan:
             assert result[0].resource_id == public_ip
             assert (
                 result[0].resource_arn
-                == f"arn:aws:ec2:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:eip-allocation/{allocation_id}"
+                == f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:eip-allocation/{allocation_id}"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
             assert result[0].status == "FAIL"
             assert (

--- a/tests/providers/aws/services/ec2/ec2_elastic_ip_unassigned/ec2_elastic_ip_unassigned_test.py
+++ b/tests/providers/aws/services/ec2/ec2_elastic_ip_unassigned/ec2_elastic_ip_unassigned_test.py
@@ -1,54 +1,26 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
 EXAMPLE_AMI_ID = "ami-12c6146b"
-AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_ec2_elastic_ip_unassigned:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_no_eips(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -70,14 +42,16 @@ class Test_ec2_elastic_ip_unassigned:
     @mock_ec2
     def test_eip_unassociated(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         allocation_id = ec2_client.allocate_address(
             Domain="vpc", Address="127.38.43.222"
         )["AllocationId"]
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -96,7 +70,7 @@ class Test_ec2_elastic_ip_unassigned:
 
             assert len(results) == 1
             assert results[0].status == "FAIL"
-            assert results[0].region == AWS_REGION
+            assert results[0].region == AWS_REGION_US_EAST_1
             assert results[0].resource_tags == []
             assert search(
                 "is not associated",
@@ -104,14 +78,14 @@ class Test_ec2_elastic_ip_unassigned:
             )
             assert (
                 results[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:eip-allocation/{allocation_id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:eip-allocation/{allocation_id}"
             )
 
     @mock_ec2
     def test_eip_associated(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
-        ec2_resource = resource("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
 
         reservation = ec2_client.run_instances(
             ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
@@ -128,7 +102,9 @@ class Test_ec2_elastic_ip_unassigned:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -147,7 +123,7 @@ class Test_ec2_elastic_ip_unassigned:
 
             assert len(results) == 1
             assert results[0].status == "PASS"
-            assert results[0].region == AWS_REGION
+            assert results[0].region == AWS_REGION_US_EAST_1
             assert results[0].resource_tags == []
             assert search(
                 "is associated",
@@ -155,5 +131,5 @@ class Test_ec2_elastic_ip_unassigned:
             )
             assert (
                 results[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:eip-allocation/{eip.allocation_id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:eip-allocation/{eip.allocation_id}"
             )

--- a/tests/providers/aws/services/ec2/ec2_instance_detailed_monitoring_enabled/ec2_instance_detailed_monitoring_enabled_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_detailed_monitoring_enabled/ec2_instance_detailed_monitoring_enabled_test.py
@@ -1,53 +1,25 @@
 from unittest import mock
 
-from boto3 import resource, session
+from boto3 import resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
 EXAMPLE_AMI_ID = "ami-12c6146b"
-AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_ec2_instance_detailed_monitoring_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_no_instances(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -68,7 +40,7 @@ class Test_ec2_instance_detailed_monitoring_enabled:
 
     @mock_ec2
     def test_instance_with_enhanced_monitoring_disabled(self):
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         instance = ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID,
             MinCount=1,
@@ -78,7 +50,9 @@ class Test_ec2_instance_detailed_monitoring_enabled:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -96,7 +70,7 @@ class Test_ec2_instance_detailed_monitoring_enabled:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             # Moto fills instance tags with None
             assert result[0].resource_tags is None
             assert (
@@ -106,12 +80,12 @@ class Test_ec2_instance_detailed_monitoring_enabled:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
 
     @mock_ec2
     def test_instance_with_enhanced_monitoring_enabled(self):
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         instance = ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID,
             MinCount=1,
@@ -121,7 +95,9 @@ class Test_ec2_instance_detailed_monitoring_enabled:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -142,7 +118,7 @@ class Test_ec2_instance_detailed_monitoring_enabled:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             # Moto fills instance tags with None
             assert result[0].resource_tags is None
             assert (
@@ -152,5 +128,5 @@ class Test_ec2_instance_detailed_monitoring_enabled:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )

--- a/tests/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled_test.py
@@ -1,54 +1,26 @@
 from re import search
 from unittest import mock
 
-from boto3 import resource, session
+from boto3 import resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
 EXAMPLE_AMI_ID = "ami-12c6146b"
-AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_ec2_instance_imdsv2_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_no_instances(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -69,7 +41,7 @@ class Test_ec2_instance_imdsv2_enabled:
 
     @mock_ec2
     def test_one_compliant_ec2(self):
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         instance = ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID,
             MinCount=1,
@@ -82,7 +54,9 @@ class Test_ec2_instance_imdsv2_enabled:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -103,7 +77,7 @@ class Test_ec2_instance_imdsv2_enabled:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             # Moto fills instance tags with None
             assert result[0].resource_tags is None
             assert search(
@@ -113,12 +87,12 @@ class Test_ec2_instance_imdsv2_enabled:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
 
     @mock_ec2
     def test_one_uncompliant_ec2_metadata_server_disabled(self):
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         instance = ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID,
             MinCount=1,
@@ -131,7 +105,9 @@ class Test_ec2_instance_imdsv2_enabled:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -152,7 +128,7 @@ class Test_ec2_instance_imdsv2_enabled:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             # Moto fills instance tags with None
             assert result[0].resource_tags is None
             assert (
@@ -162,12 +138,12 @@ class Test_ec2_instance_imdsv2_enabled:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
 
     @mock_ec2
     def test_one_uncompliant_ec2_metadata_server_enabled(self):
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         instance = ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID,
             MinCount=1,
@@ -180,7 +156,9 @@ class Test_ec2_instance_imdsv2_enabled:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -201,7 +179,7 @@ class Test_ec2_instance_imdsv2_enabled:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             # Moto fills instance tags with None
             assert result[0].resource_tags is None
             assert (
@@ -211,5 +189,5 @@ class Test_ec2_instance_imdsv2_enabled:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )

--- a/tests/providers/aws/services/ec2/ec2_instance_internet_facing_with_instance_profile/ec2_instance_internet_facing_with_instance_profile_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_internet_facing_with_instance_profile/ec2_instance_internet_facing_with_instance_profile_test.py
@@ -1,54 +1,26 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_iam
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
 EXAMPLE_AMI_ID = "ami-12c6146b"
-AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_ec2_instance_internet_facing_with_instance_profile:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_no_instances(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -75,7 +47,7 @@ class Test_ec2_instance_internet_facing_with_instance_profile:
         _ = iam.create_instance_profile(
             InstanceProfileName=profile_name,
         )
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         instance = ec2.create_instances(
@@ -94,7 +66,9 @@ class Test_ec2_instance_internet_facing_with_instance_profile:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -112,7 +86,7 @@ class Test_ec2_instance_internet_facing_with_instance_profile:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags is None
             assert result[0].status_extended == (
                 f"EC2 Instance {instance.id} is not internet facing with an instance profile."
@@ -120,7 +94,7 @@ class Test_ec2_instance_internet_facing_with_instance_profile:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
 
     @mock_iam
@@ -131,7 +105,7 @@ class Test_ec2_instance_internet_facing_with_instance_profile:
         _ = iam.create_instance_profile(
             InstanceProfileName=profile_name,
         )
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         instance = ec2.create_instances(
@@ -150,7 +124,9 @@ class Test_ec2_instance_internet_facing_with_instance_profile:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -168,7 +144,7 @@ class Test_ec2_instance_internet_facing_with_instance_profile:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags is None
             assert search(
                 "is internet-facing with Instance Profile", result[0].status_extended
@@ -176,5 +152,5 @@ class Test_ec2_instance_internet_facing_with_instance_profile:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )

--- a/tests/providers/aws/services/ec2/ec2_instance_managed_by_ssm/ec2_instance_managed_by_ssm_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_managed_by_ssm/ec2_instance_managed_by_ssm_test.py
@@ -1,54 +1,27 @@
 from unittest import mock
 
-from boto3 import resource, session
+from boto3 import resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.ssm.ssm_service import ManagedInstance
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
 EXAMPLE_AMI_ID = "ami-12c6146b"
-AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_ec2_instance_managed_by_ssm_test:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_no_instances(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         ssm_client = mock.MagicMock
         ssm_client.managed_instances = {}
@@ -81,7 +54,7 @@ class Test_ec2_instance_managed_by_ssm_test:
         ssm_client = mock.MagicMock
         ssm_client.managed_instances = {}
 
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         instance = ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID,
             MinCount=1,
@@ -94,7 +67,9 @@ class Test_ec2_instance_managed_by_ssm_test:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -119,7 +94,7 @@ class Test_ec2_instance_managed_by_ssm_test:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags is None
             assert (
                 result[0].status_extended
@@ -129,7 +104,7 @@ class Test_ec2_instance_managed_by_ssm_test:
 
     @mock_ec2
     def test_ec2_instance_managed_by_ssm_compliance_instance(self):
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         instance = ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID,
             MinCount=1,
@@ -140,15 +115,17 @@ class Test_ec2_instance_managed_by_ssm_test:
         ssm_client = mock.MagicMock
         ssm_client.managed_instances = {
             instance.id: ManagedInstance(
-                arn=f"arn:aws:ec2:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:instance/{instance.id}",
+                arn=f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:instance/{instance.id}",
                 id=instance.id,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         }
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -173,7 +150,7 @@ class Test_ec2_instance_managed_by_ssm_test:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags is None
             assert (
                 result[0].status_extended

--- a/tests/providers/aws/services/ec2/ec2_instance_older_than_specific_days/ec2_instance_older_than_specific_days_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_older_than_specific_days/ec2_instance_older_than_specific_days_test.py
@@ -2,55 +2,27 @@ import datetime
 from re import search
 from unittest import mock
 
-from boto3 import resource, session
+from boto3 import resource
 from dateutil.tz import tzutc
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
 EXAMPLE_AMI_ID = "ami-12c6146b"
-AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_ec2_instance_older_than_specific_days:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_no_instances(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         current_audit_info.audit_config = {"max_ec2_instance_age_in_days": 180}
 
         with mock.patch(
@@ -72,7 +44,7 @@ class Test_ec2_instance_older_than_specific_days:
 
     @mock_ec2
     def test_one_compliant_ec2(self):
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         instance = ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID,
             MinCount=1,
@@ -82,7 +54,9 @@ class Test_ec2_instance_older_than_specific_days:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         current_audit_info.audit_config = {"max_ec2_instance_age_in_days": 180}
 
         with mock.patch(
@@ -101,7 +75,7 @@ class Test_ec2_instance_older_than_specific_days:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags is None
             assert search(
                 f"EC2 Instance {instance.id} is not older", result[0].status_extended
@@ -109,12 +83,12 @@ class Test_ec2_instance_older_than_specific_days:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
 
     @mock_ec2
     def test_one_old_ec2(self):
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         instance = ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID,
             MinCount=1,
@@ -124,7 +98,9 @@ class Test_ec2_instance_older_than_specific_days:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         current_audit_info.audit_config = {"max_ec2_instance_age_in_days": 180}
 
         with mock.patch(
@@ -147,7 +123,7 @@ class Test_ec2_instance_older_than_specific_days:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags is None
             assert search(
                 f"EC2 Instance {instance.id} is older", result[0].status_extended
@@ -155,5 +131,5 @@ class Test_ec2_instance_older_than_specific_days:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )

--- a/tests/providers/aws/services/ec2/ec2_instance_profile_attached/ec2_instance_profile_attached_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_profile_attached/ec2_instance_profile_attached_test.py
@@ -1,54 +1,26 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_iam
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
 EXAMPLE_AMI_ID = "ami-12c6146b"
-AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_ec2_instance_profile_attached:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_no_instances(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -75,7 +47,7 @@ class Test_ec2_instance_profile_attached:
         _ = iam.create_instance_profile(
             InstanceProfileName=profile_name,
         )
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         instance = ec2.create_instances(
@@ -94,7 +66,9 @@ class Test_ec2_instance_profile_attached:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -112,7 +86,7 @@ class Test_ec2_instance_profile_attached:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags is None
             assert search(
                 "associated with Instance Profile Role",
@@ -121,12 +95,12 @@ class Test_ec2_instance_profile_attached:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
 
     @mock_ec2
     def test_one_non_compliant_ec2(self):
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         instance = ec2.create_instances(
@@ -144,7 +118,9 @@ class Test_ec2_instance_profile_attached:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -162,7 +138,7 @@ class Test_ec2_instance_profile_attached:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags is None
             assert search(
                 "not associated with an Instance Profile", result[0].status_extended
@@ -170,5 +146,5 @@ class Test_ec2_instance_profile_attached:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )

--- a/tests/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip_test.py
@@ -1,54 +1,26 @@
 from re import search
 from unittest import mock
 
-from boto3 import resource, session
+from boto3 import resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
 EXAMPLE_AMI_ID = "ami-12c6146b"
-AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_ec2_instance_public_ip:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_no_instances(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -69,7 +41,7 @@ class Test_ec2_instance_public_ip:
 
     @mock_ec2
     def test_one_compliant_ec2(self):
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         instance = ec2.create_instances(
@@ -87,7 +59,9 @@ class Test_ec2_instance_public_ip:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -105,7 +79,7 @@ class Test_ec2_instance_public_ip:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags is None
             assert search(
                 f"EC2 Instance {instance.id} does not have a Public IP.",
@@ -114,12 +88,12 @@ class Test_ec2_instance_public_ip:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
 
     @mock_ec2
     def test_one_ec2_with_public_ip(self):
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         instance = ec2.create_instances(
@@ -137,7 +111,9 @@ class Test_ec2_instance_public_ip:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -155,7 +131,7 @@ class Test_ec2_instance_public_ip:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags is None
             assert search(
                 f"EC2 Instance {instance.id} has a Public IP.",
@@ -164,5 +140,5 @@ class Test_ec2_instance_public_ip:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )

--- a/tests/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data_test.py
@@ -2,57 +2,29 @@ from os import path
 from pathlib import Path
 from unittest import mock
 
-from boto3 import resource, session
+from boto3 import resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
 EXAMPLE_AMI_ID = "ami-12c6146b"
-AWS_ACCOUNT_NUMBER = "123456789012"
 
 ACTUAL_DIRECTORY = Path(path.dirname(path.realpath(__file__)))
 FIXTURES_DIR_NAME = "fixtures"
 
 
 class Test_ec2_instance_secrets_user_data:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_no_ec2(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -73,7 +45,7 @@ class Test_ec2_instance_secrets_user_data:
 
     @mock_ec2
     def test_one_ec2_with_no_secrets(self):
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         instance = ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID,
             MinCount=1,
@@ -83,7 +55,9 @@ class Test_ec2_instance_secrets_user_data:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -108,14 +82,14 @@ class Test_ec2_instance_secrets_user_data:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
             assert result[0].resource_tags is None
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_ec2
     def test_one_ec2_with_secrets(self):
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         instance = ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID,
             MinCount=1,
@@ -125,7 +99,9 @@ class Test_ec2_instance_secrets_user_data:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -150,10 +126,10 @@ class Test_ec2_instance_secrets_user_data:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
             assert result[0].resource_tags is None
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_ec2
     def test_one_ec2_file_with_secrets(self):
@@ -163,14 +139,16 @@ class Test_ec2_instance_secrets_user_data:
             "r",
         )
         secrets = f.read()
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         instance = ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1, UserData=secrets
         )[0]
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -195,21 +173,23 @@ class Test_ec2_instance_secrets_user_data:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
             assert result[0].resource_tags is None
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_ec2
     def test_one_launch_configurations_without_user_data(self):
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         instance = ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1, UserData=""
         )[0]
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -234,10 +214,10 @@ class Test_ec2_instance_secrets_user_data:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
             assert result[0].resource_tags is None
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_ec2
     def test_one_ec2_file_with_secrets_gzip(self):
@@ -247,14 +227,16 @@ class Test_ec2_instance_secrets_user_data:
             "rb",
         )
         secrets = f.read()
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         instance = ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1, UserData=secrets
         )[0]
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -279,7 +261,7 @@ class Test_ec2_instance_secrets_user_data:
             assert result[0].resource_id == instance.id
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:instance/{instance.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:instance/{instance.id}"
             )
             assert result[0].resource_tags is None
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22_test.py
+++ b/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22_test.py
@@ -1,52 +1,23 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_networkacl_allow_ingress_tcp_port_22:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_nacls(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -70,7 +41,9 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
     def test_ec2_non_default_compliant_nacl(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -92,7 +65,7 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
 
             # by default nacls are public
             assert result[0].status == "FAIL"
-            assert result[0].region in (AWS_REGION, "eu-west-1")
+            assert result[0].region in (AWS_REGION_US_EAST_1, "eu-west-1")
             assert result[0].resource_tags == []
             assert (
                 result[0].status_extended
@@ -102,7 +75,7 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
     @mock_ec2
     def test_ec2_non_compliant_nacl(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         nacl_id = ec2_client.create_network_acl(VpcId=vpc_id)["NetworkAcl"][
             "NetworkAclId"
@@ -119,7 +92,9 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -142,7 +117,7 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
             for nacl in result:
                 if nacl.resource_id == nacl_id:
                     assert nacl.status == "FAIL"
-                    assert result[0].region in (AWS_REGION, "eu-west-1")
+                    assert result[0].region in (AWS_REGION_US_EAST_1, "eu-west-1")
                     assert result[0].resource_tags == []
                     assert (
                         nacl.status_extended
@@ -150,13 +125,13 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
                     )
                     assert (
                         nacl.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
                     )
 
     @mock_ec2
     def test_ec2_compliant_nacl(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         nacl_id = ec2_client.create_network_acl(VpcId=vpc_id)["NetworkAcl"][
             "NetworkAclId"
@@ -173,7 +148,9 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -196,7 +173,7 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
             for nacl in result:
                 if nacl.resource_id == nacl_id:
                     assert nacl.status == "PASS"
-                    assert result[0].region in (AWS_REGION, "eu-west-1")
+                    assert result[0].region in (AWS_REGION_US_EAST_1, "eu-west-1")
                     assert result[0].resource_tags == []
                     assert (
                         nacl.status_extended
@@ -204,13 +181,13 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
                     )
                     assert (
                         nacl.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
                     )
 
     @mock_ec2
     def test_ec2_non_compliant_nacl_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         nacl_id = ec2_client.create_network_acl(VpcId=vpc_id)["NetworkAcl"][
             "NetworkAclId"
@@ -226,8 +203,10 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -249,7 +228,7 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
     @mock_ec2
     def test_ec2_non_compliant_nacl_ignoring_with_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         nacl_id = ec2_client.create_network_acl(VpcId=vpc_id)["NetworkAcl"][
             "NetworkAclId"
@@ -266,8 +245,10 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -290,7 +271,7 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
             for nacl in result:
                 if nacl.resource_id == nacl_id:
                     assert nacl.status == "FAIL"
-                    assert result[0].region in (AWS_REGION, "eu-west-1")
+                    assert result[0].region in (AWS_REGION_US_EAST_1, "eu-west-1")
                     assert result[0].resource_tags == []
                     assert (
                         nacl.status_extended
@@ -298,5 +279,5 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_22:
                     )
                     assert (
                         nacl.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389_test.py
+++ b/tests/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389_test.py
@@ -1,52 +1,23 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_nacls(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -70,7 +41,9 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
     def test_ec2_non_default_compliant_nacl(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -92,7 +65,7 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
 
             # by default nacls are public
             assert result[0].status == "FAIL"
-            assert result[0].region in (AWS_REGION, "eu-west-1")
+            assert result[0].region in (AWS_REGION_US_EAST_1, "eu-west-1")
             assert result[0].resource_tags == []
             assert (
                 result[0].status_extended
@@ -102,7 +75,7 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
     @mock_ec2
     def test_ec2_non_compliant_nacl(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         nacl_id = ec2_client.create_network_acl(VpcId=vpc_id)["NetworkAcl"][
             "NetworkAclId"
@@ -119,7 +92,9 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -142,7 +117,7 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
             for nacl in result:
                 if nacl.resource_id == nacl_id:
                     assert nacl.status == "FAIL"
-                    assert result[0].region in (AWS_REGION, "eu-west-1")
+                    assert result[0].region in (AWS_REGION_US_EAST_1, "eu-west-1")
                     assert result[0].resource_tags == []
                     assert (
                         nacl.status_extended
@@ -150,13 +125,13 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
                     )
                     assert (
                         nacl.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
                     )
 
     @mock_ec2
     def test_ec2_compliant_nacl(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         nacl_id = ec2_client.create_network_acl(VpcId=vpc_id)["NetworkAcl"][
             "NetworkAclId"
@@ -173,7 +148,9 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -196,7 +173,7 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
             for nacl in result:
                 if nacl.resource_id == nacl_id:
                     assert nacl.status == "PASS"
-                    assert result[0].region in (AWS_REGION, "eu-west-1")
+                    assert result[0].region in (AWS_REGION_US_EAST_1, "eu-west-1")
                     assert result[0].resource_tags == []
                     assert (
                         nacl.status_extended
@@ -204,13 +181,13 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
                     )
                     assert (
                         nacl.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
                     )
 
     @mock_ec2
     def test_ec2_non_compliant_nacl_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         nacl_id = ec2_client.create_network_acl(VpcId=vpc_id)["NetworkAcl"][
             "NetworkAclId"
@@ -226,8 +203,10 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -249,7 +228,7 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
     @mock_ec2
     def test_ec2_non_compliant_nacl_ignoring_with_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         nacl_id = ec2_client.create_network_acl(VpcId=vpc_id)["NetworkAcl"][
             "NetworkAclId"
@@ -266,8 +245,10 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -290,7 +271,7 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
             for nacl in result:
                 if nacl.resource_id == nacl_id:
                     assert nacl.status == "FAIL"
-                    assert result[0].region in (AWS_REGION, "eu-west-1")
+                    assert result[0].region in (AWS_REGION_US_EAST_1, "eu-west-1")
                     assert result[0].resource_tags == []
                     assert (
                         nacl.status_extended
@@ -298,5 +279,5 @@ class Test_ec2_networkacl_allow_ingress_tcp_port_3389:
                     )
                     assert (
                         nacl.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:network-acl/{nacl_id}"
                     )

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port_test.py
@@ -1,59 +1,31 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[
-                    "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
-                ],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            expected_checks=[
+                "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+            ],
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -83,7 +55,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -102,7 +74,12 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            expected_checks=[
+                "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+            ],
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -128,14 +105,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has all ports open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -143,7 +120,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -162,7 +139,12 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            expected_checks=[
+                "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+            ],
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -188,14 +170,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have all ports open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -203,7 +185,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
     @mock_ec2
     def test_ec2_compliant_default_sg_only_open_to_one_port(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -227,7 +209,12 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            expected_checks=[
+                "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+            ],
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -253,14 +240,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have all ports open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -268,13 +255,18 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            expected_checks=[
+                "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+            ],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -299,11 +291,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -311,8 +303,13 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
         default_sg["GroupName"]
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            expected_checks=[
+                "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+            ],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -334,4 +331,4 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018_test.py
@@ -1,57 +1,28 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -83,7 +54,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_2
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -104,7 +75,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_2
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -132,14 +105,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_2
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has MongoDB ports 27017 and 27018 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -147,7 +120,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_2
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -168,7 +141,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_2
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -196,14 +171,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_2
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have MongoDB ports 27017 and 27018 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -211,13 +186,15 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_2
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -244,11 +221,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_2
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -256,8 +233,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_2
         default_sg["GroupName"]
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -281,4 +260,4 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_2
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21_test.py
@@ -1,57 +1,28 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -83,7 +54,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21:
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -104,7 +75,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -132,14 +105,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has FTP ports 20 and 21 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -147,7 +120,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21:
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -168,7 +141,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -196,14 +171,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have FTP ports 20 and 21 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -211,13 +186,15 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21:
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -244,11 +221,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21:
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -256,8 +233,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21:
         default_sg["GroupName"]
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -281,4 +260,4 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22_test.py
@@ -1,58 +1,29 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -82,7 +53,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -103,7 +74,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -129,7 +102,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has SSH port 22 open to the Internet."
@@ -140,7 +113,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -148,7 +121,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -169,7 +142,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -195,14 +170,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have SSH port 22 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -210,13 +185,15 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -241,11 +218,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -253,8 +230,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
         default_sg["GroupName"]
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -276,4 +255,4 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389_test.py
@@ -1,57 +1,28 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -81,13 +52,15 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -112,11 +85,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -124,8 +97,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
         default_sg["GroupName"]
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -147,12 +122,12 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -173,7 +148,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -199,14 +176,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has Microsoft RDP port 3389 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -214,7 +191,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -235,7 +212,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -261,14 +240,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have Microsoft RDP port 3389 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888_test.py
@@ -1,57 +1,28 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -83,7 +54,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -104,7 +75,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -132,14 +105,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has Casandra ports 7199, 8888 and 9160 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -147,7 +120,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -168,7 +141,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -196,14 +171,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have Casandra ports 7199, 8888 and 9160 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -211,13 +186,15 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -244,11 +221,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -256,8 +233,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7
         default_sg["GroupName"]
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -281,4 +260,4 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601_test.py
@@ -1,57 +1,28 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -83,7 +54,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsear
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -104,7 +75,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsear
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -132,14 +105,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsear
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has Elasticsearch/Kibana ports 9200, 9300 and 5601 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -147,7 +120,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsear
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -168,7 +141,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsear
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -196,14 +171,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsear
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have Elasticsearch/Kibana ports 9200, 9300 and 5601 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -211,13 +186,15 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsear
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -244,11 +221,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsear
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -256,8 +233,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsear
         default_sg["GroupName"]
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -281,4 +260,4 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsear
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092_test.py
@@ -1,57 +1,28 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -83,7 +54,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092:
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -104,7 +75,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -132,14 +105,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has Kafka port 9092 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -147,7 +120,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092:
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -168,7 +141,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -196,14 +171,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have Kafka port 9092 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -211,13 +186,15 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092:
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -244,11 +221,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092:
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -256,8 +233,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092:
         default_sg["GroupName"]
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -281,4 +260,4 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211_test.py
@@ -1,57 +1,28 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -83,7 +54,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_1
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -104,7 +75,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_1
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -132,14 +105,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_1
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has Memcached port 11211 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -147,7 +120,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_1
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -168,7 +141,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_1
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -196,14 +171,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_1
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have Memcached port 11211 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -211,13 +186,15 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_1
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -244,11 +221,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_1
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -256,8 +233,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_1
         default_sg["GroupName"]
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -281,4 +260,4 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_1
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306_test.py
@@ -1,57 +1,28 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -83,7 +54,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306:
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -104,7 +75,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -132,14 +105,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has MySQL port 3306 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -147,7 +120,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306:
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -168,7 +141,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -196,14 +171,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have MySQL port 3306 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -211,13 +186,15 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306:
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -244,11 +221,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306:
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -256,8 +233,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306:
         default_sg["GroupName"]
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -281,4 +260,4 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483_test.py
@@ -1,57 +1,28 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -83,7 +54,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -104,7 +75,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -132,14 +105,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has Oracle ports 1521 and 2483 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -147,7 +120,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -168,7 +141,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -196,14 +171,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have Oracle ports 1521 and 2483 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -211,13 +186,15 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -244,11 +221,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -256,8 +233,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521
         default_sg["GroupName"]
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -281,4 +260,4 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432_test.py
@@ -1,57 +1,28 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -83,7 +54,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_54
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -104,7 +75,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_54
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -132,14 +105,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_54
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has Postgres port 5432 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -147,7 +120,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_54
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -168,7 +141,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_54
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -196,14 +171,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_54
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have Postgres port 5432 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -211,7 +186,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_54
     @mock_ec2
     def test_ec2_compliant_default_sg_ipv4_and_ipv6(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -237,7 +212,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_54
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -265,14 +242,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_54
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have Postgres port 5432 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -280,13 +257,15 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_54
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -313,11 +292,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_54
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -325,8 +304,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_54
         default_sg["GroupName"]
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -350,4 +331,4 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_54
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379_test.py
@@ -5,8 +5,8 @@ from moto import mock_ec2
 
 from prowler.providers.aws.services.vpc.vpc_service import VPC
 from tests.providers.aws.audit_info_utils import (
-    AWS_REGION_US_EAST_1_EU_WEST_1,
-    AWS_REGION_US_EAST_1_US_EAST_1,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
     set_mocked_aws_audit_info,
 )
 
@@ -15,13 +15,13 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client_us_east_1 = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
+        ec2_client_us_east_1 = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client_us_east_1.create_vpc(CidrBlock="10.0.0.0/16")
         sgs_us_east_1 = ec2_client_us_east_1.describe_security_groups()[
             "SecurityGroups"
         ]
 
-        ec2_client_eu_west_1 = client("ec2", region_name=AWS_REGION_US_EAST_1_EU_WEST_1)
+        ec2_client_eu_west_1 = client("ec2", region_name=AWS_REGION_EU_WEST_1)
         sgs_eu_west_1 = ec2_client_eu_west_1.describe_security_groups()[
             "SecurityGroups"
         ]
@@ -29,8 +29,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
 
         current_audit_info = set_mocked_aws_audit_info(
             audited_regions=[
-                AWS_REGION_US_EAST_1_US_EAST_1,
-                AWS_REGION_US_EAST_1_EU_WEST_1,
+                AWS_REGION_US_EAST_1,
+                AWS_REGION_EU_WEST_1,
             ]
         )
 
@@ -63,14 +63,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
                 for res in result:
                     if res.resource_id == sg["GroupId"]:
                         assert res.status == "PASS"
-                        assert res.region == AWS_REGION_US_EAST_1_US_EAST_1
+                        assert res.region == AWS_REGION_US_EAST_1
                         assert (
                             res.status_extended
                             == f"Security group {sg['GroupName']} ({sg['GroupId']}) does not have Redis port 6379 open to the Internet."
                         )
                         assert (
                             res.resource_arn
-                            == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg['GroupId']}"
+                            == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg['GroupId']}"
                         )
                         assert res.resource_details == sg["GroupName"]
                         assert res.resource_tags == []
@@ -80,14 +80,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
                 for res in result:
                     if res.resource_id == sg["GroupId"]:
                         assert res.status == "PASS"
-                        assert res.region == AWS_REGION_US_EAST_1_EU_WEST_1
+                        assert res.region == AWS_REGION_EU_WEST_1
                         assert (
                             res.status_extended
                             == f"Security group {sg['GroupName']} ({sg['GroupId']}) does not have Redis port 6379 open to the Internet."
                         )
                         assert (
                             res.resource_arn
-                            == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_EU_WEST_1}:{current_audit_info.audited_account}:security-group/{sg['GroupId']}"
+                            == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_EU_WEST_1}:{current_audit_info.audited_account}:security-group/{sg['GroupId']}"
                         )
                         assert res.resource_details == sg["GroupName"]
                         assert res.resource_tags == []
@@ -95,7 +95,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client_us_east_1 = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
+        ec2_client_us_east_1 = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client_us_east_1.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client_us_east_1.describe_security_groups(
             GroupNames=["default"]
@@ -118,8 +118,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
 
         current_audit_info = set_mocked_aws_audit_info(
             audited_regions=[
-                AWS_REGION_US_EAST_1_US_EAST_1,
-                AWS_REGION_US_EAST_1_EU_WEST_1,
+                AWS_REGION_US_EAST_1,
+                AWS_REGION_EU_WEST_1,
             ]
         )
 
@@ -149,14 +149,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION_US_EAST_1_US_EAST_1
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has Redis port 6379 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -164,7 +164,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -187,8 +187,8 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
 
         current_audit_info = set_mocked_aws_audit_info(
             audited_regions=[
-                AWS_REGION_US_EAST_1_US_EAST_1,
-                AWS_REGION_US_EAST_1_EU_WEST_1,
+                AWS_REGION_US_EAST_1,
+                AWS_REGION_EU_WEST_1,
             ]
         )
         with mock.patch(
@@ -217,14 +217,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION_US_EAST_1_US_EAST_1
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have Redis port 6379 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -232,15 +232,15 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
         current_audit_info = set_mocked_aws_audit_info(
             audited_regions=[
-                AWS_REGION_US_EAST_1_US_EAST_1,
-                AWS_REGION_US_EAST_1_EU_WEST_1,
+                AWS_REGION_US_EAST_1,
+                AWS_REGION_EU_WEST_1,
             ]
         )
         current_audit_info.ignore_unused_services = True
@@ -270,11 +270,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         sgs_us_east_1 = ec2_client.describe_security_groups()["SecurityGroups"]
 
@@ -308,14 +308,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
             for sg in sgs_us_east_1:
                 if sg["GroupId"] == result[0].resource_id:
                     assert result[0].status == "PASS"
-                    assert result[0].region == AWS_REGION_US_EAST_1_US_EAST_1
+                    assert result[0].region == AWS_REGION_US_EAST_1
                     assert (
                         result[0].status_extended
                         == f"Security group {sg['GroupName']} ({sg['GroupId']}) does not have Redis port 6379 open to the Internet."
                     )
                     assert (
                         result[0].resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg['GroupId']}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg['GroupId']}"
                     )
                     assert result[0].resource_details == sg["GroupName"]
                     assert result[0].resource_tags == []

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379_test.py
@@ -5,8 +5,8 @@ from moto import mock_ec2
 
 from prowler.providers.aws.services.vpc.vpc_service import VPC
 from tests.providers.aws.audit_info_utils import (
-    AWS_REGION_EU_WEST_1,
-    AWS_REGION_US_EAST_1,
+    AWS_REGION_US_EAST_1_EU_WEST_1,
+    AWS_REGION_US_EAST_1_US_EAST_1,
     set_mocked_aws_audit_info,
 )
 
@@ -15,20 +15,23 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client_us_east_1 = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_client_us_east_1 = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
         ec2_client_us_east_1.create_vpc(CidrBlock="10.0.0.0/16")
         sgs_us_east_1 = ec2_client_us_east_1.describe_security_groups()[
             "SecurityGroups"
         ]
 
-        ec2_client_eu_west_1 = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_client_eu_west_1 = client("ec2", region_name=AWS_REGION_US_EAST_1_EU_WEST_1)
         sgs_eu_west_1 = ec2_client_eu_west_1.describe_security_groups()[
             "SecurityGroups"
         ]
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
         current_audit_info = set_mocked_aws_audit_info(
-            audited_regions=[AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+            audited_regions=[
+                AWS_REGION_US_EAST_1_US_EAST_1,
+                AWS_REGION_US_EAST_1_EU_WEST_1,
+            ]
         )
 
         with mock.patch(
@@ -60,14 +63,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
                 for res in result:
                     if res.resource_id == sg["GroupId"]:
                         assert res.status == "PASS"
-                        assert res.region == AWS_REGION_US_EAST_1
+                        assert res.region == AWS_REGION_US_EAST_1_US_EAST_1
                         assert (
                             res.status_extended
                             == f"Security group {sg['GroupName']} ({sg['GroupId']}) does not have Redis port 6379 open to the Internet."
                         )
                         assert (
                             res.resource_arn
-                            == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg['GroupId']}"
+                            == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg['GroupId']}"
                         )
                         assert res.resource_details == sg["GroupName"]
                         assert res.resource_tags == []
@@ -77,14 +80,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
                 for res in result:
                     if res.resource_id == sg["GroupId"]:
                         assert res.status == "PASS"
-                        assert res.region == AWS_REGION_EU_WEST_1
+                        assert res.region == AWS_REGION_US_EAST_1_EU_WEST_1
                         assert (
                             res.status_extended
                             == f"Security group {sg['GroupName']} ({sg['GroupId']}) does not have Redis port 6379 open to the Internet."
                         )
                         assert (
                             res.resource_arn
-                            == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_EU_WEST_1}:{current_audit_info.audited_account}:security-group/{sg['GroupId']}"
+                            == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_EU_WEST_1}:{current_audit_info.audited_account}:security-group/{sg['GroupId']}"
                         )
                         assert res.resource_details == sg["GroupName"]
                         assert res.resource_tags == []
@@ -92,7 +95,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client_us_east_1 = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_client_us_east_1 = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
         ec2_client_us_east_1.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client_us_east_1.describe_security_groups(
             GroupNames=["default"]
@@ -114,7 +117,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
         current_audit_info = set_mocked_aws_audit_info(
-            audited_regions=[AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+            audited_regions=[
+                AWS_REGION_US_EAST_1_US_EAST_1,
+                AWS_REGION_US_EAST_1_EU_WEST_1,
+            ]
         )
 
         with mock.patch(
@@ -143,14 +149,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION_US_EAST_1
+                    assert sg.region == AWS_REGION_US_EAST_1_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has Redis port 6379 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -158,7 +164,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -180,7 +186,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
         current_audit_info = set_mocked_aws_audit_info(
-            audited_regions=[AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+            audited_regions=[
+                AWS_REGION_US_EAST_1_US_EAST_1,
+                AWS_REGION_US_EAST_1_EU_WEST_1,
+            ]
         )
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -208,14 +217,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION_US_EAST_1
+                    assert sg.region == AWS_REGION_US_EAST_1_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have Redis port 6379 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -223,13 +232,16 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
         current_audit_info = set_mocked_aws_audit_info(
-            audited_regions=[AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+            audited_regions=[
+                AWS_REGION_US_EAST_1_US_EAST_1,
+                AWS_REGION_US_EAST_1_EU_WEST_1,
+            ]
         )
         current_audit_info.ignore_unused_services = True
 
@@ -258,11 +270,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
 
         sgs_us_east_1 = ec2_client.describe_security_groups()["SecurityGroups"]
 
@@ -296,14 +308,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379:
             for sg in sgs_us_east_1:
                 if sg["GroupId"] == result[0].resource_id:
                     assert result[0].status == "PASS"
-                    assert result[0].region == AWS_REGION_US_EAST_1
+                    assert result[0].region == AWS_REGION_US_EAST_1_US_EAST_1
                     assert (
                         result[0].status_extended
                         == f"Security group {sg['GroupName']} ({sg['GroupId']}) does not have Redis port 6379 open to the Internet."
                     )
                     assert (
                         result[0].resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg['GroupId']}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg['GroupId']}"
                     )
                     assert result[0].resource_details == sg["GroupName"]
                     assert result[0].resource_tags == []

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434_test.py
@@ -1,57 +1,28 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -83,7 +54,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -104,7 +75,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -132,14 +105,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has Microsoft SQL Server ports 1433 and 1434 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -147,7 +120,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -168,7 +141,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -196,14 +171,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have Microsoft SQL Server ports 1433 and 1434 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -211,13 +186,15 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -244,11 +221,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -256,8 +233,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_
         default_sg["GroupName"]
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -281,4 +260,4 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23_test.py
@@ -1,57 +1,28 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.vpc.vpc_service import VPC
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -83,7 +54,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23:
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -104,7 +75,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -132,14 +105,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has Telnet port 23 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -147,7 +120,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23:
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -168,7 +141,9 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -196,14 +171,14 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) does not have Telnet port 23 open to the Internet."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -211,13 +186,15 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23:
     @mock_ec2
     def test_ec2_default_sgs_ignoring(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -244,11 +221,11 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23:
     @mock_ec2
     def test_ec2_default_sgs_ignoring_vpc_in_use(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         ec2.create_network_interface(SubnetId=subnet.id)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -256,8 +233,10 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23:
         default_sg["GroupName"]
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
-        current_audit_info.ignore_unused_services = True
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            ignore_unused_services=True,
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -281,4 +260,4 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_wide_open_public_ipv4/ec2_securitygroup_allow_wide_open_public_ipv4_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_wide_open_public_ipv4/ec2_securitygroup_allow_wide_open_public_ipv4_test.py
@@ -1,56 +1,27 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_allow_wide_open_public_ipv4:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -77,7 +48,7 @@ class Test_ec2_securitygroup_allow_wide_open_public_ipv4:
     @mock_ec2
     def test_ec2_default_sg_with_RFC1918_address(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -96,7 +67,9 @@ class Test_ec2_securitygroup_allow_wide_open_public_ipv4:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -119,14 +92,14 @@ class Test_ec2_securitygroup_allow_wide_open_public_ipv4:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has no potential wide-open non-RFC1918 address."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -134,7 +107,7 @@ class Test_ec2_securitygroup_allow_wide_open_public_ipv4:
     @mock_ec2
     def test_ec2_default_sg_with_non_RFC1918_address(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -153,7 +126,9 @@ class Test_ec2_securitygroup_allow_wide_open_public_ipv4:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -176,14 +151,14 @@ class Test_ec2_securitygroup_allow_wide_open_public_ipv4:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has potential wide-open non-RFC1918 address 82.122.0.0/16 in ingress rule."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_default_restrict_traffic/ec2_securitygroup_default_restrict_traffic_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_default_restrict_traffic/ec2_securitygroup_default_restrict_traffic_test.py
@@ -1,51 +1,19 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_default_restrict_traffic:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_compliant_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -66,7 +34,7 @@ class Test_ec2_securitygroup_default_restrict_traffic:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -92,17 +60,17 @@ class Test_ec2_securitygroup_default_restrict_traffic:
             )
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
             )
             assert result[0].resource_details == default_sg_name
             assert result[0].resource_tags == []
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == default_sg_id
 
     @mock_ec2
     def test_ec2_non_compliant_sg_ingress_rule(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -129,7 +97,7 @@ class Test_ec2_securitygroup_default_restrict_traffic:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -155,17 +123,17 @@ class Test_ec2_securitygroup_default_restrict_traffic:
             )
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
             )
             assert result[0].resource_details == default_sg_name
             assert result[0].resource_tags == []
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == default_sg_id
 
     @mock_ec2
     def test_ec2_non_compliant_sg_egress_rule(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
         ][0]
@@ -174,7 +142,7 @@ class Test_ec2_securitygroup_default_restrict_traffic:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -200,9 +168,9 @@ class Test_ec2_securitygroup_default_restrict_traffic:
             )
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
             )
             assert result[0].resource_details == default_sg_name
             assert result[0].resource_tags == []
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == default_sg_id

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_from_launch_wizard/ec2_securitygroup_from_launch_wizard_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_from_launch_wizard/ec2_securitygroup_from_launch_wizard_test.py
@@ -1,57 +1,29 @@
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
 EXAMPLE_AMI_ID = "ami-12c6146b"
-AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_ec2_securitygroup_from_launch_wizard:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -78,7 +50,7 @@ class Test_ec2_securitygroup_from_launch_wizard:
     @mock_ec2
     def test_ec2_launch_wizard_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         sg_name = "launch-wizard-1"
         sg = ec2_client.create_security_group(
@@ -88,7 +60,9 @@ class Test_ec2_securitygroup_from_launch_wizard:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -111,21 +85,21 @@ class Test_ec2_securitygroup_from_launch_wizard:
             for sg in result:
                 if sg.resource_id == sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {sg_name} ({sg_id}) was created using the EC2 Launch Wizard."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg_id}"
                     )
                     assert sg.resource_details == sg_name
 
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -133,7 +107,7 @@ class Test_ec2_securitygroup_from_launch_wizard:
         default_sg_id = default_sg["GroupId"]
         default_sg_name = default_sg["GroupName"]
 
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID,
             MinCount=1,
@@ -145,7 +119,9 @@ class Test_ec2_securitygroup_from_launch_wizard:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -168,14 +144,14 @@ class Test_ec2_securitygroup_from_launch_wizard:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) was not created using the EC2 Launch Wizard."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used_test.py
@@ -6,7 +6,7 @@ from moto import mock_ec2, mock_iam, mock_lambda
 
 from tests.providers.aws.audit_info_utils import (
     AWS_ACCOUNT_NUMBER,
-    AWS_REGION_US_EAST_1_US_EAST_1,
+    AWS_REGION_US_EAST_1,
     set_mocked_aws_audit_info,
 )
 
@@ -18,7 +18,7 @@ class Test_ec2_securitygroup_not_used:
     @mock_lambda
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.awslambda.awslambda_service import Lambda
@@ -53,8 +53,8 @@ class Test_ec2_securitygroup_not_used:
     @mock_lambda
     def test_ec2_unused_sg(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", AWS_REGION_US_EAST_1_US_EAST_1)
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
+        ec2 = resource("ec2", AWS_REGION_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         sg_name = "test-sg"
         sg = ec2.create_security_group(
@@ -89,14 +89,14 @@ class Test_ec2_securitygroup_not_used:
             # One custom sg
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].region == AWS_REGION_US_EAST_1_US_EAST_1
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert (
                 result[0].status_extended
                 == f"Security group {sg_name} ({sg.id}) it is not being used."
             )
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
             )
             assert result[0].resource_id == sg.id
             assert result[0].resource_details == sg_name
@@ -106,8 +106,8 @@ class Test_ec2_securitygroup_not_used:
     @mock_lambda
     def test_ec2_used_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", AWS_REGION_US_EAST_1_US_EAST_1)
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
+        ec2 = resource("ec2", AWS_REGION_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         sg_name = "test-sg"
         sg = ec2.create_security_group(
@@ -144,7 +144,7 @@ class Test_ec2_securitygroup_not_used:
             # One custom sg
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION_US_EAST_1_US_EAST_1
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert (
                 result[0].status_extended
                 == f"Security group {sg_name} ({sg.id}) it is being used."
@@ -155,7 +155,7 @@ class Test_ec2_securitygroup_not_used:
             )
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
             )
             assert result[0].resource_id == sg.id
             assert result[0].resource_details == sg_name
@@ -166,8 +166,8 @@ class Test_ec2_securitygroup_not_used:
     @mock_iam
     def test_ec2_used_default_sg_by_lambda(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", AWS_REGION_US_EAST_1_US_EAST_1)
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
+        ec2 = resource("ec2", AWS_REGION_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         sg_name = "test-sg"
         sg = ec2.create_security_group(
@@ -175,13 +175,13 @@ class Test_ec2_securitygroup_not_used:
         )
         subnet = ec2.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/18")
         subnet.create_network_interface(Groups=[sg.id])
-        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
         iam_role = iam_client.create_role(
             RoleName="my-role",
             AssumeRolePolicyDocument="some policy",
             Path="/my-path/",
         )["Role"]["Arn"]
-        lambda_client = client("lambda", AWS_REGION_US_EAST_1_US_EAST_1)
+        lambda_client = client("lambda", AWS_REGION_US_EAST_1)
         lambda_client.create_function(
             FunctionName="test-function",
             Runtime="python3.11",
@@ -228,7 +228,7 @@ class Test_ec2_securitygroup_not_used:
             # One custom sg
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION_US_EAST_1_US_EAST_1
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert (
                 result[0].status_extended
                 == f"Security group {sg_name} ({sg.id}) it is being used."
@@ -239,7 +239,7 @@ class Test_ec2_securitygroup_not_used:
             )
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
             )
             assert result[0].resource_id == sg.id
             assert result[0].resource_details == sg_name
@@ -249,8 +249,8 @@ class Test_ec2_securitygroup_not_used:
     @mock_lambda
     def test_ec2_associated_sg(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", AWS_REGION_US_EAST_1_US_EAST_1)
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
+        ec2 = resource("ec2", AWS_REGION_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         sg_name = "test-sg"
         sg_name1 = "test-sg1"
@@ -304,27 +304,27 @@ class Test_ec2_securitygroup_not_used:
             # One custom sg
             assert len(result) == 2
             assert result[0].status == "FAIL"
-            assert result[0].region == AWS_REGION_US_EAST_1_US_EAST_1
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert (
                 result[0].status_extended
                 == f"Security group {sg_name} ({sg.id}) it is not being used."
             )
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
             )
             assert result[0].resource_id == sg.id
             assert result[0].resource_details == sg_name
             assert result[0].resource_tags == []
             assert result[1].status == "PASS"
-            assert result[1].region == AWS_REGION_US_EAST_1_US_EAST_1
+            assert result[1].region == AWS_REGION_US_EAST_1
             assert (
                 result[1].status_extended
                 == f"Security group {sg_name1} ({sg1.id}) it is being used."
             )
             assert (
                 result[1].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg1.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg1.id}"
             )
             assert result[1].resource_id == sg1.id
             assert result[1].resource_details == sg_name1

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used_test.py
@@ -6,7 +6,7 @@ from moto import mock_ec2, mock_iam, mock_lambda
 
 from tests.providers.aws.audit_info_utils import (
     AWS_ACCOUNT_NUMBER,
-    AWS_REGION_US_EAST_1,
+    AWS_REGION_US_EAST_1_US_EAST_1,
     set_mocked_aws_audit_info,
 )
 
@@ -18,7 +18,7 @@ class Test_ec2_securitygroup_not_used:
     @mock_lambda
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.awslambda.awslambda_service import Lambda
@@ -53,8 +53,8 @@ class Test_ec2_securitygroup_not_used:
     @mock_lambda
     def test_ec2_unused_sg(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", AWS_REGION_US_EAST_1)
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2 = resource("ec2", AWS_REGION_US_EAST_1_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         sg_name = "test-sg"
         sg = ec2.create_security_group(
@@ -89,14 +89,14 @@ class Test_ec2_securitygroup_not_used:
             # One custom sg
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].region == AWS_REGION_US_EAST_1_US_EAST_1
             assert (
                 result[0].status_extended
                 == f"Security group {sg_name} ({sg.id}) it is not being used."
             )
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
             )
             assert result[0].resource_id == sg.id
             assert result[0].resource_details == sg_name
@@ -106,8 +106,8 @@ class Test_ec2_securitygroup_not_used:
     @mock_lambda
     def test_ec2_used_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", AWS_REGION_US_EAST_1)
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2 = resource("ec2", AWS_REGION_US_EAST_1_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         sg_name = "test-sg"
         sg = ec2.create_security_group(
@@ -144,7 +144,7 @@ class Test_ec2_securitygroup_not_used:
             # One custom sg
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].region == AWS_REGION_US_EAST_1_US_EAST_1
             assert (
                 result[0].status_extended
                 == f"Security group {sg_name} ({sg.id}) it is being used."
@@ -155,7 +155,7 @@ class Test_ec2_securitygroup_not_used:
             )
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
             )
             assert result[0].resource_id == sg.id
             assert result[0].resource_details == sg_name
@@ -166,8 +166,8 @@ class Test_ec2_securitygroup_not_used:
     @mock_iam
     def test_ec2_used_default_sg_by_lambda(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", AWS_REGION_US_EAST_1)
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2 = resource("ec2", AWS_REGION_US_EAST_1_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         sg_name = "test-sg"
         sg = ec2.create_security_group(
@@ -175,13 +175,13 @@ class Test_ec2_securitygroup_not_used:
         )
         subnet = ec2.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/18")
         subnet.create_network_interface(Groups=[sg.id])
-        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
         iam_role = iam_client.create_role(
             RoleName="my-role",
             AssumeRolePolicyDocument="some policy",
             Path="/my-path/",
         )["Role"]["Arn"]
-        lambda_client = client("lambda", AWS_REGION_US_EAST_1)
+        lambda_client = client("lambda", AWS_REGION_US_EAST_1_US_EAST_1)
         lambda_client.create_function(
             FunctionName="test-function",
             Runtime="python3.11",
@@ -228,7 +228,7 @@ class Test_ec2_securitygroup_not_used:
             # One custom sg
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].region == AWS_REGION_US_EAST_1_US_EAST_1
             assert (
                 result[0].status_extended
                 == f"Security group {sg_name} ({sg.id}) it is being used."
@@ -239,7 +239,7 @@ class Test_ec2_securitygroup_not_used:
             )
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
             )
             assert result[0].resource_id == sg.id
             assert result[0].resource_details == sg_name
@@ -249,8 +249,8 @@ class Test_ec2_securitygroup_not_used:
     @mock_lambda
     def test_ec2_associated_sg(self):
         # Create EC2 Mocked Resources
-        ec2 = resource("ec2", AWS_REGION_US_EAST_1)
-        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2 = resource("ec2", AWS_REGION_US_EAST_1_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1_US_EAST_1)
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         sg_name = "test-sg"
         sg_name1 = "test-sg1"
@@ -304,27 +304,27 @@ class Test_ec2_securitygroup_not_used:
             # One custom sg
             assert len(result) == 2
             assert result[0].status == "FAIL"
-            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].region == AWS_REGION_US_EAST_1_US_EAST_1
             assert (
                 result[0].status_extended
                 == f"Security group {sg_name} ({sg.id}) it is not being used."
             )
             assert (
                 result[0].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg.id}"
             )
             assert result[0].resource_id == sg.id
             assert result[0].resource_details == sg_name
             assert result[0].resource_tags == []
             assert result[1].status == "PASS"
-            assert result[1].region == AWS_REGION_US_EAST_1
+            assert result[1].region == AWS_REGION_US_EAST_1_US_EAST_1
             assert (
                 result[1].status_extended
                 == f"Security group {sg_name1} ({sg1.id}) it is being used."
             )
             assert (
                 result[1].resource_arn
-                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg1.id}"
+                == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1_US_EAST_1}:{current_audit_info.audited_account}:security-group/{sg1.id}"
             )
             assert result[1].resource_id == sg1.id
             assert result[1].resource_details == sg_name1

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_with_many_ingress_egress_rules/ec2_securitygroup_with_many_ingress_egress_rules_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_with_many_ingress_egress_rules/ec2_securitygroup_with_many_ingress_egress_rules_test.py
@@ -1,56 +1,27 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ec2_securitygroup_with_many_ingress_egress_rules:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_ec2
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         current_audit_info.audit_config = {"max_security_group_rules": 50}
 
         with mock.patch(
@@ -78,7 +49,7 @@ class Test_ec2_securitygroup_with_many_ingress_egress_rules:
     @mock_ec2
     def test_ec2_non_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -100,7 +71,9 @@ class Test_ec2_securitygroup_with_many_ingress_egress_rules:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         current_audit_info.audit_config = {"max_security_group_rules": 50}
 
         with mock.patch(
@@ -124,14 +97,14 @@ class Test_ec2_securitygroup_with_many_ingress_egress_rules:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "FAIL"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has 60 inbound rules and 1 outbound rules."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []
@@ -139,7 +112,7 @@ class Test_ec2_securitygroup_with_many_ingress_egress_rules:
     @mock_ec2
     def test_ec2_compliant_default_sg(self):
         # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
         default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
@@ -160,7 +133,9 @@ class Test_ec2_securitygroup_with_many_ingress_egress_rules:
 
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         current_audit_info.audit_config = {"max_security_group_rules": 50}
 
         with mock.patch(
@@ -184,14 +159,14 @@ class Test_ec2_securitygroup_with_many_ingress_egress_rules:
             for sg in result:
                 if sg.resource_id == default_sg_id:
                     assert sg.status == "PASS"
-                    assert sg.region == AWS_REGION
+                    assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
                         == f"Security group {default_sg_name} ({default_sg_id}) has 1 inbound rules and 1 outbound rules."
                     )
                     assert (
                         sg.resource_arn
-                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
+                        == f"arn:{current_audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{current_audit_info.audited_account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
                     assert sg.resource_tags == []

--- a/tests/providers/aws/services/ec2/ec2_service_test.py
+++ b/tests/providers/aws/services/ec2/ec2_service_test.py
@@ -137,7 +137,10 @@ class Test_EC2_Service:
         )
         # EC2 client for this test class
         audit_info = set_mocked_aws_audit_info(
-            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
+            expected_checks=[
+                "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+            ],
         )
         ec2 = EC2(audit_info)
 

--- a/tests/providers/aws/services/ec2/ec2_service_test.py
+++ b/tests/providers/aws/services/ec2/ec2_service_test.py
@@ -3,60 +3,31 @@ import re
 from base64 import b64decode
 from datetime import datetime
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from dateutil.tz import tzutc
 from freezegun import freeze_time
 from moto import mock_ec2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.ec2.ec2_service import EC2
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
 EXAMPLE_AMI_ID = "ami-12c6146b"
 MOCK_DATETIME = datetime(2023, 1, 4, 7, 27, 30, tzinfo=tzutc())
 
 
 class Test_EC2_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["eu-west-1", "us-east-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[
-                    "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
-                ],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test EC2 Service
     @mock_ec2
     def test_service(self):
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
         assert ec2.service == "ec2"
 
@@ -64,7 +35,9 @@ class Test_EC2_Service:
     @mock_ec2
     def test_client(self):
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
         for regional_client in ec2.regional_clients.values():
             assert regional_client.__class__.__name__ == "EC2"
@@ -73,7 +46,9 @@ class Test_EC2_Service:
     @mock_ec2
     def test__get_session__(self):
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
         assert ec2.session.__class__.__name__ == "Session"
 
@@ -81,7 +56,9 @@ class Test_EC2_Service:
     @mock_ec2
     def test_audited_account(self):
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
         assert ec2.audited_account == AWS_ACCOUNT_NUMBER
 
@@ -90,8 +67,8 @@ class Test_EC2_Service:
     @freeze_time(MOCK_DATETIME)
     def test__describe_instances__(self):
         # Generate EC2 Client
-        ec2_resource = resource("ec2", region_name=AWS_REGION)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         # Get AMI image
         image_response = ec2_client.describe_images()
         image_id = image_response["Images"][0]["ImageId"]
@@ -102,13 +79,15 @@ class Test_EC2_Service:
             ImageId=image_id,
         )
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
         assert len(ec2.instances) == 1
         assert re.match(r"i-[0-9a-z]{17}", ec2.instances[0].id)
         assert (
             ec2.instances[0].arn
-            == f"arn:{audit_info.audited_partition}:ec2:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:instance/{ec2.instances[0].id}"
+            == f"arn:{audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:instance/{ec2.instances[0].id}"
         )
         assert ec2.instances[0].type == "m1.small"
         assert ec2.instances[0].state == "running"
@@ -133,7 +112,7 @@ class Test_EC2_Service:
     @mock_ec2
     def test__describe_security_groups__(self):
         # Generate EC2 Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create EC2 Security Group
         sg_id = ec2_client.create_security_group(
             Description="test-description",
@@ -157,7 +136,9 @@ class Test_EC2_Service:
             ],
         )
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
 
         assert sg_id in str(ec2.security_groups)
@@ -166,10 +147,10 @@ class Test_EC2_Service:
                 assert security_group.name == "test-security-group"
                 assert (
                     security_group.arn
-                    == f"arn:{audit_info.audited_partition}:ec2:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:security-group/{security_group.id}"
+                    == f"arn:{audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:security-group/{security_group.id}"
                 )
                 assert re.match(r"sg-[0-9a-z]{17}", security_group.id)
-                assert security_group.region == AWS_REGION
+                assert security_group.region == AWS_REGION_US_EAST_1
                 assert security_group.network_interfaces == []
                 assert security_group.ingress_rules == [
                     {
@@ -198,8 +179,8 @@ class Test_EC2_Service:
     @mock_ec2
     def test__describe_network_acls__(self):
         # Generate EC2 Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
-        ec2_resource = resource("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create EC2 VPC and SG
         vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
         nacl_id = ec2_resource.create_network_acl(
@@ -214,7 +195,9 @@ class Test_EC2_Service:
             ],
         ).id
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
 
         assert nacl_id in str(ec2.network_acls)
@@ -223,7 +206,7 @@ class Test_EC2_Service:
                 assert re.match(r"acl-[0-9a-z]{8}", acl.id)
                 assert (
                     acl.arn
-                    == f"arn:{audit_info.audited_partition}:ec2:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:network-acl/{acl.id}"
+                    == f"arn:{audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:network-acl/{acl.id}"
                 )
                 assert acl.entries == []
                 assert acl.tags == [
@@ -234,8 +217,8 @@ class Test_EC2_Service:
     @mock_ec2
     def test__describe_snapshots__(self):
         # Generate EC2 Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
-        ec2_resource = resource("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create EC2 Volume and Snapshot
         volume_id = ec2_resource.create_volume(
             AvailabilityZone="us-east-1a",
@@ -253,11 +236,11 @@ class Test_EC2_Service:
                 },
             ],
         )["SnapshotId"]
-        snapshot_arn = (
-            f"arn:aws:ec2:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:snapshot/{snapshot_id}"
-        )
+        snapshot_arn = f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:snapshot/{snapshot_id}"
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
 
         assert snapshot_id in str(ec2.snapshots)
@@ -267,7 +250,7 @@ class Test_EC2_Service:
             if snapshot.id == snapshot_id:
                 assert re.match(r"snap-[0-9a-z]{8}", snapshot.id)
                 assert snapshot.arn == snapshot_arn
-                assert snapshot.region == AWS_REGION
+                assert snapshot.region == AWS_REGION_US_EAST_1
                 assert snapshot.tags == [
                     {"Key": "test", "Value": "test"},
                 ]
@@ -278,8 +261,8 @@ class Test_EC2_Service:
     @mock_ec2
     def test__get_snapshot_public__(self):
         # Generate EC2 Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
-        ec2_resource = resource("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create EC2 Volume and Snapshot
         volume_id = ec2_resource.create_volume(
             AvailabilityZone="us-east-1a",
@@ -298,7 +281,9 @@ class Test_EC2_Service:
             SnapshotId=snapshot_id,
         )
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
 
         assert snapshot_id in str(ec2.snapshots)
@@ -307,9 +292,9 @@ class Test_EC2_Service:
                 assert re.match(r"snap-[0-9a-z]{8}", snapshot.id)
                 assert (
                     snapshot.arn
-                    == f"arn:{audit_info.audited_partition}:ec2:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:snapshot/{snapshot.id}"
+                    == f"arn:{audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:snapshot/{snapshot.id}"
                 )
-                assert snapshot.region == AWS_REGION
+                assert snapshot.region == AWS_REGION_US_EAST_1
                 assert not snapshot.encrypted
                 assert snapshot.public
 
@@ -317,7 +302,7 @@ class Test_EC2_Service:
     @mock_ec2
     def test__get_instance_user_data__(self):
         user_data = "This is some user_data"
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2.create_instances(
             ImageId=EXAMPLE_AMI_ID,
             MinCount=1,
@@ -325,30 +310,34 @@ class Test_EC2_Service:
             UserData="This is some user_data",
         )
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
         assert user_data == b64decode(ec2.instances[0].user_data).decode("utf-8")
 
     # Test EC2 Get EBS Encryption by default
     @mock_ec2
     def test__get_ebs_encryption_by_default__(self):
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client.enable_ebs_encryption_by_default()
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
 
         # One result per region
         assert len(ec2.ebs_encryption_by_default) == 2
         for result in ec2.ebs_encryption_by_default:
-            if result.region == AWS_REGION:
+            if result.region == AWS_REGION_US_EAST_1:
                 assert result.status
 
     # Test EC2 Describe Addresses
     @mock_ec2
     def test__describe_addresses__(self):
         # Generate EC2 Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         allocation_id = ec2_client.allocate_address(
             Domain="vpc",
             Address="127.38.43.222",
@@ -362,12 +351,14 @@ class Test_EC2_Service:
             ],
         )["AllocationId"]
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
         assert "127.38.43.222" in str(ec2.elastic_ips)
         assert (
             ec2.elastic_ips[0].arn
-            == f"arn:aws:ec2:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:eip-allocation/{allocation_id}"
+            == f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:eip-allocation/{allocation_id}"
         )
         assert ec2.elastic_ips[0].tags == [
             {"Key": "test", "Value": "test"},
@@ -377,8 +368,8 @@ class Test_EC2_Service:
     @mock_ec2
     def test__describe_sg_network_interfaces__(self):
         # Generate EC2 Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
-        ec2_resource = resource("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create VPC, Subnet, SecurityGroup and Network Interface
         vpc = ec2_resource.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2_resource.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
@@ -391,7 +382,9 @@ class Test_EC2_Service:
         )
 
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
 
         assert sg.id in str(ec2.security_groups)
@@ -400,10 +393,10 @@ class Test_EC2_Service:
                 assert security_group.name == "test-securitygroup"
                 assert (
                     security_group.arn
-                    == f"arn:{audit_info.audited_partition}:ec2:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:security-group/{security_group.id}"
+                    == f"arn:{audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:security-group/{security_group.id}"
                 )
                 assert re.match(r"sg-[0-9a-z]{17}", security_group.id)
-                assert security_group.region == AWS_REGION
+                assert security_group.region == AWS_REGION_US_EAST_1
                 assert eni_id in security_group.network_interfaces
                 assert security_group.ingress_rules == []
                 assert security_group.egress_rules == [
@@ -419,8 +412,8 @@ class Test_EC2_Service:
     @mock_ec2
     def test__describe_public_network_interfaces__(self):
         # Generate EC2 Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
-        ec2_resource = resource("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create VPC, Subnet, SecurityGroup and Network Interface
         vpc = ec2_resource.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2_resource.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
@@ -442,7 +435,9 @@ class Test_EC2_Service:
         )
 
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
 
         assert len(ec2.network_interfaces) == 1
@@ -451,7 +446,7 @@ class Test_EC2_Service:
         assert ec2.network_interfaces[0].type == eni.interface_type
         assert ec2.network_interfaces[0].subnet_id == subnet.id
         assert ec2.network_interfaces[0].vpc_id == vpc.id
-        assert ec2.network_interfaces[0].region == AWS_REGION
+        assert ec2.network_interfaces[0].region == AWS_REGION_US_EAST_1
         assert ec2.network_interfaces[0].tags == [
             {"Key": "string", "Value": "string"},
         ]
@@ -460,8 +455,8 @@ class Test_EC2_Service:
     @mock_ec2
     def test__describe_images__(self):
         # Generate EC2 Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
-        ec2_resource = resource("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create AMI
         tag_specifications = [
             {
@@ -486,7 +481,9 @@ class Test_EC2_Service:
         )["ImageId"]
 
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
 
         assert len(ec2.images) == 1
@@ -494,10 +491,10 @@ class Test_EC2_Service:
         assert re.match(r"ami-[0-9a-z]{8}", ec2.images[0].id)
         assert (
             ec2.images[0].arn
-            == f"arn:{audit_info.audited_partition}:ec2:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:image/{ec2.images[0].id}"
+            == f"arn:{audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:image/{ec2.images[0].id}"
         )
         assert not ec2.images[0].public
-        assert ec2.images[0].region == AWS_REGION
+        assert ec2.images[0].region == AWS_REGION_US_EAST_1
         assert ec2.images[0].tags == [
             {
                 "Key": "Base_AMI_Name",
@@ -510,10 +507,10 @@ class Test_EC2_Service:
     @mock_ec2
     def test__describe_volumes__(self):
         # Generate EC2 Client
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create Volume
         volume_id = ec2_client.create_volume(
-            AvailabilityZone=AWS_REGION,
+            AvailabilityZone=AWS_REGION_US_EAST_1,
             Encrypted=False,
             Size=40,
             TagSpecifications=[
@@ -527,7 +524,9 @@ class Test_EC2_Service:
         )["VolumeId"]
 
         # EC2 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
         ec2 = EC2(audit_info)
 
         assert len(ec2.volumes) == 1
@@ -535,9 +534,9 @@ class Test_EC2_Service:
         assert re.match(r"vol-[0-9a-z]{8}", ec2.volumes[0].id)
         assert (
             ec2.volumes[0].arn
-            == f"arn:{audit_info.audited_partition}:ec2:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:volume/{ec2.volumes[0].id}"
+            == f"arn:{audit_info.audited_partition}:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:volume/{ec2.volumes[0].id}"
         )
-        assert ec2.volumes[0].region == AWS_REGION
+        assert ec2.volumes[0].region == AWS_REGION_US_EAST_1
         assert not ec2.volumes[0].encrypted
         assert ec2.volumes[0].tags == [
             {"Key": "test", "Value": "test"},


### PR DESCRIPTION
### Description

Refactor EC2 to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
