### PR TITLE
test(audit_info): refactor efs

### DIFF
--- a/tests/providers/aws/services/efs/efs_service_test.py
+++ b/tests/providers/aws/services/efs/efs_service_test.py
@@ -2,16 +2,15 @@ import json
 from unittest.mock import patch
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_efs
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.efs.efs_service import EFS
-from prowler.providers.common.models import Audit_Metadata
-
-# Mock Test Region
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
 # Mocking Access Analyzer Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -43,9 +42,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_EU_WEST_1
+    )
+    regional_client.region = AWS_REGION_EU_WEST_1
+    return {AWS_REGION_EU_WEST_1: regional_client}
 
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
@@ -55,50 +56,20 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_EFS:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test EFS Session
     def test__get_session__(self):
-        access_analyzer = EFS(self.set_mocked_audit_info())
+        access_analyzer = EFS(set_mocked_aws_audit_info())
         assert access_analyzer.session.__class__.__name__ == "Session"
 
     # Test EFS Service
     def test__get_service__(self):
-        access_analyzer = EFS(self.set_mocked_audit_info())
+        access_analyzer = EFS(set_mocked_aws_audit_info())
         assert access_analyzer.service == "efs"
 
     @mock_efs
     # Test EFS describe file systems
     def test__describe_file_systems__(self):
-        efs_client = client("efs", AWS_REGION)
+        efs_client = client("efs", AWS_REGION_EU_WEST_1)
         efs = efs_client.create_file_system(
             CreationToken=creation_token,
             Encrypted=True,
@@ -106,7 +77,7 @@ class Test_EFS:
                 {"Key": "test", "Value": "test"},
             ],
         )
-        filesystem = EFS(self.set_mocked_audit_info())
+        filesystem = EFS(set_mocked_aws_audit_info())
         assert len(filesystem.filesystems) == 1
         assert filesystem.filesystems[0].id == efs["FileSystemId"]
         assert filesystem.filesystems[0].encrypted == efs["Encrypted"]
@@ -117,11 +88,11 @@ class Test_EFS:
     @mock_efs
     # Test EFS describe file systems
     def test__describe_file_system_policies__(self):
-        efs_client = client("efs", AWS_REGION)
+        efs_client = client("efs", AWS_REGION_EU_WEST_1)
         efs = efs_client.create_file_system(
             CreationToken=creation_token, Encrypted=True
         )
-        filesystem = EFS(self.set_mocked_audit_info())
+        filesystem = EFS(set_mocked_aws_audit_info())
         assert len(filesystem.filesystems) == 1
         assert filesystem.filesystems[0].id == efs["FileSystemId"]
         assert filesystem.filesystems[0].encrypted == efs["Encrypted"]


### PR DESCRIPTION
### Description

Refactor EFS to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
