### PR TITLE
test(audit_info): refactor s3

### DIFF
--- a/tests/providers/aws/services/s3/s3_account_level_public_access_blocks/s3_account_level_public_access_blocks_test.py
+++ b/tests/providers/aws/services/s3/s3_account_level_public_access_blocks/s3_account_level_public_access_blocks_test.py
@@ -1,54 +1,22 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_s3, mock_s3control
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_s3_account_level_public_access_blocks:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_s3
     @mock_s3control
     def test_bucket_account_public_block(self):
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -60,7 +28,7 @@ class Test_s3_account_level_public_access_blocks:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -88,13 +56,13 @@ class Test_s3_account_level_public_access_blocks:
             )
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert result[0].resource_arn == AWS_ACCOUNT_ARN
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_without_account_public_block(self):
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -106,7 +74,7 @@ class Test_s3_account_level_public_access_blocks:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -134,13 +102,13 @@ class Test_s3_account_level_public_access_blocks:
             )
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert result[0].resource_arn == AWS_ACCOUNT_ARN
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_without_account_public_block_ignoring(self):
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -152,7 +120,7 @@ class Test_s3_account_level_public_access_blocks:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         audit_info.ignore_unused_services = True
 
         with mock.patch(

--- a/tests/providers/aws/services/s3/s3_bucket_acl_prohibited/s3_bucket_acl_prohibited_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_acl_prohibited/s3_bucket_acl_prohibited_test.py
@@ -1,59 +1,25 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_s3_bucket_acl_prohibited:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_s3
     def test_bucket_no_ownership(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -82,17 +48,17 @@ class Test_s3_bucket_acl_prohibited:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     def test_bucket_without_ownership(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -121,11 +87,11 @@ class Test_s3_bucket_acl_prohibited:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     def test_bucket_acl_disabled(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(
             Bucket=bucket_name_us, ObjectOwnership="BucketOwnerEnforced"
@@ -133,7 +99,7 @@ class Test_s3_bucket_acl_prohibited:
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -162,4 +128,4 @@ class Test_s3_bucket_acl_prohibited:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/s3/s3_bucket_default_encryption/s3_bucket_default_encryption_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_default_encryption/s3_bucket_default_encryption_test.py
@@ -1,59 +1,25 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_s3_bucket_default_encryption:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_s3
     def test_bucket_no_encryption(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -82,11 +48,11 @@ class Test_s3_bucket_default_encryption:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     def test_bucket_kms_encryption(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(
             Bucket=bucket_name_us, ObjectOwnership="BucketOwnerEnforced"
@@ -108,7 +74,7 @@ class Test_s3_bucket_default_encryption:
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -137,4 +103,4 @@ class Test_s3_bucket_default_encryption:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/s3/s3_bucket_kms_encryption/s3_bucket_kms_encryption_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_kms_encryption/s3_bucket_kms_encryption_test.py
@@ -1,54 +1,20 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_s3_bucket_kms_encryption:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_s3
     def test_no_buckets(self):
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -69,13 +35,13 @@ class Test_s3_bucket_kms_encryption:
 
     @mock_s3
     def test_bucket_no_encryption(self):
-        s3_client_us_east_1 = client("s3", region_name=AWS_REGION)
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -104,11 +70,11 @@ class Test_s3_bucket_kms_encryption:
                 == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
             )
             assert result[0].resource_tags == []
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     def test_bucket_no_kms_encryption(self):
-        s3_client_us_east_1 = client("s3", region_name=AWS_REGION)
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(
             Bucket=bucket_name_us, ObjectOwnership="BucketOwnerEnforced"
@@ -129,7 +95,7 @@ class Test_s3_bucket_kms_encryption:
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -158,11 +124,11 @@ class Test_s3_bucket_kms_encryption:
                 == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
             )
             assert result[0].resource_tags == []
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     def test_bucket_kms_encryption(self):
-        s3_client_us_east_1 = client("s3", region_name=AWS_REGION)
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(
             Bucket=bucket_name_us, ObjectOwnership="BucketOwnerEnforced"
@@ -185,7 +151,7 @@ class Test_s3_bucket_kms_encryption:
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -215,11 +181,11 @@ class Test_s3_bucket_kms_encryption:
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
                 assert result[0].resource_tags == []
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     def test_bucket_kms_dsse_encryption(self):
-        s3_client_us_east_1 = client("s3", region_name=AWS_REGION)
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(
             Bucket=bucket_name_us, ObjectOwnership="BucketOwnerEnforced"
@@ -242,7 +208,7 @@ class Test_s3_bucket_kms_encryption:
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -272,4 +238,4 @@ class Test_s3_bucket_kms_encryption:
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
                 assert result[0].resource_tags == []
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/s3/s3_bucket_level_public_access_block/s3_bucket_level_public_access_block_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_level_public_access_block/s3_bucket_level_public_access_block_test.py
@@ -1,55 +1,22 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_s3, mock_s3control
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_s3_bucket_level_public_access_block:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_s3
     @mock_s3control
     def test_no_buckets(self):
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -76,7 +43,7 @@ class Test_s3_bucket_level_public_access_block:
     @mock_s3
     @mock_s3control
     def test_bucket_without_public_block(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         s3_client.put_public_access_block(
@@ -88,7 +55,7 @@ class Test_s3_bucket_level_public_access_block:
                 "RestrictPublicBuckets": False,
             },
         )
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -100,7 +67,7 @@ class Test_s3_bucket_level_public_access_block:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -133,12 +100,12 @@ class Test_s3_bucket_level_public_access_block:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_block(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         s3_client.put_public_access_block(
@@ -150,7 +117,7 @@ class Test_s3_bucket_level_public_access_block:
                 "RestrictPublicBuckets": True,
             },
         )
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -162,7 +129,7 @@ class Test_s3_bucket_level_public_access_block:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -196,12 +163,12 @@ class Test_s3_bucket_level_public_access_block:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_block_at_account(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         s3_client.put_public_access_block(
@@ -213,7 +180,7 @@ class Test_s3_bucket_level_public_access_block:
                 "RestrictPublicBuckets": False,
             },
         )
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -225,7 +192,7 @@ class Test_s3_bucket_level_public_access_block:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -259,12 +226,12 @@ class Test_s3_bucket_level_public_access_block:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_can_not_retrieve_public_access_block(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         s3_client.put_public_access_block(
@@ -276,7 +243,7 @@ class Test_s3_bucket_level_public_access_block:
                 "RestrictPublicBuckets": True,
             },
         )
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -288,7 +255,7 @@ class Test_s3_bucket_level_public_access_block:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",

--- a/tests/providers/aws/services/s3/s3_bucket_no_mfa_delete/s3_bucket_no_mfa_delete_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_no_mfa_delete/s3_bucket_no_mfa_delete_test.py
@@ -1,55 +1,21 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_s3_bucket_no_mfa_delete:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_s3
     def test_no_buckets(self):
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -77,7 +43,7 @@ class Test_s3_bucket_no_mfa_delete:
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -119,7 +85,7 @@ class Test_s3_bucket_no_mfa_delete:
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=audit_info,

--- a/tests/providers/aws/services/s3/s3_bucket_object_lock/s3_bucket_object_lock_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_object_lock/s3_bucket_object_lock_test.py
@@ -1,55 +1,21 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_s3_bucket_object_lock:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_s3
     def test_no_buckets(self):
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -71,13 +37,13 @@ class Test_s3_bucket_object_lock:
 
     @mock_s3
     def test_bucket_no_object_lock(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -106,12 +72,12 @@ class Test_s3_bucket_object_lock:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].resource_tags == []
 
     @mock_s3
     def test_bucket_object_lock_enabled(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(
             Bucket=bucket_name_us,
@@ -121,7 +87,7 @@ class Test_s3_bucket_object_lock:
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -150,5 +116,5 @@ class Test_s3_bucket_object_lock:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].resource_tags == []

--- a/tests/providers/aws/services/s3/s3_bucket_object_versioning/s3_bucket_object_versioning_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_object_versioning/s3_bucket_object_versioning_test.py
@@ -1,59 +1,25 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_s3_bucket_object_versioning:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_s3
     def test_bucket_no_object_versioning(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -82,11 +48,11 @@ class Test_s3_bucket_object_versioning:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     def test_bucket_object_versioning_enabled(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(
             Bucket=bucket_name_us, ObjectOwnership="BucketOwnerEnforced"
@@ -98,7 +64,7 @@ class Test_s3_bucket_object_versioning:
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -127,4 +93,4 @@ class Test_s3_bucket_object_versioning:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access_test.py
@@ -1,59 +1,26 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_s3, mock_s3control
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_s3_bucket_policy_public_write_access:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_s3control
     @mock_s3
     def test_bucket_no_policy(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -82,12 +49,12 @@ class Test_s3_bucket_policy_public_write_access:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3control
     @mock_s3
     def test_bucket_policy_but_account_RestrictPublicBuckets(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(
             Bucket=bucket_name_us, ObjectOwnership="BucketOwnerEnforced"
@@ -99,7 +66,7 @@ class Test_s3_bucket_policy_public_write_access:
             Policy=encryption_policy,
         )
 
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -112,7 +79,7 @@ class Test_s3_bucket_policy_public_write_access:
 
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -144,12 +111,12 @@ class Test_s3_bucket_policy_public_write_access:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3control
     @mock_s3
     def test_bucket_policy_but_bucket_RestrictPublicBuckets(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(
             Bucket=bucket_name_us, ObjectOwnership="BucketOwnerEnforced"
@@ -171,7 +138,7 @@ class Test_s3_bucket_policy_public_write_access:
             },
         )
 
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -184,7 +151,7 @@ class Test_s3_bucket_policy_public_write_access:
 
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -216,13 +183,13 @@ class Test_s3_bucket_policy_public_write_access:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3control
     @mock_s3
     @mock_s3control
     def test_bucket_comply_policy(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(
             Bucket=bucket_name_us, ObjectOwnership="BucketOwnerEnforced"
@@ -235,7 +202,7 @@ class Test_s3_bucket_policy_public_write_access:
         )
 
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -248,7 +215,7 @@ class Test_s3_bucket_policy_public_write_access:
 
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -280,13 +247,13 @@ class Test_s3_bucket_policy_public_write_access:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3control
     @mock_s3
     @mock_s3control
     def test_bucket_public_write_policy(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(
             Bucket=bucket_name_us, ObjectOwnership="BucketOwnerEnforced"
@@ -298,7 +265,7 @@ class Test_s3_bucket_policy_public_write_access:
         )
 
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -311,7 +278,7 @@ class Test_s3_bucket_policy_public_write_access:
 
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -343,4 +310,4 @@ class Test_s3_bucket_policy_public_write_access:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/s3/s3_bucket_public_access/s3_bucket_public_access_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_public_access/s3_bucket_public_access_test.py
@@ -1,56 +1,24 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_s3, mock_s3control
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_s3_bucket_public_access:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_s3
     @mock_s3control
     def test_no_buckets(self):
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -78,7 +46,7 @@ class Test_s3_bucket_public_access:
     @mock_s3control
     def test_bucket_account_public_block_without_buckets(self):
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -90,7 +58,7 @@ class Test_s3_bucket_public_access:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -120,16 +88,16 @@ class Test_s3_bucket_public_access:
                     )
                     assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                     assert result[0].resource_arn == AWS_ACCOUNT_ARN
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_account_public_block(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -141,7 +109,7 @@ class Test_s3_bucket_public_access:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -171,16 +139,16 @@ class Test_s3_bucket_public_access:
                     )
                     assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                     assert result[0].resource_arn == AWS_ACCOUNT_ARN
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_block(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -201,7 +169,7 @@ class Test_s3_bucket_public_access:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -234,17 +202,17 @@ class Test_s3_bucket_public_access:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_ACL(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -280,7 +248,7 @@ class Test_s3_bucket_public_access:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -313,16 +281,16 @@ class Test_s3_bucket_public_access:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_policy(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -348,7 +316,7 @@ class Test_s3_bucket_public_access:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -381,12 +349,12 @@ class Test_s3_bucket_public_access:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_not_public(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         s3_client.put_public_access_block(
@@ -400,7 +368,7 @@ class Test_s3_bucket_public_access:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -433,12 +401,12 @@ class Test_s3_bucket_public_access:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_can_not_retrieve_public_access_block(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         s3_client.put_public_access_block(
@@ -452,7 +420,7 @@ class Test_s3_bucket_public_access:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",

--- a/tests/providers/aws/services/s3/s3_bucket_public_list_acl/s3_bucket_public_list_acl_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_public_list_acl/s3_bucket_public_list_acl_test.py
@@ -1,55 +1,23 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_s3, mock_s3control
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_s3_bucket_public_list_acl:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_s3
     @mock_s3control
     def test_no_buckets(self):
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -77,7 +45,7 @@ class Test_s3_bucket_public_list_acl:
     @mock_s3control
     def test_bucket_account_public_block_without_buckets(self):
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -89,7 +57,7 @@ class Test_s3_bucket_public_list_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -119,16 +87,16 @@ class Test_s3_bucket_public_list_acl:
                     )
                     assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                     assert result[0].resource_arn == AWS_ACCOUNT_ARN
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_account_public_block(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -140,7 +108,7 @@ class Test_s3_bucket_public_list_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -170,16 +138,16 @@ class Test_s3_bucket_public_list_acl:
                     )
                     assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                     assert result[0].resource_arn == AWS_ACCOUNT_ARN
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_block(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -200,7 +168,7 @@ class Test_s3_bucket_public_list_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -233,17 +201,17 @@ class Test_s3_bucket_public_list_acl:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_list_ACL_AllUsers_READ(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -279,7 +247,7 @@ class Test_s3_bucket_public_list_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -313,17 +281,17 @@ class Test_s3_bucket_public_list_acl:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_list_ACL_AllUsers_READ_ACP(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -359,7 +327,7 @@ class Test_s3_bucket_public_list_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -393,17 +361,17 @@ class Test_s3_bucket_public_list_acl:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_list_ACL_AllUsers_FULL_CONTROL(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -439,7 +407,7 @@ class Test_s3_bucket_public_list_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -473,17 +441,17 @@ class Test_s3_bucket_public_list_acl:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_list_ACL_AuthenticatedUsers_READ(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -519,7 +487,7 @@ class Test_s3_bucket_public_list_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -553,17 +521,17 @@ class Test_s3_bucket_public_list_acl:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_list_ACL_AuthenticatedUsers_READ_ACP(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -599,7 +567,7 @@ class Test_s3_bucket_public_list_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -633,17 +601,17 @@ class Test_s3_bucket_public_list_acl:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_list_ACL_AuthenticatedUsers_FULL_CONTROL(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -679,7 +647,7 @@ class Test_s3_bucket_public_list_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -713,4 +681,4 @@ class Test_s3_bucket_public_list_acl:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/s3/s3_bucket_public_write_acl/s3_bucket_public_write_acl_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_public_write_acl/s3_bucket_public_write_acl_test.py
@@ -1,55 +1,23 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_s3, mock_s3control
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_s3_bucket_public_write_acl:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_s3
     @mock_s3control
     def test_no_buckets(self):
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -77,7 +45,7 @@ class Test_s3_bucket_public_write_acl:
     @mock_s3control
     def test_bucket_account_public_block_without_buckets(self):
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -89,7 +57,7 @@ class Test_s3_bucket_public_write_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -119,16 +87,16 @@ class Test_s3_bucket_public_write_acl:
                     )
                     assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                     assert result[0].resource_arn == AWS_ACCOUNT_ARN
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_account_public_block(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -140,7 +108,7 @@ class Test_s3_bucket_public_write_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -170,16 +138,16 @@ class Test_s3_bucket_public_write_acl:
                     )
                     assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                     assert result[0].resource_arn == AWS_ACCOUNT_ARN
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_block(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -200,7 +168,7 @@ class Test_s3_bucket_public_write_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -233,17 +201,17 @@ class Test_s3_bucket_public_write_acl:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_write_ACL_AllUsers_WRITE(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -279,7 +247,7 @@ class Test_s3_bucket_public_write_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -313,17 +281,17 @@ class Test_s3_bucket_public_write_acl:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_write_ACL_AllUsers_WRITE_ACP(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -359,7 +327,7 @@ class Test_s3_bucket_public_write_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -393,17 +361,17 @@ class Test_s3_bucket_public_write_acl:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_write_ACL_AllUsers_FULL_CONTROL(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -439,7 +407,7 @@ class Test_s3_bucket_public_write_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -473,17 +441,17 @@ class Test_s3_bucket_public_write_acl:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_write_ACL_AuthenticatedUsers_WRITE(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -519,7 +487,7 @@ class Test_s3_bucket_public_write_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -553,17 +521,17 @@ class Test_s3_bucket_public_write_acl:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_write_ACL_AuthenticatedUsers_WRITE_ACP(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -599,7 +567,7 @@ class Test_s3_bucket_public_write_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -633,17 +601,17 @@ class Test_s3_bucket_public_write_acl:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     @mock_s3control
     def test_bucket_public_write_ACL_AuthenticatedUsers_FULL_CONTROL(self):
-        s3_client = client("s3", region_name=AWS_REGION)
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client.create_bucket(Bucket=bucket_name_us)
         bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -679,7 +647,7 @@ class Test_s3_bucket_public_write_acl:
         )
         from prowler.providers.aws.services.s3.s3_service import S3, S3Control
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -713,4 +681,4 @@ class Test_s3_bucket_public_write_acl:
                         result[0].resource_arn
                         == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                     )
-                    assert result[0].region == AWS_REGION
+                    assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/s3/s3_bucket_secure_transport_policy/s3_bucket_secure_transport_policy_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_secure_transport_policy/s3_bucket_secure_transport_policy_test.py
@@ -1,59 +1,25 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_s3_bucket_secure_transport_policy:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_s3
     def test_bucket_no_policy(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -82,11 +48,11 @@ class Test_s3_bucket_secure_transport_policy:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     def test_bucket_comply_policy(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
 
@@ -116,7 +82,7 @@ class Test_s3_bucket_secure_transport_policy:
         )
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -145,11 +111,11 @@ class Test_s3_bucket_secure_transport_policy:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_s3
     def test_bucket_uncomply_policy(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
 
@@ -179,7 +145,7 @@ class Test_s3_bucket_secure_transport_policy:
         )
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -208,4 +174,4 @@ class Test_s3_bucket_secure_transport_policy:
                     result[0].resource_arn
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
-                assert result[0].region == "us-east-1"
+                assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/s3/s3_bucket_server_access_logging_enabled/s3_bucket_server_access_logging_enabled_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_server_access_logging_enabled/s3_bucket_server_access_logging_enabled_test.py
@@ -1,59 +1,25 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_s3_bucket_server_access_logging_enabled:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_s3
     def test_bucket_no_logging(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -85,7 +51,7 @@ class Test_s3_bucket_server_access_logging_enabled:
 
     @mock_s3
     def test_bucket_with_logging(self):
-        s3_client_us_east_1 = client("s3", region_name="us-east-1")
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
         bucket_name_us = "bucket_test_us"
         s3_client_us_east_1.create_bucket(Bucket=bucket_name_us)
         bucket_owner = s3_client_us_east_1.get_bucket_acl(Bucket=bucket_name_us)[
@@ -146,7 +112,7 @@ class Test_s3_bucket_server_access_logging_enabled:
 
         from prowler.providers.aws.services.s3.s3_service import S3
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",

--- a/tests/providers/aws/services/s3/s3_service_test.py
+++ b/tests/providers/aws/services/s3/s3_service_test.py
@@ -1,54 +1,23 @@
 import json
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_s3, mock_s3control
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.s3.s3_service import S3, S3Control
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_S3_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
 
     # Test S3 Service
     @mock_s3
     def test_service(self):
         # S3 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         s3 = S3(audit_info)
         assert s3.service == "s3"
 
@@ -56,7 +25,7 @@ class Test_S3_Service:
     @mock_s3
     def test_client(self):
         # S3 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         s3 = S3(audit_info)
         assert s3.client.__class__.__name__ == "S3"
 
@@ -64,7 +33,7 @@ class Test_S3_Service:
     @mock_s3
     def test__get_session__(self):
         # S3 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         s3 = S3(audit_info)
         assert s3.session.__class__.__name__ == "Session"
 
@@ -72,7 +41,7 @@ class Test_S3_Service:
     @mock_s3
     def test_audited_account(self):
         # S3 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         s3 = S3(audit_info)
         assert s3.audited_account == AWS_ACCOUNT_NUMBER
 
@@ -86,7 +55,7 @@ class Test_S3_Service:
         s3_client.create_bucket(Bucket=bucket_name)
 
         # S3 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         s3 = S3(audit_info)
 
         assert len(s3.buckets) == 1
@@ -111,7 +80,7 @@ class Test_S3_Service:
             VersioningConfiguration={"MFADelete": "Disabled", "Status": "Enabled"},
         )
         # S3 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         s3 = S3(audit_info)
         assert len(s3.buckets) == 1
         assert s3.buckets[0].name == bucket_name
@@ -144,7 +113,7 @@ class Test_S3_Service:
             },
             Bucket=bucket_name,
         )
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         s3 = S3(audit_info)
         assert len(s3.buckets) == 1
         assert s3.buckets[0].name == bucket_name
@@ -224,7 +193,7 @@ class Test_S3_Service:
             },
         )
         # S3 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         s3 = S3(audit_info)
         assert len(s3.buckets) == 1
         assert s3.buckets[0].name == bucket_name
@@ -245,7 +214,7 @@ class Test_S3_Service:
             Bucket=bucket_name,
             Policy=ssl_policy,
         )
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         s3 = S3(audit_info)
         assert len(s3.buckets) == 1
         assert s3.buckets[0].name == bucket_name
@@ -278,7 +247,7 @@ class Test_S3_Service:
             Bucket=bucket_name, ServerSideEncryptionConfiguration=sse_config
         )
         # S3 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         s3 = S3(audit_info)
         assert len(s3.buckets) == 1
         assert s3.buckets[0].name == bucket_name
@@ -300,7 +269,7 @@ class Test_S3_Service:
         )
 
         # S3 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         s3 = S3(audit_info)
         assert len(s3.buckets) == 1
         assert s3.buckets[0].name == bucket_name
@@ -330,7 +299,7 @@ class Test_S3_Service:
             },
         )
         # S3 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         s3 = S3(audit_info)
         assert len(s3.buckets) == 1
         assert s3.buckets[0].name == bucket_name
@@ -360,7 +329,7 @@ class Test_S3_Service:
             },
         )
         # S3 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         s3 = S3(audit_info)
 
         assert len(s3.buckets) == 1
@@ -372,7 +341,7 @@ class Test_S3_Service:
     @mock_s3control
     def test__get_public_access_block__s3_control(self):
         # Generate S3Control Client
-        s3control_client = client("s3control", region_name=AWS_REGION)
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
         s3control_client.put_public_access_block(
             AccountId=AWS_ACCOUNT_NUMBER,
             PublicAccessBlockConfiguration={
@@ -383,7 +352,7 @@ class Test_S3_Service:
             },
         )
         # S3 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         s3control = S3Control(audit_info)
         assert s3control.account_public_access_block.block_public_acls
         assert s3control.account_public_access_block.ignore_public_acls
@@ -404,7 +373,7 @@ class Test_S3_Service:
         )
 
         # S3 client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         s3 = S3(audit_info)
         assert len(s3.buckets) == 1
         assert s3.buckets[0].name == bucket_name


### PR DESCRIPTION
### Description

Refactor S3 to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
