### PR TITLE
fix(generate_regional_clients): Global is not needed anymore

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -152,17 +152,18 @@ def input_role_mfa_token_and_code() -> tuple[str]:
 
 
 def generate_regional_clients(
-    service: str, audit_info: AWS_Audit_Info, global_service: bool = False
+    service: str,
+    audit_info: AWS_Audit_Info,
 ) -> dict:
+    """generate_regional_clients returns a dict with the following format for the given service:
+
+    Example:
+        {"eu-west-1": boto3_service_client}
+    """
     try:
         regional_clients = {}
         service_regions = get_available_aws_service_regions(service, audit_info)
-        # Check if it is global service to gather only one region
-        if global_service:
-            if service_regions:
-                if audit_info.profile_region in service_regions:
-                    service_regions = [audit_info.profile_region]
-                service_regions = service_regions[:1]
+
         for region in service_regions:
             regional_client = audit_info.audit_session.client(
                 service, region_name=region, config=audit_info.session_config

--- a/prowler/providers/aws/lib/service/service.py
+++ b/prowler/providers/aws/lib/service/service.py
@@ -34,9 +34,7 @@ class AWSService:
 
         # Generate Regional Clients
         if not global_service:
-            self.regional_clients = generate_regional_clients(
-                self.service, audit_info, global_service
-            )
+            self.regional_clients = generate_regional_clients(self.service, audit_info)
 
         # Get a single region and client if the service needs it (e.g. AWS Global Service)
         # We cannot include this within an else because some services needs both the regional_clients

--- a/prowler/providers/aws/services/eks/eks_service.py
+++ b/prowler/providers/aws/services/eks/eks_service.py
@@ -4,7 +4,6 @@ from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
-from prowler.providers.aws.aws_provider import generate_regional_clients
 from prowler.providers.aws.lib.service.service import AWSService
 
 
@@ -13,7 +12,6 @@ class EKS(AWSService):
     def __init__(self, audit_info):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
         self.clusters = []
         self.__threading_call__(self.__list_clusters__)
         self.__describe_cluster__(self.regional_clients)

--- a/prowler/providers/aws/services/fms/fms_service.py
+++ b/prowler/providers/aws/services/fms/fms_service.py
@@ -5,8 +5,6 @@ from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
 from prowler.providers.aws.lib.service.service import AWSService
 
-# from prowler.providers.aws.aws_provider import generate_regional_clients
-
 
 ################## FMS
 class FMS(AWSService):

--- a/tests/providers/aws/audit_info_utils.py
+++ b/tests/providers/aws/audit_info_utils.py
@@ -3,6 +3,11 @@ from boto3 import session
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 from prowler.providers.common.models import Audit_Metadata
 
+# Root AWS Account
+AWS_ACCOUNT_NUMBER = "123456789012"
+AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+
+# Commercial Regions
 AWS_REGION_US_EAST_1 = "us-east-1"
 AWS_REGION_US_EAST_1_AZA = "us-east-1a"
 AWS_REGION_US_EAST_1_AZB = "us-east-1b"
@@ -12,10 +17,22 @@ AWS_REGION_EU_WEST_1_AZB = "eu-west-1b"
 AWS_REGION_EU_WEST_2 = "eu-west-2"
 AWS_REGION_EU_SOUTH_2 = "eu-south-2"
 AWS_REGION_US_WEST_2 = "us-west-2"
-AWS_PARTITION = "aws"
-AWS_ACCOUNT_NUMBER = "123456789012"
-AWS_ACCOUNT_ARN = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+AWS_REGION_US_EAST_2 = "us-east-2"
+
+# China Regions
+AWS_REGION_CHINA_NORHT_1 = "cn-north-1"
+
+# Gov Cloud Regions
+AWS_REGION_GOV_CLOUD_US_EAST_1 = "us-gov-east-1"
+
+# Iso Regions
+AWS_REGION_ISO_GLOBAL = "aws-iso-global"
+
+# AWS Partitions
 AWS_COMMERCIAL_PARTITION = "aws"
+AWS_GOV_CLOUD_PARTITION = "aws-us-gov"
+AWS_CHINA_PARTITION = "aws-cn"
+AWS_ISO_PARTITION = "aws-iso"
 
 
 # Mocked AWS Audit Info
@@ -23,6 +40,7 @@ def set_mocked_aws_audit_info(
     audited_regions: [str] = [],
     audited_account: str = AWS_ACCOUNT_NUMBER,
     audited_account_arn: str = AWS_ACCOUNT_ARN,
+    audited_partition: str = AWS_COMMERCIAL_PARTITION,
     expected_checks: [str] = [],
     profile_region: str = None,
     audit_config: dict = {},
@@ -38,7 +56,7 @@ def set_mocked_aws_audit_info(
         audited_account=audited_account,
         audited_account_arn=audited_account_arn,
         audited_user_id=None,
-        audited_partition=AWS_PARTITION,
+        audited_partition=audited_partition,
         audited_identity_arn=None,
         profile=None,
         profile_region=profile_region,

--- a/tests/providers/aws/audit_info_utils.py
+++ b/tests/providers/aws/audit_info_utils.py
@@ -1,6 +1,6 @@
 from boto3 import session
 
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.providers.aws.lib.audit_info.models import AWS_Assume_Role, AWS_Audit_Info
 from prowler.providers.common.models import Audit_Metadata
 
 # Root AWS Account
@@ -45,14 +45,17 @@ def set_mocked_aws_audit_info(
     profile_region: str = None,
     audit_config: dict = {},
     ignore_unused_services: bool = False,
+    assumed_role_info: AWS_Assume_Role = None,
+    audit_session: session.Session = session.Session(
+        profile_name=None,
+        botocore_session=None,
+    ),
+    original_session: session.Session = None,
 ):
     audit_info = AWS_Audit_Info(
         session_config=None,
-        original_session=None,
-        audit_session=session.Session(
-            profile_name=None,
-            botocore_session=None,
-        ),
+        original_session=original_session,
+        audit_session=audit_session,
         audited_account=audited_account,
         audited_account_arn=audited_account_arn,
         audited_user_id=None,
@@ -61,7 +64,7 @@ def set_mocked_aws_audit_info(
         profile=None,
         profile_region=profile_region,
         credentials=None,
-        assumed_role_info=None,
+        assumed_role_info=assumed_role_info,
         audited_regions=audited_regions,
         organizations_metadata=None,
         audit_resources=[],

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -459,44 +459,6 @@ class Test_AWS_Provider:
 
         assert set(generate_regional_clients_response.keys()) == set(audited_regions)
 
-    def test_generate_regional_clients_global_service(self):
-        # New Boto3 session with the previously create user
-        session = boto3.session.Session(
-            region_name=AWS_REGION,
-        )
-        audited_regions = ["eu-west-1", AWS_REGION]
-        profile_region = AWS_REGION
-        # Fulfil the input session object for Prowler
-        audit_info = AWS_Audit_Info(
-            session_config=None,
-            original_session=None,
-            audit_session=session,
-            audited_account=None,
-            audited_account_arn=None,
-            audited_partition="aws",
-            audited_identity_arn=None,
-            audited_user_id=None,
-            profile=None,
-            profile_region=profile_region,
-            credentials=None,
-            assumed_role_info=None,
-            audited_regions=audited_regions,
-            organizations_metadata=None,
-            audit_resources=None,
-            mfa_enabled=False,
-            audit_metadata=Audit_Metadata(
-                services_scanned=0,
-                expected_checks=[],
-                completed_checks=0,
-                audit_progress=0,
-            ),
-        )
-        generate_regional_clients_response = generate_regional_clients(
-            "route53", audit_info, global_service=True
-        )
-
-        assert list(generate_regional_clients_response.keys()) == [profile_region]
-
     def test_generate_regional_clients_cn_partition(self):
         # New Boto3 session with the previously create user
         session = boto3.session.Session(
@@ -529,7 +491,7 @@ class Test_AWS_Provider:
             ),
         )
         generate_regional_clients_response = generate_regional_clients(
-            "shield", audit_info, global_service=True
+            "shield", audit_info
         )
 
         # Shield does not exist in China

--- a/tests/providers/aws/lib/service/service_test.py
+++ b/tests/providers/aws/lib/service/service_test.py
@@ -43,3 +43,20 @@ class Test_AWSService:
         )
         assert service.region == AWS_REGION_US_EAST_1
         assert service.client.__class__.__name__ == service_name.upper()
+
+    def test_AWSService_init_global_service(self):
+        service_name = "cloudfront"
+        audit_info = set_mocked_aws_audit_info()
+        service = AWSService(service_name, audit_info, global_service=True)
+
+        assert service.audit_info == audit_info
+        assert service.audited_account == AWS_ACCOUNT_NUMBER
+        assert service.audited_account_arn == AWS_ACCOUNT_ARN
+        assert service.audited_partition == AWS_COMMERCIAL_PARTITION
+        assert service.audit_resources == []
+        assert service.audited_checks == []
+        assert service.session == audit_info.audit_session
+        assert service.service == service_name
+        assert not hasattr(service, "regional_clients")
+        assert service.region == AWS_REGION_US_EAST_1
+        assert service.client.__class__.__name__ == "CloudFront"

--- a/tests/providers/aws/lib/service/service_test.py
+++ b/tests/providers/aws/lib/service/service_test.py
@@ -11,7 +11,7 @@ AWS_PARTITION = "aws"
 AWS_REGION = "us-east-1"
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}

--- a/tests/providers/aws/services/accessanalyzer/accessanalyzer_service_test.py
+++ b/tests/providers/aws/services/accessanalyzer/accessanalyzer_service_test.py
@@ -58,7 +58,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}

--- a/tests/providers/aws/services/acm/acm_service_test.py
+++ b/tests/providers/aws/services/acm/acm_service_test.py
@@ -80,7 +80,7 @@ def mock_make_api_call(self, operation_name, kwargs):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}

--- a/tests/providers/aws/services/appstream/appstream_service_test.py
+++ b/tests/providers/aws/services/appstream/appstream_service_test.py
@@ -51,7 +51,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(service, region_name=AWS_REGION)
     regional_client.region = AWS_REGION
     return {AWS_REGION: regional_client}

--- a/tests/providers/aws/services/athena/athena_service_test.py
+++ b/tests/providers/aws/services/athena/athena_service_test.py
@@ -39,7 +39,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled_test.py
@@ -13,7 +13,7 @@ from tests.providers.aws.audit_info_utils import (
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_US_EAST_1
     )

--- a/tests/providers/aws/services/awslambda/awslambda_service_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_service_test.py
@@ -46,7 +46,7 @@ def mock_request_get(_):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client_eu_west_1 = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/backup/backup_service_test.py
+++ b/tests/providers/aws/services/backup/backup_service_test.py
@@ -58,7 +58,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/cloudformation/cloudformation_service_test.py
+++ b/tests/providers/aws/services/cloudformation/cloudformation_service_test.py
@@ -119,7 +119,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/codeartifact/codeartifact_service_test.py
+++ b/tests/providers/aws/services/codeartifact/codeartifact_service_test.py
@@ -86,7 +86,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/codebuild/codebuild_service_test.py
+++ b/tests/providers/aws/services/codebuild/codebuild_service_test.py
@@ -38,7 +38,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/directoryservice/directoryservice_service_test.py
+++ b/tests/providers/aws/services/directoryservice/directoryservice_service_test.py
@@ -103,7 +103,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/dlm/dlm_service_test.py
+++ b/tests/providers/aws/services/dlm/dlm_service_test.py
@@ -38,7 +38,7 @@ def mock_make_api_call(self, operation_name, kwargs):
     return make_api_call(self, operation_name, kwargs)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_US_EAST_1
     )

--- a/tests/providers/aws/services/documentdb/documentdb_service_test.py
+++ b/tests/providers/aws/services/documentdb/documentdb_service_test.py
@@ -58,7 +58,7 @@ def mock_make_api_call(self, operation_name, kwargs):
     return make_api_call(self, operation_name, kwargs)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_US_EAST_1
     )

--- a/tests/providers/aws/services/drs/drs_service_test.py
+++ b/tests/providers/aws/services/drs/drs_service_test.py
@@ -41,7 +41,7 @@ def mock_make_api_call(self, operation_name, kwargs):
     return make_api_call(self, operation_name, kwargs)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_US_EAST_1
     )

--- a/tests/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot_test.py
@@ -11,7 +11,7 @@ from tests.providers.aws.audit_info_utils import (
 )
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_US_EAST_1
     )

--- a/tests/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted_test.py
@@ -11,7 +11,7 @@ from tests.providers.aws.audit_info_utils import (
 )
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_US_EAST_1
     )

--- a/tests/providers/aws/services/ec2/ec2_ebs_volume_snapshots_exists/ec2_ebs_volume_snapshots_exists_test.py
+++ b/tests/providers/aws/services/ec2/ec2_ebs_volume_snapshots_exists/ec2_ebs_volume_snapshots_exists_test.py
@@ -13,7 +13,7 @@ from tests.providers.aws.audit_info_utils import (
 )
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_US_EAST_1
     )

--- a/tests/providers/aws/services/ecr/ecr_service_test.py
+++ b/tests/providers/aws/services/ecr/ecr_service_test.py
@@ -82,7 +82,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/ecs/ecs_service_test.py
+++ b/tests/providers/aws/services/ecs/ecs_service_test.py
@@ -10,7 +10,7 @@ from tests.providers.aws.audit_info_utils import (
 )
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/efs/efs_service_test.py
+++ b/tests/providers/aws/services/efs/efs_service_test.py
@@ -41,7 +41,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/eks/eks_service_test.py
+++ b/tests/providers/aws/services/eks/eks_service_test.py
@@ -16,7 +16,7 @@ cidr_block_subnet_1 = "10.0.0.0/22"
 cidr_block_subnet_2 = "10.0.4.0/22"
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/elasticache/elasticache_service_test.py
+++ b/tests/providers/aws/services/elasticache/elasticache_service_test.py
@@ -81,7 +81,7 @@ def mock_make_api_call(self, operation_name, kwargs):
     return make_api_call(self, operation_name, kwargs)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_US_EAST_1
     )

--- a/tests/providers/aws/services/emr/emr_service_test.py
+++ b/tests/providers/aws/services/emr/emr_service_test.py
@@ -36,7 +36,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/glacier/glacier_service_test.py
+++ b/tests/providers/aws/services/glacier/glacier_service_test.py
@@ -62,7 +62,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/glue/glue_service_test.py
+++ b/tests/providers/aws/services/glue/glue_service_test.py
@@ -104,7 +104,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_US_EAST_1
     )

--- a/tests/providers/aws/services/guardduty/guardduty_service_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_service_test.py
@@ -50,7 +50,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/inspector2/inspector2_service_test.py
+++ b/tests/providers/aws/services/inspector2/inspector2_service_test.py
@@ -69,7 +69,7 @@ def mock_make_api_call(self, operation_name, kwargs):
     return make_api_call(self, operation_name, kwargs)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/macie/macie_service_test.py
+++ b/tests/providers/aws/services/macie/macie_service_test.py
@@ -32,7 +32,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )
@@ -47,7 +47,6 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_Macie_Service:
-
     # Test Macie Client
     def test__get_client__(self):
         macie = Macie(set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1]))

--- a/tests/providers/aws/services/neptune/neptune_service_test.py
+++ b/tests/providers/aws/services/neptune/neptune_service_test.py
@@ -69,7 +69,7 @@ def mock_make_api_call(self, operation_name, kwargs):
     return make_api_call(self, operation_name, kwargs)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_US_EAST_1
     )
@@ -84,7 +84,6 @@ def mock_generate_regional_clients(service, audit_info, _):
 # Patch every AWS call using Boto3
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_Neptune_Service:
-
     # Test Neptune Service
     @mock_neptune
     def test_service(self):

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_service_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_service_test.py
@@ -51,7 +51,7 @@ def mock_make_api_call(self, operation_name, kwargs):
     return make_api_call(self, operation_name, kwargs)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_US_EAST_1
     )

--- a/tests/providers/aws/services/opensearch/opensearch_service_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_test.py
@@ -91,7 +91,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )
@@ -105,7 +105,6 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_OpenSearchService_Service:
-
     # Test OpenSearchService Service
     def test_service(self):
         audit_info = set_mocked_aws_audit_info([])

--- a/tests/providers/aws/services/redshift/redshift_service_test.py
+++ b/tests/providers/aws/services/redshift/redshift_service_test.py
@@ -46,7 +46,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )
@@ -60,7 +60,6 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_Redshift_Service:
-
     # Test Redshift Service
     def test_service(self):
         audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])

--- a/tests/providers/aws/services/resourceexplorer2/resourceexplorer2_service_test.py
+++ b/tests/providers/aws/services/resourceexplorer2/resourceexplorer2_service_test.py
@@ -30,7 +30,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
+++ b/tests/providers/aws/services/sagemaker/sagemaker_service_test.py
@@ -90,7 +90,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )
@@ -104,7 +104,6 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_SageMaker_Service:
-
     # Test SageMaker Service
     def test_service(self):
         audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])

--- a/tests/providers/aws/services/secretsmanager/secretsmanager_service_test.py
+++ b/tests/providers/aws/services/secretsmanager/secretsmanager_service_test.py
@@ -15,7 +15,7 @@ from tests.providers.aws.audit_info_utils import (
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )
@@ -29,7 +29,6 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_SecretsManager_Service:
-
     # Test SecretsManager Client
     @mock_secretsmanager
     def test__get_client__(self):

--- a/tests/providers/aws/services/securityhub/securityhub_service_test.py
+++ b/tests/providers/aws/services/securityhub/securityhub_service_test.py
@@ -44,7 +44,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )
@@ -59,7 +59,6 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_SecurityHub_Service:
-
     # Test SecurityHub Client
     def test__get_client__(self):
         security_hub = SecurityHub(set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1]))

--- a/tests/providers/aws/services/shield/shield_advanced_protection_in_associated_elastic_ips/shield_advanced_protection_in_associated_elastic_ips_test.py
+++ b/tests/providers/aws/services/shield/shield_advanced_protection_in_associated_elastic_ips/shield_advanced_protection_in_associated_elastic_ips_test.py
@@ -13,7 +13,7 @@ from tests.providers.aws.audit_info_utils import (
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/shield/shield_advanced_protection_in_internet_facing_load_balancers/shield_advanced_protection_in_internet_facing_load_balancers_test.py
+++ b/tests/providers/aws/services/shield/shield_advanced_protection_in_internet_facing_load_balancers/shield_advanced_protection_in_internet_facing_load_balancers_test.py
@@ -12,7 +12,7 @@ from tests.providers.aws.audit_info_utils import (
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )

--- a/tests/providers/aws/services/sns/sns_service_test.py
+++ b/tests/providers/aws/services/sns/sns_service_test.py
@@ -37,7 +37,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )
@@ -51,7 +51,6 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_SNS_Service:
-
     # Test SNS Service
     def test_service(self):
         audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])

--- a/tests/providers/aws/services/sqs/sqs_service_test.py
+++ b/tests/providers/aws/services/sqs/sqs_service_test.py
@@ -39,7 +39,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )
@@ -53,7 +53,6 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_SQS_Service:
-
     # Test SQS Service
     def test_service(self):
         audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])

--- a/tests/providers/aws/services/ssm/ssm_service_test.py
+++ b/tests/providers/aws/services/ssm/ssm_service_test.py
@@ -66,7 +66,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_US_EAST_1
     )

--- a/tests/providers/aws/services/ssmincidents/ssmincidents_service_test.py
+++ b/tests/providers/aws/services/ssmincidents/ssmincidents_service_test.py
@@ -54,7 +54,7 @@ def mock_make_api_call(self, operation_name, kwargs):
     return make_api_call(self, operation_name, kwargs)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_US_EAST_1
     )

--- a/tests/providers/aws/services/waf/waf_service_test.py
+++ b/tests/providers/aws/services/waf/waf_service_test.py
@@ -31,7 +31,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 
 
 # Mock generate_regional_clients()
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )
@@ -46,7 +46,6 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_WAF_Service:
-
     # Test WAF Service
     def test_service(self):
         # WAF client for this test class

--- a/tests/providers/aws/services/wellarchitected/wellarchitected_service_test.py
+++ b/tests/providers/aws/services/wellarchitected/wellarchitected_service_test.py
@@ -40,7 +40,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )
@@ -54,7 +54,6 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_WellArchitected_Service:
-
     # Test WellArchitected Service
     def test_service(self):
         audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])

--- a/tests/providers/aws/services/workspaces/workspaces_service_test.py
+++ b/tests/providers/aws/services/workspaces/workspaces_service_test.py
@@ -35,7 +35,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
-def mock_generate_regional_clients(service, audit_info, _):
+def mock_generate_regional_clients(service, audit_info):
     regional_client = audit_info.audit_session.client(
         service, region_name=AWS_REGION_EU_WEST_1
     )
@@ -49,7 +49,6 @@ def mock_generate_regional_clients(service, audit_info, _):
     new=mock_generate_regional_clients,
 )
 class Test_WorkSpaces_Service:
-
     # Test WorkSpaces Service
     def test_service(self):
         audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])


### PR DESCRIPTION
### Description

Since the creation of the `AWS_Service` class the function `generate_regional_clients` is not called anymore for global services.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
