### PR TITLE
docs(cloudshell): Update AWS CloudShell installation steps

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -136,26 +136,16 @@ Prowler is available as a project in [PyPI](https://pypi.org/project/prowler-clo
 
 === "AWS CloudShell"
 
-    Prowler can be easely executed in AWS CloudShell but it has some prerequsites to be able to to so. AWS CloudShell is a container running with `Amazon Linux release 2 (Karoo)` that comes with Python 3.7, since Prowler requires Python >= 3.9 we need to first install a newer version of Python. Follow the steps below to successfully execute Prowler v3 in AWS CloudShell:
+    After the migration of AWS CloudShell from Amazon Linux 2 to Amazon Linux 2023 [1](https://aws.amazon.com/about-aws/whats-new/2023/12/aws-cloudshell-migrated-al2023/) [2](https://docs.aws.amazon.com/cloudshell/latest/userguide/cloudshell-AL2023-migration.html), there is no longer a need to manually compile Python 3.9 as it's already included in AL2023. Prowler can thus be easily installed following the Generic method of installation via pip. Follow the steps below to successfully execute Prowler v3 in AWS CloudShell:
 
     _Requirements_:
 
-    * First install all dependences and then Python, in this case we need to compile it because there is not a package available at the time this document is written:
-    ```
-    sudo yum -y install gcc openssl-devel bzip2-devel libffi-devel
-    wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz
-    tar zxf Python-3.9.16.tgz
-    cd Python-3.9.16/
-    ./configure --enable-optimizations
-    sudo make altinstall
-    python3.9 --version
-    cd
-    ```
+    * Open AWS CloudShell `bash`.
+
     _Commands_:
 
-    * Once Python 3.9 is available we can install Prowler from pip:
     ```
-    pip3.9 install prowler
+    pip install prowler
     prowler -v
     ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,7 +136,7 @@ Prowler is available as a project in [PyPI](https://pypi.org/project/prowler-clo
 
 === "AWS CloudShell"
 
-    After the migration of AWS CloudShell from Amazon Linux 2 to Amazon Linux 2023 [1](https://aws.amazon.com/about-aws/whats-new/2023/12/aws-cloudshell-migrated-al2023/) [2](https://docs.aws.amazon.com/cloudshell/latest/userguide/cloudshell-AL2023-migration.html), there is no longer a need to manually compile Python 3.9 as it's already included in AL2023. Prowler can thus be easily installed following the Generic method of installation via pip. Follow the steps below to successfully execute Prowler v3 in AWS CloudShell:
+    After the migration of AWS CloudShell from Amazon Linux 2 to Amazon Linux 2023 [[1]](https://aws.amazon.com/about-aws/whats-new/2023/12/aws-cloudshell-migrated-al2023/) [2](https://docs.aws.amazon.com/cloudshell/latest/userguide/cloudshell-AL2023-migration.html), there is no longer a need to manually compile Python 3.9 as it's already included in AL2023. Prowler can thus be easily installed following the Generic method of installation via pip. Follow the steps below to successfully execute Prowler v3 in AWS CloudShell:
 
     _Requirements_:
 

--- a/docs/tutorials/aws/cloudshell.md
+++ b/docs/tutorials/aws/cloudshell.md
@@ -1,14 +1,17 @@
 # AWS CloudShell
 
-After the migration of AWS CloudShell from Amazon Linux 2 to Amazon Linux 2023 [1](https://aws.amazon.com/about-aws/whats-new/2023/12/aws-cloudshell-migrated-al2023/) [2](https://docs.aws.amazon.com/cloudshell/latest/userguide/cloudshell-AL2023-migration.html), there is no longer a need to manually compile Python 3.9 as it's already included in AL2023. Prowler can thus be easily installed following the Generic method of installation via pip. Follow the steps below to successfully execute Prowler v3 in AWS CloudShell:
+## Installation
+After the migration of AWS CloudShell from Amazon Linux 2 to Amazon Linux 2023 [[1]](https://aws.amazon.com/about-aws/whats-new/2023/12/aws-cloudshell-migrated-al2023/) [[2]](https://docs.aws.amazon.com/cloudshell/latest/userguide/cloudshell-AL2023-migration.html), there is no longer a need to manually compile Python 3.9 as it's already included in AL2023. Prowler can thus be easily installed following the Generic method of installation via pip. Follow the steps below to successfully execute Prowler v3 in AWS CloudShell:
 ```shell
 pip install prowler
 prowler -v
 ```
 
-- To download the results from AWS CloudShell, select Actions -> Download File and add the full path of each file. For the CSV file it will be something like `/home/cloudshell-user/output/prowler-output-123456789012-20221220191331.csv`
+## Download Files
 
-## Clone the Prowler Github Repository in CloudShell
+To download the results from AWS CloudShell, select Actions -> Download File and add the full path of each file. For the CSV file it will be something like `/home/cloudshell-user/output/prowler-output-123456789012-20221220191331.csv`
+
+## Clone Prowler from Github
 
 The limited storage that AWS CloudShell provides for the user's home directory causes issues when installing the poetry dependencies to run Prowler from GitHub. Here is a workaround:
 ```shell

--- a/docs/tutorials/aws/cloudshell.md
+++ b/docs/tutorials/aws/cloudshell.md
@@ -2,8 +2,8 @@
 
 After the migration of AWS CloudShell from Amazon Linux 2 to Amazon Linux 2023 [1](https://aws.amazon.com/about-aws/whats-new/2023/12/aws-cloudshell-migrated-al2023/) [2](https://docs.aws.amazon.com/cloudshell/latest/userguide/cloudshell-AL2023-migration.html), there is no longer a need to manually compile Python 3.9 as it's already included in AL2023. Prowler can thus be easily installed following the Generic method of installation via pip. Follow the steps below to successfully execute Prowler v3 in AWS CloudShell:
 ```shell
+pip install prowler
 prowler -v
-prowler
 ```
 
 - To download the results from AWS CloudShell, select Actions -> Download File and add the full path of each file. For the CSV file it will be something like `/home/cloudshell-user/output/prowler-output-123456789012-20221220191331.csv`

--- a/docs/tutorials/aws/cloudshell.md
+++ b/docs/tutorials/aws/cloudshell.md
@@ -1,24 +1,7 @@
 # AWS CloudShell
 
-Prowler can be easily executed in AWS CloudShell but it has some prerequisites to be able to to so. AWS CloudShell is a container running with `Amazon Linux release 2 (Karoo)` that comes with Python 3.7, since Prowler requires Python >= 3.9 we need to first install a newer version of Python. Follow the steps below to successfully execute Prowler v3 in AWS CloudShell:
-
-- First install all dependences and then Python, in this case we need to compile it because there is not a package available at the time this document is written:
-```
-sudo yum -y install gcc openssl-devel bzip2-devel libffi-devel
-wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz
-tar zxf Python-3.9.16.tgz
-cd Python-3.9.16/
-./configure --enable-optimizations
-sudo make altinstall
-python3.9 --version
-cd
-```
-- Once Python 3.9 is available we can install Prowler from pip:
-```
-pip3.9 install prowler
-```
-- Now enjoy Prowler:
-```
+After the migration of AWS CloudShell from Amazon Linux 2 to Amazon Linux 2023 [1](https://aws.amazon.com/about-aws/whats-new/2023/12/aws-cloudshell-migrated-al2023/) [2](https://docs.aws.amazon.com/cloudshell/latest/userguide/cloudshell-AL2023-migration.html), there is no longer a need to manually compile Python 3.9 as it's already included in AL2023. Prowler can thus be easily installed following the Generic method of installation via pip. Follow the steps below to successfully execute Prowler v3 in AWS CloudShell:
+```shell
 prowler -v
 prowler
 ```


### PR DESCRIPTION
### Context

The current installation instructions became obsolete after the recent migration of AWS CloudShell to Amazon Linux 2023 [1](https://aws.amazon.com/about-aws/whats-new/2023/12/aws-cloudshell-migrated-al2023/) [2](https://docs.aws.amazon.com/cloudshell/latest/userguide/cloudshell-AL2023-migration.html).


### Description

Remove steps to manually compile and install Python 3.9 from source. Replicate steps from the Generic installation method via pip.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
