### PR TITLE
feat(securityhub): Send only FAILs but storing all in the output files

### DIFF
--- a/prowler/providers/aws/lib/arguments/arguments.py
+++ b/prowler/providers/aws/lib/arguments/arguments.py
@@ -84,6 +84,11 @@ def init_parser(self):
         action="store_true",
         help="Skip updating previous findings of Prowler in Security Hub",
     )
+    aws_security_hub_subparser.add_argument(
+        "--send-sh-only-fails",
+        action="store_true",
+        help="Send only Prowler failed findings to SecurityHub",
+    )
     # AWS Quick Inventory
     aws_quick_inventory_subparser = aws_parser.add_argument_group("Quick Inventory")
     aws_quick_inventory_subparser.add_argument(

--- a/prowler/providers/aws/lib/security_hub/security_hub.py
+++ b/prowler/providers/aws/lib/security_hub/security_hub.py
@@ -29,7 +29,9 @@ def prepare_security_hub_findings(
             continue
 
         # Handle quiet mode
-        if output_options.is_quiet and finding.status != "FAIL":
+        if (
+            output_options.is_quiet or output_options.send_sh_only_fails
+        ) and finding.status != "FAIL":
             continue
 
         # Get the finding region

--- a/prowler/providers/common/outputs.py
+++ b/prowler/providers/common/outputs.py
@@ -134,6 +134,7 @@ class Aws_Output_Options(Provider_Output_Options):
 
         # Security Hub Outputs
         self.security_hub_enabled = arguments.security_hub
+        self.send_sh_only_fails = arguments.send_sh_only_fails
         if arguments.security_hub:
             if not self.output_modes:
                 self.output_modes = ["json-asff"]

--- a/prowler/providers/common/outputs.py
+++ b/prowler/providers/common/outputs.py
@@ -69,7 +69,8 @@ class Provider_Output_Options:
         if arguments.output_directory:
             if not isdir(arguments.output_directory):
                 if arguments.output_modes:
-                    makedirs(arguments.output_directory)
+                    # exist_ok is set to True not to raise FileExistsError
+                    makedirs(arguments.output_directory, exist_ok=True)
 
 
 class Azure_Output_Options(Provider_Output_Options):

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -882,6 +882,12 @@ class Test_Parser:
         parsed = self.parser.parse(command)
         assert parsed.skip_sh_update
 
+    def test_aws_parser_send_only_fail(self):
+        argument = "--send-sh-only-fails"
+        command = [prowler_command, argument]
+        parsed = self.parser.parse(command)
+        assert parsed.send_sh_only_fails
+
     def test_aws_parser_quick_inventory_short(self):
         argument = "-i"
         command = [prowler_command, argument]

--- a/tests/providers/common/common_outputs_test.py
+++ b/tests/providers/common/common_outputs_test.py
@@ -96,6 +96,7 @@ class Test_Common_Output_Options:
         arguments.shodan = "test-api-key"
         arguments.only_logs = False
         arguments.unix_timestamp = False
+        arguments.send_sh_only_fails = True
 
         audit_info = self.set_mocked_aws_audit_info()
         allowlist_file = ""
@@ -105,6 +106,7 @@ class Test_Common_Output_Options:
         )
         assert isinstance(output_options, Aws_Output_Options)
         assert output_options.security_hub_enabled
+        assert output_options.send_sh_only_fails
         assert output_options.is_quiet
         assert output_options.output_modes == ["html", "csv", "json", "json-asff"]
         assert output_options.output_directory == arguments.output_directory
@@ -160,6 +162,7 @@ class Test_Common_Output_Options:
         arguments.shodan = "test-api-key"
         arguments.only_logs = False
         arguments.unix_timestamp = False
+        arguments.send_sh_only_fails = True
 
         # Mock AWS Audit Info
         audit_info = self.set_mocked_aws_audit_info()
@@ -171,6 +174,7 @@ class Test_Common_Output_Options:
         )
         assert isinstance(output_options, Aws_Output_Options)
         assert output_options.security_hub_enabled
+        assert output_options.send_sh_only_fails
         assert output_options.is_quiet
         assert output_options.output_modes == ["html", "csv", "json", "json-asff"]
         assert output_options.output_directory == arguments.output_directory


### PR DESCRIPTION
### Description

Send only FAILs to Security Hub but storing all in the output files using a new `--send-sh-only-fails` flag.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
