### PR TITLE
fix(gcp): improve logging messages

### DIFF
--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+from colorama import Fore, Style
 from google import auth
 from googleapiclient import discovery
 
@@ -88,5 +89,8 @@ class GCP_Provider:
         except Exception as error:
             logger.error(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+            print(
+                f"\n{Fore.YELLOW}Cloud Resource Manager API {Style.RESET_ALL}has not been used before or it is disabled.\nEnable it by visiting https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/ then retry."
             )
             return []

--- a/prowler/providers/gcp/lib/service/service.py
+++ b/prowler/providers/gcp/lib/service/service.py
@@ -62,7 +62,7 @@ class GCPService:
                     project_ids.append(project_id)
                 else:
                     print(
-                        f"\n{Fore.YELLOW}{self.service} API {Style.RESET_ALL}has not been used in project {project_id} before or it is disabled.\nEnable it by visiting https://console.developers.google.com/apis/api/dataproc.googleapis.com/overview?project={project_id} then retry."
+                        f"\n{Fore.YELLOW}{self.service} API {Style.RESET_ALL}has not been used in project {project_id} before or it is disabled.\nEnable it by visiting https://console.developers.google.com/apis/api/{self.service}.googleapis.com/overview?project={project_id} then retry."
                     )
             except Exception as error:
                 logger.error(


### PR DESCRIPTION
### Context

If an user does not have the `cloudresourcemanager` API enabled, it will throw an ERROR log and abort the execution of Prowler and he may not see it.

### Description

Adding a print showing that the `cloudresourcemanager` API is not enabled and also solves a typo in the other print.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
