### PR TITLE
test(audit_info): refactor organizations

### DIFF
--- a/tests/providers/aws/services/organizations/organizations_account_part_of_organizations/organizations_account_part_of_organizations_test.py
+++ b/tests/providers/aws/services/organizations/organizations_account_part_of_organizations/organizations_account_part_of_organizations_test.py
@@ -1,55 +1,23 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_organizations
 
-from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.organizations.organizations_service import (
     Organizations,
 )
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_ID = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_organizations_account_part_of_organizations:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_ID,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_ID}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=[AWS_REGION],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_organizations
     def test_no_organization(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -75,11 +43,11 @@ class Test_organizations_account_part_of_organizations:
                 )
                 assert result[0].resource_id == "AWS Organization"
                 assert result[0].resource_arn == AWS_ACCOUNT_ARN
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_EU_WEST_1
 
     @mock_organizations
     def test_organization(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         # Create Organization
         conn = client("organizations")
@@ -109,4 +77,4 @@ class Test_organizations_account_part_of_organizations:
                 )
                 assert result[0].resource_id == response["Organization"]["Id"]
                 assert result[0].resource_arn == response["Organization"]["Arn"]
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/organizations/organizations_service_test.py
+++ b/tests/providers/aws/services/organizations/organizations_service_test.py
@@ -1,16 +1,15 @@
 import json
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_organizations
-from moto.core import DEFAULT_ACCOUNT_ID
 
-from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.organizations.organizations_service import (
     Organizations,
 )
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "eu-west-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 def scp_restrict_regions_with_deny():
@@ -18,51 +17,19 @@ def scp_restrict_regions_with_deny():
 
 
 class Test_Organizations_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=DEFAULT_ACCOUNT_ID,
-            audited_account_arn=f"arn:aws:iam::{DEFAULT_ACCOUNT_ID}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_organizations
     def test_service(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         organizations = Organizations(audit_info)
         assert organizations.service == "organizations"
 
     @mock_organizations
     def test__describe_organization__(self):
         # Create Organization
-        conn = client("organizations", region_name=AWS_REGION)
+        conn = client("organizations", region_name=AWS_REGION_EU_WEST_1)
         response = conn.create_organization()
         # Mock
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         organizations = Organizations(audit_info)
         # Tests
         assert len(organizations.organizations) == 1
@@ -78,7 +45,7 @@ class Test_Organizations_Service:
     @mock_organizations
     def test__list_policies__(self):
         # Create Policy
-        conn = client("organizations", region_name=AWS_REGION)
+        conn = client("organizations", region_name=AWS_REGION_EU_WEST_1)
         conn.create_organization()
         response = conn.create_policy(
             Content=scp_restrict_regions_with_deny(),
@@ -87,7 +54,7 @@ class Test_Organizations_Service:
             Type="SERVICE_CONTROL_POLICY",
         )
         # Mock
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         organizations = Organizations(audit_info)
         # Tests
         for policy in organizations.policies:

--- a/tests/providers/aws/services/organizations/organizations_tags_policies_enabled_and_attached/organizations_tags_policies_enabled_and_attached_test.py
+++ b/tests/providers/aws/services/organizations/organizations_tags_policies_enabled_and_attached/organizations_tags_policies_enabled_and_attached_test.py
@@ -1,57 +1,23 @@
 from unittest import mock
 
-from boto3 import session
-
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.organizations.organizations_service import (
     Organization,
     Policy,
 )
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_ID = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
 # Moto: NotImplementedError: The TAG_POLICY policy type has not been implemented
 # Needs to Mock manually
 
 
 class Test_organizations_tags_policies_enabled_and_attached:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_ID,
-            audited_account_arn=AWS_ACCOUNT_ARN,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     def test_organization_no_organization(self):
         organizations_client = mock.MagicMock
-        organizations_client.region = AWS_REGION
+        organizations_client.region = AWS_REGION_EU_WEST_1
         organizations_client.organizations = [
             Organization(
                 arn=AWS_ACCOUNT_ARN,
@@ -61,7 +27,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
             )
         ]
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -87,11 +53,11 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 )
                 assert result[0].resource_id == "AWS Organization"
                 assert result[0].resource_arn == AWS_ACCOUNT_ARN
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_organization_with_tag_policies_not_attached(self):
         organizations_client = mock.MagicMock
-        organizations_client.region = AWS_REGION
+        organizations_client.region = AWS_REGION_EU_WEST_1
         organizations_client.organizations = [
             Organization(
                 id="o-1234567890",
@@ -112,7 +78,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
             )
         ]
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -141,11 +107,11 @@ class Test_organizations_tags_policies_enabled_and_attached:
                     result[0].resource_arn
                     == "arn:aws:organizations::1234567890:organization/o-1234567890"
                 )
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_organization_with_tag_policies_attached(self):
         organizations_client = mock.MagicMock
-        organizations_client.region = AWS_REGION
+        organizations_client.region = AWS_REGION_EU_WEST_1
         organizations_client.organizations = [
             Organization(
                 id="o-1234567890",
@@ -166,7 +132,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
             )
         ]
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -195,4 +161,4 @@ class Test_organizations_tags_policies_enabled_and_attached:
                     result[0].resource_arn
                     == "arn:aws:organizations::1234567890:organization/o-1234567890"
                 )
-                assert result[0].region == AWS_REGION
+                assert result[0].region == AWS_REGION_EU_WEST_1


### PR DESCRIPTION
### Description

Refactor Organizations to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
