### PR TITLE
fix(trustedadvisor): solve trustedadvisor check metadata

### DIFF
--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_premium_support_plan_subscribed/trustedadvisor_premium_support_plan_subscribed.metadata.json
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_premium_support_plan_subscribed/trustedadvisor_premium_support_plan_subscribed.metadata.json
@@ -7,7 +7,7 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:iam::AWS_ACCOUNT_NUMBER:root",
   "Severity": "low",
-  "ResourceType": "",
+  "ResourceType": "Other",
   "Description": "Check if a Premium support plan is subscribed.",
   "Risk": "Ensure that the appropriate support level is enabled for the necessary AWS accounts. For example, if an AWS account is being used to host production systems and environments, it is highly recommended that the minimum AWS Support Plan should be Business.",
   "RelatedUrl": "https://aws.amazon.com/premiumsupport/plans/",


### PR DESCRIPTION
### Context

An empty ResourceType is giving the following Security Hub error: `data.Resources[0].Type should NOT be shorter than 1 characters`

### Description

Add Other as Resource Type for not leaving it empty.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
