### PR TITLE
test(aws_account_id): refactor

### DIFF
--- a/tests/providers/aws/services/apigateway/apigateway_authorizers_enabled/apigateway_authorizers_enabled_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_authorizers_enabled/apigateway_authorizers_enabled_test.py
@@ -2,9 +2,9 @@ from unittest import mock
 
 from boto3 import client
 from moto import mock_apigateway, mock_iam, mock_lambda
-from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_EU_WEST_1,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_audit_info,
@@ -68,7 +68,7 @@ class Test_apigateway_restapi_authorizers_enabled:
             name="test",
             restApiId=rest_api["id"],
             type="TOKEN",
-            authorizerUri=f"arn:aws:apigateway:{apigateway_client.meta.region_name}:lambda:path/2015-03-31/functions/arn:aws:lambda:{apigateway_client.meta.region_name}:{ACCOUNT_ID}:function:{authorizer['FunctionName']}/invocations",
+            authorizerUri=f"arn:aws:apigateway:{apigateway_client.meta.region_name}:lambda:path/2015-03-31/functions/arn:aws:lambda:{apigateway_client.meta.region_name}:{AWS_ACCOUNT_NUMBER}:function:{authorizer['FunctionName']}/invocations",
         )
         from prowler.providers.aws.services.apigateway.apigateway_service import (
             APIGateway,

--- a/tests/providers/aws/services/appstream/appstream_service_test.py
+++ b/tests/providers/aws/services/appstream/appstream_service_test.py
@@ -1,17 +1,16 @@
 from unittest.mock import patch
 
 import botocore
-from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.appstream.appstream_service import AppStream
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_audit_info,
 )
 
 # Mock Test Region
 AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
 
 # Mocking Access Analyzer Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -29,7 +28,7 @@ def mock_make_api_call(self, operation_name, kwarg):
         return {
             "Fleets": [
                 {
-                    "Arn": f"arn:aws:appstream:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:fleet/test-prowler3-0",
+                    "Arn": f"arn:aws:appstream:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:fleet/test-prowler3-0",
                     "Name": "test-prowler3-0",
                     "MaxUserDurationInSeconds": 100,
                     "DisconnectTimeoutInSeconds": 900,
@@ -37,7 +36,7 @@ def mock_make_api_call(self, operation_name, kwarg):
                     "EnableDefaultInternetAccess": False,
                 },
                 {
-                    "Arn": f"arn:aws:appstream:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:fleet/test-prowler3-1",
+                    "Arn": f"arn:aws:appstream:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:fleet/test-prowler3-1",
                     "Name": "test-prowler3-1",
                     "MaxUserDurationInSeconds": 57600,
                     "DisconnectTimeoutInSeconds": 900,
@@ -87,7 +86,7 @@ class Test_AppStream_Service:
 
         assert (
             appstream.fleets[0].arn
-            == f"arn:aws:appstream:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:fleet/test-prowler3-0"
+            == f"arn:aws:appstream:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:fleet/test-prowler3-0"
         )
         assert appstream.fleets[0].name == "test-prowler3-0"
         assert appstream.fleets[0].max_user_duration_in_seconds == 100
@@ -98,7 +97,7 @@ class Test_AppStream_Service:
 
         assert (
             appstream.fleets[1].arn
-            == f"arn:aws:appstream:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:fleet/test-prowler3-1"
+            == f"arn:aws:appstream:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:fleet/test-prowler3-1"
         )
         assert appstream.fleets[1].name == "test-prowler3-1"
         assert appstream.fleets[1].max_user_duration_in_seconds == 57600

--- a/tests/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled_test.py
@@ -3,10 +3,10 @@ from unittest import mock
 from boto3 import client
 from mock import patch
 from moto import mock_cloudtrail, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.awslambda.awslambda_service import Function
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_audit_info,
 )
@@ -65,7 +65,7 @@ class Test_awslambda_function_invoke_api_operations_cloudtrail_logging_enabled:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "python3.9"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         lambda_client.functions = {
             function_name: Function(
                 name=function_name,
@@ -128,7 +128,7 @@ class Test_awslambda_function_invoke_api_operations_cloudtrail_logging_enabled:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "python3.9"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         lambda_client.functions = {
             function_name: Function(
                 name=function_name,
@@ -203,7 +203,7 @@ class Test_awslambda_function_invoke_api_operations_cloudtrail_logging_enabled:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "python3.9"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         lambda_client.functions = {
             function_name: Function(
                 name=function_name,

--- a/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code_test.py
@@ -2,13 +2,13 @@ import zipfile
 from unittest import mock
 
 from awslambda_service_test import create_zip_file
-from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.awslambda.awslambda_service import (
     Function,
     LambdaCode,
 )
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_audit_info,
 )
@@ -40,7 +40,7 @@ class Test_awslambda_function_no_secrets_in_code:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         code_with_secrets = """
         def lambda_handler(event, context):
                 db_password = "test-password"
@@ -91,7 +91,7 @@ class Test_awslambda_function_no_secrets_in_code:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         code_with_secrets = """
         def lambda_handler(event, context):
                 print("custom log event")

--- a/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables_test.py
@@ -1,9 +1,8 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.awslambda.awslambda_service import Function
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_audit_info,
 )
@@ -35,7 +34,7 @@ class Test_awslambda_function_no_secrets_in_variables:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
 
         lambda_client.functions = {
             "function_name": Function(
@@ -77,7 +76,7 @@ class Test_awslambda_function_no_secrets_in_variables:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
 
         lambda_client.functions = {
             "function_name": Function(
@@ -120,7 +119,7 @@ class Test_awslambda_function_no_secrets_in_variables:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
 
         lambda_client.functions = {
             "function_name": Function(

--- a/tests/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible_test.py
@@ -1,9 +1,8 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.awslambda.awslambda_service import Function
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_audit_info,
 )
@@ -35,13 +34,13 @@ class Test_awslambda_function_not_publicly_accessible:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         lambda_policy = {
             "Version": "2012-10-17",
             "Statement": [
                 {
                     "Sid": "public-access",
-                    "Principal": {"AWS": ["*", DEFAULT_ACCOUNT_ID]},
+                    "Principal": {"AWS": ["*", AWS_ACCOUNT_NUMBER]},
                     "Effect": "Allow",
                     "Action": [
                         "lambda:InvokeFunction",
@@ -92,13 +91,13 @@ class Test_awslambda_function_not_publicly_accessible:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         lambda_policy = {
             "Version": "2012-10-17",
             "Statement": [
                 {
                     "Sid": "public-access",
-                    "Principal": {"AWS": [DEFAULT_ACCOUNT_ID]},
+                    "Principal": {"AWS": [AWS_ACCOUNT_NUMBER]},
                     "Effect": "Allow",
                     "Action": [
                         "lambda:InvokeFunction",
@@ -149,7 +148,7 @@ class Test_awslambda_function_not_publicly_accessible:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         lambda_policy = {
             "Version": "2012-10-17",
             "Statement": [

--- a/tests/providers/aws/services/awslambda/awslambda_function_url_cors_policy/awslambda_function_url_cors_policy_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_url_cors_policy/awslambda_function_url_cors_policy_test.py
@@ -1,7 +1,5 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.awslambda.awslambda_service import (
     AuthType,
     Function,
@@ -9,6 +7,7 @@ from prowler.providers.aws.services.awslambda.awslambda_service import (
     URLConfigCORS,
 )
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_audit_info,
 )
@@ -40,7 +39,7 @@ class Test_awslambda_function_url_cors_policy:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
@@ -86,7 +85,7 @@ class Test_awslambda_function_url_cors_policy:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "python3.9"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
@@ -132,7 +131,7 @@ class Test_awslambda_function_url_cors_policy:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "python3.9"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,

--- a/tests/providers/aws/services/awslambda/awslambda_function_url_public/awslambda_function_url_public_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_url_public/awslambda_function_url_public_test.py
@@ -1,7 +1,5 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.awslambda.awslambda_service import (
     AuthType,
     Function,
@@ -9,6 +7,7 @@ from prowler.providers.aws.services.awslambda.awslambda_service import (
     URLConfigCORS,
 )
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_audit_info,
 )
@@ -40,7 +39,7 @@ class Test_awslambda_function_url_public:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
@@ -86,7 +85,7 @@ class Test_awslambda_function_url_public:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "python3.9"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,

--- a/tests/providers/aws/services/awslambda/awslambda_function_using_supported_runtimes/awslambda_function_using_supported_runtimes_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_using_supported_runtimes/awslambda_function_using_supported_runtimes_test.py
@@ -1,9 +1,8 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.awslambda.awslambda_service import Function
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_audit_info,
 )
@@ -35,7 +34,7 @@ class Test_awslambda_function_using_supported_runtimes:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
@@ -94,7 +93,7 @@ class Test_awslambda_function_using_supported_runtimes:
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "python3.9"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,
@@ -152,7 +151,7 @@ class Test_awslambda_function_using_supported_runtimes:
     def test_function_no_runtime(self):
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
-        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:function/{function_name}"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
         lambda_client.functions = {
             "function_name": Function(
                 name=function_name,

--- a/tests/providers/aws/services/awslambda/awslambda_service_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_service_test.py
@@ -8,10 +8,10 @@ from unittest.mock import patch
 import mock
 from boto3 import client, resource
 from moto import mock_iam, mock_lambda, mock_s3
-from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.awslambda.awslambda_service import AuthType, Lambda
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_EU_WEST_1,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_audit_info,
@@ -132,7 +132,7 @@ class Test_Lambda_Service:
                     "Action": "lambda:GetFunction",
                     "Principal": "*",
                     "Effect": "Allow",
-                    "Resource": f"arn:aws:lambda:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:function:{lambda_name}",
+                    "Resource": f"arn:aws:lambda:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:function:{lambda_name}",
                     "Sid": "test",
                 }
             ],

--- a/tests/providers/aws/services/cloudformation/cloudformation_service_test.py
+++ b/tests/providers/aws/services/cloudformation/cloudformation_service_test.py
@@ -6,12 +6,12 @@ import boto3
 import botocore
 from dateutil.tz import tzutc
 from moto import mock_cloudformation
-from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.cloudformation.cloudformation_service import (
     CloudFormation,
 )
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_EU_WEST_1,
     set_mocked_aws_audit_info,
 )
@@ -172,7 +172,7 @@ class Test_CloudFormation_Service:
         stack_arn = cloudformation_client.create_stack(
             StackName="Test-Stack",
             TemplateBody=json.dumps(dummy_template),
-            RoleARN=f"arn:aws:iam::{DEFAULT_ACCOUNT_ID}:role/moto",
+            RoleARN=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:role/moto",
             Tags=[
                 {"Key": "Tag1", "Value": "Value1"},
                 {"Key": "Tag2", "Value": "Value2"},

--- a/tests/providers/aws/services/cloudfront/cloudfront_distributions_field_level_encryption_enabled/cloudfront_distributions_field_level_encryption_enabled_test.py
+++ b/tests/providers/aws/services/cloudfront/cloudfront_distributions_field_level_encryption_enabled/cloudfront_distributions_field_level_encryption_enabled_test.py
@@ -1,16 +1,15 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.cloudfront.cloudfront_service import (
     DefaultCacheConfigBehaviour,
     Distribution,
     ViewerProtocolPolicy,
 )
+from tests.providers.aws.audit_info_utils import AWS_ACCOUNT_NUMBER
 
 DISTRIBUTION_ID = "E27LVI50CSW06W"
 DISTRIBUTION_ARN = (
-    f"arn:aws:cloudfront::{DEFAULT_ACCOUNT_ID}:distribution/{DISTRIBUTION_ID}"
+    f"arn:aws:cloudfront::{AWS_ACCOUNT_NUMBER}:distribution/{DISTRIBUTION_ID}"
 )
 REGION = "eu-west-1"
 

--- a/tests/providers/aws/services/cloudfront/cloudfront_distributions_geo_restrictions_enabled/cloudfront_distributions_geo_restrictions_enabled_test.py
+++ b/tests/providers/aws/services/cloudfront/cloudfront_distributions_geo_restrictions_enabled/cloudfront_distributions_geo_restrictions_enabled_test.py
@@ -1,15 +1,14 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.cloudfront.cloudfront_service import (
     Distribution,
     GeoRestrictionType,
 )
+from tests.providers.aws.audit_info_utils import AWS_ACCOUNT_NUMBER
 
 DISTRIBUTION_ID = "E27LVI50CSW06W"
 DISTRIBUTION_ARN = (
-    f"arn:aws:cloudfront::{DEFAULT_ACCOUNT_ID}:distribution/{DISTRIBUTION_ID}"
+    f"arn:aws:cloudfront::{AWS_ACCOUNT_NUMBER}:distribution/{DISTRIBUTION_ID}"
 )
 REGION = "eu-west-1"
 

--- a/tests/providers/aws/services/cloudfront/cloudfront_distributions_https_enabled/cloudfront_distributions_https_enabled_test.py
+++ b/tests/providers/aws/services/cloudfront/cloudfront_distributions_https_enabled/cloudfront_distributions_https_enabled_test.py
@@ -1,16 +1,15 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.cloudfront.cloudfront_service import (
     DefaultCacheConfigBehaviour,
     Distribution,
     ViewerProtocolPolicy,
 )
+from tests.providers.aws.audit_info_utils import AWS_ACCOUNT_NUMBER
 
 DISTRIBUTION_ID = "E27LVI50CSW06W"
 DISTRIBUTION_ARN = (
-    f"arn:aws:cloudfront::{DEFAULT_ACCOUNT_ID}:distribution/{DISTRIBUTION_ID}"
+    f"arn:aws:cloudfront::{AWS_ACCOUNT_NUMBER}:distribution/{DISTRIBUTION_ID}"
 )
 REGION = "eu-west-1"
 

--- a/tests/providers/aws/services/cloudfront/cloudfront_distributions_logging_enabled/cloudfront_distributions_logging_enabled_test.py
+++ b/tests/providers/aws/services/cloudfront/cloudfront_distributions_logging_enabled/cloudfront_distributions_logging_enabled_test.py
@@ -1,16 +1,15 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.cloudfront.cloudfront_service import (
     DefaultCacheConfigBehaviour,
     Distribution,
     ViewerProtocolPolicy,
 )
+from tests.providers.aws.audit_info_utils import AWS_ACCOUNT_NUMBER
 
 DISTRIBUTION_ID = "E27LVI50CSW06W"
 DISTRIBUTION_ARN = (
-    f"arn:aws:cloudfront::{DEFAULT_ACCOUNT_ID}:distribution/{DISTRIBUTION_ID}"
+    f"arn:aws:cloudfront::{AWS_ACCOUNT_NUMBER}:distribution/{DISTRIBUTION_ID}"
 )
 REGION = "eu-west-1"
 

--- a/tests/providers/aws/services/cloudfront/cloudfront_distributions_using_deprecated_ssl_protocols/cloudfront_distributions_using_deprecated_ssl_protocols_test.py
+++ b/tests/providers/aws/services/cloudfront/cloudfront_distributions_using_deprecated_ssl_protocols/cloudfront_distributions_using_deprecated_ssl_protocols_test.py
@@ -1,12 +1,11 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.cloudfront.cloudfront_service import Distribution
+from tests.providers.aws.audit_info_utils import AWS_ACCOUNT_NUMBER
 
 DISTRIBUTION_ID = "E27LVI50CSW06W"
 DISTRIBUTION_ARN = (
-    f"arn:aws:cloudfront::{DEFAULT_ACCOUNT_ID}:distribution/{DISTRIBUTION_ID}"
+    f"arn:aws:cloudfront::{AWS_ACCOUNT_NUMBER}:distribution/{DISTRIBUTION_ID}"
 )
 REGION = "eu-west-1"
 

--- a/tests/providers/aws/services/cloudfront/cloudfront_distributions_using_waf/cloudfront_distributions_using_waf_test.py
+++ b/tests/providers/aws/services/cloudfront/cloudfront_distributions_using_waf/cloudfront_distributions_using_waf_test.py
@@ -1,12 +1,11 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.cloudfront.cloudfront_service import Distribution
+from tests.providers.aws.audit_info_utils import AWS_ACCOUNT_NUMBER
 
 DISTRIBUTION_ID = "E27LVI50CSW06W"
 DISTRIBUTION_ARN = (
-    f"arn:aws:cloudfront::{DEFAULT_ACCOUNT_ID}:distribution/{DISTRIBUTION_ID}"
+    f"arn:aws:cloudfront::{AWS_ACCOUNT_NUMBER}:distribution/{DISTRIBUTION_ID}"
 )
 REGION = "eu-west-1"
 

--- a/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_test.py
+++ b/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_test.py
@@ -1,7 +1,5 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.codeartifact.codeartifact_service import (
     LatestPackageVersion,
     LatestPackageVersionStatus,
@@ -13,6 +11,7 @@ from prowler.providers.aws.services.codeartifact.codeartifact_service import (
     Restrictions,
     RestrictionValues,
 )
+from tests.providers.aws.audit_info_utils import AWS_ACCOUNT_NUMBER
 
 AWS_REGION = "eu-west-1"
 
@@ -65,7 +64,7 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
         codeartifact_client = mock.MagicMock
         package_name = "test-package"
         package_namespace = "test-namespace"
-        repository_arn = f"arn:aws:codebuild:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:repository/test-repository"
+        repository_arn = f"arn:aws:codebuild:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:repository/test-repository"
         codeartifact_client.repositories = {
             "test-repository": Repository(
                 name="test-repository",
@@ -125,7 +124,7 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
         codeartifact_client = mock.MagicMock
         package_name = "test-package"
         package_namespace = "test-namespace"
-        repository_arn = f"arn:aws:codebuild:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:repository/test-repository"
+        repository_arn = f"arn:aws:codebuild:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:repository/test-repository"
         codeartifact_client.repositories = {
             "test-repository": Repository(
                 name="test-repository",

--- a/tests/providers/aws/services/directoryservice/directoryservice_directory_monitor_notifications/directoryservice_directory_monitor_notifications_test.py
+++ b/tests/providers/aws/services/directoryservice/directoryservice_directory_monitor_notifications/directoryservice_directory_monitor_notifications_test.py
@@ -1,17 +1,15 @@
 from datetime import datetime
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.directoryservice.directoryservice_service import (
     Directory,
     DirectoryType,
     EventTopics,
     EventTopicStatus,
 )
+from tests.providers.aws.audit_info_utils import AWS_ACCOUNT_NUMBER
 
 AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
 
 
 class Test_directoryservice_directory_monitor_notifications:
@@ -88,7 +86,7 @@ class Test_directoryservice_directory_monitor_notifications:
                 region=AWS_REGION,
                 event_topics=[
                     EventTopics(
-                        topic_arn=f"arn:aws:sns:{AWS_REGION}:{DEFAULT_ACCOUNT_ID}:test-topic",
+                        topic_arn=f"arn:aws:sns:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:test-topic",
                         topic_name="test-topic",
                         status=EventTopicStatus.Registered,
                         created_date_time=datetime(2022, 1, 1),

--- a/tests/providers/aws/services/emr/emr_cluster_account_public_block_enabled/emr_cluster_account_public_block_enabled_test.py
+++ b/tests/providers/aws/services/emr/emr_cluster_account_public_block_enabled/emr_cluster_account_public_block_enabled_test.py
@@ -1,17 +1,18 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.emr.emr_service import (
     BlockPublicAccessConfiguration,
 )
-from tests.providers.aws.audit_info_utils import AWS_REGION_EU_WEST_1
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 
 class Test_emr_cluster_account_public_block_enabled:
     def test_account_public_block_enabled(self):
         emr_client = mock.MagicMock
-        emr_client.audited_account = DEFAULT_ACCOUNT_ID
+        emr_client.audited_account = AWS_ACCOUNT_NUMBER
         emr_client.block_public_access_configuration = {
             AWS_REGION_EU_WEST_1: BlockPublicAccessConfiguration(
                 block_public_security_group_rules=True
@@ -31,7 +32,7 @@ class Test_emr_cluster_account_public_block_enabled:
 
             assert len(result) == 1
             assert result[0].region == AWS_REGION_EU_WEST_1
-            assert result[0].resource_id == DEFAULT_ACCOUNT_ID
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
@@ -40,7 +41,7 @@ class Test_emr_cluster_account_public_block_enabled:
 
     def test_account_public_block_disabled(self):
         emr_client = mock.MagicMock
-        emr_client.audited_account = DEFAULT_ACCOUNT_ID
+        emr_client.audited_account = AWS_ACCOUNT_NUMBER
         emr_client.block_public_access_configuration = {
             AWS_REGION_EU_WEST_1: BlockPublicAccessConfiguration(
                 block_public_security_group_rules=False
@@ -60,7 +61,7 @@ class Test_emr_cluster_account_public_block_enabled:
 
             assert len(result) == 1
             assert result[0].region == AWS_REGION_EU_WEST_1
-            assert result[0].resource_id == DEFAULT_ACCOUNT_ID
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended

--- a/tests/providers/aws/services/emr/emr_cluster_master_nodes_no_public_ip/emr_cluster_master_nodes_no_public_ip_test.py
+++ b/tests/providers/aws/services/emr/emr_cluster_master_nodes_no_public_ip/emr_cluster_master_nodes_no_public_ip_test.py
@@ -1,9 +1,10 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.emr.emr_service import Cluster, ClusterStatus
-from tests.providers.aws.audit_info_utils import AWS_REGION_EU_WEST_1
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 
 class Test_emr_cluster_master_nodes_no_public_ip:
@@ -28,7 +29,7 @@ class Test_emr_cluster_master_nodes_no_public_ip:
         emr_client = mock.MagicMock
         cluster_name = "test-cluster"
         cluster_id = "j-XWO1UKVCC6FCV"
-        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:cluster/{cluster_name}"
+        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:cluster/{cluster_name}"
         emr_client.clusters = {
             "test-cluster": Cluster(
                 id=cluster_id,
@@ -66,7 +67,7 @@ class Test_emr_cluster_master_nodes_no_public_ip:
         emr_client = mock.MagicMock
         cluster_name = "test-cluster"
         cluster_id = "j-XWO1UKVCC6FCV"
-        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:cluster/{cluster_name}"
+        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:cluster/{cluster_name}"
         emr_client.clusters = {
             "test-cluster": Cluster(
                 id=cluster_id,
@@ -104,7 +105,7 @@ class Test_emr_cluster_master_nodes_no_public_ip:
         emr_client = mock.MagicMock
         cluster_name = "test-cluster"
         cluster_id = "j-XWO1UKVCC6FCV"
-        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:cluster/{cluster_name}"
+        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:cluster/{cluster_name}"
         emr_client.clusters = {
             "test-cluster": Cluster(
                 id=cluster_id,
@@ -134,7 +135,7 @@ class Test_emr_cluster_master_nodes_no_public_ip:
         emr_client = mock.MagicMock
         cluster_name = "test-cluster"
         cluster_id = "j-XWO1UKVCC6FCV"
-        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:cluster/{cluster_name}"
+        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:cluster/{cluster_name}"
         emr_client.clusters = {
             "test-cluster": Cluster(
                 id=cluster_id,

--- a/tests/providers/aws/services/emr/emr_cluster_publicly_accesible/emr_cluster_publicly_accesible_test.py
+++ b/tests/providers/aws/services/emr/emr_cluster_publicly_accesible/emr_cluster_publicly_accesible_test.py
@@ -3,10 +3,10 @@ from uuid import uuid4
 
 from boto3 import resource
 from moto import mock_ec2
-from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.emr.emr_service import Cluster, ClusterStatus, Node
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_EU_WEST_1,
     set_mocked_aws_audit_info,
 )
@@ -56,7 +56,7 @@ class Test_emr_cluster_publicly_accesible:
         emr_client = mock.MagicMock
         cluster_name = "test-cluster"
         cluster_id = "j-XWO1UKVCC6FCV"
-        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:cluster/{cluster_name}"
+        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:cluster/{cluster_name}"
         emr_client.clusters = {
             "test-cluster": Cluster(
                 id=cluster_id,
@@ -124,7 +124,7 @@ class Test_emr_cluster_publicly_accesible:
         emr_client = mock.MagicMock
         cluster_name = "test-cluster"
         cluster_id = "j-XWO1UKVCC6FCV"
-        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:cluster/{cluster_name}"
+        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:cluster/{cluster_name}"
         emr_client.clusters = {
             "test-cluster": Cluster(
                 id=cluster_id,
@@ -201,7 +201,7 @@ class Test_emr_cluster_publicly_accesible:
         emr_client = mock.MagicMock
         cluster_name = "test-cluster"
         cluster_id = "j-XWO1UKVCC6FCV"
-        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:cluster/{cluster_name}"
+        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:cluster/{cluster_name}"
         emr_client.clusters = {
             "test-cluster": Cluster(
                 id=cluster_id,
@@ -284,7 +284,7 @@ class Test_emr_cluster_publicly_accesible:
         emr_client = mock.MagicMock
         cluster_name = "test-cluster"
         cluster_id = "j-XWO1UKVCC6FCV"
-        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:cluster/{cluster_name}"
+        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:cluster/{cluster_name}"
         emr_client.clusters = {
             "test-cluster": Cluster(
                 id=cluster_id,
@@ -370,7 +370,7 @@ class Test_emr_cluster_publicly_accesible:
         emr_client = mock.MagicMock
         cluster_name = "test-cluster"
         cluster_id = "j-XWO1UKVCC6FCV"
-        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:cluster/{cluster_name}"
+        cluster_arn = f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:cluster/{cluster_name}"
         emr_client.clusters = {
             "test-cluster": Cluster(
                 id=cluster_id,

--- a/tests/providers/aws/services/emr/emr_service_test.py
+++ b/tests/providers/aws/services/emr/emr_service_test.py
@@ -4,10 +4,10 @@ from unittest.mock import patch
 import botocore
 from boto3 import client
 from moto import mock_emr
-from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.emr.emr_service import EMR, ClusterStatus
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_EU_WEST_1,
     set_mocked_aws_audit_info,
 )
@@ -101,7 +101,7 @@ class Test_EMR_Service:
         assert emr.clusters[cluster_id].status == ClusterStatus.WAITING
         assert (
             emr.clusters[cluster_id].arn
-            == f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:cluster/{cluster_id}"
+            == f"arn:aws:elasticmapreduce:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:cluster/{cluster_id}"
         )
         assert emr.clusters[cluster_id].region == AWS_REGION_EU_WEST_1
         assert (

--- a/tests/providers/aws/services/route53/route53_public_hosted_zones_cloudwatch_logging_enabled/route53_public_hosted_zones_cloudwatch_logging_enabled_test.py
+++ b/tests/providers/aws/services/route53/route53_public_hosted_zones_cloudwatch_logging_enabled/route53_public_hosted_zones_cloudwatch_logging_enabled_test.py
@@ -1,12 +1,13 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.route53.route53_service import (
     HostedZone,
     LoggingConfig,
 )
-from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+)
 
 
 class Test_route53_public_hosted_zones_cloudwatch_logging_enabled:
@@ -36,7 +37,7 @@ class Test_route53_public_hosted_zones_cloudwatch_logging_enabled:
         hosted_zone_name = "test-domain.com"
         hosted_zone_id = "ABCDEF12345678"
         log_group_name = "test-log-group"
-        log_group_arn = f"rn:aws:logs:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:log-group:{log_group_name}"
+        log_group_arn = f"rn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:{log_group_name}"
         route53.hosted_zones = {
             hosted_zone_name: HostedZone(
                 name=hosted_zone_name,

--- a/tests/providers/aws/services/secretsmanager/secretsmanager_automatic_rotation_enabled/secretsmanager_automatic_rotation_enabled_test.py
+++ b/tests/providers/aws/services/secretsmanager/secretsmanager_automatic_rotation_enabled/secretsmanager_automatic_rotation_enabled_test.py
@@ -1,9 +1,10 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.secretsmanager.secretsmanager_service import Secret
-from tests.providers.aws.audit_info_utils import AWS_REGION_EU_WEST_1
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 
 class Test_secretsmanager_automatic_rotation_enabled:
@@ -27,7 +28,7 @@ class Test_secretsmanager_automatic_rotation_enabled:
     def test_secret_rotation_disabled(self):
         secretsmanager_client = mock.MagicMock
         secret_name = "test-secret"
-        secret_arn = f"arn:aws:secretsmanager:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:secret:{secret_name}"
+        secret_arn = f"arn:aws:secretsmanager:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:secret:{secret_name}"
         secretsmanager_client.secrets = {
             secret_name: Secret(
                 arn=secret_arn,
@@ -61,7 +62,7 @@ class Test_secretsmanager_automatic_rotation_enabled:
     def test_secret_rotation_enabled(self):
         secretsmanager_client = mock.MagicMock
         secret_name = "test-secret"
-        secret_arn = f"arn:aws:secretsmanager:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:secret:{secret_name}"
+        secret_arn = f"arn:aws:secretsmanager:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:secret:{secret_name}"
         secretsmanager_client.secrets = {
             secret_name: Secret(
                 arn=secret_arn,

--- a/tests/providers/aws/services/shield/shield_advanced_protection_in_associated_elastic_ips/shield_advanced_protection_in_associated_elastic_ips_test.py
+++ b/tests/providers/aws/services/shield/shield_advanced_protection_in_associated_elastic_ips/shield_advanced_protection_in_associated_elastic_ips_test.py
@@ -3,10 +3,10 @@ from unittest import mock
 from boto3 import client
 from mock import patch
 from moto import mock_ec2
-from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.shield.shield_service import Protection
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_EU_WEST_1,
     set_mocked_aws_audit_info,
 )
@@ -61,7 +61,7 @@ class Test_shield_advanced_protection_in_associated_elastic_ips:
         ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
         resp = ec2_client.allocate_address(Domain="vpc", Address="127.38.43.222")
         allocation_id = resp["AllocationId"]
-        elastic_ip_arn = f"arn:aws:ec2:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:eip-allocation/{allocation_id}"
+        elastic_ip_arn = f"arn:aws:ec2:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:eip-allocation/{allocation_id}"
 
         # Shield Client
         shield_client = mock.MagicMock
@@ -114,7 +114,7 @@ class Test_shield_advanced_protection_in_associated_elastic_ips:
         ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
         resp = ec2_client.allocate_address(Domain="vpc", Address="127.38.43.222")
         allocation_id = resp["AllocationId"]
-        elastic_ip_arn = f"arn:aws:ec2:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:eip-allocation/{allocation_id}"
+        elastic_ip_arn = f"arn:aws:ec2:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:eip-allocation/{allocation_id}"
 
         # Shield Client
         shield_client = mock.MagicMock
@@ -158,7 +158,7 @@ class Test_shield_advanced_protection_in_associated_elastic_ips:
         ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
         resp = ec2_client.allocate_address(Domain="vpc", Address="127.38.43.222")
         allocation_id = resp["AllocationId"]
-        _ = f"arn:aws:ec2:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:eip-allocation/{allocation_id}"
+        _ = f"arn:aws:ec2:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:eip-allocation/{allocation_id}"
 
         # Shield Client
         shield_client = mock.MagicMock

--- a/tests/providers/aws/services/shield/shield_advanced_protection_in_classic_load_balancers/shield_advanced_protection_in_classic_load_balancers_test.py
+++ b/tests/providers/aws/services/shield/shield_advanced_protection_in_classic_load_balancers/shield_advanced_protection_in_classic_load_balancers_test.py
@@ -2,10 +2,10 @@ from unittest import mock
 
 from boto3 import client, resource
 from moto import mock_ec2, mock_elb
-from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.shield.shield_service import Protection
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_EU_WEST_1,
     set_mocked_aws_audit_info,
 )
@@ -62,7 +62,7 @@ class Test_shield_advanced_protection_in_classic_load_balancers:
             Scheme="internet-facing",
             SecurityGroups=[security_group.id],
         )
-        elb_arn = f"arn:aws:elasticloadbalancing:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:loadbalancer/{elb_name}"
+        elb_arn = f"arn:aws:elasticloadbalancing:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:loadbalancer/{elb_name}"
 
         # Shield Client
         shield_client = mock.MagicMock
@@ -130,7 +130,7 @@ class Test_shield_advanced_protection_in_classic_load_balancers:
             Scheme="internet-facing",
             SecurityGroups=[security_group.id],
         )
-        elb_arn = f"arn:aws:elasticloadbalancing:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:loadbalancer/{elb_name}"
+        elb_arn = f"arn:aws:elasticloadbalancing:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:loadbalancer/{elb_name}"
 
         # Shield Client
         shield_client = mock.MagicMock
@@ -189,7 +189,7 @@ class Test_shield_advanced_protection_in_classic_load_balancers:
             Scheme="internet-facing",
             SecurityGroups=[security_group.id],
         )
-        _ = f"arn:aws:elasticloadbalancing:{AWS_REGION_EU_WEST_1}:{DEFAULT_ACCOUNT_ID}:loadbalancer/{elb_name}"
+        _ = f"arn:aws:elasticloadbalancing:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:loadbalancer/{elb_name}"
 
         # Shield Client
         shield_client = mock.MagicMock

--- a/tests/providers/aws/services/shield/shield_advanced_protection_in_cloudfront_distributions/shield_advanced_protection_in_cloudfront_distributions_test.py
+++ b/tests/providers/aws/services/shield/shield_advanced_protection_in_cloudfront_distributions/shield_advanced_protection_in_cloudfront_distributions_test.py
@@ -1,10 +1,11 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.cloudfront.cloudfront_service import Distribution
 from prowler.providers.aws.services.shield.shield_service import Protection
-from tests.providers.aws.audit_info_utils import AWS_REGION_EU_WEST_1
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 
 class Test_shield_advanced_protection_in_cloudfront_distributions:
@@ -36,7 +37,7 @@ class Test_shield_advanced_protection_in_cloudfront_distributions:
         cloudfront_client = mock.MagicMock
         distribution_id = "EDFDVBD632BHDS5"
         distribution_arn = (
-            f"arn:aws:cloudfront::{DEFAULT_ACCOUNT_ID}:distribution/{distribution_id}"
+            f"arn:aws:cloudfront::{AWS_ACCOUNT_NUMBER}:distribution/{distribution_id}"
         )
         cloudfront_client.distributions = {
             distribution_id: Distribution(
@@ -92,7 +93,7 @@ class Test_shield_advanced_protection_in_cloudfront_distributions:
         cloudfront_client = mock.MagicMock
         distribution_id = "EDFDVBD632BHDS5"
         distribution_arn = (
-            f"arn:aws:cloudfront::{DEFAULT_ACCOUNT_ID}:distribution/{distribution_id}"
+            f"arn:aws:cloudfront::{AWS_ACCOUNT_NUMBER}:distribution/{distribution_id}"
         )
         cloudfront_client.distributions = {
             distribution_id: Distribution(
@@ -139,7 +140,7 @@ class Test_shield_advanced_protection_in_cloudfront_distributions:
         cloudfront_client = mock.MagicMock
         distribution_id = "EDFDVBD632BHDS5"
         distribution_arn = (
-            f"arn:aws:cloudfront::{DEFAULT_ACCOUNT_ID}:distribution/{distribution_id}"
+            f"arn:aws:cloudfront::{AWS_ACCOUNT_NUMBER}:distribution/{distribution_id}"
         )
         cloudfront_client.distributions = {
             distribution_id: Distribution(

--- a/tests/providers/aws/services/shield/shield_advanced_protection_in_global_accelerators/shield_advanced_protection_in_global_accelerators_test.py
+++ b/tests/providers/aws/services/shield/shield_advanced_protection_in_global_accelerators/shield_advanced_protection_in_global_accelerators_test.py
@@ -1,12 +1,13 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.globalaccelerator.globalaccelerator_service import (
     Accelerator,
 )
 from prowler.providers.aws.services.shield.shield_service import Protection
-from tests.providers.aws.audit_info_utils import AWS_REGION_EU_WEST_1
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+)
 
 
 class Test_shield_advanced_protection_in_global_accelerators:
@@ -38,7 +39,7 @@ class Test_shield_advanced_protection_in_global_accelerators:
         globalaccelerator_client = mock.MagicMock
         accelerator_name = "1234abcd-abcd-1234-abcd-1234abcdefgh"
         accelerator_id = "1234abcd-abcd-1234-abcd-1234abcdefgh"
-        accelerator_arn = f"arn:aws:globalaccelerator::{DEFAULT_ACCOUNT_ID}:accelerator/{accelerator_id}"
+        accelerator_arn = f"arn:aws:globalaccelerator::{AWS_ACCOUNT_NUMBER}:accelerator/{accelerator_id}"
         globalaccelerator_client.accelerators = {
             accelerator_name: Accelerator(
                 arn=accelerator_arn,
@@ -93,7 +94,7 @@ class Test_shield_advanced_protection_in_global_accelerators:
         globalaccelerator_client = mock.MagicMock
         accelerator_name = "1234abcd-abcd-1234-abcd-1234abcdefgh"
         accelerator_id = "1234abcd-abcd-1234-abcd-1234abcdefgh"
-        accelerator_arn = f"arn:aws:globalaccelerator::{DEFAULT_ACCOUNT_ID}:accelerator/{accelerator_id}"
+        accelerator_arn = f"arn:aws:globalaccelerator::{AWS_ACCOUNT_NUMBER}:accelerator/{accelerator_id}"
         globalaccelerator_client.accelerators = {
             accelerator_name: Accelerator(
                 arn=accelerator_arn,
@@ -139,7 +140,7 @@ class Test_shield_advanced_protection_in_global_accelerators:
         globalaccelerator_client = mock.MagicMock
         accelerator_name = "1234abcd-abcd-1234-abcd-1234abcdefgh"
         accelerator_id = "1234abcd-abcd-1234-abcd-1234abcdefgh"
-        accelerator_arn = f"arn:aws:globalaccelerator::{DEFAULT_ACCOUNT_ID}:accelerator/{accelerator_id}"
+        accelerator_arn = f"arn:aws:globalaccelerator::{AWS_ACCOUNT_NUMBER}:accelerator/{accelerator_id}"
         globalaccelerator_client.accelerators = {
             accelerator_name: Accelerator(
                 arn=accelerator_arn,

--- a/tests/providers/aws/services/shield/shield_service_test.py
+++ b/tests/providers/aws/services/shield/shield_service_test.py
@@ -1,9 +1,9 @@
 import botocore
 from mock import patch
-from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.shield.shield_service import Shield
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_EU_WEST_1,
     set_mocked_aws_audit_info,
 )
@@ -20,7 +20,7 @@ def mock_make_api_call(self, operation_name, kwarg):
                 {
                     "Id": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
                     "Name": "Protection for CloudFront distribution",
-                    "ResourceArn": f"arn:aws:cloudfront::{DEFAULT_ACCOUNT_ID}:distribution/E198WC25FXOWY8",
+                    "ResourceArn": f"arn:aws:cloudfront::{AWS_ACCOUNT_NUMBER}:distribution/E198WC25FXOWY8",
                 }
             ]
         }
@@ -68,7 +68,7 @@ class Test_Shield_Service:
         protection_name = "Protection for CloudFront distribution"
         cloudfront_distribution_id = "E198WC25FXOWY8"
         resource_arn = (
-            f"arn:aws:cloudfront::{DEFAULT_ACCOUNT_ID}:distribution/{cloudfront_distribution_id}",
+            f"arn:aws:cloudfront::{AWS_ACCOUNT_NUMBER}:distribution/{cloudfront_distribution_id}",
         )
 
         assert shield.protections

--- a/tests/providers/aws/services/ssm/ssm_document_secrets/ssm_document_secrets_test.py
+++ b/tests/providers/aws/services/ssm/ssm_document_secrets/ssm_document_secrets_test.py
@@ -1,9 +1,10 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.ssm.ssm_service import Document
-from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+)
 
 
 class Test_ssm_documents_secrets:
@@ -27,8 +28,8 @@ class Test_ssm_documents_secrets:
     def test_document_with_secrets(self):
         ssm_client = mock.MagicMock
         document_name = "test-document"
-        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:document/{document_name}"
-        ssm_client.audited_account = DEFAULT_ACCOUNT_ID
+        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:document/{document_name}"
+        ssm_client.audited_account = AWS_ACCOUNT_NUMBER
         ssm_client.documents = {
             document_name: Document(
                 arn=document_arn,
@@ -63,8 +64,8 @@ class Test_ssm_documents_secrets:
     def test_document_no_secrets(self):
         ssm_client = mock.MagicMock
         document_name = "test-document"
-        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:document/{document_name}"
-        ssm_client.audited_account = DEFAULT_ACCOUNT_ID
+        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:document/{document_name}"
+        ssm_client.audited_account = AWS_ACCOUNT_NUMBER
         ssm_client.documents = {
             document_name: Document(
                 arn=document_arn,

--- a/tests/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public_test.py
+++ b/tests/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public_test.py
@@ -1,9 +1,10 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.ssm.ssm_service import Document
-from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+)
 
 
 class Test_ssm_documents_set_as_public:
@@ -27,8 +28,8 @@ class Test_ssm_documents_set_as_public:
     def test_document_public(self):
         ssm_client = mock.MagicMock
         document_name = "test-document"
-        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:document/{document_name}"
-        ssm_client.audited_account = DEFAULT_ACCOUNT_ID
+        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:document/{document_name}"
+        ssm_client.audited_account = AWS_ACCOUNT_NUMBER
         ssm_client.documents = {
             document_name: Document(
                 arn=document_arn,
@@ -62,8 +63,8 @@ class Test_ssm_documents_set_as_public:
     def test_document_not_public(self):
         ssm_client = mock.MagicMock
         document_name = "test-document"
-        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:document/{document_name}"
-        ssm_client.audited_account = DEFAULT_ACCOUNT_ID
+        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:document/{document_name}"
+        ssm_client.audited_account = AWS_ACCOUNT_NUMBER
         ssm_client.documents = {
             document_name: Document(
                 arn=document_arn,

--- a/tests/providers/aws/services/ssm/ssm_managed_compliant_patching/ssm_managed_compliant_patching_test.py
+++ b/tests/providers/aws/services/ssm/ssm_managed_compliant_patching/ssm_managed_compliant_patching_test.py
@@ -1,12 +1,13 @@
 from unittest import mock
 
-from moto.core import DEFAULT_ACCOUNT_ID
-
 from prowler.providers.aws.services.ssm.ssm_service import (
     ComplianceResource,
     ResourceStatus,
 )
-from tests.providers.aws.audit_info_utils import AWS_REGION_US_EAST_1
+from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+)
 
 
 class Test_ssm_managed_compliant_patching:
@@ -30,7 +31,7 @@ class Test_ssm_managed_compliant_patching:
     def test_compliance_resources_compliant(self):
         ssm_client = mock.MagicMock
         instance_id = "i-1234567890abcdef0"
-        ssm_client.audited_account = DEFAULT_ACCOUNT_ID
+        ssm_client.audited_account = AWS_ACCOUNT_NUMBER
         ssm_client.compliance_resources = {
             instance_id: ComplianceResource(
                 id="i-1234567890abcdef0",
@@ -63,7 +64,7 @@ class Test_ssm_managed_compliant_patching:
     def test_compliance_resources_non_compliant(self):
         ssm_client = mock.MagicMock
         instance_id = "i-1234567890abcdef0"
-        ssm_client.audited_account = DEFAULT_ACCOUNT_ID
+        ssm_client.audited_account = AWS_ACCOUNT_NUMBER
         ssm_client.compliance_resources = {
             instance_id: ComplianceResource(
                 id="i-1234567890abcdef0",

--- a/tests/providers/aws/services/ssm/ssm_service_test.py
+++ b/tests/providers/aws/services/ssm/ssm_service_test.py
@@ -4,10 +4,10 @@ import botocore
 import yaml
 from boto3 import client
 from moto import mock_ssm
-from moto.core import DEFAULT_ACCOUNT_ID
 
 from prowler.providers.aws.services.ssm.ssm_service import SSM, ResourceStatus
 from tests.providers.aws.audit_info_utils import (
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_audit_info,
 )
@@ -169,12 +169,12 @@ class Test_SSM_Service:
         ssm_client.modify_document_permission(
             Name=ssm_document_name,
             PermissionType="Share",
-            AccountIdsToAdd=[DEFAULT_ACCOUNT_ID],
+            AccountIdsToAdd=[AWS_ACCOUNT_NUMBER],
         )
 
         ssm = SSM(set_mocked_aws_audit_info([AWS_REGION_US_EAST_1]))
 
-        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{DEFAULT_ACCOUNT_ID}:document/{ssm_document_name}"
+        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:document/{ssm_document_name}"
 
         assert len(ssm.documents) == 1
         assert ssm.documents
@@ -186,7 +186,7 @@ class Test_SSM_Service:
             {"Key": "test", "Value": "test"},
         ]
         assert ssm.documents[document_arn].content == yaml.safe_load(ssm_document_yaml)
-        assert ssm.documents[document_arn].account_owners == [DEFAULT_ACCOUNT_ID]
+        assert ssm.documents[document_arn].account_owners == [AWS_ACCOUNT_NUMBER]
 
     @mock_ssm
     def test__list_resource_compliance_summaries__(self):


### PR DESCRIPTION
### Description

Refactor to use the `AWS_ACCOUNT_NUMBER` instead of the `moto.DEFAULT_ACCOUNT_ID`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
