### PR TITLE
test(audit_info): refactor fms

### DIFF
--- a/tests/providers/aws/services/fms/fms_policy_compliant/fms_policy_compliant_test.py
+++ b/tests/providers/aws/services/fms/fms_policy_compliant/fms_policy_compliant_test.py
@@ -4,15 +4,16 @@ from prowler.providers.aws.services.fms.fms_service import (
     Policy,
     PolicyAccountComplianceStatus,
 )
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+)
 
 
 class Test_fms_policy_compliant:
     def test_fms_not_admin(self):
         fms_client = mock.MagicMock
-        fms_client.region = AWS_REGION
+        fms_client.region = AWS_REGION_US_EAST_1
         fms_client.fms_admin_account = False
         with mock.patch(
             "prowler.providers.aws.services.fms.fms_service.FMS",
@@ -32,7 +33,7 @@ class Test_fms_policy_compliant:
         fms_client = mock.MagicMock
         fms_client.audited_account = AWS_ACCOUNT_NUMBER
         fms_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-        fms_client.region = AWS_REGION
+        fms_client.region = AWS_REGION_US_EAST_1
         fms_client.fms_admin_account = True
         fms_client.fms_policies = [
             Policy(
@@ -72,13 +73,13 @@ class Test_fms_policy_compliant:
             )
             assert result[0].resource_id == "12345678901"
             assert result[0].resource_arn == "arn:aws:fms:us-east-1:12345678901"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     def test_fms_admin_with_compliant_policies(self):
         fms_client = mock.MagicMock
         fms_client.audited_account = AWS_ACCOUNT_NUMBER
         fms_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-        fms_client.region = AWS_REGION
+        fms_client.region = AWS_REGION_US_EAST_1
         fms_client.fms_admin_account = True
         fms_client.fms_policies = [
             Policy(
@@ -117,13 +118,13 @@ class Test_fms_policy_compliant:
             )
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert result[0].resource_arn == f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     def test_fms_admin_with_non_and_compliant_policies(self):
         fms_client = mock.MagicMock
         fms_client.audited_account = AWS_ACCOUNT_NUMBER
         fms_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
-        fms_client.region = AWS_REGION
+        fms_client.region = AWS_REGION_US_EAST_1
         fms_client.fms_admin_account = True
         fms_client.fms_policies = [
             Policy(
@@ -168,4 +169,4 @@ class Test_fms_policy_compliant:
             )
             assert result[0].resource_id == "12345678901"
             assert result[0].resource_arn == "arn:aws:fms:us-east-1:12345678901"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/fms/fms_service_test.py
+++ b/tests/providers/aws/services/fms/fms_service_test.py
@@ -2,14 +2,10 @@ from datetime import datetime
 from unittest.mock import patch
 
 import botocore
-from boto3 import session
 
-from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.fms.fms_service import FMS
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import set_mocked_aws_audit_info
 
-# Mock Test Region
-AWS_REGION = "us-east-1"
 POLICY_ARN = "arn:aws:fms:us-east-1:123456789012:policy/MyFMSManagedPolicy"
 POLICY_ID = "12345678-1234-1234-1234-123456789012"
 POLICY_NAME = "MyFMSManagedPolicy"
@@ -65,49 +61,18 @@ def mock_make_api_call(self, operation_name, kwargs):
 # Patch every AWS call using Boto3
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_FMS_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=None,
-            audited_account_arn=None,
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     def test__get_client__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         fms = FMS(audit_info)
         assert fms.client.__class__.__name__ == "FMS"
 
     def test__get_service__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         fms = FMS(audit_info)
         assert fms.service == "fms"
 
     def test__list_policies__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         fms = FMS(audit_info)
         assert len(fms.fms_policies) == 1
         assert fms.fms_admin_account is True
@@ -123,7 +88,7 @@ class Test_FMS_Service:
         )
 
     def test__list_compliance_status__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         fms = FMS(audit_info)
         assert len(fms.fms_policies) == 1
         assert fms.fms_policies[0].compliance_status[0].status == "COMPLIANT"


### PR DESCRIPTION
### Description

Refactor FMS to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
