### PR TITLE
chore(actions prowler4): add prowler 4.0 branch to actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master", prowler-2, prowler-3.0-dev ]
+    branches: [ "master", "prowler-4.0-dev" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ "master", "prowler-4.0-dev" ]
   schedule:
     - cron: '00 12 * * *'
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - "master"
+      - "prowler-4.0-dev"
   pull_request:
     branches:
       - "master"
+      - "prowler-4.0-dev"
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Context

We need PR/CodeQL actions to be launched when a PR to  branch `prowler-4.0` is created


### Description

Add branch to triggers for that actions


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
