### PR TITLE
fix(gcp): fix UnknownApiNameOrVersion error

### DIFF
--- a/prowler/providers/gcp/lib/service/service.py
+++ b/prowler/providers/gcp/lib/service/service.py
@@ -27,7 +27,7 @@ class GCPService:
         self.default_project_id = audit_info.default_project_id
         self.region = region
         self.client = self.__generate_client__(
-            service, api_version, audit_info.credentials
+            self.service, api_version, audit_info.credentials
         )
         # Only project ids that have their API enabled will be scanned
         self.project_ids = self.__is_api_active__(audit_info.project_ids)


### PR DESCRIPTION
### Context

We were not converting the service name to lower case so the API URLs were failing in some environments.
For example, the Compute Service API was case sensitive.

### Description

Fix `UnknownApiNameOrVersion` error by assuring the service name to be in lower case.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
