### PR TITLE
test(audit_info): refactor redshift

### DIFF
--- a/tests/providers/aws/services/redshift/redshift_cluster_audit_logging/redshift_cluster_audit_logging_test.py
+++ b/tests/providers/aws/services/redshift/redshift_cluster_audit_logging/redshift_cluster_audit_logging_test.py
@@ -3,11 +3,15 @@ from unittest import mock
 from uuid import uuid4
 
 from prowler.providers.aws.services.redshift.redshift_service import Cluster
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
 CLUSTER_ID = str(uuid4())
-CLUSTER_ARN = f"arn:aws:redshift:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:cluster:{CLUSTER_ID}"
+CLUSTER_ARN = (
+    f"arn:aws:redshift:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:cluster:{CLUSTER_ID}"
+)
 
 
 class Test_redshift_cluster_audit_logging:
@@ -33,7 +37,7 @@ class Test_redshift_cluster_audit_logging:
             Cluster(
                 id=CLUSTER_ID,
                 arn=CLUSTER_ARN,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 logging_enabled=False,
             )
         )
@@ -59,7 +63,7 @@ class Test_redshift_cluster_audit_logging:
             Cluster(
                 id=CLUSTER_ID,
                 arn=CLUSTER_ARN,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 logging_enabled=True,
                 endpoint_address="192.192.192.192",
             )

--- a/tests/providers/aws/services/redshift/redshift_cluster_automated_snapshot/redshift_cluster_automated_snapshot_test.py
+++ b/tests/providers/aws/services/redshift/redshift_cluster_automated_snapshot/redshift_cluster_automated_snapshot_test.py
@@ -3,12 +3,15 @@ from unittest import mock
 from uuid import uuid4
 
 from prowler.providers.aws.services.redshift.redshift_service import Cluster
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 CLUSTER_ID = str(uuid4())
-CLUSTER_ARN = f"arn:aws:redshift:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:cluster:{CLUSTER_ID}"
+CLUSTER_ARN = (
+    f"arn:aws:redshift:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:cluster:{CLUSTER_ID}"
+)
 
 
 class Test_redshift_cluster_automated_snapshot:
@@ -34,7 +37,7 @@ class Test_redshift_cluster_automated_snapshot:
             Cluster(
                 id=CLUSTER_ID,
                 arn=CLUSTER_ARN,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 cluster_snapshots=False,
             )
         )
@@ -60,7 +63,7 @@ class Test_redshift_cluster_automated_snapshot:
             Cluster(
                 id=CLUSTER_ID,
                 arn=CLUSTER_ARN,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 cluster_snapshots=True,
             )
         )

--- a/tests/providers/aws/services/redshift/redshift_cluster_automatic_upgrades/redshift_cluster_automatic_upgrades_test.py
+++ b/tests/providers/aws/services/redshift/redshift_cluster_automatic_upgrades/redshift_cluster_automatic_upgrades_test.py
@@ -3,11 +3,15 @@ from unittest import mock
 from uuid import uuid4
 
 from prowler.providers.aws.services.redshift.redshift_service import Cluster
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
 CLUSTER_ID = str(uuid4())
-CLUSTER_ARN = f"arn:aws:redshift:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:cluster:{CLUSTER_ID}"
+CLUSTER_ARN = (
+    f"arn:aws:redshift:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:cluster:{CLUSTER_ID}"
+)
 
 
 class Test_redshift_cluster_automatic_upgrades:
@@ -33,7 +37,7 @@ class Test_redshift_cluster_automatic_upgrades:
             Cluster(
                 id=CLUSTER_ID,
                 arn=CLUSTER_ARN,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 allow_version_upgrade=False,
             )
         )
@@ -59,7 +63,7 @@ class Test_redshift_cluster_automatic_upgrades:
             Cluster(
                 id=CLUSTER_ID,
                 arn=CLUSTER_ARN,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 allow_version_upgrade=True,
             )
         )

--- a/tests/providers/aws/services/redshift/redshift_cluster_public_access/redshift_cluster_public_access_test.py
+++ b/tests/providers/aws/services/redshift/redshift_cluster_public_access/redshift_cluster_public_access_test.py
@@ -3,11 +3,15 @@ from unittest import mock
 from uuid import uuid4
 
 from prowler.providers.aws.services.redshift.redshift_service import Cluster
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
 CLUSTER_ID = str(uuid4())
-CLUSTER_ARN = f"arn:aws:redshift:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:cluster:{CLUSTER_ID}"
+CLUSTER_ARN = (
+    f"arn:aws:redshift:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:cluster:{CLUSTER_ID}"
+)
 
 
 class Test_redshift_cluster_public_access:
@@ -33,7 +37,7 @@ class Test_redshift_cluster_public_access:
             Cluster(
                 id=CLUSTER_ID,
                 arn=CLUSTER_ARN,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 public_access=True,
                 endpoint_address="192.192.192.192",
             )
@@ -60,7 +64,7 @@ class Test_redshift_cluster_public_access:
             Cluster(
                 id=CLUSTER_ID,
                 arn=CLUSTER_ARN,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 public_access=False,
                 endpoint_address="192.192.192.192",
             )
@@ -87,7 +91,7 @@ class Test_redshift_cluster_public_access:
             Cluster(
                 id=CLUSTER_ID,
                 arn=CLUSTER_ARN,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 public_access=True,
             )
         )

--- a/tests/providers/aws/services/redshift/redshift_service_test.py
+++ b/tests/providers/aws/services/redshift/redshift_service_test.py
@@ -2,15 +2,15 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_redshift
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.redshift.redshift_service import Redshift
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "eu-west-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
 topic_name = "test-topic"
 test_policy = {
@@ -19,7 +19,7 @@ test_policy = {
             "Effect": "Allow",
             "Principal": {"AWS": f"{AWS_ACCOUNT_NUMBER}"},
             "Action": ["redshift:Publish"],
-            "Resource": f"arn:aws:redshift:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:{topic_name}",
+            "Resource": f"arn:aws:redshift:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:{topic_name}",
         }
     ]
 }
@@ -47,9 +47,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_EU_WEST_1
+    )
+    regional_client.region = AWS_REGION_EU_WEST_1
+    return {AWS_REGION_EU_WEST_1: regional_client}
 
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
@@ -58,59 +60,29 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_Redshift_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
 
     # Test Redshift Service
     def test_service(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         redshift = Redshift(audit_info)
         assert redshift.service == "redshift"
 
     # Test Redshift client
     def test_client(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         redshift = Redshift(audit_info)
         for reg_client in redshift.regional_clients.values():
             assert reg_client.__class__.__name__ == "Redshift"
 
     # Test Redshift session
     def test__get_session__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         redshift = Redshift(audit_info)
         assert redshift.session.__class__.__name__ == "Session"
 
     @mock_redshift
     def test_describe_clusters(self):
-        redshift_client = client("redshift", region_name=AWS_REGION)
+        redshift_client = client("redshift", region_name=AWS_REGION_EU_WEST_1)
         response = redshift_client.create_cluster(
             DBName="test",
             ClusterIdentifier=cluster_id,
@@ -123,12 +95,12 @@ class Test_Redshift_Service:
                 {"Key": "test", "Value": "test"},
             ],
         )
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         redshift = Redshift(audit_info)
 
         assert len(redshift.clusters) == 1
         assert redshift.clusters[0].id == cluster_id
-        assert redshift.clusters[0].region == AWS_REGION
+        assert redshift.clusters[0].region == AWS_REGION_EU_WEST_1
         assert redshift.clusters[0].public_access
         assert (
             redshift.clusters[0].endpoint_address
@@ -144,7 +116,7 @@ class Test_Redshift_Service:
 
     @mock_redshift
     def test_describe_logging_status(self):
-        redshift_client = client("redshift", region_name=AWS_REGION)
+        redshift_client = client("redshift", region_name=AWS_REGION_EU_WEST_1)
         response = redshift_client.create_cluster(
             DBName="test",
             ClusterIdentifier=cluster_id,
@@ -154,12 +126,12 @@ class Test_Redshift_Service:
             MasterUserPassword="password",
             PubliclyAccessible=True,
         )
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         redshift = Redshift(audit_info)
 
         assert len(redshift.clusters) == 1
         assert redshift.clusters[0].id == cluster_id
-        assert redshift.clusters[0].region == AWS_REGION
+        assert redshift.clusters[0].region == AWS_REGION_EU_WEST_1
         assert redshift.clusters[0].public_access
         assert (
             redshift.clusters[0].endpoint_address
@@ -174,7 +146,7 @@ class Test_Redshift_Service:
 
     @mock_redshift
     def test_describe_describe_cluster_snapshot(self):
-        redshift_client = client("redshift", region_name=AWS_REGION)
+        redshift_client = client("redshift", region_name=AWS_REGION_EU_WEST_1)
         response = redshift_client.create_cluster(
             DBName="test",
             ClusterIdentifier=cluster_id,
@@ -184,12 +156,12 @@ class Test_Redshift_Service:
             MasterUserPassword="password",
             PubliclyAccessible=True,
         )
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         redshift = Redshift(audit_info)
 
         assert len(redshift.clusters) == 1
         assert redshift.clusters[0].id == cluster_id
-        assert redshift.clusters[0].region == AWS_REGION
+        assert redshift.clusters[0].region == AWS_REGION_EU_WEST_1
         assert redshift.clusters[0].public_access
         assert (
             redshift.clusters[0].endpoint_address


### PR DESCRIPTION
### Description

Refactor Redshift to use the set_mocked_aws_audit_info helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
