### PR TITLE
fix(threading): Improved threading for the AWS Service

### DIFF
--- a/prowler/providers/aws/lib/service/service.py
+++ b/prowler/providers/aws/lib/service/service.py
@@ -1,5 +1,5 @@
 import threading
-
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from prowler.providers.aws.aws_provider import (
     generate_regional_clients,
     get_default_region,
@@ -47,11 +47,19 @@ class AWSService:
     def __get_session__(self):
         return self.session
 
-    def __threading_call__(self, call):
-        threads = []
-        for regional_client in self.regional_clients.values():
-            threads.append(threading.Thread(target=call, args=(regional_client,)))
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
+    def __threading_call__(self, call, iterator=None, max_workers=10):
+        # Use the provided iterator, or default to self.regional_clients
+        items = iterator if iterator is not None else self.regional_clients.values()
+
+        # Using ThreadPoolExecutor for managing threads
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            # Submit tasks to the executor
+            futures = [executor.submit(call, item) for item in items]
+
+            # Wait for all tasks to complete
+            for future in as_completed(futures):
+                try:
+                    future.result()  # Raises exceptions from the thread, if any
+                except Exception as e:
+                    # Handle exceptions if necessary
+                    pass  # Replace 'pass' with any additional exception handling logic

--- a/prowler/providers/aws/lib/service/service.py
+++ b/prowler/providers/aws/lib/service/service.py
@@ -7,6 +7,8 @@ from prowler.providers.aws.aws_provider import (
 )
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
 
+MAX_WORKERS = 10
+
 
 class AWSService:
     """The AWSService class offers a parent class for each AWS Service to generate:
@@ -47,7 +49,7 @@ class AWSService:
         self.client = self.session.client(self.service, self.region)
 
         # Thread pool for __threading_call__
-        self.thread_pool = ThreadPoolExecutor(max_workers=10)
+        self.thread_pool = ThreadPoolExecutor(max_workers=MAX_WORKERS)
 
     def __get_session__(self):
         return self.session

--- a/prowler/providers/aws/lib/service/service.py
+++ b/prowler/providers/aws/lib/service/service.py
@@ -44,6 +44,11 @@ class AWSService:
         self.region = get_default_region(self.service, audit_info)
         self.client = self.session.client(self.service, self.region)
 
+        # Thread pool for __threading_call__
+        self.thread_pool = ThreadPoolExecutor(
+                                max_workers=10
+                            )
+
     def __get_session__(self):
         return self.session
 
@@ -68,7 +73,7 @@ class AWSService:
         # Using ThreadPoolExecutor for managing threads
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             # Submit tasks to the executor
-            futures = [executor.submit(call, item) for item in items]
+            futures = [self.thread_pool.submit(call, item) for item in items]
 
             # Wait for all tasks to complete
             for future in as_completed(futures):

--- a/prowler/providers/aws/lib/service/service.py
+++ b/prowler/providers/aws/lib/service/service.py
@@ -1,10 +1,11 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from prowler.lib.logger import logger
 from prowler.providers.aws.aws_provider import (
     generate_regional_clients,
     get_default_region,
 )
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.lib.logger import logger
 
 
 class AWSService:
@@ -12,6 +13,7 @@ class AWSService:
     - AWS Regional Clients
     - Shared information like the account ID and ARN, the the AWS partition and the checks audited
     - AWS Session
+    - Thread pool for the __threading_call__
     - Also handles if the AWS Service is Global
     """
 
@@ -45,9 +47,7 @@ class AWSService:
         self.client = self.session.client(self.service, self.region)
 
         # Thread pool for __threading_call__
-        self.thread_pool = ThreadPoolExecutor(
-                                max_workers=10
-                            )
+        self.thread_pool = ThreadPoolExecutor(max_workers=10)
 
     def __get_session__(self):
         return self.session
@@ -59,14 +59,19 @@ class AWSService:
         item_count = len(items)
 
         # Trim leading and trailing underscores from the call's name
-        call_name = call.__name__.strip('_')
+        call_name = call.__name__.strip("_")
         # Add Capitalization
-        call_name = ' '.join([x.capitalize() for x in call_name.split('_')])
+        call_name = " ".join([x.capitalize() for x in call_name.split("_")])
 
         # Print a message based on the call's name, and if its regional or processing a list of items
-        logger.info(
-            f"{self.service.upper()} - Starting threads for '{call_name}' function {f'across {item_count} regions...' if iterator is None else f'to process {item_count} items...'}"
-        )
+        if iterator is None:
+            logger.info(
+                f"{self.service.upper()} - Starting threads for '{call_name}' function across {item_count} regions..."
+            )
+        else:
+            logger.info(
+                f"{self.service.upper()} - Starting threads for '{call_name}' function to process {item_count} items..."
+            )
 
         # Submit tasks to the thread pool
         futures = [self.thread_pool.submit(call, item) for item in items]
@@ -75,6 +80,6 @@ class AWSService:
         for future in as_completed(futures):
             try:
                 future.result()  # Raises exceptions from the thread, if any
-            except Exception as e:
+            except Exception:
                 # Handle exceptions if necessary
-                pass  # Replace 'pass' with any additional exception handling logic
+                pass  # Replace 'pass' with any additional exception handling logic. Currently handled within the called function

--- a/prowler/providers/aws/lib/service/service.py
+++ b/prowler/providers/aws/lib/service/service.py
@@ -64,10 +64,9 @@ class AWSService:
         call_name = ' '.join([x.capitalize() for x in call_name.split('_')])
 
         # Print a message based on the call's name, and if its regional or processing a list of items
-        if iterator == None:
-            logger.info(f"{self.service.upper()} - Starting threads for '{call_name}' function across {item_count} regions...")
-        else:
-            logger.info(f"{self.service.upper()} - Starting threads for '{call_name}' function to process {item_count} items...")
+        logger.info(
+            f"{self.service.upper()} - Starting threads for '{call_name}' function {f'across {item_count} regions...' if iterator is None else f'to process {item_count} items...'}"
+        )
 
         # Submit tasks to the thread pool
         futures = [self.thread_pool.submit(call, item) for item in items]

--- a/prowler/providers/aws/lib/service/service.py
+++ b/prowler/providers/aws/lib/service/service.py
@@ -69,16 +69,13 @@ class AWSService:
         else:
             logger.info(f"{self.service.upper()} - Starting threads for '{call_name}' function to process {item_count} items...")
 
+        # Submit tasks to the thread pool
+        futures = [self.thread_pool.submit(call, item) for item in items]
 
-        # Using ThreadPoolExecutor for managing threads
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            # Submit tasks to the executor
-            futures = [self.thread_pool.submit(call, item) for item in items]
-
-            # Wait for all tasks to complete
-            for future in as_completed(futures):
-                try:
-                    future.result()  # Raises exceptions from the thread, if any
-                except Exception as e:
-                    # Handle exceptions if necessary
-                    pass  # Replace 'pass' with any additional exception handling logic
+        # Wait for all tasks to complete
+        for future in as_completed(futures):
+            try:
+                future.result()  # Raises exceptions from the thread, if any
+            except Exception as e:
+                # Handle exceptions if necessary
+                pass  # Replace 'pass' with any additional exception handling logic

--- a/prowler/providers/aws/lib/service/service.py
+++ b/prowler/providers/aws/lib/service/service.py
@@ -52,7 +52,7 @@ class AWSService:
     def __get_session__(self):
         return self.session
 
-    def __threading_call__(self, call, iterator=None, max_workers=10):
+    def __threading_call__(self, call, iterator=None):
         # Use the provided iterator, or default to self.regional_clients
         items = iterator if iterator is not None else self.regional_clients.values()
         # Determine the total count for logging

--- a/prowler/providers/aws/lib/service/service.py
+++ b/prowler/providers/aws/lib/service/service.py
@@ -1,10 +1,10 @@
-import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from prowler.providers.aws.aws_provider import (
     generate_regional_clients,
     get_default_region,
 )
 from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
+from prowler.lib.logger import logger
 
 
 class AWSService:
@@ -50,6 +50,20 @@ class AWSService:
     def __threading_call__(self, call, iterator=None, max_workers=10):
         # Use the provided iterator, or default to self.regional_clients
         items = iterator if iterator is not None else self.regional_clients.values()
+        # Determine the total count for logging
+        item_count = len(items)
+
+        # Trim leading and trailing underscores from the call's name
+        call_name = call.__name__.strip('_')
+        # Add Capitalization
+        call_name = ' '.join([x.capitalize() for x in call_name.split('_')])
+
+        # Print a message based on the call's name, and if its regional or processing a list of items
+        if iterator == None:
+            logger.info(f"{self.service.upper()} - Starting threads for '{call_name}' function across {item_count} regions...")
+        else:
+            logger.info(f"{self.service.upper()} - Starting threads for '{call_name}' function to process {item_count} items...")
+
 
         # Using ThreadPoolExecutor for managing threads
         with ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -41,7 +41,6 @@ class EC2(AWSService):
         self.__threading_call__(self.__describe_addresses__)
 
     def __describe_instances__(self, regional_client):
-        logger.info("EC2 - Describing EC2 Instances...")
         try:
             describe_instances_paginator = regional_client.get_paginator(
                 "describe_instances"
@@ -106,7 +105,6 @@ class EC2(AWSService):
             )
 
     def __describe_security_groups__(self, regional_client):
-        logger.info("EC2 - Describing Security Groups...")
         try:
             describe_security_groups_paginator = regional_client.get_paginator(
                 "describe_security_groups"
@@ -155,7 +153,6 @@ class EC2(AWSService):
             )
 
     def __describe_network_acls__(self, regional_client):
-        logger.info("EC2 - Describing Network ACLs...")
         try:
             describe_network_acls_paginator = regional_client.get_paginator(
                 "describe_network_acls"
@@ -186,7 +183,6 @@ class EC2(AWSService):
             )
 
     def __describe_snapshots__(self, regional_client):
-        logger.info("EC2 - Describing Snapshots...")
         try:
             snapshots_in_region = False
             describe_snapshots_paginator = regional_client.get_paginator(
@@ -220,7 +216,6 @@ class EC2(AWSService):
             )
 
     def __get_snapshot_public__(self, snapshot):
-        logger.info("EC2 - Getting snapshot volume attribute permissions...")
         try:
             regional_client = self.regional_clients[snapshot.region]
             snapshot_public = regional_client.describe_snapshot_attribute(
@@ -244,7 +239,6 @@ class EC2(AWSService):
             )
 
     def __describe_public_network_interfaces__(self, regional_client):
-        logger.info("EC2 - Describing Network Interfaces...")
         try:
             # Get Network Interfaces with Public IPs
             describe_network_interfaces_paginator = regional_client.get_paginator(
@@ -271,7 +265,6 @@ class EC2(AWSService):
             )
 
     def __describe_sg_network_interfaces__(self, regional_client):
-        logger.info("EC2 - Describing Network Interfaces...")
         try:
             # Get Network Interfaces for Security Groups
             for sg in self.security_groups:
@@ -297,7 +290,6 @@ class EC2(AWSService):
             )
 
     def __get_instance_user_data__(self, instance):
-        logger.info("EC2 - Getting instance user data...")
         try:
             regional_client = self.regional_clients[instance.region]
             user_data = regional_client.describe_instance_attribute(
@@ -316,7 +308,6 @@ class EC2(AWSService):
             )
 
     def __describe_images__(self, regional_client):
-        logger.info("EC2 - Describing Images...")
         try:
             for image in regional_client.describe_images(Owners=["self"])["Images"]:
                 arn = f"arn:{self.audited_partition}:ec2:{regional_client.region}:{self.audited_account}:image/{image['ImageId']}"
@@ -339,7 +330,6 @@ class EC2(AWSService):
             )
 
     def __describe_volumes__(self, regional_client):
-        logger.info("EC2 - Describing Volumes...")
         try:
             describe_volumes_paginator = regional_client.get_paginator(
                 "describe_volumes"
@@ -365,7 +355,6 @@ class EC2(AWSService):
             )
 
     def __describe_addresses__(self, regional_client):
-        logger.info("EC2 - Describing Elastic IPs...")
         try:
             for address in regional_client.describe_addresses()["Addresses"]:
                 public_ip = None
@@ -397,7 +386,6 @@ class EC2(AWSService):
             )
 
     def __get_ebs_encryption_by_default__(self, regional_client):
-        logger.info("EC2 - Get EBS Encryption By Default...")
         try:
             volumes_in_region = False
             for volume in self.volumes:

--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -27,7 +27,7 @@ class EC2(AWSService):
         self.volumes_with_snapshots = {}
         self.regions_with_snapshots = {}
         self.__threading_call__(self.__describe_snapshots__)
-        self.__threading_call__(self.__get_snapshot_public__, self.snapshots)
+        self.__threading_call__(self.__determine_public_snapshots__, self.snapshots)
         self.network_interfaces = []
         self.__threading_call__(self.__describe_public_network_interfaces__)
         self.__threading_call__(self.__describe_sg_network_interfaces__)
@@ -36,9 +36,9 @@ class EC2(AWSService):
         self.volumes = []
         self.__threading_call__(self.__describe_volumes__)
         self.ebs_encryption_by_default = []
-        self.__threading_call__(self.__get_ebs_encryption_by_default__)
+        self.__threading_call__(self.__get_ebs_encryption_settings__)
         self.elastic_ips = []
-        self.__threading_call__(self.__describe_addresses__)
+        self.__threading_call__(self.__describe_ec2_addresses__)
 
     def __describe_instances__(self, regional_client):
         try:
@@ -215,7 +215,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_snapshot_public__(self, snapshot):
+    def __determine_public_snapshots__(self, snapshot):
         try:
             regional_client = self.regional_clients[snapshot.region]
             snapshot_public = regional_client.describe_snapshot_attribute(
@@ -354,7 +354,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_addresses__(self, regional_client):
+    def __describe_ec2_addresses__(self, regional_client):
         try:
             for address in regional_client.describe_addresses()["Addresses"]:
                 public_ip = None
@@ -385,7 +385,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_ebs_encryption_by_default__(self, regional_client):
+    def __get_ebs_encryption_settings__(self, regional_client):
         try:
             volumes_in_region = False
             for volume in self.volumes:

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -28,6 +28,7 @@ class S3(AWSService):
         self.__threading_call__(self.__get_bucket_tagging__)
 
     # In the S3 service we override the "__threading_call__" method because we spawn a process per bucket instead of per region
+    # TODO: Replace the above function with the service __threading_call__ using the buckets as the iterator
     def __threading_call__(self, call):
         threads = []
         for bucket in self.buckets:


### PR DESCRIPTION
### Context

Improved the threading implementation for the `AWSService` base class to allow for an optional `iterator` parameter to be passed to it. It will then create a thread per item. This can be used in cases when we are not just listing resources in a region - such as collecting user data for each EC2 instance or collecting details for each EBS snapshot.

Also changed the implementation to use a thread pool.

### Description

Added an optional iterator for when threading needs to be implemented against a list of items, not just the regional clients

Also changed from using the `threading` lib to the `concurrent.futures.ThreadPoolExecutor` thread pool. It manages a pool of reusable threads and efficiently handles a large number of tasks. This is to reduce the overhead of creating a thread once-per-iterator-item.

The behavior is nearly identical to the previous implementation when an `iterator` parameter isnt passed to the __threading_call__ function (except for the max_workers set to 10, which may be less than the number of concurrent threads before when 1 was created per region. This could be increased to ~20 (this is approximately the max regions I think?) to replicate the concurrency achieved before). The back-off strategy implemented by boto for retries should avoid the API rate-limiting being an issue. We could also increase the max retries to 5 by default for added safety. 

But now an additional `iterator` parameter can be passed. I have implemented this for the functions that collect information for the snapshots and ec2 instance user data.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
