### PR TITLE
test(audit_info): refactor opensearch

### DIFF
--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_audit_logging_enabled/opensearch_service_domains_audit_logging_enabled_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_audit_logging_enabled/opensearch_service_domains_audit_logging_enabled_test.py
@@ -5,9 +5,10 @@ from prowler.providers.aws.services.opensearch.opensearch_service import (
     OpenSearchDomain,
     PublishingLoggingOption,
 )
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 domain_name = "test-domain"
 domain_arn = f"arn:aws:es:us-west-2:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}"
@@ -33,7 +34,9 @@ class Test_opensearch_service_domains_audit_logging_enabled:
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
         opensearch_client.opensearch_domains.append(
-            OpenSearchDomain(name=domain_name, region=AWS_REGION, arn=domain_arn)
+            OpenSearchDomain(
+                name=domain_name, region=AWS_REGION_EU_WEST_1, arn=domain_arn
+            )
         )
         opensearch_client.opensearch_domains[0].logging = []
 
@@ -57,7 +60,9 @@ class Test_opensearch_service_domains_audit_logging_enabled:
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
         opensearch_client.opensearch_domains.append(
-            OpenSearchDomain(name=domain_name, region=AWS_REGION, arn=domain_arn)
+            OpenSearchDomain(
+                name=domain_name, region=AWS_REGION_EU_WEST_1, arn=domain_arn
+            )
         )
         opensearch_client.opensearch_domains[0].logging = []
         opensearch_client.opensearch_domains[0].logging.append(

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_cloudwatch_logging_enabled/opensearch_service_domains_cloudwatch_logging_enabled_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_cloudwatch_logging_enabled/opensearch_service_domains_cloudwatch_logging_enabled_test.py
@@ -5,9 +5,10 @@ from prowler.providers.aws.services.opensearch.opensearch_service import (
     OpenSearchDomain,
     PublishingLoggingOption,
 )
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 domain_name = "test-domain"
 domain_arn = f"arn:aws:es:us-west-2:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}"
@@ -33,7 +34,9 @@ class Test_opensearch_service_domains_cloudwatch_logging_enabled:
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
         opensearch_client.opensearch_domains.append(
-            OpenSearchDomain(name=domain_name, region=AWS_REGION, arn=domain_arn)
+            OpenSearchDomain(
+                name=domain_name, region=AWS_REGION_EU_WEST_1, arn=domain_arn
+            )
         )
         opensearch_client.opensearch_domains[0].logging = []
 
@@ -60,7 +63,9 @@ class Test_opensearch_service_domains_cloudwatch_logging_enabled:
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
         opensearch_client.opensearch_domains.append(
-            OpenSearchDomain(name=domain_name, region=AWS_REGION, arn=domain_arn)
+            OpenSearchDomain(
+                name=domain_name, region=AWS_REGION_EU_WEST_1, arn=domain_arn
+            )
         )
         opensearch_client.opensearch_domains[0].logging = []
         opensearch_client.opensearch_domains[0].logging.append(
@@ -90,7 +95,9 @@ class Test_opensearch_service_domains_cloudwatch_logging_enabled:
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
         opensearch_client.opensearch_domains.append(
-            OpenSearchDomain(name=domain_name, region=AWS_REGION, arn=domain_arn)
+            OpenSearchDomain(
+                name=domain_name, region=AWS_REGION_EU_WEST_1, arn=domain_arn
+            )
         )
         opensearch_client.opensearch_domains[0].logging = []
         opensearch_client.opensearch_domains[0].logging.append(
@@ -120,7 +127,9 @@ class Test_opensearch_service_domains_cloudwatch_logging_enabled:
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
         opensearch_client.opensearch_domains.append(
-            OpenSearchDomain(name=domain_name, region=AWS_REGION, arn=domain_arn)
+            OpenSearchDomain(
+                name=domain_name, region=AWS_REGION_EU_WEST_1, arn=domain_arn
+            )
         )
         opensearch_client.opensearch_domains[0].logging = []
         logging_options = [

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_encryption_at_rest_enabled/opensearch_service_domains_encryption_at_rest_enabled_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_encryption_at_rest_enabled/opensearch_service_domains_encryption_at_rest_enabled_test.py
@@ -4,9 +4,10 @@ from unittest import mock
 from prowler.providers.aws.services.opensearch.opensearch_service import (
     OpenSearchDomain,
 )
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 domain_name = "test-domain"
 domain_arn = f"arn:aws:es:us-west-2:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}"
@@ -34,7 +35,7 @@ class Test_opensearch_service_domains_encryption_at_rest_enabled:
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=domain_arn,
                 encryption_at_rest=False,
             )
@@ -65,7 +66,7 @@ class Test_opensearch_service_domains_encryption_at_rest_enabled:
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=domain_arn,
                 encryption_at_rest=True,
             )

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_https_communications_enforced/opensearch_service_domains_https_communications_enforced_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_https_communications_enforced/opensearch_service_domains_https_communications_enforced_test.py
@@ -4,9 +4,10 @@ from unittest import mock
 from prowler.providers.aws.services.opensearch.opensearch_service import (
     OpenSearchDomain,
 )
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 domain_name = "test-domain"
 domain_arn = f"arn:aws:es:us-west-2:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}"
@@ -33,7 +34,10 @@ class Test_opensearch_service_domains_https_communications_enforced:
         opensearch_client.opensearch_domains = []
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
-                name=domain_name, region=AWS_REGION, arn=domain_arn, enforce_https=False
+                name=domain_name,
+                region=AWS_REGION_EU_WEST_1,
+                arn=domain_arn,
+                enforce_https=False,
             )
         )
         opensearch_client.opensearch_domains[0].logging = []
@@ -61,7 +65,10 @@ class Test_opensearch_service_domains_https_communications_enforced:
         opensearch_client.opensearch_domains = []
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
-                name=domain_name, region=AWS_REGION, arn=domain_arn, enforce_https=True
+                name=domain_name,
+                region=AWS_REGION_EU_WEST_1,
+                arn=domain_arn,
+                enforce_https=True,
             )
         )
         opensearch_client.opensearch_domains[0].logging = []

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_internal_user_database_enabled/opensearch_service_domains_internal_user_database_enabled_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_internal_user_database_enabled/opensearch_service_domains_internal_user_database_enabled_test.py
@@ -4,9 +4,10 @@ from unittest import mock
 from prowler.providers.aws.services.opensearch.opensearch_service import (
     OpenSearchDomain,
 )
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 domain_name = "test-domain"
 domain_arn = f"arn:aws:es:us-west-2:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}"
@@ -34,7 +35,7 @@ class Test_opensearch_service_domains_internal_user_database_enabled:
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=domain_arn,
                 internal_user_database=False,
             )
@@ -66,7 +67,7 @@ class Test_opensearch_service_domains_internal_user_database_enabled:
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=domain_arn,
                 internal_user_database=True,
             )

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_node_to_node_encryption_enabled/opensearch_service_domains_node_to_node_encryption_enabled_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_node_to_node_encryption_enabled/opensearch_service_domains_node_to_node_encryption_enabled_test.py
@@ -4,9 +4,10 @@ from unittest import mock
 from prowler.providers.aws.services.opensearch.opensearch_service import (
     OpenSearchDomain,
 )
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 domain_name = "test-domain"
 domain_arn = f"arn:aws:es:us-west-2:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}"
@@ -34,7 +35,7 @@ class Test_opensearch_service_domains_node_to_node_encryption_enabled:
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=domain_arn,
                 node_to_node_encryption=False,
             )
@@ -66,7 +67,7 @@ class Test_opensearch_service_domains_node_to_node_encryption_enabled:
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=domain_arn,
                 node_to_node_encryption=True,
             )

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
@@ -3,9 +3,10 @@ from unittest import mock
 from prowler.providers.aws.services.opensearch.opensearch_service import (
     OpenSearchDomain,
 )
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 domain_name = "test-domain"
 domain_arn = f"arn:aws:es:us-west-2:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}"
@@ -95,7 +96,7 @@ class Test_opensearch_service_domains_not_publicly_accessible:
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=domain_arn,
                 access_policy=policy_data_restricted,
             )
@@ -127,7 +128,7 @@ class Test_opensearch_service_domains_not_publicly_accessible:
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=domain_arn,
                 access_policy=policy_data_not_restricted,
             )
@@ -159,7 +160,7 @@ class Test_opensearch_service_domains_not_publicly_accessible:
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=domain_arn,
                 access_policy=policy_data_not_restricted_principal,
             )
@@ -191,7 +192,7 @@ class Test_opensearch_service_domains_not_publicly_accessible:
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=domain_arn,
                 access_policy=policy_data_source_ip_full,
             )
@@ -223,7 +224,7 @@ class Test_opensearch_service_domains_not_publicly_accessible:
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=domain_arn,
                 access_policy=policy_data_source_whole_internet,
             )

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_updated_to_the_latest_service_software_version/opensearch_service_domains_updated_to_the_latest_service_software_version_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_updated_to_the_latest_service_software_version/opensearch_service_domains_updated_to_the_latest_service_software_version_test.py
@@ -4,9 +4,10 @@ from unittest import mock
 from prowler.providers.aws.services.opensearch.opensearch_service import (
     OpenSearchDomain,
 )
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 domain_name = "test-domain"
 domain_arn = f"arn:aws:es:us-west-2:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}"
@@ -36,7 +37,7 @@ class Test_opensearch_service_domains_updated_to_the_latest_service_software_ver
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=domain_arn,
                 update_available=False,
             )
@@ -69,7 +70,7 @@ class Test_opensearch_service_domains_updated_to_the_latest_service_software_ver
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=domain_arn,
                 update_available=True,
             )

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_use_cognito_authentication_for_kibana/opensearch_service_domains_use_cognito_authentication_for_kibana_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_use_cognito_authentication_for_kibana/opensearch_service_domains_use_cognito_authentication_for_kibana_test.py
@@ -4,9 +4,10 @@ from unittest import mock
 from prowler.providers.aws.services.opensearch.opensearch_service import (
     OpenSearchDomain,
 )
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 domain_name = "test-domain"
 domain_arn = f"arn:aws:es:us-west-2:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}"
@@ -34,7 +35,7 @@ class Test_opensearch_service_domains_use_cognito_authentication_for_kibana:
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=domain_arn,
                 cognito_options=False,
             )
@@ -66,7 +67,7 @@ class Test_opensearch_service_domains_use_cognito_authentication_for_kibana:
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=domain_arn,
                 cognito_options=True,
             )

--- a/tests/providers/aws/services/opensearch/opensearch_service_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_test.py
@@ -2,16 +2,15 @@ from json import dumps
 from unittest.mock import patch
 
 import botocore
-from boto3 import session
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.opensearch.opensearch_service import (
     OpenSearchService,
 )
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "eu-west-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
 test_domain_name = "test"
 domain_arn = f"arn:aws:es:us-west-2:{AWS_ACCOUNT_NUMBER}:domain/{test_domain_name}"
@@ -93,9 +92,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_EU_WEST_1
+    )
+    regional_client.region = AWS_REGION_EU_WEST_1
+    return {AWS_REGION_EU_WEST_1: regional_client}
 
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
@@ -104,71 +105,41 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_OpenSearchService_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
 
     # Test OpenSearchService Service
     def test_service(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([])
         opensearch = OpenSearchService(audit_info)
         assert opensearch.service == "opensearch"
 
     # Test OpenSearchService_ client
     def test_client(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([])
         opensearch = OpenSearchService(audit_info)
         for reg_client in opensearch.regional_clients.values():
             assert reg_client.__class__.__name__ == "OpenSearchService"
 
     # Test OpenSearchService session
     def test__get_session__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([])
         opensearch = OpenSearchService(audit_info)
         assert opensearch.session.__class__.__name__ == "Session"
 
     # Test OpenSearchService list domains names
     def test__list_domain_names__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([])
         opensearch = OpenSearchService(audit_info)
         assert len(opensearch.opensearch_domains) == 1
         assert opensearch.opensearch_domains[0].name == test_domain_name
-        assert opensearch.opensearch_domains[0].region == AWS_REGION
+        assert opensearch.opensearch_domains[0].region == AWS_REGION_EU_WEST_1
 
     # Test OpenSearchService describ domain config
     def test__describe_domain_config__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([])
         opensearch = OpenSearchService(audit_info)
         assert len(opensearch.opensearch_domains) == 1
         assert opensearch.opensearch_domains[0].name == test_domain_name
-        assert opensearch.opensearch_domains[0].region == AWS_REGION
+        assert opensearch.opensearch_domains[0].region == AWS_REGION_EU_WEST_1
         assert opensearch.opensearch_domains[0].access_policy
         assert opensearch.opensearch_domains[0].logging[0].name == "SEARCH_SLOW_LOGS"
         assert opensearch.opensearch_domains[0].logging[0].enabled
@@ -179,11 +150,11 @@ class Test_OpenSearchService_Service:
 
     # Test OpenSearchService describ domain
     def test__describe_domain__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([])
         opensearch = OpenSearchService(audit_info)
         assert len(opensearch.opensearch_domains) == 1
         assert opensearch.opensearch_domains[0].name == test_domain_name
-        assert opensearch.opensearch_domains[0].region == AWS_REGION
+        assert opensearch.opensearch_domains[0].region == AWS_REGION_EU_WEST_1
         assert opensearch.opensearch_domains[0].arn == domain_arn
         assert opensearch.opensearch_domains[0].access_policy
         assert (


### PR DESCRIPTION
### Description

Refactor Opensearch to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
