### PR TITLE
test(audit_info): refactor ecs

### DIFF
--- a/tests/providers/aws/services/ecs/ecs_service_test.py
+++ b/tests/providers/aws/services/ecs/ecs_service_test.py
@@ -1,20 +1,21 @@
 from unittest.mock import patch
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_ecs
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.ecs.ecs_service import ECS
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "eu-west-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_EU_WEST_1
+    )
+    regional_client.region = AWS_REGION_EU_WEST_1
+    return {AWS_REGION_EU_WEST_1: regional_client}
 
 
 @patch(
@@ -22,60 +23,29 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_ECS_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test ECS Service
     def test_service(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         ecs = ECS(audit_info)
         assert ecs.service == "ecs"
 
     # Test ECS client
     def test_client(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         ecs = ECS(audit_info)
         for reg_client in ecs.regional_clients.values():
             assert reg_client.__class__.__name__ == "ECS"
 
     # Test ECS session
     def test__get_session__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         ecs = ECS(audit_info)
         assert ecs.session.__class__.__name__ == "Session"
 
     # Test list ECS task definitions
     @mock_ecs
     def test__list_task_definitions__(self):
-        ecs_client = client("ecs", region_name=AWS_REGION)
+        ecs_client = client("ecs", region_name=AWS_REGION_EU_WEST_1)
 
         definition = dict(
             family="test_ecs_task",
@@ -89,7 +59,7 @@ class Test_ECS_Service:
         )
 
         task_definition = ecs_client.register_task_definition(**definition)
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         ecs = ECS(audit_info)
 
         assert len(ecs.task_definitions) == 1
@@ -105,7 +75,7 @@ class Test_ECS_Service:
     @mock_ecs
     # Test describe ECS task definitions
     def test__describe_task_definitions__(self):
-        ecs_client = client("ecs", region_name=AWS_REGION)
+        ecs_client = client("ecs", region_name=AWS_REGION_EU_WEST_1)
 
         definition = dict(
             family="test_ecs_task",
@@ -126,7 +96,7 @@ class Test_ECS_Service:
         )
 
         task_definition = ecs_client.register_task_definition(**definition)
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         ecs = ECS(audit_info)
 
         assert len(ecs.task_definitions) == 1


### PR DESCRIPTION
### Description

Refactor ECS to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
