### PR TITLE
test(audit_info): refactor kms

### DIFF
--- a/tests/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled_test.py
+++ b/tests/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled_test.py
@@ -1,52 +1,20 @@
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_kms
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_kms_cmk_rotation_enabled:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_kms
     def test_kms_no_key(self):
         from prowler.providers.aws.services.kms.kms_service import KMS
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -68,14 +36,14 @@ class Test_kms_cmk_rotation_enabled:
     @mock_kms
     def test_kms_cmk_rotation_enabled(self):
         # Generate KMS Client
-        kms_client = client("kms", region_name=AWS_REGION)
+        kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
         # Creaty KMS key with rotation
         key = kms_client.create_key()["KeyMetadata"]
         kms_client.enable_key_rotation(KeyId=key["KeyId"])
 
         from prowler.providers.aws.services.kms.kms_service import KMS
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -104,13 +72,13 @@ class Test_kms_cmk_rotation_enabled:
     @mock_kms
     def test_kms_cmk_rotation_disabled(self):
         # Generate KMS Client
-        kms_client = client("kms", region_name=AWS_REGION)
+        kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
         # Creaty KMS key without rotation
         key = kms_client.create_key()["KeyMetadata"]
 
         from prowler.providers.aws.services.kms.kms_service import KMS
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",

--- a/tests/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible_test.py
@@ -1,53 +1,21 @@
 import json
 from unittest import mock
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_kms
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_kms_key_not_publicly_accessible:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=["us-east-1", "eu-west-1"],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-
-        return audit_info
-
     @mock_kms
     def test_no_kms_keys(self):
         from prowler.providers.aws.services.kms.kms_service import KMS
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -69,13 +37,13 @@ class Test_kms_key_not_publicly_accessible:
     @mock_kms
     def test_kms_key_not_publicly_accessible(self):
         # Generate KMS Client
-        kms_client = client("kms", region_name=AWS_REGION)
+        kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
         # Creaty KMS key without policy
         key = kms_client.create_key()["KeyMetadata"]
 
         from prowler.providers.aws.services.kms.kms_service import KMS
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -104,7 +72,7 @@ class Test_kms_key_not_publicly_accessible:
     @mock_kms
     def test_kms_key_public_accessible(self):
         # Generate KMS Client
-        kms_client = client("kms", region_name=AWS_REGION)
+        kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
         # Creaty KMS key with public policy
         key = kms_client.create_key(
             Policy=json.dumps(
@@ -126,7 +94,7 @@ class Test_kms_key_not_publicly_accessible:
 
         from prowler.providers.aws.services.kms.kms_service import KMS
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -155,7 +123,7 @@ class Test_kms_key_not_publicly_accessible:
     @mock_kms
     def test_kms_key_empty_principal(self):
         # Generate KMS Client
-        kms_client = client("kms", region_name=AWS_REGION)
+        kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
         # Creaty KMS key with public policy
         key = kms_client.create_key(
             Policy=json.dumps(
@@ -176,7 +144,7 @@ class Test_kms_key_not_publicly_accessible:
 
         from prowler.providers.aws.services.kms.kms_service import KMS
 
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",

--- a/tests/providers/aws/services/kms/kms_service_test.py
+++ b/tests/providers/aws/services/kms/kms_service_test.py
@@ -1,53 +1,23 @@
 import json
 
-from boto3 import client, session
+from boto3 import client
 from moto import mock_kms
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.kms.kms_service import KMS
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_ACM_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
 
     # Test KMS Service
     @mock_kms
     def test_service(self):
         # KMS client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         kms = KMS(audit_info)
         assert kms.service == "kms"
 
@@ -55,7 +25,7 @@ class Test_ACM_Service:
     @mock_kms
     def test_client(self):
         # KMS client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         kms = KMS(audit_info)
         for regional_client in kms.regional_clients.values():
             assert regional_client.__class__.__name__ == "KMS"
@@ -64,7 +34,7 @@ class Test_ACM_Service:
     @mock_kms
     def test__get_session__(self):
         # KMS client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         kms = KMS(audit_info)
         assert kms.session.__class__.__name__ == "Session"
 
@@ -72,7 +42,7 @@ class Test_ACM_Service:
     @mock_kms
     def test_audited_account(self):
         # KMS client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         kms = KMS(audit_info)
         assert kms.audited_account == AWS_ACCOUNT_NUMBER
 
@@ -80,12 +50,12 @@ class Test_ACM_Service:
     @mock_kms
     def test__list_keys__(self):
         # Generate KMS Client
-        kms_client = client("kms", region_name=AWS_REGION)
+        kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
         # Create KMS keys
         key1 = kms_client.create_key()["KeyMetadata"]
         key2 = kms_client.create_key()["KeyMetadata"]
         # KMS client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         kms = KMS(audit_info)
         assert len(kms.keys) == 2
         assert kms.keys[0].arn == key1["Arn"]
@@ -95,7 +65,7 @@ class Test_ACM_Service:
     @mock_kms
     def test__describe_key__(self):
         # Generate KMS Client
-        kms_client = client("kms", region_name=AWS_REGION)
+        kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
         # Create KMS keys
         key1 = kms_client.create_key(
             Tags=[
@@ -103,7 +73,7 @@ class Test_ACM_Service:
             ],
         )["KeyMetadata"]
         # KMS client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         kms = KMS(audit_info)
         assert len(kms.keys) == 1
         assert kms.keys[0].arn == key1["Arn"]
@@ -118,13 +88,13 @@ class Test_ACM_Service:
     @mock_kms
     def test__get_key_rotation_status__(self):
         # Generate KMS Client
-        kms_client = client("kms", region_name=AWS_REGION)
+        kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
         # Create KMS keys
         key1 = kms_client.create_key()["KeyMetadata"]
         key2 = kms_client.create_key()["KeyMetadata"]
         kms_client.enable_key_rotation(KeyId=key2["KeyId"])
         # KMS client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         kms = KMS(audit_info)
         assert len(kms.keys) == 2
         assert kms.keys[0].arn == key1["Arn"]
@@ -166,12 +136,12 @@ class Test_ACM_Service:
             }
         )
         # Generate KMS Client
-        kms_client = client("kms", region_name=AWS_REGION)
+        kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
         # Create KMS keys
         key1 = kms_client.create_key(Policy=default_policy)["KeyMetadata"]
         key2 = kms_client.create_key(Policy=public_policy)["KeyMetadata"]
         # KMS client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
         kms = KMS(audit_info)
         assert len(kms.keys) == 2
         assert kms.keys[0].arn == key1["Arn"]


### PR DESCRIPTION
### Description

Refactor KMS to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
