### PR TITLE
test(audit_info): refactor guardduty

### DIFF
--- a/tests/providers/aws/services/guardduty/guardduty_centrally_managed/guardduty_centrally_managed_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_centrally_managed/guardduty_centrally_managed_test.py
@@ -2,14 +2,14 @@ from unittest import mock
 from uuid import uuid4
 
 from prowler.providers.aws.services.guardduty.guardduty_service import Detector
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
 AWS_ACCOUNT_NUMBER_ADMIN = "123456789013"
 DETECTOR_ID = str(uuid4())
-DETECTOR_ARN = (
-    f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:detector/{DETECTOR_ID}"
-)
+DETECTOR_ARN = f"arn:aws:guardduty:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:detector/{DETECTOR_ID}"
 
 
 class Test_guardduty_centrally_managed:
@@ -34,7 +34,7 @@ class Test_guardduty_centrally_managed:
         guardduty_client.detectors.append(
             Detector(
                 id=DETECTOR_ID,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=DETECTOR_ARN,
                 status=False,
                 findings=[str(uuid4())],
@@ -59,7 +59,7 @@ class Test_guardduty_centrally_managed:
                 == f"GuardDuty detector {DETECTOR_ID} is not centrally managed."
             )
             assert result[0].resource_id == DETECTOR_ID
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
             assert result[0].resource_arn == DETECTOR_ARN
 
     def test_not_enabled_account_detector(self):
@@ -68,7 +68,7 @@ class Test_guardduty_centrally_managed:
         guardduty_client.detectors.append(
             Detector(
                 id=AWS_ACCOUNT_NUMBER,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=DETECTOR_ARN,
                 enabled_in_account=False,
             )
@@ -93,7 +93,7 @@ class Test_guardduty_centrally_managed:
         guardduty_client.detectors.append(
             Detector(
                 id=DETECTOR_ID,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=DETECTOR_ARN,
                 status=False,
                 findings=[str(uuid4())],
@@ -119,7 +119,7 @@ class Test_guardduty_centrally_managed:
                 == f"GuardDuty detector {DETECTOR_ID} is centrally managed by account {AWS_ACCOUNT_NUMBER_ADMIN}."
             )
             assert result[0].resource_id == DETECTOR_ID
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
             assert result[0].resource_arn == DETECTOR_ARN
 
     def test_detector_administrator(self):
@@ -128,7 +128,7 @@ class Test_guardduty_centrally_managed:
         guardduty_client.detectors.append(
             Detector(
                 id=DETECTOR_ID,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=DETECTOR_ARN,
                 status=False,
                 findings=[str(uuid4())],
@@ -154,5 +154,5 @@ class Test_guardduty_centrally_managed:
                 == f"GuardDuty detector {DETECTOR_ID} is administrator account with 1 member accounts."
             )
             assert result[0].resource_id == DETECTOR_ID
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
             assert result[0].resource_arn == DETECTOR_ARN

--- a/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_test.py
@@ -2,24 +2,25 @@ from unittest import mock
 from uuid import uuid4
 
 from prowler.providers.aws.services.guardduty.guardduty_service import Detector
-
-AWS_REGION = "us-east-1"
-AWS_ACCOUNT_ID = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_ID}:root"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_ARN,
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 DETECTOR_ID = str(uuid4())
-DETECTOR_ARN = f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_ID}:detector/{DETECTOR_ID}"
+DETECTOR_ARN = f"arn:aws:guardduty:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:detector/{DETECTOR_ID}"
 
 
 class Test_:
     def test_no_detectors(self):
         guardduty_client = mock.MagicMock
-        guardduty_client.region = AWS_REGION
+        guardduty_client.region = AWS_REGION_EU_WEST_1
         guardduty_client.detectors = []
         guardduty_client.detectors.append(
             Detector(
-                id=AWS_ACCOUNT_ID,
-                region=AWS_REGION,
+                id=AWS_ACCOUNT_NUMBER,
+                region=AWS_REGION_EU_WEST_1,
                 arn=AWS_ACCOUNT_ARN,
                 enabled_in_account=False,
             )
@@ -38,9 +39,9 @@ class Test_:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].status_extended == "GuardDuty is not enabled."
-            assert result[0].resource_id == AWS_ACCOUNT_ID
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert result[0].resource_arn == AWS_ACCOUNT_ARN
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_guardduty_enabled(self):
         guardduty_client = mock.MagicMock
@@ -48,7 +49,7 @@ class Test_:
         guardduty_client.detectors.append(
             Detector(
                 id=DETECTOR_ID,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=DETECTOR_ARN,
                 status=True,
             )
@@ -71,17 +72,17 @@ class Test_:
             )
             assert result[0].resource_id == DETECTOR_ID
             assert result[0].resource_arn == DETECTOR_ARN
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_guardduty_configured_but_suspended(self):
         guardduty_client = mock.MagicMock
-        guardduty_client.region = AWS_REGION
+        guardduty_client.region = AWS_REGION_EU_WEST_1
         guardduty_client.detectors = []
         guardduty_client.detectors.append(
             Detector(
                 id=DETECTOR_ID,
                 arn=DETECTOR_ARN,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 status=False,
             )
         )
@@ -103,17 +104,17 @@ class Test_:
             )
             assert result[0].resource_id == DETECTOR_ID
             assert result[0].resource_arn == DETECTOR_ARN
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_guardduty_not_configured(self):
         guardduty_client = mock.MagicMock
         guardduty_client.detectors = []
-        guardduty_client.region = AWS_REGION
+        guardduty_client.region = AWS_REGION_EU_WEST_1
         guardduty_client.detectors.append(
             Detector(
                 id=DETECTOR_ID,
                 arn=DETECTOR_ARN,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
             )
         )
         with mock.patch(
@@ -134,7 +135,7 @@ class Test_:
             )
             assert result[0].resource_id == DETECTOR_ID
             assert result[0].resource_arn == DETECTOR_ARN
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_guardduty_not_configured_allowlisted(self):
         guardduty_client = mock.MagicMock
@@ -145,7 +146,7 @@ class Test_:
             Detector(
                 id=DETECTOR_ID,
                 arn=DETECTOR_ARN,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
             )
         )
         with mock.patch(
@@ -166,4 +167,4 @@ class Test_:
             )
             assert result[0].resource_id == DETECTOR_ID
             assert result[0].resource_arn == DETECTOR_ARN
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/guardduty/guardduty_no_high_severity_findings/guardduty_no_high_severity_findings_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_no_high_severity_findings/guardduty_no_high_severity_findings_test.py
@@ -3,14 +3,13 @@ from unittest import mock
 from uuid import uuid4
 
 from prowler.providers.aws.services.guardduty.guardduty_service import Detector
-
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 DETECTOR_ID = str(uuid4())
-DETECTOR_ARN = (
-    f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:detector/{DETECTOR_ID}"
-)
+DETECTOR_ARN = f"arn:aws:guardduty:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:detector/{DETECTOR_ID}"
 
 
 class Test_guardduty_no_high_severity_findings:
@@ -36,7 +35,7 @@ class Test_guardduty_no_high_severity_findings:
             Detector(
                 id=DETECTOR_ID,
                 arn=DETECTOR_ARN,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
             )
         )
         with mock.patch(
@@ -56,7 +55,7 @@ class Test_guardduty_no_high_severity_findings:
             )
             assert result[0].resource_id == DETECTOR_ID
             assert result[0].resource_arn == DETECTOR_ARN
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_not_enabled_account_detector(self):
         guardduty_client = mock.MagicMock
@@ -65,7 +64,7 @@ class Test_guardduty_no_high_severity_findings:
             Detector(
                 id=AWS_ACCOUNT_NUMBER,
                 arn=DETECTOR_ARN,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 enabled_in_account=False,
             )
         )
@@ -87,7 +86,7 @@ class Test_guardduty_no_high_severity_findings:
         guardduty_client.detectors.append(
             Detector(
                 id=DETECTOR_ID,
-                region=AWS_REGION,
+                region=AWS_REGION_EU_WEST_1,
                 arn=DETECTOR_ARN,
                 status=False,
                 findings=[str(uuid4())],
@@ -108,4 +107,4 @@ class Test_guardduty_no_high_severity_findings:
             assert search("has 1 high severity findings", result[0].status_extended)
             assert result[0].resource_id == DETECTOR_ID
             assert result[0].resource_arn == DETECTOR_ARN
-            assert result[0].region == AWS_REGION
+            assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/guardduty/guardduty_service_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_service_test.py
@@ -2,16 +2,18 @@ from datetime import datetime
 from unittest.mock import patch
 
 import botocore
-from boto3 import client, session
+from boto3 import client
 from moto import mock_guardduty
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.aws.services.guardduty.guardduty_service import GuardDuty
-from prowler.providers.common.models import Audit_Metadata
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_audit_info,
+)
 
 AWS_ACCOUNT_NUMBER_ADMIN = "123456789013"
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_REGION = "eu-west-1"
+
 
 make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -49,9 +51,11 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 def mock_generate_regional_clients(service, audit_info, _):
-    regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
-    regional_client.region = AWS_REGION
-    return {AWS_REGION: regional_client}
+    regional_client = audit_info.audit_session.client(
+        service, region_name=AWS_REGION_EU_WEST_1
+    )
+    regional_client.region = AWS_REGION_EU_WEST_1
+    return {AWS_REGION_EU_WEST_1: regional_client}
 
 
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
@@ -60,161 +64,130 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_GuardDuty_Service:
-    # Mocked Audit Info
-    def set_mocked_audit_info(self):
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session.Session(
-                profile_name=None,
-                botocore_session=None,
-            ),
-            audited_account=AWS_ACCOUNT_NUMBER,
-            audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-            audited_user_id=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            profile=None,
-            profile_region=None,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=None,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        return audit_info
-
     # Test GuardDuty Service
     def test_service(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         guardduty = GuardDuty(audit_info)
         assert guardduty.service == "guardduty"
 
     # Test GuardDuty client
     def test_client(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         guardduty = GuardDuty(audit_info)
         for reg_client in guardduty.regional_clients.values():
             assert reg_client.__class__.__name__ == "GuardDuty"
 
     # Test GuardDuty session
     def test__get_session__(self):
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         guardduty = GuardDuty(audit_info)
         assert guardduty.session.__class__.__name__ == "Session"
 
     @mock_guardduty
     # Test GuardDuty session
     def test__list_detectors__(self):
-        guardduty_client = client("guardduty", region_name=AWS_REGION)
+        guardduty_client = client("guardduty", region_name=AWS_REGION_EU_WEST_1)
         response = guardduty_client.create_detector(Enable=True, Tags={"test": "test"})
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         guardduty = GuardDuty(audit_info)
 
         assert len(guardduty.detectors) == 1
         assert guardduty.detectors[0].id == response["DetectorId"]
         assert (
             guardduty.detectors[0].arn
-            == f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:detector/{response['DetectorId']}"
+            == f"arn:aws:guardduty:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:detector/{response['DetectorId']}"
         )
         assert guardduty.detectors[0].enabled_in_account
         assert len(guardduty.detectors[0].findings) == 1
         assert guardduty.detectors[0].member_accounts == ["123456789012"]
         assert guardduty.detectors[0].administrator_account == "123456789013"
-        assert guardduty.detectors[0].region == AWS_REGION
+        assert guardduty.detectors[0].region == AWS_REGION_EU_WEST_1
         assert guardduty.detectors[0].tags == [{"test": "test"}]
 
     @mock_guardduty
     # Test GuardDuty session
     def test__get_detector__(self):
-        guardduty_client = client("guardduty", region_name=AWS_REGION)
+        guardduty_client = client("guardduty", region_name=AWS_REGION_EU_WEST_1)
         response = guardduty_client.create_detector(Enable=True)
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         guardduty = GuardDuty(audit_info)
 
         assert len(guardduty.detectors) == 1
         assert guardduty.detectors[0].id == response["DetectorId"]
         assert (
             guardduty.detectors[0].arn
-            == f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:detector/{response['DetectorId']}"
+            == f"arn:aws:guardduty:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:detector/{response['DetectorId']}"
         )
         assert guardduty.detectors[0].enabled_in_account
         assert len(guardduty.detectors[0].findings) == 1
         assert guardduty.detectors[0].member_accounts == ["123456789012"]
         assert guardduty.detectors[0].administrator_account == "123456789013"
-        assert guardduty.detectors[0].region == AWS_REGION
+        assert guardduty.detectors[0].region == AWS_REGION_EU_WEST_1
         assert guardduty.detectors[0].tags == [{"test": "test"}]
 
     @mock_guardduty
     # Test GuardDuty session
     def test__list_findings__(self):
-        guardduty_client = client("guardduty", region_name=AWS_REGION)
+        guardduty_client = client("guardduty", region_name=AWS_REGION_EU_WEST_1)
         response = guardduty_client.create_detector(Enable=True)
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         guardduty = GuardDuty(audit_info)
 
         assert len(guardduty.detectors) == 1
         assert guardduty.detectors[0].id == response["DetectorId"]
         assert (
             guardduty.detectors[0].arn
-            == f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:detector/{response['DetectorId']}"
+            == f"arn:aws:guardduty:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:detector/{response['DetectorId']}"
         )
         assert guardduty.detectors[0].enabled_in_account
         assert len(guardduty.detectors[0].findings) == 1
         assert guardduty.detectors[0].member_accounts == ["123456789012"]
         assert guardduty.detectors[0].administrator_account == "123456789013"
-        assert guardduty.detectors[0].region == AWS_REGION
+        assert guardduty.detectors[0].region == AWS_REGION_EU_WEST_1
         assert guardduty.detectors[0].tags == [{"test": "test"}]
 
     @mock_guardduty
     def test__list_members__(self):
-        guardduty_client = client("guardduty", region_name=AWS_REGION)
+        guardduty_client = client("guardduty", region_name=AWS_REGION_EU_WEST_1)
         response = guardduty_client.create_detector(Enable=True)
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         guardduty = GuardDuty(audit_info)
 
         assert len(guardduty.detectors) == 1
         assert guardduty.detectors[0].id == response["DetectorId"]
         assert (
             guardduty.detectors[0].arn
-            == f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:detector/{response['DetectorId']}"
+            == f"arn:aws:guardduty:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:detector/{response['DetectorId']}"
         )
         assert guardduty.detectors[0].enabled_in_account
         assert len(guardduty.detectors[0].findings) == 1
         assert guardduty.detectors[0].member_accounts == ["123456789012"]
         assert guardduty.detectors[0].administrator_account == "123456789013"
-        assert guardduty.detectors[0].region == AWS_REGION
+        assert guardduty.detectors[0].region == AWS_REGION_EU_WEST_1
         assert guardduty.detectors[0].tags == [{"test": "test"}]
 
     @mock_guardduty
     # Test GuardDuty session
     def test__get_administrator_account__(self):
-        guardduty_client = client("guardduty", region_name=AWS_REGION)
+        guardduty_client = client("guardduty", region_name=AWS_REGION_EU_WEST_1)
         response = guardduty_client.create_detector(Enable=True)
 
-        audit_info = self.set_mocked_audit_info()
+        audit_info = set_mocked_aws_audit_info()
         guardduty = GuardDuty(audit_info)
 
         assert len(guardduty.detectors) == 1
         assert guardduty.detectors[0].id == response["DetectorId"]
         assert (
             guardduty.detectors[0].arn
-            == f"arn:aws:guardduty:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:detector/{response['DetectorId']}"
+            == f"arn:aws:guardduty:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:detector/{response['DetectorId']}"
         )
         assert guardduty.detectors[0].enabled_in_account
         assert len(guardduty.detectors[0].findings) == 1
         assert guardduty.detectors[0].member_accounts == ["123456789012"]
         assert guardduty.detectors[0].administrator_account == "123456789013"
-        assert guardduty.detectors[0].region == AWS_REGION
+        assert guardduty.detectors[0].region == AWS_REGION_EU_WEST_1
         assert guardduty.detectors[0].tags == [{"test": "test"}]


### PR DESCRIPTION
### Description

Refactor GuardDuty to use the `set_mocked_aws_audit_info` helper.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
