### PR TITLE
test(audit_info): refactor shub

### DIFF
--- a/tests/providers/aws/services/securityhub/securityhub_enabled/securityhub_enabled_test.py
+++ b/tests/providers/aws/services/securityhub/securityhub_enabled/securityhub_enabled_test.py
@@ -3,16 +3,13 @@ from unittest import mock
 from prowler.providers.aws.services.securityhub.securityhub_service import (
     SecurityHubHub,
 )
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_ID = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
+from tests.providers.aws.audit_info_utils import AWS_ACCOUNT_ARN, AWS_REGION_EU_WEST_1
 
 
 class Test_securityhub_enabled:
     def test_securityhub_hub_inactive(self):
         securityhub_client = mock.MagicMock
-        securityhub_client.region = AWS_REGION
+        securityhub_client.region = AWS_REGION_EU_WEST_1
         securityhub_client.securityhubs = [
             SecurityHubHub(
                 arn=AWS_ACCOUNT_ARN,
@@ -20,7 +17,7 @@ class Test_securityhub_enabled:
                 status="NOT_AVAILABLE",
                 standards="",
                 integrations="",
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
             )
         ]
         with mock.patch(
@@ -39,7 +36,7 @@ class Test_securityhub_enabled:
             assert result[0].status_extended == "Security Hub is not enabled."
             assert result[0].resource_id == "Security Hub"
             assert result[0].resource_arn == AWS_ACCOUNT_ARN
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_securityhub_hub_active_with_standards(self):
         securityhub_client = mock.MagicMock
@@ -75,7 +72,7 @@ class Test_securityhub_enabled:
                 result[0].resource_arn
                 == "arn:aws:securityhub:us-east-1:0123456789012:hub/default"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_securityhub_hub_active_with_integrations(self):
         securityhub_client = mock.MagicMock
@@ -111,11 +108,11 @@ class Test_securityhub_enabled:
                 result[0].resource_arn
                 == "arn:aws:securityhub:us-east-1:0123456789012:hub/default"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_securityhub_hub_active_without_integrations_or_standards(self):
         securityhub_client = mock.MagicMock
-        securityhub_client.region = AWS_REGION
+        securityhub_client.region = AWS_REGION_EU_WEST_1
         securityhub_client.securityhubs = [
             SecurityHubHub(
                 arn="arn:aws:securityhub:us-east-1:0123456789012:hub/default",
@@ -148,12 +145,12 @@ class Test_securityhub_enabled:
                 result[0].resource_arn
                 == "arn:aws:securityhub:us-east-1:0123456789012:hub/default"
             )
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_securityhub_hub_active_without_integrations_or_standards_allowlisted(self):
         securityhub_client = mock.MagicMock
         securityhub_client.audit_config = {"allowlist_non_default_regions": True}
-        securityhub_client.region = AWS_REGION
+        securityhub_client.region = AWS_REGION_EU_WEST_1
         securityhub_client.securityhubs = [
             SecurityHubHub(
                 arn="arn:aws:securityhub:us-east-1:0123456789012:hub/default",

--- a/tests/providers/aws/services/securityhub/securityhub_service_test.py
+++ b/tests/providers/aws/services/securityhub/securityhub_service_test.py
@@ -1,15 +1,13 @@
 from unittest.mock import patch
 
 import botocore
-from boto3 import session
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.securityhub.securityhub_service import SecurityHub
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
-# Mock Test Region
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
 # Mocking Access Analyzer Calls
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -47,9 +45,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 # Mock generate_regional_clients()
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_EU_WEST_1
+    )
+    regional_client.region = AWS_REGION_EU_WEST_1
+    return {AWS_REGION_EU_WEST_1: regional_client}
 
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
@@ -59,53 +59,23 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_SecurityHub_Service:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
 
     # Test SecurityHub Client
     def test__get_client__(self):
-        security_hub = SecurityHub(self.set_mocked_audit_info())
+        security_hub = SecurityHub(set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1]))
         assert (
-            security_hub.regional_clients[AWS_REGION].__class__.__name__
+            security_hub.regional_clients[AWS_REGION_EU_WEST_1].__class__.__name__
             == "SecurityHub"
         )
 
     # Test SecurityHub Session
     def test__get_session__(self):
-        security_hub = SecurityHub(self.set_mocked_audit_info())
+        security_hub = SecurityHub(set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1]))
         assert security_hub.session.__class__.__name__ == "Session"
 
     def test__describe_hub__(self):
         # Set partition for the service
-        securityhub = SecurityHub(self.set_mocked_audit_info())
+        securityhub = SecurityHub(set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1]))
         assert len(securityhub.securityhubs) == 1
         assert (
             securityhub.securityhubs[0].arn


### PR DESCRIPTION
### Description

Refactor SecurityHub to use the set_mocked_aws_audit_info helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
