### PR TITLE
chore(s3 bucket input validation): validates input bucket

### DIFF
--- a/prowler/providers/aws/lib/arguments/arguments.py
+++ b/prowler/providers/aws/lib/arguments/arguments.py
@@ -1,4 +1,5 @@
 from argparse import ArgumentTypeError, Namespace
+from re import search
 
 from prowler.providers.aws.aws_provider import get_aws_available_regions
 from prowler.providers.aws.lib.arn.arn import arn_type
@@ -99,6 +100,7 @@ def init_parser(self):
         "-B",
         "--output-bucket",
         nargs="?",
+        type=validate_bucket,
         default=None,
         help="Custom output bucket, requires -M <mode> and it can work also with -o flag.",
     )
@@ -106,6 +108,7 @@ def init_parser(self):
         "-D",
         "--output-bucket-no-assume",
         nargs="?",
+        type=validate_bucket,
         default=None,
         help="Same as -B but do not use the assumed role credentials to put objects to the bucket, instead uses the initial credentials.",
     )
@@ -185,3 +188,13 @@ def validate_arguments(arguments: Namespace) -> tuple[bool, str]:
             return (False, "To use -I/-T options -R option is needed")
 
     return (True, "")
+
+
+def validate_bucket(bucket_name):
+    """validate_bucket validates that the input bucket_name is valid"""
+    if search("(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$", bucket_name):
+        return bucket_name
+    else:
+        raise ArgumentTypeError(
+            "Bucket name must be valid (https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)"
+        )

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -5,6 +5,7 @@ import pytest
 from mock import patch
 
 from prowler.lib.cli.parser import ProwlerArgumentParser
+from prowler.providers.aws.lib.arguments.arguments import validate_bucket
 from prowler.providers.azure.lib.arguments.arguments import validate_azure_region
 
 prowler_command = "prowler"
@@ -1132,3 +1133,28 @@ class Test_Parser:
             match=f"Region {invalid_region} not allowed, allowed regions are {' '.join(expected_regions)}",
         ):
             validate_azure_region(invalid_region)
+
+    def test_validate_bucket_invalid_bucket_names(self):
+        bad_bucket_names = [
+            "xn--bucket-name",
+            "mrryadfpcwlscicvnrchmtmyhwrvzkgfgdxnlnvaaummnywciixnzvycnzmhhpwb",
+            "192.168.5.4",
+            "bucket-name-s3alias",
+            "bucket-name-s3alias-",
+            "bucket-n$ame",
+            "bu",
+        ]
+        for bucket_name in bad_bucket_names:
+            with pytest.raises(ArgumentTypeError) as argument_error:
+                validate_bucket(bucket_name)
+
+            assert argument_error.type == ArgumentTypeError
+            assert (
+                argument_error.value.args[0]
+                == "Bucket name must be valid (https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)"
+            )
+
+    def test_validate_bucket_valid_bucket_names(self):
+        valid_bucket_names = ["bucket-name" "test" "test-test-test"]
+        for bucket_name in valid_bucket_names:
+            assert validate_bucket(bucket_name) == bucket_name


### PR DESCRIPTION
### Context

When using s3 bucket as output Prowler was not testing if input was a correct bucket name


### Description

Test when receiving the argument that is valid


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
