### PR TITLE
test(audit_info): refactor route53

### DIFF
--- a/tests/providers/aws/services/route53/route53_dangling_ip_subdomain_takeover/route53_dangling_ip_subdomain_takeover_test.py
+++ b/tests/providers/aws/services/route53/route53_dangling_ip_subdomain_takeover/route53_dangling_ip_subdomain_takeover_test.py
@@ -1,56 +1,23 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_route53
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_route53_dangling_ip_subdomain_takeover:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=DEFAULT_ACCOUNT_ID,
-            audited_account_arn=f"arn:aws:iam::{DEFAULT_ACCOUNT_ID}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=[AWS_REGION],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_ec2
     @mock_route53
     def test_no_hosted_zones(self):
         from prowler.providers.aws.services.ec2.ec2_service import EC2
         from prowler.providers.aws.services.route53.route53_service import Route53
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -77,7 +44,7 @@ class Test_route53_dangling_ip_subdomain_takeover:
     @mock_ec2
     @mock_route53
     def test_hosted_zone_no_records(self):
-        conn = client("route53", region_name=AWS_REGION)
+        conn = client("route53", region_name=AWS_REGION_US_EAST_1)
 
         conn.create_hosted_zone(
             Name="testdns.aws.com.", CallerReference=str(hash("foo"))
@@ -86,7 +53,7 @@ class Test_route53_dangling_ip_subdomain_takeover:
         from prowler.providers.aws.services.ec2.ec2_service import EC2
         from prowler.providers.aws.services.route53.route53_service import Route53
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -113,7 +80,7 @@ class Test_route53_dangling_ip_subdomain_takeover:
     @mock_ec2
     @mock_route53
     def test_hosted_zone_private_record(self):
-        conn = client("route53", region_name=AWS_REGION)
+        conn = client("route53", region_name=AWS_REGION_US_EAST_1)
 
         zone_id = conn.create_hosted_zone(
             Name="testdns.aws.com.", CallerReference=str(hash("foo"))
@@ -137,7 +104,7 @@ class Test_route53_dangling_ip_subdomain_takeover:
         from prowler.providers.aws.services.ec2.ec2_service import EC2
         from prowler.providers.aws.services.route53.route53_service import Route53
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -177,7 +144,7 @@ class Test_route53_dangling_ip_subdomain_takeover:
     @mock_ec2
     @mock_route53
     def test_hosted_zone_external_record(self):
-        conn = client("route53", region_name=AWS_REGION)
+        conn = client("route53", region_name=AWS_REGION_US_EAST_1)
 
         zone_id = conn.create_hosted_zone(
             Name="testdns.aws.com.", CallerReference=str(hash("foo"))
@@ -201,7 +168,7 @@ class Test_route53_dangling_ip_subdomain_takeover:
         from prowler.providers.aws.services.ec2.ec2_service import EC2
         from prowler.providers.aws.services.route53.route53_service import Route53
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -241,7 +208,7 @@ class Test_route53_dangling_ip_subdomain_takeover:
     @mock_ec2
     @mock_route53
     def test_hosted_zone_dangling_public_record(self):
-        conn = client("route53", region_name=AWS_REGION)
+        conn = client("route53", region_name=AWS_REGION_US_EAST_1)
 
         zone_id = conn.create_hosted_zone(
             Name="testdns.aws.com.", CallerReference=str(hash("foo"))
@@ -265,7 +232,7 @@ class Test_route53_dangling_ip_subdomain_takeover:
         from prowler.providers.aws.services.ec2.ec2_service import EC2
         from prowler.providers.aws.services.route53.route53_service import Route53
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -305,8 +272,8 @@ class Test_route53_dangling_ip_subdomain_takeover:
     @mock_ec2
     @mock_route53
     def test_hosted_zone_eip_record(self):
-        conn = client("route53", region_name=AWS_REGION)
-        ec2 = client("ec2", region_name=AWS_REGION)
+        conn = client("route53", region_name=AWS_REGION_US_EAST_1)
+        ec2 = client("ec2", region_name=AWS_REGION_US_EAST_1)
 
         ec2.allocate_address(Domain="vpc", Address="17.5.7.3")
 
@@ -332,7 +299,7 @@ class Test_route53_dangling_ip_subdomain_takeover:
         from prowler.providers.aws.services.ec2.ec2_service import EC2
         from prowler.providers.aws.services.route53.route53_service import Route53
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -372,9 +339,9 @@ class Test_route53_dangling_ip_subdomain_takeover:
     @mock_ec2
     @mock_route53
     def test_hosted_zone_eni_record(self):
-        conn = client("route53", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
-        ec2_client = client("ec2", region_name=AWS_REGION)
+        conn = client("route53", region_name=AWS_REGION_US_EAST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
         subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
         eni_id = ec2.create_network_interface(SubnetId=subnet.id).id
@@ -405,7 +372,7 @@ class Test_route53_dangling_ip_subdomain_takeover:
         from prowler.providers.aws.services.ec2.ec2_service import EC2
         from prowler.providers.aws.services.route53.route53_service import Route53
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",

--- a/tests/providers/aws/services/route53/route53_domains_privacy_protection_enabled/route53_domains_privacy_protection_enabled_test.py
+++ b/tests/providers/aws/services/route53/route53_domains_privacy_protection_enabled/route53_domains_privacy_protection_enabled_test.py
@@ -1,8 +1,7 @@
 from unittest import mock
 
 from prowler.providers.aws.services.route53.route53_service import Domain
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
 
 
 class Test_route53_domains_privacy_protection_enabled:
@@ -29,7 +28,7 @@ class Test_route53_domains_privacy_protection_enabled:
         domain_name = "test-domain.com"
         route53domains.domains = {
             domain_name: Domain(
-                name=domain_name, region=AWS_REGION, admin_privacy=False
+                name=domain_name, region=AWS_REGION_US_EAST_1, admin_privacy=False
             )
         }
 
@@ -47,7 +46,7 @@ class Test_route53_domains_privacy_protection_enabled:
 
             assert len(result) == 1
             assert result[0].resource_id == domain_name
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
@@ -58,7 +57,9 @@ class Test_route53_domains_privacy_protection_enabled:
         route53domains = mock.MagicMock
         domain_name = "test-domain.com"
         route53domains.domains = {
-            domain_name: Domain(name=domain_name, region=AWS_REGION, admin_privacy=True)
+            domain_name: Domain(
+                name=domain_name, region=AWS_REGION_US_EAST_1, admin_privacy=True
+            )
         }
 
         with mock.patch(
@@ -75,7 +76,7 @@ class Test_route53_domains_privacy_protection_enabled:
 
             assert len(result) == 1
             assert result[0].resource_id == domain_name
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended

--- a/tests/providers/aws/services/route53/route53_domains_transferlock_enabled/route53_domains_transferlock_enabled_test.py
+++ b/tests/providers/aws/services/route53/route53_domains_transferlock_enabled/route53_domains_transferlock_enabled_test.py
@@ -1,8 +1,7 @@
 from unittest import mock
 
 from prowler.providers.aws.services.route53.route53_service import Domain
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
 
 
 class Test_route53_domains_transferlock_enabled:
@@ -30,7 +29,7 @@ class Test_route53_domains_transferlock_enabled:
         route53domains.domains = {
             domain_name: Domain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 admin_privacy=False,
                 status_list=[""],
             )
@@ -50,7 +49,7 @@ class Test_route53_domains_transferlock_enabled:
 
             assert len(result) == 1
             assert result[0].resource_id == domain_name
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
@@ -63,7 +62,7 @@ class Test_route53_domains_transferlock_enabled:
         route53domains.domains = {
             domain_name: Domain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 admin_privacy=False,
                 status_list=["clientTransferProhibited"],
             )
@@ -83,7 +82,7 @@ class Test_route53_domains_transferlock_enabled:
 
             assert len(result) == 1
             assert result[0].resource_id == domain_name
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended

--- a/tests/providers/aws/services/route53/route53_public_hosted_zones_cloudwatch_logging_enabled/route53_public_hosted_zones_cloudwatch_logging_enabled_test.py
+++ b/tests/providers/aws/services/route53/route53_public_hosted_zones_cloudwatch_logging_enabled/route53_public_hosted_zones_cloudwatch_logging_enabled_test.py
@@ -6,8 +6,7 @@ from prowler.providers.aws.services.route53.route53_service import (
     HostedZone,
     LoggingConfig,
 )
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
 
 
 class Test_route53_public_hosted_zones_cloudwatch_logging_enabled:
@@ -37,16 +36,14 @@ class Test_route53_public_hosted_zones_cloudwatch_logging_enabled:
         hosted_zone_name = "test-domain.com"
         hosted_zone_id = "ABCDEF12345678"
         log_group_name = "test-log-group"
-        log_group_arn = (
-            f"rn:aws:logs:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:log-group:{log_group_name}"
-        )
+        log_group_arn = f"rn:aws:logs:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:log-group:{log_group_name}"
         route53.hosted_zones = {
             hosted_zone_name: HostedZone(
                 name=hosted_zone_name,
                 arn=f"arn:aws:route53:::{hosted_zone_id}",
                 id=hosted_zone_id,
                 private_zone=False,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 logging_config=LoggingConfig(cloudwatch_log_group_arn=log_group_arn),
             )
         }
@@ -68,7 +65,7 @@ class Test_route53_public_hosted_zones_cloudwatch_logging_enabled:
 
             assert len(result) == 1
             assert result[0].resource_id == hosted_zone_id
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
@@ -85,7 +82,7 @@ class Test_route53_public_hosted_zones_cloudwatch_logging_enabled:
                 arn=f"arn:aws:route53:::{hosted_zone_id}",
                 id=hosted_zone_id,
                 private_zone=False,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         }
 
@@ -106,7 +103,7 @@ class Test_route53_public_hosted_zones_cloudwatch_logging_enabled:
 
             assert len(result) == 1
             assert result[0].resource_id == hosted_zone_id
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
@@ -123,7 +120,7 @@ class Test_route53_public_hosted_zones_cloudwatch_logging_enabled:
                 arn=f"arn:aws:route53:::{hosted_zone_id}",
                 id=hosted_zone_id,
                 private_zone=True,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         }
 

--- a/tests/providers/aws/services/route53/route53domains_service_test.py
+++ b/tests/providers/aws/services/route53/route53domains_service_test.py
@@ -2,14 +2,12 @@ from datetime import datetime
 from unittest.mock import patch
 
 import botocore
-from boto3 import session
 
-from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.route53.route53_service import Route53Domains
-from prowler.providers.common.models import Audit_Metadata
-
-# Mock Test Region
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 # Mocking Access Analyzer Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -71,60 +69,38 @@ def mock_make_api_call(self, operation_name, kwarg):
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_Route53_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=None,
-            audited_account_arn=None,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
 
     # Test Route53Domains Client
     def test__get_client__(self):
-        route53domains = Route53Domains(self.set_mocked_audit_info())
+        route53domains = Route53Domains(
+            set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
+        )
         assert route53domains.client.__class__.__name__ == "Route53Domains"
 
     # Test Route53Domains Session
     def test__get_session__(self):
-        route53domains = Route53Domains(self.set_mocked_audit_info())
+        route53domains = Route53Domains(
+            set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
+        )
         assert route53domains.session.__class__.__name__ == "Session"
 
     # Test Route53Domains Service
     def test__get_service__(self):
-        route53domains = Route53Domains(self.set_mocked_audit_info())
+        route53domains = Route53Domains(
+            set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
+        )
         assert route53domains.service == "route53domains"
 
     def test__list_domains__(self):
-        route53domains = Route53Domains(self.set_mocked_audit_info())
+        route53domains = Route53Domains(
+            set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
+        )
         domain_name = "test.domain.com"
         assert len(route53domains.domains)
         assert route53domains.domains
         assert route53domains.domains[domain_name]
         assert route53domains.domains[domain_name].name == domain_name
-        assert route53domains.domains[domain_name].region == AWS_REGION
+        assert route53domains.domains[domain_name].region == AWS_REGION_US_EAST_1
         assert route53domains.domains[domain_name].admin_privacy
         assert route53domains.domains[domain_name].status_list
         assert len(route53domains.domains[domain_name].status_list) == 1


### PR DESCRIPTION
### Description

Refactor Route53 to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
