### PR TITLE
docs(cloudshell): Add missing steps to workaround

### DIFF
--- a/docs/tutorials/aws/cloudshell.md
+++ b/docs/tutorials/aws/cloudshell.md
@@ -31,9 +31,10 @@ The limited storage that AWS CloudShell provides for the user's home directory c
 ```shell
 git clone https://github.com/prowler-cloud/prowler.git
 cd prowler
-git checkout master
 pip install poetry
 mkdir /tmp/pypoetry
 poetry config cache-dir /tmp/pypoetry
 poetry shell
+poetry install
+python prowler.py -v
 ```


### PR DESCRIPTION
### Context

In issue #3187 I provided incomplete steps to @jfagoagas for my workaround which were transferred as-is via #3190. This PR adds the missing commands to get a complete workaround.


### Description

Remove the git checkout command as it was superfluous. Add 2 more commands that mirror the rest of the steps needed.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
