### PR TITLE
test(audit_info): refactor macie

### DIFF
--- a/tests/providers/aws/services/macie/macie_is_enabled/macie_is_enabled_test.py
+++ b/tests/providers/aws/services/macie/macie_is_enabled/macie_is_enabled_test.py
@@ -1,62 +1,26 @@
 from unittest import mock
 
-from boto3 import session
 from moto import mock_s3
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.macie.macie_service import Session
 from prowler.providers.aws.services.s3.s3_service import Bucket
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_macie_is_enabled:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     @mock_s3
     def test_macie_disabled(self):
         s3_client = mock.MagicMock
-        s3_client.audit_info = self.set_mocked_audit_info()
+        s3_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         s3_client.buckets = []
         s3_client.regions_with_buckets = []
 
         macie_client = mock.MagicMock
-        macie_client.audit_info = self.set_mocked_audit_info()
+        macie_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         macie_client.audited_account = AWS_ACCOUNT_NUMBER
         macie_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
         macie_client.sessions = [
@@ -65,7 +29,7 @@ class Test_macie_is_enabled:
                 region="eu-west-1",
             )
         ]
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -93,12 +57,12 @@ class Test_macie_is_enabled:
     @mock_s3
     def test_macie_enabled(self):
         s3_client = mock.MagicMock
-        s3_client.audit_info = self.set_mocked_audit_info()
+        s3_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         s3_client.buckets = []
         s3_client.regions_with_buckets = []
 
         macie_client = mock.MagicMock
-        macie_client.audit_info = self.set_mocked_audit_info()
+        macie_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         macie_client.audited_account = AWS_ACCOUNT_NUMBER
         macie_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
         macie_client.sessions = [
@@ -107,7 +71,7 @@ class Test_macie_is_enabled:
                 region="eu-west-1",
             )
         ]
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -135,12 +99,12 @@ class Test_macie_is_enabled:
     @mock_s3
     def test_macie_suspended_ignored(self):
         s3_client = mock.MagicMock
-        s3_client.audit_info = self.set_mocked_audit_info()
+        s3_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         s3_client.buckets = []
         s3_client.regions_with_buckets = []
 
         macie_client = mock.MagicMock
-        macie_client.audit_info = self.set_mocked_audit_info()
+        macie_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         macie_client.audited_account = AWS_ACCOUNT_NUMBER
         macie_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
         macie_client.sessions = [
@@ -150,7 +114,7 @@ class Test_macie_is_enabled:
             )
         ]
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         macie_client.audit_info.ignore_unused_services = True
 
         with mock.patch(
@@ -176,29 +140,29 @@ class Test_macie_is_enabled:
     @mock_s3
     def test_macie_suspended_ignored_with_buckets(self):
         s3_client = mock.MagicMock
-        s3_client.regions_with_buckets = [AWS_REGION]
-        s3_client.audit_info = self.set_mocked_audit_info()
+        s3_client.regions_with_buckets = [AWS_REGION_EU_WEST_1]
+        s3_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         s3_client.buckets = [
             Bucket(
                 name="test",
                 arn="test-arn",
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
             )
         ]
 
         macie_client = mock.MagicMock
-        macie_client.audit_info = self.set_mocked_audit_info()
+        macie_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         macie_client.audited_account = AWS_ACCOUNT_NUMBER
         macie_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
         macie_client.sessions = [
             Session(
                 status="PAUSED",
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
             )
         ]
 
         macie_client.audit_info.ignore_unused_services = True
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -228,10 +192,10 @@ class Test_macie_is_enabled:
     @mock_s3
     def test_macie_suspended(self):
         s3_client = mock.MagicMock
-        s3_client.audit_info = self.set_mocked_audit_info()
+        s3_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         macie_client = mock.MagicMock
-        macie_client.audit_info = self.set_mocked_audit_info()
+        macie_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         macie_client.audited_account = AWS_ACCOUNT_NUMBER
         macie_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
         macie_client.sessions = [
@@ -240,7 +204,7 @@ class Test_macie_is_enabled:
                 region="eu-west-1",
             )
         ]
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",

--- a/tests/providers/aws/services/macie/macie_service_test.py
+++ b/tests/providers/aws/services/macie/macie_service_test.py
@@ -2,15 +2,12 @@ import datetime
 from unittest.mock import patch
 
 import botocore
-from boto3 import session
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.macie.macie_service import Macie, Session
-from prowler.providers.common.models import Audit_Metadata
-
-# Mock Test Region
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
 # Mocking Macie2 Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -36,9 +33,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 # Mock generate_regional_clients()
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_EU_WEST_1
+    )
+    regional_client.region = AWS_REGION_EU_WEST_1
+    return {AWS_REGION_EU_WEST_1: regional_client}
 
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
@@ -48,55 +47,27 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_Macie_Service:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
 
     # Test Macie Client
     def test__get_client__(self):
-        macie = Macie(self.set_mocked_audit_info())
-        assert macie.regional_clients[AWS_REGION].__class__.__name__ == "Macie2"
+        macie = Macie(set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1]))
+        assert (
+            macie.regional_clients[AWS_REGION_EU_WEST_1].__class__.__name__ == "Macie2"
+        )
 
     # Test Macie Session
     def test__get_session__(self):
-        macie = Macie(self.set_mocked_audit_info())
+        macie = Macie(set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1]))
         assert macie.session.__class__.__name__ == "Session"
 
     # Test Macie Service
     def test__get_service__(self):
-        macie = Macie(self.set_mocked_audit_info())
+        macie = Macie(set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1]))
         assert macie.service == "macie2"
 
     def test__get_macie_session__(self):
         # Set partition for the service
-        macie = Macie(self.set_mocked_audit_info())
+        macie = Macie(set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1]))
         macie.sessions = [
             Session(
                 status="ENABLED",
@@ -105,4 +76,4 @@ class Test_Macie_Service:
         ]
         assert len(macie.sessions) == 1
         assert macie.sessions[0].status == "ENABLED"
-        assert macie.sessions[0].region == AWS_REGION
+        assert macie.sessions[0].region == AWS_REGION_EU_WEST_1


### PR DESCRIPTION
### Description

Refactor Macie to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
