### PR TITLE
test(audit_info): refactor glue

### DIFF
--- a/tests/providers/aws/services/glue/glue_data_catalogs_connection_passwords_encryption_enabled/glue_data_catalogs_connection_passwords_encryption_enabled_test.py
+++ b/tests/providers/aws/services/glue/glue_data_catalogs_connection_passwords_encryption_enabled/glue_data_catalogs_connection_passwords_encryption_enabled_test.py
@@ -1,52 +1,16 @@
 from unittest import mock
 
-from boto3 import session
-
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.glue.glue_service import CatalogEncryptionSetting
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_glue_data_catalogs_connection_passwords_encryption_enabled:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-            ignore_unused_services=False,
-        )
-        return audit_info
-
     def test_glue_no_settings(self):
         glue_client = mock.MagicMock
-        glue_client.audit_info = self.set_mocked_audit_info()
+        glue_client.audit_info = set_mocked_aws_audit_info()
         glue_client.catalog_encryption_settings = []
 
         with mock.patch(
@@ -65,13 +29,13 @@ class Test_glue_data_catalogs_connection_passwords_encryption_enabled:
 
     def test_glue_catalog_password_unencrypted(self):
         glue_client = mock.MagicMock
-        glue_client.audit_info = self.set_mocked_audit_info()
+        glue_client.audit_info = set_mocked_aws_audit_info()
         glue_client.catalog_encryption_settings = [
             CatalogEncryptionSetting(
                 mode="DISABLED",
                 tables=False,
                 kms_id=None,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 password_encryption=False,
                 password_kms_id=None,
             )
@@ -97,17 +61,17 @@ class Test_glue_data_catalogs_connection_passwords_encryption_enabled:
                 == "Glue data catalog connection password is not encrypted."
             )
             assert result[0].resource_id == "12345678912"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     def test_glue_catalog_password_unencrypted_ignoring(self):
         glue_client = mock.MagicMock
-        glue_client.audit_info = self.set_mocked_audit_info()
+        glue_client.audit_info = set_mocked_aws_audit_info()
         glue_client.catalog_encryption_settings = [
             CatalogEncryptionSetting(
                 mode="DISABLED",
                 tables=False,
                 kms_id=None,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 password_encryption=False,
                 password_kms_id=None,
             )
@@ -130,13 +94,13 @@ class Test_glue_data_catalogs_connection_passwords_encryption_enabled:
 
     def test_glue_catalog_password_unencrypted_ignoring_with_tables(self):
         glue_client = mock.MagicMock
-        glue_client.audit_info = self.set_mocked_audit_info()
+        glue_client.audit_info = set_mocked_aws_audit_info()
         glue_client.catalog_encryption_settings = [
             CatalogEncryptionSetting(
                 mode="DISABLED",
                 tables=True,
                 kms_id=None,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 password_encryption=False,
                 password_kms_id=None,
             )
@@ -162,16 +126,16 @@ class Test_glue_data_catalogs_connection_passwords_encryption_enabled:
                 == "Glue data catalog connection password is not encrypted."
             )
             assert result[0].resource_id == "12345678912"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     def test_glue_catalog_encrypted(self):
         glue_client = mock.MagicMock
-        glue_client.audit_info = self.set_mocked_audit_info()
+        glue_client.audit_info = set_mocked_aws_audit_info()
         glue_client.catalog_encryption_settings = [
             CatalogEncryptionSetting(
                 mode="DISABLED",
                 tables=False,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 password_encryption=True,
                 password_kms_id="kms-key",
             )
@@ -197,4 +161,4 @@ class Test_glue_data_catalogs_connection_passwords_encryption_enabled:
                 == "Glue data catalog connection password is encrypted with KMS key kms-key."
             )
             assert result[0].resource_id == "12345678912"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/glue/glue_data_catalogs_metadata_encryption_enabled/glue_data_catalogs_metadata_encryption_enabled_test.py
+++ b/tests/providers/aws/services/glue/glue_data_catalogs_metadata_encryption_enabled/glue_data_catalogs_metadata_encryption_enabled_test.py
@@ -1,53 +1,17 @@
 from re import search
 from unittest import mock
 
-from boto3 import session
-
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.glue.glue_service import CatalogEncryptionSetting
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 
 class Test_glue_data_catalogs_metadata_encryption_enabled:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-                region_name=AWS_REGION,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=AWS_REGION,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-            ignore_unused_services=False,
-        )
-        return audit_info
-
     def test_glue_no_settings(self):
         glue_client = mock.MagicMock
-        glue_client.audit_info = self.set_mocked_audit_info()
+        glue_client.audit_info = set_mocked_aws_audit_info
         glue_client.catalog_encryption_settings = []
 
         with mock.patch(
@@ -66,13 +30,13 @@ class Test_glue_data_catalogs_metadata_encryption_enabled:
 
     def test_glue_catalog_unencrypted(self):
         glue_client = mock.MagicMock
-        glue_client.audit_info = self.set_mocked_audit_info()
+        glue_client.audit_info = set_mocked_aws_audit_info()
         glue_client.catalog_encryption_settings = [
             CatalogEncryptionSetting(
                 mode="disabled.",
                 tables=False,
                 kms_id=None,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 password_encryption=False,
                 password_kms_id=None,
             )
@@ -98,17 +62,17 @@ class Test_glue_data_catalogs_metadata_encryption_enabled:
                 == "Glue data catalog settings have metadata encryption disabled."
             )
             assert result[0].resource_id == "12345678912"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     def test_glue_catalog_unencrypted_ignoring(self):
         glue_client = mock.MagicMock
-        glue_client.audit_info = self.set_mocked_audit_info()
+        glue_client.audit_info = set_mocked_aws_audit_info()
         glue_client.catalog_encryption_settings = [
             CatalogEncryptionSetting(
                 mode="disabled.",
                 tables=False,
                 kms_id=None,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 password_encryption=False,
                 password_kms_id=None,
             )
@@ -132,13 +96,13 @@ class Test_glue_data_catalogs_metadata_encryption_enabled:
 
     def test_glue_catalog_unencrypted_ignoring_with_tables(self):
         glue_client = mock.MagicMock
-        glue_client.audit_info = self.set_mocked_audit_info()
+        glue_client.audit_info = set_mocked_aws_audit_info()
         glue_client.catalog_encryption_settings = [
             CatalogEncryptionSetting(
                 mode="disabled.",
                 tables=True,
                 kms_id=None,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 password_encryption=False,
                 password_kms_id=None,
             )
@@ -165,17 +129,17 @@ class Test_glue_data_catalogs_metadata_encryption_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == "12345678912"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     def test_glue_catalog_encrypted(self):
         glue_client = mock.MagicMock
-        glue_client.audit_info = self.set_mocked_audit_info()
+        glue_client.audit_info = set_mocked_aws_audit_info()
         glue_client.catalog_encryption_settings = [
             CatalogEncryptionSetting(
                 mode="SSE-KMS",
                 kms_id="kms-key",
                 tables=False,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 password_encryption=False,
                 password_kms_id=None,
             )
@@ -201,4 +165,4 @@ class Test_glue_data_catalogs_metadata_encryption_enabled:
                 == "Glue data catalog settings have metadata encryption enabled with KMS key kms-key."
             )
             assert result[0].resource_id == "12345678912"
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/glue/glue_database_connections_ssl_enabled/glue_database_connections_ssl_enabled_test.py
+++ b/tests/providers/aws/services/glue/glue_database_connections_ssl_enabled/glue_database_connections_ssl_enabled_test.py
@@ -2,8 +2,7 @@ from re import search
 from unittest import mock
 
 from prowler.providers.aws.services.glue.glue_service import Connection
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
 
 
 class Test_glue_database_connections_ssl_enabled:
@@ -37,7 +36,7 @@ class Test_glue_database_connections_ssl_enabled:
                     "CONNECTOR_URL": "s3://bck-dev",
                     "CONNECTOR_CLASS_NAME": "test",
                 },
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]
@@ -76,7 +75,7 @@ class Test_glue_database_connections_ssl_enabled:
                     "CONNECTOR_CLASS_NAME": "test",
                     "JDBC_ENFORCE_SSL": "true",
                 },
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]

--- a/tests/providers/aws/services/glue/glue_development_endpoints_cloudwatch_logs_encryption_enabled/glue_development_endpoints_cloudwatch_logs_encryption_enabled_test.py
+++ b/tests/providers/aws/services/glue/glue_development_endpoints_cloudwatch_logs_encryption_enabled/glue_development_endpoints_cloudwatch_logs_encryption_enabled_test.py
@@ -2,8 +2,7 @@ from re import search
 from unittest import mock
 
 from prowler.providers.aws.services.glue.glue_service import DevEndpoint, SecurityConfig
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
 
 
 class Test_glue_development_endpoints_cloudwatch_logs_encryption_enabled:
@@ -31,7 +30,7 @@ class Test_glue_development_endpoints_cloudwatch_logs_encryption_enabled:
             DevEndpoint(
                 name="test",
                 security="sec_config",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]
@@ -42,7 +41,7 @@ class Test_glue_development_endpoints_cloudwatch_logs_encryption_enabled:
                 cw_key_arn="key_arn",
                 s3_encryption="DISABLED",
                 jb_encryption="DISABLED",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         ]
 
@@ -73,7 +72,7 @@ class Test_glue_development_endpoints_cloudwatch_logs_encryption_enabled:
             DevEndpoint(
                 name="test",
                 security="sec_config",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]
@@ -83,7 +82,7 @@ class Test_glue_development_endpoints_cloudwatch_logs_encryption_enabled:
                 s3_encryption="DISABLED",
                 cw_encryption="DISABLED",
                 jb_encryption="DISABLED",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         ]
 
@@ -114,7 +113,7 @@ class Test_glue_development_endpoints_cloudwatch_logs_encryption_enabled:
             DevEndpoint(
                 name="test",
                 security="sec_config",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]

--- a/tests/providers/aws/services/glue/glue_development_endpoints_job_bookmark_encryption_enabled/glue_development_endpoints_job_bookmark_encryption_enabled_test.py
+++ b/tests/providers/aws/services/glue/glue_development_endpoints_job_bookmark_encryption_enabled/glue_development_endpoints_job_bookmark_encryption_enabled_test.py
@@ -2,8 +2,7 @@ from re import search
 from unittest import mock
 
 from prowler.providers.aws.services.glue.glue_service import DevEndpoint, SecurityConfig
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
 
 
 class Test_glue_development_endpoints_job_bookmark_encryption_enabled:
@@ -31,7 +30,7 @@ class Test_glue_development_endpoints_job_bookmark_encryption_enabled:
             DevEndpoint(
                 name="test",
                 security="sec_config",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]
@@ -42,7 +41,7 @@ class Test_glue_development_endpoints_job_bookmark_encryption_enabled:
                 jb_key_arn="key_arn",
                 cw_encryption="DISABLED",
                 s3_encryption="DISABLED",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         ]
 
@@ -73,7 +72,7 @@ class Test_glue_development_endpoints_job_bookmark_encryption_enabled:
             DevEndpoint(
                 name="test",
                 security="sec_config",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]
@@ -83,7 +82,7 @@ class Test_glue_development_endpoints_job_bookmark_encryption_enabled:
                 s3_encryption="DISABLED",
                 cw_encryption="DISABLED",
                 jb_encryption="DISABLED",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         ]
 
@@ -114,7 +113,7 @@ class Test_glue_development_endpoints_job_bookmark_encryption_enabled:
             DevEndpoint(
                 name="test",
                 security="sec_config",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]

--- a/tests/providers/aws/services/glue/glue_development_endpoints_s3_encryption_enabled/glue_development_endpoints_s3_encryption_enabled_test.py
+++ b/tests/providers/aws/services/glue/glue_development_endpoints_s3_encryption_enabled/glue_development_endpoints_s3_encryption_enabled_test.py
@@ -2,8 +2,7 @@ from re import search
 from unittest import mock
 
 from prowler.providers.aws.services.glue.glue_service import DevEndpoint, SecurityConfig
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
 
 
 class Test_glue_development_endpoints_s3_encryption_enabled:
@@ -31,7 +30,7 @@ class Test_glue_development_endpoints_s3_encryption_enabled:
             DevEndpoint(
                 name="test",
                 security="sec_config",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]
@@ -42,7 +41,7 @@ class Test_glue_development_endpoints_s3_encryption_enabled:
                 s3_key_arn="key_arn",
                 cw_encryption="DISABLED",
                 jb_encryption="DISABLED",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         ]
 
@@ -73,7 +72,7 @@ class Test_glue_development_endpoints_s3_encryption_enabled:
             DevEndpoint(
                 name="test",
                 security="sec_config",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]
@@ -83,7 +82,7 @@ class Test_glue_development_endpoints_s3_encryption_enabled:
                 s3_encryption="DISABLED",
                 cw_encryption="DISABLED",
                 jb_encryption="DISABLED",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         ]
 
@@ -114,7 +113,7 @@ class Test_glue_development_endpoints_s3_encryption_enabled:
             DevEndpoint(
                 name="test",
                 security="sec_config",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]

--- a/tests/providers/aws/services/glue/glue_etl_jobs_amazon_s3_encryption_enabled/glue_etl_jobs_amazon_s3_encryption_enabled_test.py
+++ b/tests/providers/aws/services/glue/glue_etl_jobs_amazon_s3_encryption_enabled/glue_etl_jobs_amazon_s3_encryption_enabled_test.py
@@ -2,8 +2,7 @@ from re import search
 from unittest import mock
 
 from prowler.providers.aws.services.glue.glue_service import Job, SecurityConfig
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
 
 
 class Test_glue_etl_jobs_amazon_s3_encryption_enabled:
@@ -32,7 +31,7 @@ class Test_glue_etl_jobs_amazon_s3_encryption_enabled:
                 name="test",
                 security="sec_config",
                 arguments=None,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]
@@ -43,7 +42,7 @@ class Test_glue_etl_jobs_amazon_s3_encryption_enabled:
                 s3_key_arn="key_arn",
                 cw_encryption="DISABLED",
                 jb_encryption="DISABLED",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         ]
 
@@ -75,7 +74,7 @@ class Test_glue_etl_jobs_amazon_s3_encryption_enabled:
                 name="test",
                 security="sec_config",
                 arguments=None,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]
@@ -85,7 +84,7 @@ class Test_glue_etl_jobs_amazon_s3_encryption_enabled:
                 s3_encryption="DISABLED",
                 cw_encryption="DISABLED",
                 jb_encryption="DISABLED",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         ]
 
@@ -116,7 +115,7 @@ class Test_glue_etl_jobs_amazon_s3_encryption_enabled:
             Job(
                 name="test",
                 security="sec_config",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]
@@ -153,7 +152,7 @@ class Test_glue_etl_jobs_amazon_s3_encryption_enabled:
                     "--encryption-type": "sse-s3",
                     "--enable-job-insights": "false",
                 },
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]

--- a/tests/providers/aws/services/glue/glue_etl_jobs_cloudwatch_logs_encryption_enabled/glue_etl_jobs_cloudwatch_logs_encryption_enabled_test.py
+++ b/tests/providers/aws/services/glue/glue_etl_jobs_cloudwatch_logs_encryption_enabled/glue_etl_jobs_cloudwatch_logs_encryption_enabled_test.py
@@ -2,8 +2,7 @@ from re import search
 from unittest import mock
 
 from prowler.providers.aws.services.glue.glue_service import Job, SecurityConfig
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
 
 
 class Test_glue_etl_jobs_cloudwatch_logs_encryption_enabled:
@@ -32,7 +31,7 @@ class Test_glue_etl_jobs_cloudwatch_logs_encryption_enabled:
                 name="test",
                 security="sec_config",
                 arguments=None,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]
@@ -43,7 +42,7 @@ class Test_glue_etl_jobs_cloudwatch_logs_encryption_enabled:
                 cw_key_arn="key_arn",
                 s3_encryption="DISABLED",
                 jb_encryption="DISABLED",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         ]
 
@@ -75,7 +74,7 @@ class Test_glue_etl_jobs_cloudwatch_logs_encryption_enabled:
                 name="test",
                 security="sec_config",
                 arguments=None,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]
@@ -85,7 +84,7 @@ class Test_glue_etl_jobs_cloudwatch_logs_encryption_enabled:
                 s3_encryption="DISABLED",
                 cw_encryption="DISABLED",
                 jb_encryption="DISABLED",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         ]
 
@@ -116,7 +115,7 @@ class Test_glue_etl_jobs_cloudwatch_logs_encryption_enabled:
             Job(
                 name="test",
                 security="sec_config",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]

--- a/tests/providers/aws/services/glue/glue_etl_jobs_job_bookmark_encryption_enabled/glue_etl_jobs_job_bookmark_encryption_enabled_test.py
+++ b/tests/providers/aws/services/glue/glue_etl_jobs_job_bookmark_encryption_enabled/glue_etl_jobs_job_bookmark_encryption_enabled_test.py
@@ -2,8 +2,7 @@ from re import search
 from unittest import mock
 
 from prowler.providers.aws.services.glue.glue_service import Job, SecurityConfig
-
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
 
 
 class Test_glue_etl_jobs_job_bookmark_encryption_enabled:
@@ -32,7 +31,7 @@ class Test_glue_etl_jobs_job_bookmark_encryption_enabled:
                 name="test",
                 security="sec_config",
                 arguments=None,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]
@@ -43,7 +42,7 @@ class Test_glue_etl_jobs_job_bookmark_encryption_enabled:
                 jb_key_arn="key_arn",
                 s3_encryption="DISABLED",
                 cw_encryption="DISABLED",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         ]
 
@@ -75,7 +74,7 @@ class Test_glue_etl_jobs_job_bookmark_encryption_enabled:
                 name="test",
                 security="sec_config",
                 arguments=None,
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]
@@ -85,7 +84,7 @@ class Test_glue_etl_jobs_job_bookmark_encryption_enabled:
                 s3_encryption="DISABLED",
                 cw_encryption="DISABLED",
                 jb_encryption="DISABLED",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
             )
         ]
 
@@ -116,7 +115,7 @@ class Test_glue_etl_jobs_job_bookmark_encryption_enabled:
             Job(
                 name="test",
                 security="sec_config",
-                region=AWS_REGION,
+                region=AWS_REGION_US_EAST_1,
                 arn="arn_test",
             )
         ]

--- a/tests/providers/aws/services/glue/glue_service_test.py
+++ b/tests/providers/aws/services/glue/glue_service_test.py
@@ -1,15 +1,14 @@
 from unittest.mock import patch
 
 import botocore
-from boto3 import session
 from moto import mock_glue
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.glue.glue_service import Glue
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "us-east-1"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_audit_info,
+)
 
 # Mocking Access Analyzer Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -106,9 +105,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 # Mock generate_regional_clients()
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_US_EAST_1
+    )
+    regional_client.region = AWS_REGION_US_EAST_1
+    return {AWS_REGION_US_EAST_1: regional_client}
 
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
@@ -118,42 +119,11 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_Glue_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test Glue Service
     @mock_glue
     def test_service(self):
         # Glue client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         glue = Glue(audit_info)
         assert glue.service == "glue"
 
@@ -161,7 +131,7 @@ class Test_Glue_Service:
     @mock_glue
     def test_client(self):
         # Glue client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         glue = Glue(audit_info)
         for regional_client in glue.regional_clients.values():
             assert regional_client.__class__.__name__ == "Glue"
@@ -170,7 +140,7 @@ class Test_Glue_Service:
     @mock_glue
     def test__get_session__(self):
         # Glue client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         glue = Glue(audit_info)
         assert glue.session.__class__.__name__ == "Session"
 
@@ -178,25 +148,25 @@ class Test_Glue_Service:
     @mock_glue
     def test_audited_account(self):
         # Glue client for this test class
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         glue = Glue(audit_info)
         assert glue.audited_account == AWS_ACCOUNT_NUMBER
 
     # Test Glue Search Tables
     @mock_glue
     def test__search_tables__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         glue = Glue(audit_info)
         assert len(glue.tables) == 1
         assert glue.tables[0].name == "table"
         assert glue.tables[0].database == "database"
         assert glue.tables[0].catalog == "catalog"
-        assert glue.tables[0].region == AWS_REGION
+        assert glue.tables[0].region == AWS_REGION_US_EAST_1
 
     # Test Glue Get Connections
     @mock_glue
     def test__get_connections__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         glue = Glue(audit_info)
         assert len(glue.connections) == 1
         assert glue.connections[0].name == "connection"
@@ -208,46 +178,46 @@ class Test_Glue_Service:
             "CONNECTOR_CLASS_NAME": "test",
             "JDBC_ENFORCE_SSL": "true",
         }
-        assert glue.connections[0].region == AWS_REGION
+        assert glue.connections[0].region == AWS_REGION_US_EAST_1
 
     # Test Glue Get Catalog Encryption
     @mock_glue
     def test__get_data_catalog_encryption_settings__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         glue = Glue(audit_info)
         assert len(glue.catalog_encryption_settings) == 1
         assert glue.catalog_encryption_settings[0].mode == "SSE-KMS"
         assert glue.catalog_encryption_settings[0].kms_id == "kms_key"
         assert glue.catalog_encryption_settings[0].password_encryption
         assert glue.catalog_encryption_settings[0].password_kms_id == "password_key"
-        assert glue.catalog_encryption_settings[0].region == AWS_REGION
+        assert glue.catalog_encryption_settings[0].region == AWS_REGION_US_EAST_1
 
     # Test Glue Get Dev Endpoints
     @mock_glue
     def test__get_dev_endpoints__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         glue = Glue(audit_info)
         assert len(glue.dev_endpoints) == 1
         assert glue.dev_endpoints[0].name == "endpoint"
         assert glue.dev_endpoints[0].security == "security_config"
-        assert glue.dev_endpoints[0].region == AWS_REGION
+        assert glue.dev_endpoints[0].region == AWS_REGION_US_EAST_1
 
     # Test Glue Get Security Configs
     @mock_glue
     def test__get_security_configurations__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         glue = Glue(audit_info)
         assert len(glue.security_configs) == 1
         assert glue.security_configs[0].name == "test"
         assert glue.security_configs[0].s3_encryption == "DISABLED"
         assert glue.security_configs[0].cw_encryption == "DISABLED"
         assert glue.security_configs[0].jb_encryption == "DISABLED"
-        assert glue.security_configs[0].region == AWS_REGION
+        assert glue.security_configs[0].region == AWS_REGION_US_EAST_1
 
     # Test Glue Get Security Configs
     @mock_glue
     def test__get_jobs__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         glue = Glue(audit_info)
         assert len(glue.jobs) == 1
         assert glue.jobs[0].name == "job"
@@ -256,4 +226,4 @@ class Test_Glue_Service:
             "--encryption-type": "sse-s3",
             "--enable-job-insights": "false",
         }
-        assert glue.jobs[0].region == AWS_REGION
+        assert glue.jobs[0].region == AWS_REGION_US_EAST_1


### PR DESCRIPTION
### Description

Refactor Glue to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
