### PR TITLE
test(audit_info): refactor secretsmanager

### DIFF
--- a/tests/providers/aws/services/secretsmanager/secretsmanager_automatic_rotation_enabled/secretsmanager_automatic_rotation_enabled_test.py
+++ b/tests/providers/aws/services/secretsmanager/secretsmanager_automatic_rotation_enabled/secretsmanager_automatic_rotation_enabled_test.py
@@ -3,9 +3,7 @@ from unittest import mock
 from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.secretsmanager.secretsmanager_service import Secret
-
-# Mock Test Region
-AWS_REGION = "eu-west-1"
+from tests.providers.aws.audit_info_utils import AWS_REGION_EU_WEST_1
 
 
 class Test_secretsmanager_automatic_rotation_enabled:
@@ -29,11 +27,11 @@ class Test_secretsmanager_automatic_rotation_enabled:
     def test_secret_rotation_disabled(self):
         secretsmanager_client = mock.MagicMock
         secret_name = "test-secret"
-        secret_arn = f"arn:aws:secretsmanager:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:secret:{secret_name}"
+        secret_arn = f"arn:aws:secretsmanager:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:secret:{secret_name}"
         secretsmanager_client.secrets = {
             secret_name: Secret(
                 arn=secret_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 name=secret_name,
                 rotation_enabled=False,
             )
@@ -51,7 +49,7 @@ class Test_secretsmanager_automatic_rotation_enabled:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
             assert result[0].resource_id == secret_name
             assert result[0].resource_arn == secret_arn
             assert result[0].status == "FAIL"
@@ -63,11 +61,11 @@ class Test_secretsmanager_automatic_rotation_enabled:
     def test_secret_rotation_enabled(self):
         secretsmanager_client = mock.MagicMock
         secret_name = "test-secret"
-        secret_arn = f"arn:aws:secretsmanager:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:secret:{secret_name}"
+        secret_arn = f"arn:aws:secretsmanager:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:secret:{secret_name}"
         secretsmanager_client.secrets = {
             secret_name: Secret(
                 arn=secret_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 name=secret_name,
                 rotation_enabled=True,
             )
@@ -85,7 +83,7 @@ class Test_secretsmanager_automatic_rotation_enabled:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
             assert result[0].resource_id == secret_name
             assert result[0].resource_arn == secret_arn
             assert result[0].status == "PASS"

--- a/tests/providers/aws/services/secretsmanager/secretsmanager_service_test.py
+++ b/tests/providers/aws/services/secretsmanager/secretsmanager_service_test.py
@@ -2,25 +2,25 @@ import io
 import zipfile
 from unittest.mock import patch
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_iam, mock_lambda, mock_s3, mock_secretsmanager
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.secretsmanager.secretsmanager_service import (
     SecretsManager,
 )
-from prowler.providers.common.models import Audit_Metadata
-
-# Mock Test Region
-AWS_REGION = "eu-west-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 # Mock generate_regional_clients()
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_EU_WEST_1
+    )
+    regional_client.region = AWS_REGION_EU_WEST_1
+    return {AWS_REGION_EU_WEST_1: regional_client}
 
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
@@ -29,57 +29,28 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_SecretsManager_Service:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=DEFAULT_ACCOUNT_ID,
-            audited_account_arn=f"arn:aws:iam::{DEFAULT_ACCOUNT_ID}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
 
     # Test SecretsManager Client
     @mock_secretsmanager
     def test__get_client__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         secretsmanager = SecretsManager(audit_info)
         assert (
-            secretsmanager.regional_clients[AWS_REGION].__class__.__name__
+            secretsmanager.regional_clients[AWS_REGION_EU_WEST_1].__class__.__name__
             == "SecretsManager"
         )
 
     # Test SecretsManager Session
     @mock_secretsmanager
     def test__get_session__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         secretsmanager = SecretsManager(audit_info)
         assert secretsmanager.session.__class__.__name__ == "Session"
 
     # Test SecretsManager Service
     @mock_secretsmanager
     def test__get_service__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         secretsmanager = SecretsManager(audit_info)
         assert secretsmanager.service == "secretsmanager"
 
@@ -89,7 +60,9 @@ class Test_SecretsManager_Service:
     @mock_iam
     @mock_s3
     def test__list_secrets__(self):
-        secretsmanager_client = client("secretsmanager", region_name=AWS_REGION)
+        secretsmanager_client = client(
+            "secretsmanager", region_name=AWS_REGION_EU_WEST_1
+        )
         # Create Secret
         resp = secretsmanager_client.create_secret(
             Name="test-secret",
@@ -101,17 +74,17 @@ class Test_SecretsManager_Service:
         secret_arn = resp["ARN"]
         secret_name = resp["Name"]
         # Create IAM Lambda Role
-        iam_client = client("iam", region_name=AWS_REGION)
+        iam_client = client("iam", region_name=AWS_REGION_EU_WEST_1)
         iam_role = iam_client.create_role(
             RoleName="rotation-lambda-role",
             AssumeRolePolicyDocument="test-policy",
             Path="/",
         )["Role"]["Arn"]
         # Create S3 Bucket
-        s3_client = resource("s3", region_name=AWS_REGION)
+        s3_client = resource("s3", region_name=AWS_REGION_EU_WEST_1)
         s3_client.create_bucket(
             Bucket="test-bucket",
-            CreateBucketConfiguration={"LocationConstraint": AWS_REGION},
+            CreateBucketConfiguration={"LocationConstraint": AWS_REGION_EU_WEST_1},
         )
         # Create Lambda Code
         zip_output = io.BytesIO()
@@ -127,7 +100,7 @@ class Test_SecretsManager_Service:
         zip_file.close()
         zip_output.seek(0)
         # Create Rotation Lambda
-        lambda_client = client("lambda", region_name=AWS_REGION)
+        lambda_client = client("lambda", region_name=AWS_REGION_EU_WEST_1)
         resp = lambda_client.create_function(
             FunctionName="rotation-lambda",
             Runtime="python3.7",
@@ -158,7 +131,7 @@ class Test_SecretsManager_Service:
         )
 
         # Set partition for the service
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         secretsmanager = SecretsManager(audit_info)
 
         assert len(secretsmanager.secrets) == 1
@@ -166,7 +139,7 @@ class Test_SecretsManager_Service:
         assert secretsmanager.secrets[secret_arn]
         assert secretsmanager.secrets[secret_arn].name == secret_name
         assert secretsmanager.secrets[secret_arn].arn == secret_arn
-        assert secretsmanager.secrets[secret_arn].region == AWS_REGION
+        assert secretsmanager.secrets[secret_arn].region == AWS_REGION_EU_WEST_1
         assert secretsmanager.secrets[secret_arn].rotation_enabled is True
         assert secretsmanager.secrets[secret_arn].tags == [
             {"Key": "test", "Value": "test"},


### PR DESCRIPTION
### Description

Refactor SecretsManager to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
