### PR TITLE
test(audit_info): refactor elbv2

### DIFF
--- a/tests/providers/aws/audit_info_utils.py
+++ b/tests/providers/aws/audit_info_utils.py
@@ -5,6 +5,8 @@ from prowler.providers.common.models import Audit_Metadata
 
 AWS_REGION_US_EAST_1 = "us-east-1"
 AWS_REGION_EU_WEST_1 = "eu-west-1"
+AWS_REGION_EU_WEST_1_AZA = "eu-west-1a"
+AWS_REGION_EU_WEST_1_AZB = "eu-west-1b"
 AWS_REGION_EU_WEST_2 = "eu-west-2"
 AWS_REGION_EU_SOUTH_2 = "eu-south-2"
 AWS_PARTITION = "aws"

--- a/tests/providers/aws/services/elb/elb_insecure_ssl_ciphers/elb_insecure_ssl_ciphers_test.py
+++ b/tests/providers/aws/services/elb/elb_insecure_ssl_ciphers/elb_insecure_ssl_ciphers_test.py
@@ -5,8 +5,8 @@ from moto import mock_ec2, mock_elb
 
 from tests.providers.aws.audit_info_utils import (
     AWS_REGION_EU_WEST_1,
+    AWS_REGION_EU_WEST_1_AZA,
     AWS_REGION_US_EAST_1,
-    AWS_REGION_US_EAST_1_AZA,
     set_mocked_aws_audit_info,
 )
 
@@ -54,7 +54,7 @@ class Test_elb_insecure_ssl_ciphers:
                 {"Protocol": "tcp", "LoadBalancerPort": 80, "InstancePort": 8080},
                 {"Protocol": "https", "LoadBalancerPort": 443, "InstancePort": 9000},
             ],
-            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
+            AvailabilityZones=[AWS_REGION_EU_WEST_1_AZA],
             Scheme="internal",
             SecurityGroups=[security_group.id],
         )
@@ -110,7 +110,7 @@ class Test_elb_insecure_ssl_ciphers:
                 {"Protocol": "tcp", "LoadBalancerPort": 80, "InstancePort": 8080},
                 {"Protocol": "https", "LoadBalancerPort": 443, "InstancePort": 9000},
             ],
-            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
+            AvailabilityZones=[AWS_REGION_EU_WEST_1_AZA],
             Scheme="internal",
             SecurityGroups=[security_group.id],
         )

--- a/tests/providers/aws/services/elb/elb_internet_facing/elb_internet_facing_test.py
+++ b/tests/providers/aws/services/elb/elb_internet_facing/elb_internet_facing_test.py
@@ -5,8 +5,8 @@ from moto import mock_ec2, mock_elb
 
 from tests.providers.aws.audit_info_utils import (
     AWS_REGION_EU_WEST_1,
+    AWS_REGION_EU_WEST_1_AZA,
     AWS_REGION_US_EAST_1,
-    AWS_REGION_US_EAST_1_AZA,
     set_mocked_aws_audit_info,
 )
 
@@ -57,7 +57,7 @@ class Test_elb_request_smugling:
                 {"Protocol": "tcp", "LoadBalancerPort": 80, "InstancePort": 8080},
                 {"Protocol": "http", "LoadBalancerPort": 81, "InstancePort": 9000},
             ],
-            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
+            AvailabilityZones=[AWS_REGION_EU_WEST_1_AZA],
             Scheme="internal",
             SecurityGroups=[security_group.id],
         )
@@ -103,7 +103,7 @@ class Test_elb_request_smugling:
                 {"Protocol": "tcp", "LoadBalancerPort": 80, "InstancePort": 8080},
                 {"Protocol": "http", "LoadBalancerPort": 81, "InstancePort": 9000},
             ],
-            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
+            AvailabilityZones=[AWS_REGION_EU_WEST_1_AZA],
             Scheme="internet-facing",
             SecurityGroups=[security_group.id],
         )

--- a/tests/providers/aws/services/elb/elb_logging_enabled/elb_logging_enabled_test.py
+++ b/tests/providers/aws/services/elb/elb_logging_enabled/elb_logging_enabled_test.py
@@ -5,8 +5,8 @@ from moto import mock_ec2, mock_elb
 
 from tests.providers.aws.audit_info_utils import (
     AWS_REGION_EU_WEST_1,
+    AWS_REGION_EU_WEST_1_AZA,
     AWS_REGION_US_EAST_1,
-    AWS_REGION_US_EAST_1_AZA,
     set_mocked_aws_audit_info,
 )
 
@@ -57,7 +57,7 @@ class Test_elb_logging_enabled:
                 {"Protocol": "tcp", "LoadBalancerPort": 80, "InstancePort": 8080},
                 {"Protocol": "http", "LoadBalancerPort": 81, "InstancePort": 9000},
             ],
-            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
+            AvailabilityZones=[AWS_REGION_EU_WEST_1_AZA],
             Scheme="internal",
             SecurityGroups=[security_group.id],
         )
@@ -105,7 +105,7 @@ class Test_elb_logging_enabled:
                 {"Protocol": "tcp", "LoadBalancerPort": 80, "InstancePort": 8080},
                 {"Protocol": "http", "LoadBalancerPort": 81, "InstancePort": 9000},
             ],
-            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
+            AvailabilityZones=[AWS_REGION_EU_WEST_1_AZA],
             Scheme="internal",
             SecurityGroups=[security_group.id],
         )

--- a/tests/providers/aws/services/elb/elb_ssl_listeners/elb_ssl_listeners_test.py
+++ b/tests/providers/aws/services/elb/elb_ssl_listeners/elb_ssl_listeners_test.py
@@ -5,8 +5,8 @@ from moto import mock_ec2, mock_elb
 
 from tests.providers.aws.audit_info_utils import (
     AWS_REGION_EU_WEST_1,
+    AWS_REGION_EU_WEST_1_AZA,
     AWS_REGION_US_EAST_1,
-    AWS_REGION_US_EAST_1_AZA,
     set_mocked_aws_audit_info,
 )
 
@@ -57,7 +57,7 @@ class Test_elb_ssl_listeners:
                 {"Protocol": "tcp", "LoadBalancerPort": 80, "InstancePort": 8080},
                 {"Protocol": "http", "LoadBalancerPort": 81, "InstancePort": 9000},
             ],
-            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
+            AvailabilityZones=[AWS_REGION_EU_WEST_1_AZA],
             Scheme="internal",
             SecurityGroups=[security_group.id],
         )
@@ -101,7 +101,7 @@ class Test_elb_ssl_listeners:
             Listeners=[
                 {"Protocol": "https", "LoadBalancerPort": 443, "InstancePort": 9000},
             ],
-            AvailabilityZones=[AWS_REGION_US_EAST_1_AZA],
+            AvailabilityZones=[AWS_REGION_EU_WEST_1_AZA],
             Scheme="internal",
             SecurityGroups=[security_group.id],
         )

--- a/tests/providers/aws/services/elbv2/elbv2_deletion_protection/elbv2_deletion_protection_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_deletion_protection/elbv2_deletion_protection_test.py
@@ -1,58 +1,31 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_elbv2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_EU_WEST_1_AZA,
+    AWS_REGION_EU_WEST_1_AZB,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_elbv2_deletion_protection:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_elbv2
     def test_elb_no_balancers(self):
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_deletion_protection.elbv2_deletion_protection.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_deletion_protection.elbv2_deletion_protection import (
@@ -67,18 +40,22 @@ class Test_elbv2_deletion_protection:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_without_deletion_protection(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -100,10 +77,12 @@ class Test_elbv2_deletion_protection:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_deletion_protection.elbv2_deletion_protection.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_deletion_protection.elbv2_deletion_protection import (
                 elbv2_deletion_protection,
@@ -124,18 +103,22 @@ class Test_elbv2_deletion_protection:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_with_deletion_protection(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -156,10 +139,12 @@ class Test_elbv2_deletion_protection:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_deletion_protection.elbv2_deletion_protection.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_deletion_protection.elbv2_deletion_protection import (
                 elbv2_deletion_protection,

--- a/tests/providers/aws/services/elbv2/elbv2_desync_mitigation_mode/elbv2_desync_mitigation_mode_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_desync_mitigation_mode/elbv2_desync_mitigation_mode_test.py
@@ -1,58 +1,31 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_elbv2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_EU_WEST_1_AZA,
+    AWS_REGION_EU_WEST_1_AZB,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_elbv2_desync_mitigation_mode:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_elbv2
     def test_elb_no_balancers(self):
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode import (
@@ -67,18 +40,22 @@ class Test_elbv2_desync_mitigation_mode:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_without_desync_mitigation_mode_and_not_dropping_headers(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -104,10 +81,12 @@ class Test_elbv2_desync_mitigation_mode:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode import (
                 elbv2_desync_mitigation_mode,
@@ -128,18 +107,22 @@ class Test_elbv2_desync_mitigation_mode:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_without_desync_mitigation_mode_but_dropping_headers(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -165,10 +148,12 @@ class Test_elbv2_desync_mitigation_mode:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode import (
                 elbv2_desync_mitigation_mode,
@@ -189,18 +174,22 @@ class Test_elbv2_desync_mitigation_mode:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_with_desync_mitigation_mode(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -221,10 +210,12 @@ class Test_elbv2_desync_mitigation_mode:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_desync_mitigation_mode.elbv2_desync_mitigation_mode import (
                 elbv2_desync_mitigation_mode,

--- a/tests/providers/aws/services/elbv2/elbv2_insecure_ssl_ciphers/elbv2_insecure_ssl_ciphers_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_insecure_ssl_ciphers/elbv2_insecure_ssl_ciphers_test.py
@@ -1,58 +1,31 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_elbv2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_EU_WEST_1_AZA,
+    AWS_REGION_EU_WEST_1_AZB,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_elbv2_insecure_ssl_ciphers:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_elbv2
     def test_elb_no_balancers(self):
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_insecure_ssl_ciphers.elbv2_insecure_ssl_ciphers.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_insecure_ssl_ciphers.elbv2_insecure_ssl_ciphers import (
@@ -67,18 +40,22 @@ class Test_elbv2_insecure_ssl_ciphers:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_listener_with_secure_policy(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -117,10 +94,12 @@ class Test_elbv2_insecure_ssl_ciphers:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_insecure_ssl_ciphers.elbv2_insecure_ssl_ciphers.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_insecure_ssl_ciphers.elbv2_insecure_ssl_ciphers import (
                 elbv2_insecure_ssl_ciphers,
@@ -141,18 +120,22 @@ class Test_elbv2_insecure_ssl_ciphers:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_with_HTTPS_listener(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -189,10 +172,12 @@ class Test_elbv2_insecure_ssl_ciphers:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_insecure_ssl_ciphers.elbv2_insecure_ssl_ciphers.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_insecure_ssl_ciphers.elbv2_insecure_ssl_ciphers import (
                 elbv2_insecure_ssl_ciphers,

--- a/tests/providers/aws/services/elbv2/elbv2_internet_facing/elbv2_internet_facing_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_internet_facing/elbv2_internet_facing_test.py
@@ -1,58 +1,31 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_elbv2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_EU_WEST_1_AZA,
+    AWS_REGION_EU_WEST_1_AZB,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_elbv2_internet_facing:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_elbv2
     def test_elb_no_balancers(self):
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_internet_facing.elbv2_internet_facing.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_internet_facing.elbv2_internet_facing import (
@@ -67,18 +40,22 @@ class Test_elbv2_internet_facing:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_private(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -93,10 +70,12 @@ class Test_elbv2_internet_facing:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_internet_facing.elbv2_internet_facing.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_internet_facing.elbv2_internet_facing import (
                 elbv2_internet_facing,
@@ -117,18 +96,22 @@ class Test_elbv2_internet_facing:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_internet_facing(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -142,10 +125,12 @@ class Test_elbv2_internet_facing:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_internet_facing.elbv2_internet_facing.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_internet_facing.elbv2_internet_facing import (
                 elbv2_internet_facing,

--- a/tests/providers/aws/services/elbv2/elbv2_listeners_underneath/elbv2_listeners_underneath_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_listeners_underneath/elbv2_listeners_underneath_test.py
@@ -1,58 +1,31 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_elbv2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_EU_WEST_1_AZA,
+    AWS_REGION_EU_WEST_1_AZB,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_elbv2_listeners_underneath:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_elbv2
     def test_elb_no_balancers(self):
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_listeners_underneath.elbv2_listeners_underneath.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_listeners_underneath.elbv2_listeners_underneath import (
@@ -67,18 +40,22 @@ class Test_elbv2_listeners_underneath:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_without_listeners(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -93,10 +70,12 @@ class Test_elbv2_listeners_underneath:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_listeners_underneath.elbv2_listeners_underneath.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_listeners_underneath.elbv2_listeners_underneath import (
                 elbv2_listeners_underneath,
@@ -117,18 +96,22 @@ class Test_elbv2_listeners_underneath:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_with_listeners(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -164,10 +147,12 @@ class Test_elbv2_listeners_underneath:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_listeners_underneath.elbv2_listeners_underneath.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_listeners_underneath.elbv2_listeners_underneath import (
                 elbv2_listeners_underneath,

--- a/tests/providers/aws/services/elbv2/elbv2_logging_enabled/elbv2_logging_enabled_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_logging_enabled/elbv2_logging_enabled_test.py
@@ -1,58 +1,31 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_elbv2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_EU_WEST_1_AZA,
+    AWS_REGION_EU_WEST_1_AZB,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_elbv2_logging_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_elbv2
     def test_elb_no_balancers(self):
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_logging_enabled.elbv2_logging_enabled.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_logging_enabled.elbv2_logging_enabled import (
@@ -67,18 +40,22 @@ class Test_elbv2_logging_enabled:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_without_logging_enabled(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -103,10 +80,12 @@ class Test_elbv2_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_logging_enabled.elbv2_logging_enabled.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_logging_enabled.elbv2_logging_enabled import (
                 elbv2_logging_enabled,
@@ -127,18 +106,22 @@ class Test_elbv2_logging_enabled:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_with_logging_enabled(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -162,10 +145,12 @@ class Test_elbv2_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_logging_enabled.elbv2_logging_enabled.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_logging_enabled.elbv2_logging_enabled import (
                 elbv2_logging_enabled,

--- a/tests/providers/aws/services/elbv2/elbv2_ssl_listeners/elbv2_ssl_listeners_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_ssl_listeners/elbv2_ssl_listeners_test.py
@@ -1,58 +1,31 @@
 from re import search
 from unittest import mock
 
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_elbv2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_EU_WEST_1_AZA,
+    AWS_REGION_EU_WEST_1_AZB,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_elbv2_ssl_listeners:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_elbv2
     def test_elb_no_balancers(self):
         from prowler.providers.aws.services.elbv2.elbv2_service import ELBv2
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners import (
@@ -67,18 +40,22 @@ class Test_elbv2_ssl_listeners:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_with_HTTP_listener(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -115,10 +92,12 @@ class Test_elbv2_ssl_listeners:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners import (
                 elbv2_ssl_listeners,
@@ -139,18 +118,22 @@ class Test_elbv2_ssl_listeners:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_with_HTTPS_listener(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -186,10 +169,12 @@ class Test_elbv2_ssl_listeners:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners import (
                 elbv2_ssl_listeners,
@@ -210,18 +195,22 @@ class Test_elbv2_ssl_listeners:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_with_HTTPS_redirection(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
 
         security_group = ec2.create_security_group(
             GroupName="a-security-group", Description="First One"
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -250,10 +239,12 @@ class Test_elbv2_ssl_listeners:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             from prowler.providers.aws.services.elbv2.elbv2_ssl_listeners.elbv2_ssl_listeners import (
                 elbv2_ssl_listeners,

--- a/tests/providers/aws/services/elbv2/elbv2_waf_acl_attached/elbv2_waf_acl_attached_test.py
+++ b/tests/providers/aws/services/elbv2/elbv2_waf_acl_attached/elbv2_waf_acl_attached_test.py
@@ -2,14 +2,16 @@ from re import search
 from unittest import mock
 
 import botocore
-from boto3 import client, resource, session
+from boto3 import client, resource
 from moto import mock_ec2, mock_elbv2, mock_wafv2
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_EU_WEST_1_AZA,
+    AWS_REGION_EU_WEST_1_AZB,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 # Mocking WAF-Regional Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -34,37 +36,6 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 class Test_elbv2_waf_acl_attached:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_wafv2
     @mock_elbv2
     def test_elb_no_balancers(self):
@@ -74,16 +45,22 @@ class Test_elbv2_waf_acl_attached:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_waf_acl_attached.elbv2_waf_acl_attached.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_waf_acl_attached.elbv2_waf_acl_attached.wafv2_client",
-            new=WAFv2(self.set_mocked_audit_info()),
+            new=WAFv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_waf_acl_attached.elbv2_waf_acl_attached.waf_client",
-            new=WAF(self.set_mocked_audit_info()),
+            new=WAF(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_waf_acl_attached.elbv2_waf_acl_attached import (
@@ -99,8 +76,8 @@ class Test_elbv2_waf_acl_attached:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_without_WAF(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
         wafv2 = client("wafv2", region_name="us-east-1")
         _ = wafv2.create_web_acl(
             Scope="REGIONAL",
@@ -117,10 +94,14 @@ class Test_elbv2_waf_acl_attached:
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -137,16 +118,22 @@ class Test_elbv2_waf_acl_attached:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_waf_acl_attached.elbv2_waf_acl_attached.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_waf_acl_attached.elbv2_waf_acl_attached.wafv2_client",
-            new=WAFv2(self.set_mocked_audit_info()),
+            new=WAFv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_waf_acl_attached.elbv2_waf_acl_attached.waf_client",
-            new=WAF(self.set_mocked_audit_info()),
+            new=WAF(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.elbv2.elbv2_waf_acl_attached.elbv2_waf_acl_attached import (
@@ -169,8 +156,8 @@ class Test_elbv2_waf_acl_attached:
     @mock_ec2
     @mock_elbv2
     def test_elbv2_with_WAF(self):
-        conn = client("elbv2", region_name=AWS_REGION)
-        ec2 = resource("ec2", region_name=AWS_REGION)
+        conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
+        ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
         wafv2 = client("wafv2", region_name="us-east-1")
         waf = wafv2.create_web_acl(
             Scope="REGIONAL",
@@ -187,10 +174,14 @@ class Test_elbv2_waf_acl_attached:
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=f"{AWS_REGION}a"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZA,
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=f"{AWS_REGION}b"
+            VpcId=vpc.id,
+            CidrBlock="172.28.7.0/26",
+            AvailabilityZone=AWS_REGION_EU_WEST_1_AZB,
         )
 
         lb = conn.create_load_balancer(
@@ -209,17 +200,25 @@ class Test_elbv2_waf_acl_attached:
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
-            new=self.set_mocked_audit_info(),
+            new=set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_waf_acl_attached.elbv2_waf_acl_attached.elbv2_client",
-            new=ELBv2(self.set_mocked_audit_info()),
+            new=ELBv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ), mock.patch(
             "prowler.providers.aws.services.elbv2.elbv2_waf_acl_attached.elbv2_waf_acl_attached.wafv2_client",
-            new=WAFv2(self.set_mocked_audit_info()),
+            new=WAFv2(
+                set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
+            ),
         ) as service_client:
             with mock.patch(
                 "prowler.providers.aws.services.elbv2.elbv2_waf_acl_attached.elbv2_waf_acl_attached.waf_client",
-                new=WAF(self.set_mocked_audit_info()),
+                new=WAF(
+                    set_mocked_aws_audit_info(
+                        [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+                    )
+                ),
             ):
                 # Test Check
                 from prowler.providers.aws.services.elbv2.elbv2_waf_acl_attached.elbv2_waf_acl_attached import (


### PR DESCRIPTION
### Description

Refactor ELBv2 to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
