### PR TITLE
chore(elb): Improve status in elbv2_insecure_ssl_ciphers

### DIFF
--- a/prowler/providers/aws/services/elbv2/elbv2_insecure_ssl_ciphers/elbv2_insecure_ssl_ciphers.py
+++ b/prowler/providers/aws/services/elbv2/elbv2_insecure_ssl_ciphers/elbv2_insecure_ssl_ciphers.py
@@ -33,7 +33,7 @@ class elbv2_insecure_ssl_ciphers(Check):
                     and listener.ssl_policy not in secure_ssl_policies
                 ):
                     report.status = "FAIL"
-                    report.status_extended = f"ELBv2 {lb.name} has listeners with insecure SSL protocols or ciphers."
+                    report.status_extended = f"ELBv2 {lb.name} has listeners with insecure SSL protocols or ciphers ({listener.ssl_policy})."
 
             findings.append(report)
 


### PR DESCRIPTION
More descriptive status_extended message that includes the offending SSL policy

### Context

Just adding more info to the output so it's quicker to investigate the finding


### Description

Added the SSL Policy name in brackets to the status_extended message


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
