### PR TITLE
fix(cloudtrail): Handle UnsupportedOperationException

### DIFF
--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -140,7 +140,16 @@ class Cloudtrail(AWSService):
                                 error.response["Error"]["Code"]
                                 == "InsightNotEnabledException"
                             ):
-                                continue
+                                logger.warning(
+                                    f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                                )
+                            elif (
+                                error.response["Error"]["Code"]
+                                == "UnsupportedOperationException"
+                            ):
+                                logger.warning(
+                                    f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                                )
                             else:
                                 logger.error(
                                     f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"


### PR DESCRIPTION
### Description

Handle `UnsupportedOperationException` CloudTrail GetInsightSelectors.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
