### PR TITLE
test(audit_info): refactor rds

### DIFF
--- a/tests/providers/aws/services/rds/rds_instance_backup_enabled/rds_instance_backup_enabled_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_backup_enabled/rds_instance_backup_enabled_test.py
@@ -2,15 +2,14 @@ from re import search
 from unittest import mock
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_rds
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
-
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -32,43 +31,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_rds_instance_backup_enabled:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_rds
     def test_rds_no_instances(self):
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -90,7 +57,7 @@ class Test_rds_instance_backup_enabled:
 
     @mock_rds
     def test_rds_instance_no_backup(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -101,7 +68,7 @@ class Test_rds_instance_backup_enabled:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -128,16 +95,16 @@ class Test_rds_instance_backup_enabled:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []
 
     @mock_rds
     def test_rds_instance_with_backup(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -148,7 +115,7 @@ class Test_rds_instance_backup_enabled:
         )
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -173,9 +140,9 @@ class Test_rds_instance_backup_enabled:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_instance_deletion_protection/rds_instance_deletion_protection_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_deletion_protection/rds_instance_deletion_protection_test.py
@@ -2,15 +2,14 @@ from re import search
 from unittest import mock
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_rds
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
-
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -32,43 +31,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_rds_instance_deletion_protection:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_rds
     def test_rds_no_instances(self):
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -90,7 +57,7 @@ class Test_rds_instance_deletion_protection:
 
     @mock_rds
     def test_rds_instance_no_deletion_protection(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -101,7 +68,7 @@ class Test_rds_instance_deletion_protection:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
             new=audit_info,
@@ -125,16 +92,16 @@ class Test_rds_instance_deletion_protection:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []
 
     @mock_rds
     def test_rds_instance_with_deletion_protection(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -146,7 +113,7 @@ class Test_rds_instance_deletion_protection:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -171,16 +138,16 @@ class Test_rds_instance_deletion_protection:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []
 
     @mock_rds
     def test_rds_instance_without_cluster_deletion_protection(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_cluster(
             DBClusterIdentifier="db-cluster-1",
             AllocatedStorage=10,
@@ -204,7 +171,7 @@ class Test_rds_instance_deletion_protection:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -229,16 +196,16 @@ class Test_rds_instance_deletion_protection:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []
 
     @mock_rds
     def test_rds_instance_with_cluster_deletion_protection(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_cluster(
             DBClusterIdentifier="db-cluster-1",
             AllocatedStorage=10,
@@ -262,7 +229,7 @@ class Test_rds_instance_deletion_protection:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -287,9 +254,9 @@ class Test_rds_instance_deletion_protection:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_instance_deprecated_engine_version/rds_instance_deprecated_engine_version_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_deprecated_engine_version/rds_instance_deprecated_engine_version_test.py
@@ -2,14 +2,14 @@ from unittest import mock
 from unittest.mock import patch
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_rds
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -31,43 +31,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_rds_instance_deprecated_engine_version:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=[AWS_REGION],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_rds
     def test_rds_no_instances(self):
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -89,7 +57,7 @@ class Test_rds_instance_deprecated_engine_version:
 
     @mock_rds
     def test_rds_instance_no_deprecated_engine_version(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -101,7 +69,7 @@ class Test_rds_instance_deprecated_engine_version:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -126,16 +94,16 @@ class Test_rds_instance_deprecated_engine_version:
                     == "RDS instance db-master-1 is not using a deprecated engine mysql with version 8.0.32."
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []
 
     @mock_rds
     def test_rds_instance_deprecated_engine_version(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-2",
             AllocatedStorage=10,
@@ -147,7 +115,7 @@ class Test_rds_instance_deprecated_engine_version:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -172,9 +140,9 @@ class Test_rds_instance_deprecated_engine_version:
                     == "RDS instance db-master-2 is using a deprecated engine mysql with version 8.0.23."
                 )
                 assert result[0].resource_id == "db-master-2"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-2"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-2"
                 )
                 assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_instance_enhanced_monitoring_enabled/rds_instance_enhanced_monitoring_enabled_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_enhanced_monitoring_enabled/rds_instance_enhanced_monitoring_enabled_test.py
@@ -2,14 +2,14 @@ from re import search
 from unittest import mock
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_rds
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -31,43 +31,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_rds_instance_enhanced_monitoring_enabled:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_rds
     def test_rds_no_instances(self):
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -89,7 +57,7 @@ class Test_rds_instance_enhanced_monitoring_enabled:
 
     @mock_rds
     def test_rds_instance_no_monitoring(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -100,7 +68,7 @@ class Test_rds_instance_enhanced_monitoring_enabled:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -125,16 +93,16 @@ class Test_rds_instance_enhanced_monitoring_enabled:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []
 
     @mock_rds
     def test_rds_instance_with_monitoring(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -145,7 +113,7 @@ class Test_rds_instance_enhanced_monitoring_enabled:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -171,9 +139,9 @@ class Test_rds_instance_enhanced_monitoring_enabled:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_instance_integration_cloudwatch_logs/rds_instance_integration_cloudwatch_logs_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_integration_cloudwatch_logs/rds_instance_integration_cloudwatch_logs_test.py
@@ -2,14 +2,14 @@ from re import search
 from unittest import mock
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_rds
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -31,43 +31,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_rds_instance_integration_cloudwatch_logs:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_rds
     def test_rds_no_instances(self):
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -89,7 +57,7 @@ class Test_rds_instance_integration_cloudwatch_logs:
 
     @mock_rds
     def test_rds_instance_no_logs(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -100,7 +68,7 @@ class Test_rds_instance_integration_cloudwatch_logs:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -125,16 +93,16 @@ class Test_rds_instance_integration_cloudwatch_logs:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []
 
     @mock_rds
     def test_rds_instance_with_logs(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -146,7 +114,7 @@ class Test_rds_instance_integration_cloudwatch_logs:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -171,9 +139,9 @@ class Test_rds_instance_integration_cloudwatch_logs:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_instance_minor_version_upgrade_enabled/rds_instance_minor_version_upgrade_enabled_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_minor_version_upgrade_enabled/rds_instance_minor_version_upgrade_enabled_test.py
@@ -2,14 +2,14 @@ from re import search
 from unittest import mock
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_rds
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -31,43 +31,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_rds_instance_minor_version_upgrade_enabled:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_rds
     def test_rds_no_instances(self):
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -89,7 +57,7 @@ class Test_rds_instance_minor_version_upgrade_enabled:
 
     @mock_rds
     def test_rds_instance_no_auto_upgrade(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -100,7 +68,7 @@ class Test_rds_instance_minor_version_upgrade_enabled:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -125,16 +93,16 @@ class Test_rds_instance_minor_version_upgrade_enabled:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []
 
     @mock_rds
     def test_rds_instance_with_auto_upgrade(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -146,7 +114,7 @@ class Test_rds_instance_minor_version_upgrade_enabled:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -171,9 +139,9 @@ class Test_rds_instance_minor_version_upgrade_enabled:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az_test.py
@@ -2,15 +2,15 @@ from re import search
 from unittest import mock
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_rds
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.rds.rds_service import DBCluster, DBInstance
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -32,43 +32,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_rds_instance_multi_az:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_rds
     def test_rds_no_instances(self):
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -90,7 +58,7 @@ class Test_rds_instance_multi_az:
 
     @mock_rds
     def test_rds_instance_no_multi_az(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -100,7 +68,7 @@ class Test_rds_instance_multi_az:
         )
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -125,16 +93,16 @@ class Test_rds_instance_multi_az:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []
 
     @mock_rds
     def test_rds_instance_multi_az(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -146,7 +114,7 @@ class Test_rds_instance_multi_az:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -171,18 +139,16 @@ class Test_rds_instance_multi_az:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []
 
     def test_rds_instance_in_cluster_multi_az(self):
         rds_client = mock.MagicMock
-        cluster_arn = (
-            f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:cluster:test-cluster"
-        )
+        cluster_arn = f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:test-cluster"
         rds_client.db_clusters = {
             cluster_arn: DBCluster(
                 id="test-cluster",
@@ -198,14 +164,14 @@ class Test_rds_instance_multi_az:
                 deletion_protection=False,
                 parameter_group="",
                 multi_az=True,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 tags=[],
             )
         }
         rds_client.db_instances = [
             DBInstance(
                 id="test-instance",
-                arn=f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:test-instance",
+                arn=f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:test-instance",
                 endpoint="",
                 engine="aurora",
                 engine_version="1.0.0",
@@ -220,12 +186,12 @@ class Test_rds_instance_multi_az:
                 multi_az=False,
                 cluster_id="test-cluster",
                 cluster_arn=cluster_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 tags=[],
             )
         ]
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -250,18 +216,16 @@ class Test_rds_instance_multi_az:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "test-instance"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:test-instance"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:test-instance"
                 )
                 assert result[0].resource_tags == []
 
     def test_rds_instance_in_cluster_without_multi_az(self):
         rds_client = mock.MagicMock
-        cluster_arn = (
-            f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:cluster:test-cluster"
-        )
+        cluster_arn = f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:test-cluster"
         rds_client.db_clusters = {
             cluster_arn: DBCluster(
                 id="test-cluster",
@@ -277,14 +241,14 @@ class Test_rds_instance_multi_az:
                 deletion_protection=False,
                 parameter_group="",
                 multi_az=False,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 tags=[],
             )
         }
         rds_client.db_instances = [
             DBInstance(
                 id="test-instance",
-                arn=f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:test-instance",
+                arn=f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:test-instance",
                 endpoint="",
                 engine="aurora",
                 engine_version="1.0.0",
@@ -299,12 +263,12 @@ class Test_rds_instance_multi_az:
                 multi_az=False,
                 cluster_id="test-cluster",
                 cluster_arn=cluster_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 tags=[],
             )
         ]
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -329,9 +293,9 @@ class Test_rds_instance_multi_az:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "test-instance"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:test-instance"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:test-instance"
                 )
                 assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
@@ -2,14 +2,14 @@ from re import search
 from unittest import mock
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_rds
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -31,43 +31,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_rds_instance_no_public_access:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_rds
     def test_rds_no_instances(self):
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -89,7 +57,7 @@ class Test_rds_instance_no_public_access:
 
     @mock_rds
     def test_rds_instance_private(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -100,7 +68,7 @@ class Test_rds_instance_no_public_access:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -125,16 +93,16 @@ class Test_rds_instance_no_public_access:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []
 
     @mock_rds
     def test_rds_instance_public(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -146,7 +114,7 @@ class Test_rds_instance_no_public_access:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -171,9 +139,9 @@ class Test_rds_instance_no_public_access:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_instance_storage_encrypted/rds_instance_storage_encrypted_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_storage_encrypted/rds_instance_storage_encrypted_test.py
@@ -2,14 +2,14 @@ from re import search
 from unittest import mock
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_rds
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -31,43 +31,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_rds_instance_storage_encrypted:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_rds
     def test_rds_no_instances(self):
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -89,7 +57,7 @@ class Test_rds_instance_storage_encrypted:
 
     @mock_rds
     def test_rds_instance_no_encryption(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -99,7 +67,7 @@ class Test_rds_instance_storage_encrypted:
         )
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -124,16 +92,16 @@ class Test_rds_instance_storage_encrypted:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []
 
     @mock_rds
     def test_rds_instance_with_encryption(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -145,7 +113,7 @@ class Test_rds_instance_storage_encrypted:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -170,9 +138,9 @@ class Test_rds_instance_storage_encrypted:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted_test.py
@@ -2,14 +2,14 @@ from re import search
 from unittest import mock
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_rds
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -31,43 +31,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_rds_instance_transport_encrypted:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_rds
     def test_rds_no_instances(self):
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -89,7 +57,7 @@ class Test_rds_instance_transport_encrypted:
 
     @mock_rds
     def test_rds_aurora_instance(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_parameter_group(
             DBParameterGroupName="test",
             DBParameterGroupFamily="default.aurora-postgresql14",
@@ -105,7 +73,7 @@ class Test_rds_instance_transport_encrypted:
         )
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -127,7 +95,7 @@ class Test_rds_instance_transport_encrypted:
 
     @mock_rds
     def test_rds_instance_no_ssl(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_parameter_group(
             DBParameterGroupName="test",
             DBParameterGroupFamily="default.postgres9.3",
@@ -155,7 +123,7 @@ class Test_rds_instance_transport_encrypted:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -180,16 +148,16 @@ class Test_rds_instance_transport_encrypted:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []
 
     @mock_rds
     def test_rds_instance_with_ssl(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_parameter_group(
             DBParameterGroupName="test",
             DBParameterGroupFamily="default.postgres9.3",
@@ -217,7 +185,7 @@ class Test_rds_instance_transport_encrypted:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -242,9 +210,9 @@ class Test_rds_instance_transport_encrypted:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "db-master-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_service_test.py
+++ b/tests/providers/aws/services/rds/rds_service_test.py
@@ -1,15 +1,15 @@
 from unittest.mock import patch
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_rds
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.rds.rds_service import RDS
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -31,42 +31,12 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_RDS_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=[AWS_REGION],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
 
     # Test Dynamo Service
     @mock_rds
     def test_service(self):
         # Dynamo client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         rds = RDS(audit_info)
         assert rds.service == "rds"
 
@@ -74,7 +44,7 @@ class Test_RDS_Service:
     @mock_rds
     def test_client(self):
         # Dynamo client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         rds = RDS(audit_info)
         for regional_client in rds.regional_clients.values():
             assert regional_client.__class__.__name__ == "RDS"
@@ -83,7 +53,7 @@ class Test_RDS_Service:
     @mock_rds
     def test__get_session__(self):
         # Dynamo client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         rds = RDS(audit_info)
         assert rds.session.__class__.__name__ == "Session"
 
@@ -91,14 +61,14 @@ class Test_RDS_Service:
     @mock_rds
     def test_audited_account(self):
         # Dynamo client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         rds = RDS(audit_info)
         assert rds.audited_account == AWS_ACCOUNT_NUMBER
 
     # Test RDS Describe DB Instances
     @mock_rds
     def test__describe_db_instances__(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_parameter_group(
             DBParameterGroupName="test",
             DBParameterGroupFamily="default.postgres9.3",
@@ -123,11 +93,11 @@ class Test_RDS_Service:
             ],
         )
         # RDS client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         rds = RDS(audit_info)
         assert len(rds.db_instances) == 1
         assert rds.db_instances[0].id == "db-master-1"
-        assert rds.db_instances[0].region == AWS_REGION
+        assert rds.db_instances[0].region == AWS_REGION_US_EAST_1
         assert (
             rds.db_instances[0].endpoint["Address"]
             == "db-master-1.aaaaaaaaaa.us-east-1.rds.amazonaws.com"
@@ -147,7 +117,7 @@ class Test_RDS_Service:
 
     @mock_rds
     def test__describe_db_parameters__(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_parameter_group(
             DBParameterGroupName="test",
             DBParameterGroupFamily="default.postgres9.3",
@@ -173,11 +143,11 @@ class Test_RDS_Service:
             ],
         )
         # RDS client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         rds = RDS(audit_info)
         assert len(rds.db_instances) == 1
         assert rds.db_instances[0].id == "db-master-1"
-        assert rds.db_instances[0].region == AWS_REGION
+        assert rds.db_instances[0].region == AWS_REGION_US_EAST_1
         for parameter in rds.db_instances[0].parameters:
             if parameter["ParameterName"] == "rds.force_ssl":
                 assert parameter["ParameterValue"] == "1"
@@ -185,7 +155,7 @@ class Test_RDS_Service:
     # Test RDS Describe DB Snapshots
     @mock_rds
     def test__describe_db_snapshots__(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-primary-1",
             AllocatedStorage=10,
@@ -198,18 +168,18 @@ class Test_RDS_Service:
             DBInstanceIdentifier="db-primary-1", DBSnapshotIdentifier="snapshot-1"
         )
         # RDS client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         rds = RDS(audit_info)
         assert len(rds.db_snapshots) == 1
         assert rds.db_snapshots[0].id == "snapshot-1"
         assert rds.db_snapshots[0].instance_id == "db-primary-1"
-        assert rds.db_snapshots[0].region == AWS_REGION
+        assert rds.db_snapshots[0].region == AWS_REGION_US_EAST_1
         assert not rds.db_snapshots[0].public
 
     # Test RDS Describe DB Clusters
     @mock_rds
     def test__describe_db_clusters__(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         cluster_id = "db-master-1"
         conn.create_db_parameter_group(
             DBParameterGroupName="test",
@@ -235,19 +205,17 @@ class Test_RDS_Service:
             ],
         )
         # RDS client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         rds = RDS(audit_info)
 
-        db_cluster_arn = (
-            f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:cluster:{cluster_id}"
-        )
+        db_cluster_arn = f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:{cluster_id}"
 
         assert len(rds.db_clusters) == 1
         assert rds.db_clusters[db_cluster_arn].id == "db-master-1"
         assert rds.db_clusters[db_cluster_arn].engine == "postgres"
-        assert rds.db_clusters[db_cluster_arn].region == AWS_REGION
+        assert rds.db_clusters[db_cluster_arn].region == AWS_REGION_US_EAST_1
         assert (
-            f"{AWS_REGION}.rds.amazonaws.com"
+            f"{AWS_REGION_US_EAST_1}.rds.amazonaws.com"
             in rds.db_clusters[db_cluster_arn].endpoint
         )
         assert rds.db_clusters[db_cluster_arn].status == "available"
@@ -266,7 +234,7 @@ class Test_RDS_Service:
     # Test RDS Describe DB Cluster Snapshots
     @mock_rds
     def test__describe_db_cluster_snapshots__(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_cluster(
             DBClusterIdentifier="db-primary-1",
             AllocatedStorage=10,
@@ -280,20 +248,25 @@ class Test_RDS_Service:
             DBClusterIdentifier="db-primary-1", DBClusterSnapshotIdentifier="snapshot-1"
         )
         # RDS client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         rds = RDS(audit_info)
         assert len(rds.db_cluster_snapshots) == 1
         assert rds.db_cluster_snapshots[0].id == "snapshot-1"
         assert rds.db_cluster_snapshots[0].cluster_id == "db-primary-1"
-        assert rds.db_cluster_snapshots[0].region == AWS_REGION
+        assert rds.db_cluster_snapshots[0].region == AWS_REGION_US_EAST_1
         assert not rds.db_cluster_snapshots[0].public
 
     # Test RDS describe db engine versions
     @mock_rds
     def test__describe_db_engine_versions__(self):
         # RDS client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         rds = RDS(audit_info)
-        assert "mysql" in rds.db_engines[AWS_REGION]
-        assert rds.db_engines[AWS_REGION]["mysql"].engine_versions == ["8.0.32"]
-        assert rds.db_engines[AWS_REGION]["mysql"].engine_description == "description"
+        assert "mysql" in rds.db_engines[AWS_REGION_US_EAST_1]
+        assert rds.db_engines[AWS_REGION_US_EAST_1]["mysql"].engine_versions == [
+            "8.0.32"
+        ]
+        assert (
+            rds.db_engines[AWS_REGION_US_EAST_1]["mysql"].engine_description
+            == "description"
+        )

--- a/tests/providers/aws/services/rds/rds_snapshots_public_access/rds_snapshots_public_access_test.py
+++ b/tests/providers/aws/services/rds/rds_snapshots_public_access/rds_snapshots_public_access_test.py
@@ -2,14 +2,14 @@ from re import search
 from unittest import mock
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_rds
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -39,44 +39,12 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 class Test_rds_snapshots_public_access:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=[AWS_REGION],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_rds
     @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     def test_rds_no_snapshots(self):
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -99,7 +67,7 @@ class Test_rds_snapshots_public_access:
     @mock_rds
     @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     def test_rds_private_snapshot(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-primary-1",
             AllocatedStorage=10,
@@ -114,7 +82,7 @@ class Test_rds_snapshots_public_access:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -143,7 +111,7 @@ class Test_rds_snapshots_public_access:
     @mock_rds
     @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     def test_rds_public_snapshot(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-primary-1",
             AllocatedStorage=10,
@@ -158,7 +126,7 @@ class Test_rds_snapshots_public_access:
 
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -184,17 +152,17 @@ class Test_rds_snapshots_public_access:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "snapshot-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:snapshot:snapshot-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:snapshot:snapshot-1"
                 )
                 assert result[0].resource_tags == []
 
     @mock_rds
     @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     def test_rds_cluster_private_snapshot(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_cluster(
             DBClusterIdentifier="db-primary-1",
             AllocatedStorage=10,
@@ -209,7 +177,7 @@ class Test_rds_snapshots_public_access:
         )
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -234,17 +202,17 @@ class Test_rds_snapshots_public_access:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "snapshot-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:cluster-snapshot:snapshot-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster-snapshot:snapshot-1"
                 )
                 assert result[0].resource_tags == []
 
     @mock_rds
     @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     def test_rds_cluster_public_snapshot(self):
-        conn = client("rds", region_name=AWS_REGION)
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_cluster(
             DBClusterIdentifier="db-primary-1",
             AllocatedStorage=10,
@@ -259,7 +227,7 @@ class Test_rds_snapshots_public_access:
         )
         from prowler.providers.aws.services.rds.rds_service import RDS
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -285,9 +253,9 @@ class Test_rds_snapshots_public_access:
                     result[0].status_extended,
                 )
                 assert result[0].resource_id == "snapshot-1"
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:cluster-snapshot:snapshot-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster-snapshot:snapshot-1"
                 )
                 assert result[0].resource_tags == []


### PR DESCRIPTION
### Description

Refactor RDS to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
