### PR TITLE
test(audit_info): refactor ecr

### DIFF
--- a/tests/providers/aws/services/ecr/ecr_registry_scan_images_on_push_enabled/ecr_registry_scan_images_on_push_enabled_test.py
+++ b/tests/providers/aws/services/ecr/ecr_registry_scan_images_on_push_enabled/ecr_registry_scan_images_on_push_enabled_test.py
@@ -1,19 +1,17 @@
 from re import search
 from unittest import mock
 
-from boto3 import session
-
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.ecr.ecr_service import (
     Registry,
     Repository,
     ScanningRule,
 )
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
-# Mock Test Region
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
 repository_name = "test_repo"
 repository_arn = (
     f"arn:aws:ecr:eu-west-1:{AWS_ACCOUNT_NUMBER}:repository/{repository_name}"
@@ -21,43 +19,13 @@ repository_arn = (
 
 
 class Test_ecr_registry_scan_images_on_push_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=None,
-            audited_account_arn=None,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     def test_no_registries(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_registry_scan_images_on_push_enabled.ecr_registry_scan_images_on_push_enabled.ecr_client",
             ecr_client,
@@ -73,9 +41,9 @@ class Test_ecr_registry_scan_images_on_push_enabled:
     def test_registry_no_repositories(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[],
             rules=[],
@@ -83,7 +51,7 @@ class Test_ecr_registry_scan_images_on_push_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_registry_scan_images_on_push_enabled.ecr_registry_scan_images_on_push_enabled.ecr_client",
             ecr_client,
@@ -99,15 +67,15 @@ class Test_ecr_registry_scan_images_on_push_enabled:
     def test_registry_scan_on_push_enabled(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy="",
                     images_details=None,
@@ -124,7 +92,7 @@ class Test_ecr_registry_scan_images_on_push_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_registry_scan_images_on_push_enabled.ecr_registry_scan_images_on_push_enabled.ecr_client",
             ecr_client,
@@ -139,20 +107,20 @@ class Test_ecr_registry_scan_images_on_push_enabled:
             assert result[0].status == "PASS"
             assert search("with scan on push", result[0].status_extended)
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_scan_on_push_enabled_with_filters(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy="",
                     images_details=None,
@@ -169,7 +137,7 @@ class Test_ecr_registry_scan_images_on_push_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_registry_scan_images_on_push_enabled.ecr_registry_scan_images_on_push_enabled.ecr_client",
             ecr_client,
@@ -187,20 +155,20 @@ class Test_ecr_registry_scan_images_on_push_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_scan_on_push_disabled(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy="",
                     images_details=None,
@@ -212,7 +180,7 @@ class Test_ecr_registry_scan_images_on_push_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_registry_scan_images_on_push_enabled.ecr_registry_scan_images_on_push_enabled.ecr_client",
             ecr_client,
@@ -227,4 +195,4 @@ class Test_ecr_registry_scan_images_on_push_enabled:
             assert result[0].status == "FAIL"
             assert search("scanning without scan on push", result[0].status_extended)
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/ecr/ecr_repositories_lifecycle_policy_enabled/ecr_repositories_lifecycle_policy_enabled_test.py
+++ b/tests/providers/aws/services/ecr/ecr_repositories_lifecycle_policy_enabled/ecr_repositories_lifecycle_policy_enabled_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 
-from boto3 import session
-
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.ecr.ecr_service import Registry, Repository
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
-# Mock Test Region
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
 repository_name = "test_repo"
 repository_arn = (
     f"arn:aws:ecr:eu-west-1:{AWS_ACCOUNT_NUMBER}:repository/{repository_name}"
@@ -28,35 +26,6 @@ repo_policy_public = {
 
 class Test_ecr_repositories_lifecycle_policy_enabled:
     # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=None,
-            audited_account_arn=None,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
 
     def test_no_registries(self):
         ecr_client = mock.MagicMock
@@ -64,7 +33,7 @@ class Test_ecr_repositories_lifecycle_policy_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_lifecycle_policy_enabled.ecr_repositories_lifecycle_policy_enabled.ecr_client",
             ecr_client,
@@ -80,9 +49,9 @@ class Test_ecr_repositories_lifecycle_policy_enabled:
     def test_registry_no_repositories(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[],
             rules=[],
@@ -90,7 +59,7 @@ class Test_ecr_repositories_lifecycle_policy_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_lifecycle_policy_enabled.ecr_repositories_lifecycle_policy_enabled.ecr_client",
             ecr_client,
@@ -106,16 +75,16 @@ class Test_ecr_repositories_lifecycle_policy_enabled:
     def test_lifecycle_policy(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             rules=[],
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy=repo_policy_public,
                     images_details=None,
@@ -126,7 +95,7 @@ class Test_ecr_repositories_lifecycle_policy_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_lifecycle_policy_enabled.ecr_repositories_lifecycle_policy_enabled.ecr_client",
             ecr_client,
@@ -150,16 +119,16 @@ class Test_ecr_repositories_lifecycle_policy_enabled:
     def test_no_lifecycle_policy(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             rules=[],
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=False,
                     policy=repo_policy_public,
                     images_details=None,
@@ -170,7 +139,7 @@ class Test_ecr_repositories_lifecycle_policy_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_lifecycle_policy_enabled.ecr_repositories_lifecycle_policy_enabled.ecr_client",
             ecr_client,

--- a/tests/providers/aws/services/ecr/ecr_repositories_not_publicly_accessible/ecr_repositories_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/ecr/ecr_repositories_not_publicly_accessible/ecr_repositories_not_publicly_accessible_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 
-from boto3 import session
-
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.ecr.ecr_service import Registry, Repository
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
-# Mock Test Region
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
 repository_name = "test_repo"
 repository_arn = (
     f"arn:aws:ecr:eu-west-1:{AWS_ACCOUNT_NUMBER}:repository/{repository_name}"
@@ -40,35 +38,6 @@ repo_policy_public = {
 
 class Test_ecr_repositories_not_publicly_accessible:
     # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=None,
-            audited_account_arn=None,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
 
     def test_no_registries(self):
         ecr_client = mock.MagicMock
@@ -76,7 +45,7 @@ class Test_ecr_repositories_not_publicly_accessible:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_not_publicly_accessible.ecr_repositories_not_publicly_accessible.ecr_client",
             ecr_client,
@@ -92,9 +61,9 @@ class Test_ecr_repositories_not_publicly_accessible:
     def test_registry_no_repositories(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[],
             rules=[],
@@ -102,7 +71,7 @@ class Test_ecr_repositories_not_publicly_accessible:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_not_publicly_accessible.ecr_repositories_not_publicly_accessible.ecr_client",
             ecr_client,
@@ -118,15 +87,15 @@ class Test_ecr_repositories_not_publicly_accessible:
     def test_repository_not_public(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy=repo_policy_not_public,
                     images_details=None,
@@ -138,7 +107,7 @@ class Test_ecr_repositories_not_publicly_accessible:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_not_publicly_accessible.ecr_repositories_not_publicly_accessible.ecr_client",
             ecr_client,
@@ -161,15 +130,15 @@ class Test_ecr_repositories_not_publicly_accessible:
     def test_repository_public(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy=repo_policy_public,
                     images_details=None,
@@ -181,7 +150,7 @@ class Test_ecr_repositories_not_publicly_accessible:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_not_publicly_accessible.ecr_repositories_not_publicly_accessible.ecr_client",
             ecr_client,

--- a/tests/providers/aws/services/ecr/ecr_repositories_scan_images_on_push_enabled/ecr_repositories_scan_images_on_push_enabled_test.py
+++ b/tests/providers/aws/services/ecr/ecr_repositories_scan_images_on_push_enabled/ecr_repositories_scan_images_on_push_enabled_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 
-from boto3 import session
-
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.ecr.ecr_service import Registry, Repository
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
-# Mock Test Region
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
 repository_name = "test_repo"
 repository_arn = (
     f"arn:aws:ecr:eu-west-1:{AWS_ACCOUNT_NUMBER}:repository/{repository_name}"
@@ -28,35 +26,6 @@ repo_policy_public = {
 
 class Test_ecr_repositories_scan_images_on_push_enabled:
     # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=None,
-            audited_account_arn=None,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
 
     def test_no_registries(self):
         ecr_client = mock.MagicMock
@@ -64,7 +33,7 @@ class Test_ecr_repositories_scan_images_on_push_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_scan_images_on_push_enabled.ecr_repositories_scan_images_on_push_enabled.ecr_client",
             ecr_client,
@@ -80,9 +49,9 @@ class Test_ecr_repositories_scan_images_on_push_enabled:
     def test_registry_no_repositories(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[],
             rules=[],
@@ -90,7 +59,7 @@ class Test_ecr_repositories_scan_images_on_push_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_scan_images_on_push_enabled.ecr_repositories_scan_images_on_push_enabled.ecr_client",
             ecr_client,
@@ -106,15 +75,15 @@ class Test_ecr_repositories_scan_images_on_push_enabled:
     def test_scan_on_push_disabled(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy=repo_policy_public,
                     images_details=None,
@@ -126,7 +95,7 @@ class Test_ecr_repositories_scan_images_on_push_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_scan_images_on_push_enabled.ecr_repositories_scan_images_on_push_enabled.ecr_client",
             ecr_client,
@@ -149,15 +118,15 @@ class Test_ecr_repositories_scan_images_on_push_enabled:
     def test_scan_on_push_enabled(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=False,
                     policy=repo_policy_public,
                     images_details=None,
@@ -169,7 +138,7 @@ class Test_ecr_repositories_scan_images_on_push_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_scan_images_on_push_enabled.ecr_repositories_scan_images_on_push_enabled.ecr_client",
             ecr_client,

--- a/tests/providers/aws/services/ecr/ecr_repositories_scan_vulnerabilities_in_latest_image/ecr_repositories_scan_vulnerabilities_in_latest_image_test.py
+++ b/tests/providers/aws/services/ecr/ecr_repositories_scan_vulnerabilities_in_latest_image/ecr_repositories_scan_vulnerabilities_in_latest_image_test.py
@@ -1,20 +1,18 @@
 from datetime import datetime
 from unittest import mock
 
-from boto3 import session
-
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.ecr.ecr_service import (
     FindingSeverityCounts,
     ImageDetails,
     Registry,
     Repository,
 )
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
-# Mock Test Region
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
 repository_name = "test_repo"
 repository_arn = (
     f"arn:aws:ecr:eu-west-1:{AWS_ACCOUNT_NUMBER}:repository/{repository_name}"
@@ -35,35 +33,6 @@ repo_policy_public = {
 
 class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
     # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=None,
-            audited_account_arn=None,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
 
     def test_no_registries(self):
         ecr_client = mock.MagicMock
@@ -72,7 +41,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_client",
             ecr_client,
@@ -88,9 +57,9 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
     def test_registry_no_repositories(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[],
             rules=[],
@@ -99,7 +68,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_client",
             ecr_client,
@@ -115,15 +84,15 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
     def test_empty_repository(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy=repo_policy_public,
                     images_details=[],
@@ -136,7 +105,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_client",
             ecr_client,
@@ -152,15 +121,15 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
     def test_image_scaned_without_findings(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy=repo_policy_public,
                     images_details=[
@@ -183,7 +152,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_client",
             ecr_client,
@@ -206,15 +175,15 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
     def test_image_scanned_with_findings_default_severity_MEDIUM(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy=repo_policy_public,
                     images_details=[
@@ -241,7 +210,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_client",
             ecr_client,
@@ -264,15 +233,15 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
     def test_image_scanned_with_findings_default_severity_HIGH(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy=repo_policy_public,
                     images_details=[
@@ -299,7 +268,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_client",
             ecr_client,
@@ -322,15 +291,15 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
     def test_image_scanned_with_findings_default_severity_CRITICAL(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy=repo_policy_public,
                     images_details=[
@@ -357,7 +326,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_client",
             ecr_client,
@@ -380,15 +349,15 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
     def test_image_scanned_without_CRITICAL_findings_default_severity_CRITICAL(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy=repo_policy_public,
                     images_details=[
@@ -415,7 +384,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_client",
             ecr_client,
@@ -440,15 +409,15 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
     ):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy=repo_policy_public,
                     images_details=[
@@ -475,7 +444,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_client",
             ecr_client,
@@ -498,15 +467,15 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
     def test_image_scanned_fail_scan(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy=repo_policy_public,
                     images_details=[
@@ -529,7 +498,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_client",
             ecr_client,
@@ -552,15 +521,15 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
     def test_image_not_scanned(self):
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = Registry(
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
-            region=AWS_REGION,
+            region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
                 Repository(
                     name=repository_name,
                     arn=repository_arn,
-                    region=AWS_REGION,
+                    region=AWS_REGION_EU_WEST_1,
                     scan_on_push=True,
                     policy=repo_policy_public,
                     images_details=[
@@ -583,7 +552,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            self.set_mocked_audit_info(),
+            set_mocked_aws_audit_info(),
         ), mock.patch(
             "prowler.providers.aws.services.ecr.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_repositories_scan_vulnerabilities_in_latest_image.ecr_client",
             ecr_client,

--- a/tests/providers/aws/services/ecr/ecr_service_test.py
+++ b/tests/providers/aws/services/ecr/ecr_service_test.py
@@ -2,15 +2,15 @@ from datetime import datetime
 from unittest.mock import patch
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_ecr
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.ecr.ecr_service import ECR, ScanningRule
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "eu-west-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
 repo_arn = f"arn:aws:ecr:eu-west-1:{AWS_ACCOUNT_NUMBER}:repository/test-repo"
 repo_name = "test-repo"
@@ -83,9 +83,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_EU_WEST_1
+    )
+    regional_client.region = AWS_REGION_EU_WEST_1
+    return {AWS_REGION_EU_WEST_1: regional_client}
 
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
@@ -95,60 +97,29 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_ECR_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test ECR Service
     def test_service(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         ecr = ECR(audit_info)
         assert ecr.service == "ecr"
 
     # Test ECR client
     def test_client(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         ecr = ECR(audit_info)
         for regional_client in ecr.regional_clients.values():
             assert regional_client.__class__.__name__ == "ECR"
 
     # Test ECR session
     def test__get_session__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         ecr = ECR(audit_info)
         assert ecr.session.__class__.__name__ == "Session"
 
     # Test describe ECR repositories
     @mock_ecr
     def test__describe_registries_and_repositories__(self):
-        ecr_client = client("ecr", region_name=AWS_REGION)
+        ecr_client = client("ecr", region_name=AWS_REGION_EU_WEST_1)
         ecr_client.create_repository(
             repositoryName=repo_name,
             imageScanningConfiguration={"scanOnPush": True},
@@ -156,58 +127,62 @@ class Test_ECR_Service:
                 {"Key": "test", "Value": "test"},
             ],
         )
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         ecr = ECR(audit_info)
 
         assert len(ecr.registries) == 1
-        assert ecr.registries[AWS_REGION].id == AWS_ACCOUNT_NUMBER
-        assert ecr.registries[AWS_REGION].region == AWS_REGION
-        assert len(ecr.registries[AWS_REGION].repositories) == 1
+        assert ecr.registries[AWS_REGION_EU_WEST_1].id == AWS_ACCOUNT_NUMBER
+        assert ecr.registries[AWS_REGION_EU_WEST_1].region == AWS_REGION_EU_WEST_1
+        assert len(ecr.registries[AWS_REGION_EU_WEST_1].repositories) == 1
 
-        assert ecr.registries[AWS_REGION].repositories[0].name == repo_name
-        assert ecr.registries[AWS_REGION].repositories[0].arn == repo_arn
-        assert ecr.registries[AWS_REGION].repositories[0].scan_on_push
-        assert ecr.registries[AWS_REGION].repositories[0].tags == [
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].name == repo_name
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].arn == repo_arn
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].scan_on_push
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].tags == [
             {"Key": "test", "Value": "test"},
         ]
 
     # Test describe ECR repository policies
     @mock_ecr
     def test__describe_repository_policies__(self):
-        ecr_client = client("ecr", region_name=AWS_REGION)
+        ecr_client = client("ecr", region_name=AWS_REGION_EU_WEST_1)
         ecr_client.create_repository(
             repositoryName=repo_name,
             imageScanningConfiguration={"scanOnPush": True},
         )
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         ecr = ECR(audit_info)
         assert len(ecr.registries) == 1
-        assert len(ecr.registries[AWS_REGION].repositories) == 1
-        assert ecr.registries[AWS_REGION].repositories[0].name == repo_name
-        assert ecr.registries[AWS_REGION].repositories[0].arn == repo_arn
-        assert ecr.registries[AWS_REGION].repositories[0].scan_on_push
+        assert len(ecr.registries[AWS_REGION_EU_WEST_1].repositories) == 1
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].name == repo_name
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].arn == repo_arn
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].scan_on_push
         assert (
-            ecr.registries[AWS_REGION].repositories[0].policy["Statement"][0]["Sid"]
+            ecr.registries[AWS_REGION_EU_WEST_1]
+            .repositories[0]
+            .policy["Statement"][0]["Sid"]
             == "Allow Describe Images"
         )
         assert (
-            ecr.registries[AWS_REGION].repositories[0].policy["Statement"][0]["Effect"]
+            ecr.registries[AWS_REGION_EU_WEST_1]
+            .repositories[0]
+            .policy["Statement"][0]["Effect"]
             == "Allow"
         )
         assert (
-            ecr.registries[AWS_REGION]
+            ecr.registries[AWS_REGION_EU_WEST_1]
             .repositories[0]
             .policy["Statement"][0]["Principal"]["AWS"][0]
             == f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
         )
         assert (
-            ecr.registries[AWS_REGION]
+            ecr.registries[AWS_REGION_EU_WEST_1]
             .repositories[0]
             .policy["Statement"][0]["Action"][0]
             == "ecr:DescribeImages"
         )
         assert (
-            ecr.registries[AWS_REGION]
+            ecr.registries[AWS_REGION_EU_WEST_1]
             .repositories[0]
             .policy["Statement"][0]["Action"][1]
             == "ecr:DescribeRepositories"
@@ -216,71 +191,80 @@ class Test_ECR_Service:
     # Test describe ECR repository lifecycle policies
     @mock_ecr
     def test__get_lifecycle_policies__(self):
-        ecr_client = client("ecr", region_name=AWS_REGION)
+        ecr_client = client("ecr", region_name=AWS_REGION_EU_WEST_1)
         ecr_client.create_repository(
             repositoryName=repo_name,
             imageScanningConfiguration={"scanOnPush": True},
         )
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         ecr = ECR(audit_info)
         assert len(ecr.registries) == 1
-        assert len(ecr.registries[AWS_REGION].repositories) == 1
-        assert ecr.registries[AWS_REGION].repositories[0].name == repo_name
-        assert ecr.registries[AWS_REGION].repositories[0].arn == repo_arn
-        assert ecr.registries[AWS_REGION].repositories[0].scan_on_push
-        assert ecr.registries[AWS_REGION].repositories[0].lifecycle_policy
+        assert len(ecr.registries[AWS_REGION_EU_WEST_1].repositories) == 1
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].name == repo_name
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].arn == repo_arn
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].scan_on_push
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].lifecycle_policy
 
     # Test get image details
     @mock_ecr
     def test__get_image_details__(self):
-        ecr_client = client("ecr", region_name=AWS_REGION)
+        ecr_client = client("ecr", region_name=AWS_REGION_EU_WEST_1)
         ecr_client.create_repository(
             repositoryName=repo_name,
             imageScanningConfiguration={"scanOnPush": True},
         )
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         ecr = ECR(audit_info)
         assert len(ecr.registries) == 1
-        assert len(ecr.registries[AWS_REGION].repositories) == 1
-        assert ecr.registries[AWS_REGION].repositories[0].name == repo_name
-        assert ecr.registries[AWS_REGION].repositories[0].arn == repo_arn
-        assert ecr.registries[AWS_REGION].repositories[0].scan_on_push
-        assert len(ecr.registries[AWS_REGION].repositories[0].images_details) == 2
+        assert len(ecr.registries[AWS_REGION_EU_WEST_1].repositories) == 1
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].name == repo_name
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].arn == repo_arn
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].scan_on_push
+        assert (
+            len(ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].images_details)
+            == 2
+        )
         # First image pushed
-        assert ecr.registries[AWS_REGION].repositories[0].images_details[
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].images_details[
             0
         ].image_pushed_at == datetime(2023, 1, 1)
         assert (
-            ecr.registries[AWS_REGION].repositories[0].images_details[0].latest_tag
+            ecr.registries[AWS_REGION_EU_WEST_1]
+            .repositories[0]
+            .images_details[0]
+            .latest_tag
             == "test-tag1"
         )
         assert (
-            ecr.registries[AWS_REGION].repositories[0].images_details[0].latest_digest
+            ecr.registries[AWS_REGION_EU_WEST_1]
+            .repositories[0]
+            .images_details[0]
+            .latest_digest
             == "sha256:d8868e50ac4c7104d2200d42f432b661b2da8c1e417ccfae217e6a1e04bb9295"
         )
         assert (
-            ecr.registries[AWS_REGION]
+            ecr.registries[AWS_REGION_EU_WEST_1]
             .repositories[0]
             .images_details[0]
             .scan_findings_status
             == "COMPLETE"
         )
         assert (
-            ecr.registries[AWS_REGION]
+            ecr.registries[AWS_REGION_EU_WEST_1]
             .repositories[0]
             .images_details[0]
             .scan_findings_severity_count.critical
             == 1
         )
         assert (
-            ecr.registries[AWS_REGION]
+            ecr.registries[AWS_REGION_EU_WEST_1]
             .repositories[0]
             .images_details[0]
             .scan_findings_severity_count.high
             == 2
         )
         assert (
-            ecr.registries[AWS_REGION]
+            ecr.registries[AWS_REGION_EU_WEST_1]
             .repositories[0]
             .images_details[0]
             .scan_findings_severity_count.medium
@@ -288,40 +272,46 @@ class Test_ECR_Service:
         )
 
         # Second image pushed
-        assert ecr.registries[AWS_REGION].repositories[0].images_details[
+        assert ecr.registries[AWS_REGION_EU_WEST_1].repositories[0].images_details[
             1
         ].image_pushed_at == datetime(2023, 1, 2)
         assert (
-            ecr.registries[AWS_REGION].repositories[0].images_details[1].latest_tag
+            ecr.registries[AWS_REGION_EU_WEST_1]
+            .repositories[0]
+            .images_details[1]
+            .latest_tag
             == "test-tag2"
         )
         assert (
-            ecr.registries[AWS_REGION].repositories[0].images_details[1].latest_digest
+            ecr.registries[AWS_REGION_EU_WEST_1]
+            .repositories[0]
+            .images_details[1]
+            .latest_digest
             == "sha256:83251ac64627fc331584f6c498b3aba5badc01574e2c70b2499af3af16630eed"
         )
         assert (
-            ecr.registries[AWS_REGION]
+            ecr.registries[AWS_REGION_EU_WEST_1]
             .repositories[0]
             .images_details[1]
             .scan_findings_status
             == "COMPLETE"
         )
         assert (
-            ecr.registries[AWS_REGION]
+            ecr.registries[AWS_REGION_EU_WEST_1]
             .repositories[0]
             .images_details[1]
             .scan_findings_severity_count.critical
             == 1
         )
         assert (
-            ecr.registries[AWS_REGION]
+            ecr.registries[AWS_REGION_EU_WEST_1]
             .repositories[0]
             .images_details[1]
             .scan_findings_severity_count.high
             == 2
         )
         assert (
-            ecr.registries[AWS_REGION]
+            ecr.registries[AWS_REGION_EU_WEST_1]
             .repositories[0]
             .images_details[1]
             .scan_findings_severity_count.medium
@@ -331,12 +321,12 @@ class Test_ECR_Service:
     # Test get ECR Registries Scanning Configuration
     @mock_ecr
     def test__get_registry_scanning_configuration__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         ecr = ECR(audit_info)
         assert len(ecr.registries) == 1
-        assert ecr.registries[AWS_REGION].id == AWS_ACCOUNT_NUMBER
-        assert ecr.registries[AWS_REGION].scan_type == "BASIC"
-        assert ecr.registries[AWS_REGION].rules == [
+        assert ecr.registries[AWS_REGION_EU_WEST_1].id == AWS_ACCOUNT_NUMBER
+        assert ecr.registries[AWS_REGION_EU_WEST_1].scan_type == "BASIC"
+        assert ecr.registries[AWS_REGION_EU_WEST_1].rules == [
             ScanningRule(
                 scan_frequency="SCAN_ON_PUSH",
                 scan_filters=[{"filter": "*", "filterType": "WILDCARD"}],


### PR DESCRIPTION
### Description

Refactor ECR to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
