### PR TITLE
test(audit_info): refactor elb

### DIFF
--- a/tests/providers/aws/audit_info_utils.py
+++ b/tests/providers/aws/audit_info_utils.py
@@ -5,6 +5,7 @@ from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION_US_EAST_1 = "us-east-1"
 AWS_REGION_EU_WEST_1 = "eu-west-1"
+AWS_REGION_US_EAST_1_AZA = "eu-west-1a"
 AWS_REGION_EU_WEST_2 = "eu-west-2"
 AWS_REGION_EU_SOUTH_2 = "eu-south-2"
 AWS_PARTITION = "aws"

--- a/tests/providers/aws/services/elb/elb_insecure_ssl_ciphers/elb_insecure_ssl_ciphers_test.py
+++ b/tests/providers/aws/services/elb/elb_insecure_ssl_ciphers/elb_insecure_ssl_ciphers_test.py
@@ -1,61 +1,32 @@
-from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_elb
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
-elb_arn = (
-    f"arn:aws:elasticloadbalancing:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:loadbalancer/my-lb"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    AWS_REGION_US_EAST_1_AZA,
+    set_mocked_aws_audit_info,
 )
+
+AWS_ACCOUNT_NUMBER = "123456789012"
+elb_arn = f"arn:aws:elasticloadbalancing:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:loadbalancer/my-lb"
 
 
 class Test_elb_insecure_ssl_ciphers:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_elb
     def test_elb_no_balancers(self):
         from prowler.providers.aws.services.elb.elb_service import ELB
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elb.elb_insecure_ssl_ciphers.elb_insecure_ssl_ciphers.elb_client",
-            new=ELB(self.set_mocked_audit_info()),
+            new=ELB(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.elb.elb_insecure_ssl_ciphers.elb_insecure_ssl_ciphers import (
@@ -70,8 +41,8 @@ class Test_elb_insecure_ssl_ciphers:
     @mock_ec2
     @mock_elb
     def test_elb_listener_with_secure_policy(self):
-        elb = client("elb", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        elb = client("elb", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="sg01", Description="Test security group sg01"
@@ -83,7 +54,7 @@ class Test_elb_insecure_ssl_ciphers:
                 {"Protocol": "tcp", "LoadBalancerPort": 80, "InstancePort": 8080},
                 {"Protocol": "https", "LoadBalancerPort": 443, "InstancePort": 9000},
             ],
-            AvailabilityZones=[f"{AWS_REGION}a"],
+            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
             Scheme="internal",
             SecurityGroups=[security_group.id],
         )
@@ -99,10 +70,12 @@ class Test_elb_insecure_ssl_ciphers:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elb.elb_insecure_ssl_ciphers.elb_insecure_ssl_ciphers.elb_client",
-            new=ELB(self.set_mocked_audit_info()),
+            new=ELB(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elb.elb_insecure_ssl_ciphers.elb_insecure_ssl_ciphers import (
                 elb_insecure_ssl_ciphers,
@@ -113,18 +86,19 @@ class Test_elb_insecure_ssl_ciphers:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert search(
-                "does not have insecure SSL protocols or ciphers",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == "ELB my-lb does not have insecure SSL protocols or ciphers."
             )
             assert result[0].resource_id == "my-lb"
             assert result[0].resource_arn == elb_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_ec2
     @mock_elb
     def test_elb_with_HTTPS_listener(self):
-        elb = client("elb", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        elb = client("elb", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="sg01", Description="Test security group sg01"
@@ -136,7 +110,7 @@ class Test_elb_insecure_ssl_ciphers:
                 {"Protocol": "tcp", "LoadBalancerPort": 80, "InstancePort": 8080},
                 {"Protocol": "https", "LoadBalancerPort": 443, "InstancePort": 9000},
             ],
-            AvailabilityZones=[f"{AWS_REGION}a"],
+            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
             Scheme="internal",
             SecurityGroups=[security_group.id],
         )
@@ -145,10 +119,12 @@ class Test_elb_insecure_ssl_ciphers:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elb.elb_insecure_ssl_ciphers.elb_insecure_ssl_ciphers.elb_client",
-            new=ELB(self.set_mocked_audit_info()),
+            new=ELB(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elb.elb_insecure_ssl_ciphers.elb_insecure_ssl_ciphers import (
                 elb_insecure_ssl_ciphers,
@@ -159,9 +135,10 @@ class Test_elb_insecure_ssl_ciphers:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert search(
-                "has listeners with insecure SSL protocols or ciphers",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == "ELB my-lb has listeners with insecure SSL protocols or ciphers."
             )
             assert result[0].resource_id == "my-lb"
             assert result[0].resource_arn == elb_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/elb/elb_internet_facing/elb_internet_facing_test.py
+++ b/tests/providers/aws/services/elb/elb_internet_facing/elb_internet_facing_test.py
@@ -1,11 +1,14 @@
-from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_elb
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    AWS_REGION_US_EAST_1_AZA,
+    set_mocked_aws_audit_info,
+)
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -15,47 +18,18 @@ elb_arn = (
 
 
 class Test_elb_request_smugling:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_elb
     def test_elb_no_balancers(self):
         from prowler.providers.aws.services.elb.elb_service import ELB
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elb.elb_internet_facing.elb_internet_facing.elb_client",
-            new=ELB(self.set_mocked_audit_info()),
+            new=ELB(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.elb.elb_internet_facing.elb_internet_facing import (
@@ -83,7 +57,7 @@ class Test_elb_request_smugling:
                 {"Protocol": "tcp", "LoadBalancerPort": 80, "InstancePort": 8080},
                 {"Protocol": "http", "LoadBalancerPort": 81, "InstancePort": 9000},
             ],
-            AvailabilityZones=[f"{AWS_REGION}a"],
+            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
             Scheme="internal",
             SecurityGroups=[security_group.id],
         )
@@ -92,10 +66,12 @@ class Test_elb_request_smugling:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elb.elb_internet_facing.elb_internet_facing.elb_client",
-            new=ELB(self.set_mocked_audit_info()),
+            new=ELB(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elb.elb_internet_facing.elb_internet_facing import (
                 elb_internet_facing,
@@ -106,12 +82,10 @@ class Test_elb_request_smugling:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert search(
-                "is not internet facing",
-                result[0].status_extended,
-            )
+            assert result[0].status_extended == "ELB my-lb is not internet facing."
             assert result[0].resource_id == "my-lb"
             assert result[0].resource_arn == elb_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_ec2
     @mock_elb
@@ -129,7 +103,7 @@ class Test_elb_request_smugling:
                 {"Protocol": "tcp", "LoadBalancerPort": 80, "InstancePort": 8080},
                 {"Protocol": "http", "LoadBalancerPort": 81, "InstancePort": 9000},
             ],
-            AvailabilityZones=[f"{AWS_REGION}a"],
+            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
             Scheme="internet-facing",
             SecurityGroups=[security_group.id],
         )
@@ -138,10 +112,12 @@ class Test_elb_request_smugling:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elb.elb_internet_facing.elb_internet_facing.elb_client",
-            new=ELB(self.set_mocked_audit_info()),
+            new=ELB(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elb.elb_internet_facing.elb_internet_facing import (
                 elb_internet_facing,
@@ -152,9 +128,10 @@ class Test_elb_request_smugling:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert search(
-                "is internet facing",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == "ELB my-lb is internet facing in my-lb.us-east-1.elb.amazonaws.com."
             )
             assert result[0].resource_id == "my-lb"
             assert result[0].resource_arn == elb_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/elb/elb_logging_enabled/elb_logging_enabled_test.py
+++ b/tests/providers/aws/services/elb/elb_logging_enabled/elb_logging_enabled_test.py
@@ -1,11 +1,14 @@
-from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_elb
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    AWS_REGION_US_EAST_1_AZA,
+    set_mocked_aws_audit_info,
+)
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -15,47 +18,18 @@ elb_arn = (
 
 
 class Test_elb_logging_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_elb
     def test_elb_no_balancers(self):
         from prowler.providers.aws.services.elb.elb_service import ELB
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elb.elb_logging_enabled.elb_logging_enabled.elb_client",
-            new=ELB(self.set_mocked_audit_info()),
+            new=ELB(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.elb.elb_logging_enabled.elb_logging_enabled import (
@@ -83,7 +57,7 @@ class Test_elb_logging_enabled:
                 {"Protocol": "tcp", "LoadBalancerPort": 80, "InstancePort": 8080},
                 {"Protocol": "http", "LoadBalancerPort": 81, "InstancePort": 9000},
             ],
-            AvailabilityZones=[f"{AWS_REGION}a"],
+            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
             Scheme="internal",
             SecurityGroups=[security_group.id],
         )
@@ -92,10 +66,12 @@ class Test_elb_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elb.elb_logging_enabled.elb_logging_enabled.elb_client",
-            new=ELB(self.set_mocked_audit_info()),
+            new=ELB(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elb.elb_logging_enabled.elb_logging_enabled import (
                 elb_logging_enabled,
@@ -106,9 +82,9 @@ class Test_elb_logging_enabled:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert search(
-                "does not have access logs configured",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == "ELB my-lb does not have access logs configured."
             )
             assert result[0].resource_id == "my-lb"
             assert result[0].resource_arn == elb_arn
@@ -129,7 +105,7 @@ class Test_elb_logging_enabled:
                 {"Protocol": "tcp", "LoadBalancerPort": 80, "InstancePort": 8080},
                 {"Protocol": "http", "LoadBalancerPort": 81, "InstancePort": 9000},
             ],
-            AvailabilityZones=[f"{AWS_REGION}a"],
+            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
             Scheme="internal",
             SecurityGroups=[security_group.id],
         )
@@ -150,10 +126,12 @@ class Test_elb_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elb.elb_logging_enabled.elb_logging_enabled.elb_client",
-            new=ELB(self.set_mocked_audit_info()),
+            new=ELB(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elb.elb_logging_enabled.elb_logging_enabled import (
                 elb_logging_enabled,
@@ -164,9 +142,9 @@ class Test_elb_logging_enabled:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert search(
-                "has access logs to S3 configured",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == "ELB my-lb has access logs to S3 configured."
             )
             assert result[0].resource_id == "my-lb"
             assert result[0].resource_arn == elb_arn

--- a/tests/providers/aws/services/elb/elb_ssl_listeners/elb_ssl_listeners_test.py
+++ b/tests/providers/aws/services/elb/elb_ssl_listeners/elb_ssl_listeners_test.py
@@ -1,11 +1,14 @@
-from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_elb
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    AWS_REGION_US_EAST_1_AZA,
+    set_mocked_aws_audit_info,
+)
 
 AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
@@ -15,47 +18,18 @@ elb_arn = (
 
 
 class Test_elb_ssl_listeners:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_elb
     def test_elb_no_balancers(self):
         from prowler.providers.aws.services.elb.elb_service import ELB
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elb.elb_ssl_listeners.elb_ssl_listeners.elb_client",
-            new=ELB(self.set_mocked_audit_info()),
+            new=ELB(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.elb.elb_ssl_listeners.elb_ssl_listeners import (
@@ -83,7 +57,7 @@ class Test_elb_ssl_listeners:
                 {"Protocol": "tcp", "LoadBalancerPort": 80, "InstancePort": 8080},
                 {"Protocol": "http", "LoadBalancerPort": 81, "InstancePort": 9000},
             ],
-            AvailabilityZones=[f"{AWS_REGION}a"],
+            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
             Scheme="internal",
             SecurityGroups=[security_group.id],
         )
@@ -92,10 +66,12 @@ class Test_elb_ssl_listeners:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elb.elb_ssl_listeners.elb_ssl_listeners.elb_client",
-            new=ELB(self.set_mocked_audit_info()),
+            new=ELB(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elb.elb_ssl_listeners.elb_ssl_listeners import (
                 elb_ssl_listeners,
@@ -106,10 +82,7 @@ class Test_elb_ssl_listeners:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert search(
-                "has non-encrypted listeners",
-                result[0].status_extended,
-            )
+            assert result[0].status_extended == "ELB my-lb has non-encrypted listeners."
             assert result[0].resource_id == "my-lb"
             assert result[0].resource_arn == elb_arn
 
@@ -128,7 +101,7 @@ class Test_elb_ssl_listeners:
             Listeners=[
                 {"Protocol": "https", "LoadBalancerPort": 443, "InstancePort": 9000},
             ],
-            AvailabilityZones=[f"{AWS_REGION}a"],
+            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
             Scheme="internal",
             SecurityGroups=[security_group.id],
         )
@@ -136,10 +109,12 @@ class Test_elb_ssl_listeners:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elb.elb_ssl_listeners.elb_ssl_listeners.elb_client",
-            new=ELB(self.set_mocked_audit_info()),
+            new=ELB(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elb.elb_ssl_listeners.elb_ssl_listeners import (
                 elb_ssl_listeners,
@@ -150,9 +125,6 @@ class Test_elb_ssl_listeners:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert search(
-                "has HTTPS listeners only",
-                result[0].status_extended,
-            )
+            assert result[0].status_extended == "ELB my-lb has HTTPS listeners only."
             assert result[0].resource_id == "my-lb"
             assert result[0].resource_arn == elb_arn


### PR DESCRIPTION
### Description

Refactor ELB to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
