### PR TITLE
test(audit_info): refactor inspector2

### DIFF
--- a/tests/providers/aws/services/inspector2/inspector2_findings_exist/inspector2_findings_exist_test.py
+++ b/tests/providers/aws/services/inspector2/inspector2_findings_exist/inspector2_findings_exist_test.py
@@ -1,72 +1,46 @@
 from unittest import mock
 
-from boto3 import session
-
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.ecr.ecr_service import Repository
 from prowler.providers.aws.services.inspector2.inspector2_service import (
     Inspector,
     InspectorFinding,
 )
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_ID = "123456789012"
 FINDING_ARN = (
     "arn:aws:inspector2:us-east-1:123456789012:finding/0e436649379db5f327e3cf5bb4421d76"
 )
 
 
 class Test_inspector2_findings_exist:
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_ID,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_ID}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=[AWS_REGION],
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     def test_inspector2_disabled(self):
         # Mock the inspector2 client
         inspector2_client = mock.MagicMock
         awslambda_client = mock.MagicMock
         ecr_client = mock.MagicMock
         ec2_client = mock.MagicMock
-        ec2_client.audit_info = self.set_mocked_audit_info()
-        ecr_client.audit_info = self.set_mocked_audit_info()
-        awslambda_client.audit_info = self.set_mocked_audit_info()
-        inspector2_client.audit_info = self.set_mocked_audit_info()
-        inspector2_client.audited_account = AWS_ACCOUNT_ID
-        inspector2_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
-        inspector2_client.region = AWS_REGION
+        ec2_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        ecr_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        awslambda_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        inspector2_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
+        inspector2_client.audited_account_arn = (
+            f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+        )
+        inspector2_client.region = AWS_REGION_EU_WEST_1
         inspector2_client.inspectors = [
             Inspector(
-                id=AWS_ACCOUNT_ID, status="DISABLED", region=AWS_REGION, findings=[]
+                id=AWS_ACCOUNT_NUMBER,
+                status="DISABLED",
+                region=AWS_REGION_EU_WEST_1,
+                findings=[],
             )
         ]
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -102,12 +76,12 @@ class Test_inspector2_findings_exist:
                                 result[0].status_extended
                                 == "Inspector2 is not enabled."
                             )
-                            assert result[0].resource_id == AWS_ACCOUNT_ID
+                            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                             assert (
                                 result[0].resource_arn
-                                == f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
+                                == f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
                             )
-                            assert result[0].region == AWS_REGION
+                            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_enabled_no_finding(self):
         # Mock the inspector2 client
@@ -115,19 +89,24 @@ class Test_inspector2_findings_exist:
         awslambda_client = mock.MagicMock
         ecr_client = mock.MagicMock
         ec2_client = mock.MagicMock
-        ec2_client.audit_info = self.set_mocked_audit_info()
-        ecr_client.audit_info = self.set_mocked_audit_info()
-        awslambda_client.audit_info = self.set_mocked_audit_info()
-        inspector2_client.audit_info = self.set_mocked_audit_info()
-        inspector2_client.audited_account = AWS_ACCOUNT_ID
-        inspector2_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
-        inspector2_client.region = AWS_REGION
+        ec2_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        ecr_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        awslambda_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        inspector2_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
+        inspector2_client.audited_account_arn = (
+            f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+        )
+        inspector2_client.region = AWS_REGION_EU_WEST_1
         inspector2_client.inspectors = [
             Inspector(
-                id=AWS_ACCOUNT_ID, status="ENABLED", region=AWS_REGION, findings=[]
+                id=AWS_ACCOUNT_NUMBER,
+                status="ENABLED",
+                region=AWS_REGION_EU_WEST_1,
+                findings=[],
             )
         ]
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -163,12 +142,12 @@ class Test_inspector2_findings_exist:
                                 result[0].status_extended
                                 == "Inspector2 is enabled with no findings."
                             )
-                            assert result[0].resource_id == AWS_ACCOUNT_ID
+                            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                             assert (
                                 result[0].resource_arn
-                                == f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
+                                == f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
                             )
-                            assert result[0].region == AWS_REGION
+                            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_enabled_with_no_active_finding(self):
         # Mock the inspector2 client
@@ -176,22 +155,24 @@ class Test_inspector2_findings_exist:
         awslambda_client = mock.MagicMock
         ecr_client = mock.MagicMock
         ec2_client = mock.MagicMock
-        ec2_client.audit_info = self.set_mocked_audit_info()
-        ecr_client.audit_info = self.set_mocked_audit_info()
-        awslambda_client.audit_info = self.set_mocked_audit_info()
-        inspector2_client.audit_info = self.set_mocked_audit_info()
-        inspector2_client.audited_account = AWS_ACCOUNT_ID
-        inspector2_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
-        inspector2_client.region = AWS_REGION
+        ec2_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        ecr_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        awslambda_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        inspector2_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
+        inspector2_client.audited_account_arn = (
+            f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+        )
+        inspector2_client.region = AWS_REGION_EU_WEST_1
         inspector2_client.inspectors = [
             Inspector(
-                id=AWS_ACCOUNT_ID,
-                region=AWS_REGION,
+                id=AWS_ACCOUNT_NUMBER,
+                region=AWS_REGION_EU_WEST_1,
                 status="ENABLED",
                 findings=[
                     InspectorFinding(
                         arn=FINDING_ARN,
-                        region=AWS_REGION,
+                        region=AWS_REGION_EU_WEST_1,
                         severity="MEDIUM",
                         status="NOT_ACTIVE",
                         title="CVE-2022-40897 - setuptools",
@@ -199,7 +180,7 @@ class Test_inspector2_findings_exist:
                 ],
             )
         ]
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -235,12 +216,12 @@ class Test_inspector2_findings_exist:
                                 result[0].status_extended
                                 == "Inspector2 is enabled with no active findings."
                             )
-                            assert result[0].resource_id == AWS_ACCOUNT_ID
+                            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                             assert (
                                 result[0].resource_arn
-                                == f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
+                                == f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
                             )
-                            assert result[0].region == AWS_REGION
+                            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_enabled_with_active_finding(self):
         # Mock the inspector2 client
@@ -248,22 +229,24 @@ class Test_inspector2_findings_exist:
         awslambda_client = mock.MagicMock
         ecr_client = mock.MagicMock
         ec2_client = mock.MagicMock
-        ec2_client.audit_info = self.set_mocked_audit_info()
-        ecr_client.audit_info = self.set_mocked_audit_info()
-        awslambda_client.audit_info = self.set_mocked_audit_info()
-        inspector2_client.audit_info = self.set_mocked_audit_info()
-        inspector2_client.audited_account = AWS_ACCOUNT_ID
-        inspector2_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
-        inspector2_client.region = AWS_REGION
+        ec2_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        ecr_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        awslambda_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        inspector2_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
+        inspector2_client.audited_account_arn = (
+            f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+        )
+        inspector2_client.region = AWS_REGION_EU_WEST_1
         inspector2_client.inspectors = [
             Inspector(
-                id=AWS_ACCOUNT_ID,
-                region=AWS_REGION,
+                id=AWS_ACCOUNT_NUMBER,
+                region=AWS_REGION_EU_WEST_1,
                 status="ENABLED",
                 findings=[
                     InspectorFinding(
                         arn=FINDING_ARN,
-                        region=AWS_REGION,
+                        region=AWS_REGION_EU_WEST_1,
                         severity="MEDIUM",
                         status="ACTIVE",
                         title="CVE-2022-40897 - setuptools",
@@ -271,7 +254,7 @@ class Test_inspector2_findings_exist:
                 ],
             )
         ]
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -307,12 +290,12 @@ class Test_inspector2_findings_exist:
                                 result[0].status_extended
                                 == "There are 1 ACTIVE Inspector2 findings."
                             )
-                            assert result[0].resource_id == AWS_ACCOUNT_ID
+                            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                             assert (
                                 result[0].resource_arn
-                                == f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
+                                == f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
                             )
-                            assert result[0].region == AWS_REGION
+                            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_enabled_with_active_and_closed_findings(self):
         # Mock the inspector2 client
@@ -320,29 +303,31 @@ class Test_inspector2_findings_exist:
         awslambda_client = mock.MagicMock
         ecr_client = mock.MagicMock
         ec2_client = mock.MagicMock
-        ec2_client.audit_info = self.set_mocked_audit_info()
-        ecr_client.audit_info = self.set_mocked_audit_info()
-        awslambda_client.audit_info = self.set_mocked_audit_info()
-        inspector2_client.audit_info = self.set_mocked_audit_info()
-        inspector2_client.audited_account = AWS_ACCOUNT_ID
-        inspector2_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
-        inspector2_client.region = AWS_REGION
+        ec2_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        ecr_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        awslambda_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        inspector2_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
+        inspector2_client.audited_account_arn = (
+            f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+        )
+        inspector2_client.region = AWS_REGION_EU_WEST_1
         inspector2_client.inspectors = [
             Inspector(
-                id=AWS_ACCOUNT_ID,
-                region=AWS_REGION,
+                id=AWS_ACCOUNT_NUMBER,
+                region=AWS_REGION_EU_WEST_1,
                 status="ENABLED",
                 findings=[
                     InspectorFinding(
                         arn=FINDING_ARN,
-                        region=AWS_REGION,
+                        region=AWS_REGION_EU_WEST_1,
                         severity="MEDIUM",
                         status="ACTIVE",
                         title="CVE-2022-40897 - setuptools",
                     ),
                     InspectorFinding(
                         arn=FINDING_ARN,
-                        region=AWS_REGION,
+                        region=AWS_REGION_EU_WEST_1,
                         severity="MEDIUM",
                         status="CLOSED",
                         title="CVE-2022-27404 - freetype",
@@ -350,7 +335,7 @@ class Test_inspector2_findings_exist:
                 ],
             )
         ]
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -386,12 +371,12 @@ class Test_inspector2_findings_exist:
                                 result[0].status_extended
                                 == "There are 1 ACTIVE Inspector2 findings."
                             )
-                            assert result[0].resource_id == AWS_ACCOUNT_ID
+                            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                             assert (
                                 result[0].resource_arn
-                                == f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
+                                == f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
                             )
-                            assert result[0].region == AWS_REGION
+                            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_inspector2_disabled_ignoring(self):
         # Mock the inspector2 client
@@ -400,24 +385,29 @@ class Test_inspector2_findings_exist:
         awslambda_client.functions = {}
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = mock.MagicMock
-        ecr_client.registries[AWS_REGION].repositories = []
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = mock.MagicMock
+        ecr_client.registries[AWS_REGION_EU_WEST_1].repositories = []
         ec2_client = mock.MagicMock
         ec2_client.instances = []
-        ec2_client.audit_info = self.set_mocked_audit_info()
-        ecr_client.audit_info = self.set_mocked_audit_info()
-        awslambda_client.audit_info = self.set_mocked_audit_info()
-        inspector2_client.audit_info = self.set_mocked_audit_info()
+        ec2_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        ecr_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        awslambda_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        inspector2_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         inspector2_client.audit_info.ignore_unused_services = True
-        inspector2_client.audited_account = AWS_ACCOUNT_ID
-        inspector2_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
-        inspector2_client.region = AWS_REGION
+        inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
+        inspector2_client.audited_account_arn = (
+            f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+        )
+        inspector2_client.region = AWS_REGION_EU_WEST_1
         inspector2_client.inspectors = [
             Inspector(
-                id=AWS_ACCOUNT_ID, status="DISABLED", region=AWS_REGION, findings=[]
+                id=AWS_ACCOUNT_NUMBER,
+                status="DISABLED",
+                region=AWS_REGION_EU_WEST_1,
+                findings=[],
             )
         ]
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -456,10 +446,10 @@ class Test_inspector2_findings_exist:
         awslambda_client.functions = {}
         ecr_client = mock.MagicMock
         ecr_client.registries = {}
-        ecr_client.registries[AWS_REGION] = mock.MagicMock
+        ecr_client.registries[AWS_REGION_EU_WEST_1] = mock.MagicMock
         repository_name = "test_repo"
         repository_arn = (
-            f"arn:aws:ecr:eu-west-1:{AWS_ACCOUNT_ID}:repository/{repository_name}"
+            f"arn:aws:ecr:eu-west-1:{AWS_ACCOUNT_NUMBER}:repository/{repository_name}"
         )
         repo_policy_public = {
             "Version": "2012-10-17",
@@ -468,17 +458,17 @@ class Test_inspector2_findings_exist:
                     "Sid": "ECRRepositoryPolicy",
                     "Effect": "Allow",
                     "Principal": {
-                        "AWS": f"arn:aws:iam::{AWS_ACCOUNT_ID}:user/username"
+                        "AWS": f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:user/username"
                     },
                     "Action": ["ecr:DescribeImages", "ecr:DescribeRepositories"],
                 }
             ],
         }
-        ecr_client.registries[AWS_REGION].repositories = [
+        ecr_client.registries[AWS_REGION_EU_WEST_1].repositories = [
             Repository(
                 name=repository_name,
                 arn=repository_arn,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 scan_on_push=True,
                 policy=repo_policy_public,
                 images_details=None,
@@ -487,20 +477,25 @@ class Test_inspector2_findings_exist:
         ]
         ec2_client = mock.MagicMock
         ec2_client.instances = []
-        ec2_client.audit_info = self.set_mocked_audit_info()
-        ecr_client.audit_info = self.set_mocked_audit_info()
-        awslambda_client.audit_info = self.set_mocked_audit_info()
-        inspector2_client.audit_info = self.set_mocked_audit_info()
+        ec2_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        ecr_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        awslambda_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        inspector2_client.audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         inspector2_client.audit_info.ignore_unused_services = True
-        inspector2_client.audited_account = AWS_ACCOUNT_ID
-        inspector2_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
-        inspector2_client.region = AWS_REGION
+        inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
+        inspector2_client.audited_account_arn = (
+            f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+        )
+        inspector2_client.region = AWS_REGION_EU_WEST_1
         inspector2_client.inspectors = [
             Inspector(
-                id=AWS_ACCOUNT_ID, status="DISABLED", region=AWS_REGION, findings=[]
+                id=AWS_ACCOUNT_NUMBER,
+                status="DISABLED",
+                region=AWS_REGION_EU_WEST_1,
+                findings=[],
             )
         ]
-        current_audit_info = self.set_mocked_audit_info()
+        current_audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
 
         with mock.patch(
             "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
@@ -535,9 +530,9 @@ class Test_inspector2_findings_exist:
                                 result[0].status_extended
                                 == "Inspector2 is not enabled."
                             )
-                            assert result[0].resource_id == AWS_ACCOUNT_ID
+                            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                             assert (
                                 result[0].resource_arn
-                                == f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
+                                == f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
                             )
-                            assert result[0].region == AWS_REGION
+                            assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/inspector2/inspector2_service_test.py
+++ b/tests/providers/aws/services/inspector2/inspector2_service_test.py
@@ -2,14 +2,14 @@ from datetime import datetime
 from unittest.mock import patch
 
 import botocore
-from boto3 import session
 
-from prowler.providers.aws.lib.audit_info.audit_info import AWS_Audit_Info
 from prowler.providers.aws.services.inspector2.inspector2_service import Inspector2
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_ID = "123456789012"
 FINDING_ARN = (
     "arn:aws:inspector2:us-east-1:123456789012:finding/0e436649379db5f327e3cf5bb4421d76"
 )
@@ -24,7 +24,7 @@ def mock_make_api_call(self, operation_name, kwargs):
         return {
             "accounts": [
                 {
-                    "accountId": AWS_ACCOUNT_ID,
+                    "accountId": AWS_ACCOUNT_NUMBER,
                     "resourceState": {
                         "ec2": {
                             "errorCode": "ALREADY_ENABLED",
@@ -54,7 +54,7 @@ def mock_make_api_call(self, operation_name, kwargs):
         return {
             "findings": [
                 {
-                    "awsAccountId": AWS_ACCOUNT_ID,
+                    "awsAccountId": AWS_ACCOUNT_NUMBER,
                     "findingArn": FINDING_ARN,
                     "description": "Finding Description",
                     "severity": "MEDIUM",
@@ -70,9 +70,11 @@ def mock_make_api_call(self, operation_name, kwargs):
 
 
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_EU_WEST_1
+    )
+    regional_client.region = AWS_REGION_EU_WEST_1
+    return {AWS_REGION_EU_WEST_1: regional_client}
 
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
@@ -82,63 +84,33 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_Inspector2_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_ID,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_ID}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     def test__get_client__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         inspector2 = Inspector2(audit_info)
         assert (
-            inspector2.regional_clients[AWS_REGION].__class__.__name__ == "Inspector2"
+            inspector2.regional_clients[AWS_REGION_EU_WEST_1].__class__.__name__
+            == "Inspector2"
         )
 
     def test__get_service__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         inspector2 = Inspector2(audit_info)
         assert inspector2.service == "inspector2"
 
     def test__batch_get_account_status__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         inspector2 = Inspector2(audit_info)
         assert len(inspector2.inspectors) == 1
-        assert inspector2.inspectors[0].id == AWS_ACCOUNT_ID
-        assert inspector2.inspectors[0].region == AWS_REGION
+        assert inspector2.inspectors[0].id == AWS_ACCOUNT_NUMBER
+        assert inspector2.inspectors[0].region == AWS_REGION_EU_WEST_1
         assert inspector2.inspectors[0].status == "ENABLED"
 
     def test__list_findings__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
         inspector2 = Inspector2(audit_info)
         assert len(inspector2.inspectors[0].findings) == 1
         assert inspector2.inspectors[0].findings[0].arn == FINDING_ARN
-        assert inspector2.inspectors[0].findings[0].region == AWS_REGION
+        assert inspector2.inspectors[0].findings[0].region == AWS_REGION_EU_WEST_1
         assert inspector2.inspectors[0].findings[0].severity == "MEDIUM"
         assert inspector2.inspectors[0].findings[0].status == "ACTIVE"
         assert (


### PR DESCRIPTION
### Description

Refactor Inspector2 to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
