### PR TITLE
test(audit_info): refactor resourceexplorer2

### DIFF
--- a/tests/providers/aws/services/resourceexplorer2/resourceexplorer2_indexes_found/resourceexplorer2_indexes_found_test.py
+++ b/tests/providers/aws/services/resourceexplorer2/resourceexplorer2_indexes_found/resourceexplorer2_indexes_found_test.py
@@ -1,50 +1,18 @@
 from unittest import mock
 
-from boto3 import session
-
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.resourceexplorer2.resourceexplorer2_service import (
     Indexes,
 )
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+)
 
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
 INDEX_ARN = "arn:aws:resource-explorer-2:ap-south-1:123456789012:index/123456-2896-4fe8-93d2-15ec137e5c47"
 INDEX_REGION = "us-east-1"
 
 
 class Test_resourceexplorer2_indexes_found:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=[AWS_REGION],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     def test_no_indexes_found(self):
         resourceexplorer2_client = mock.MagicMock
         resourceexplorer2_client.indexes = []
@@ -52,7 +20,7 @@ class Test_resourceexplorer2_indexes_found:
         resourceexplorer2_client.audited_account_arn = (
             f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
         )
-        resourceexplorer2_client.region = AWS_REGION
+        resourceexplorer2_client.region = AWS_REGION_US_EAST_1
         with mock.patch(
             "prowler.providers.aws.services.resourceexplorer2.resourceexplorer2_service.ResourceExplorer2",
             new=resourceexplorer2_client,
@@ -71,7 +39,7 @@ class Test_resourceexplorer2_indexes_found:
             assert result[0].status_extended == "No Resource Explorer Indexes found."
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert result[0].resource_arn == f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     def test_one_index_found(self):
         resourceexplorer2_client = mock.MagicMock
@@ -82,7 +50,7 @@ class Test_resourceexplorer2_indexes_found:
         resourceexplorer2_client.audited_account_arn = (
             f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
         )
-        resourceexplorer2_client.region = AWS_REGION
+        resourceexplorer2_client.region = AWS_REGION_US_EAST_1
         with mock.patch(
             "prowler.providers.aws.services.resourceexplorer2.resourceexplorer2_service.ResourceExplorer2",
             new=resourceexplorer2_client,
@@ -101,4 +69,4 @@ class Test_resourceexplorer2_indexes_found:
             assert result[0].status_extended == "Resource Explorer Indexes found: 1."
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert result[0].resource_arn == INDEX_ARN
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/resourceexplorer2/resourceexplorer2_service_test.py
+++ b/tests/providers/aws/services/resourceexplorer2/resourceexplorer2_service_test.py
@@ -1,16 +1,15 @@
 from unittest.mock import patch
 
 import botocore
-from boto3 import session
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.resourceexplorer2.resourceexplorer2_service import (
     ResourceExplorer2,
 )
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "eu-west-1"
 INDEX_ARN = "arn:aws:resource-explorer-2:ap-south-1:123456789012:index/123456-2896-4fe8-93d2-15ec137e5c47"
 INDEX_REGION = "us-east-1"
 
@@ -32,9 +31,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_EU_WEST_1
+    )
+    regional_client.region = AWS_REGION_EU_WEST_1
+    return {AWS_REGION_EU_WEST_1: regional_client}
 
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
@@ -43,52 +44,21 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_ResourceExplorer2_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     def test__get_client__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         resourceeplorer2 = ResourceExplorer2(audit_info)
         assert (
-            resourceeplorer2.regional_clients[AWS_REGION].__class__.__name__
+            resourceeplorer2.regional_clients[AWS_REGION_EU_WEST_1].__class__.__name__
             == "ResourceExplorer"
         )
 
     def test__get_service__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         resourceeplorer2 = ResourceExplorer2(audit_info)
         assert resourceeplorer2.service == "resource-explorer-2"
 
     def test__list_indexes__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         resourceeplorer2 = ResourceExplorer2(audit_info)
         assert len(resourceeplorer2.indexes) == 1
         assert resourceeplorer2.indexes[0].arn == INDEX_ARN


### PR DESCRIPTION
### Description

Refactor ResoureExplorer2 to use the set_mocked_aws_audit_info helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
