### PR TITLE
feat(aws): Added AWS role session name parameter

### DIFF
--- a/docs/tutorials/aws/role-assumption.md
+++ b/docs/tutorials/aws/role-assumption.md
@@ -23,6 +23,15 @@ prowler aws -R arn:aws:iam::<account_id>:role/<role_name>
 prowler aws -T/--session-duration <seconds> -I/--external-id <external_id> -R arn:aws:iam::<account_id>:role/<role_name>
 ```
 
+## Custom Role Session Name
+
+Prowler can use your custom Role Session name with:
+```console
+prowler aws --role-session-name <role_session_name>
+```
+
+> It defaults to `ProwlerAssessmentSession`
+
 ## STS Endpoint Region
 
 If you are using Prowler in AWS regions that are not enabled by default you need to use the argument `--sts-endpoint-region` to point the AWS STS API calls `assume-role` and `get-caller-identity` to the non-default region, e.g.: `prowler aws --sts-endpoint-region eu-south-2`.

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -115,7 +115,7 @@ def assume_role(
     try:
         assume_role_arguments = {
             "RoleArn": assumed_role_info.role_arn,
-            "RoleSessionName": "ProwlerAsessmentSession",
+            "RoleSessionName": assumed_role_info.role_session_name,
             "DurationSeconds": assumed_role_info.session_duration,
         }
 

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -116,7 +116,7 @@ def assume_role(
         role_session_name = (
             assumed_role_info.role_session_name
             if assumed_role_info.role_session_name
-            else "ProwlerAsessmentSession"
+            else "ProwlerAssessmentSession"
         )
 
         assume_role_arguments = {

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -113,9 +113,15 @@ def assume_role(
     sts_endpoint_region: str = None,
 ) -> dict:
     try:
+        role_session_name = (
+            assumed_role_info.role_session_name
+            if assumed_role_info.role_session_name
+            else "ProwlerAsessmentSession"
+        )
+
         assume_role_arguments = {
             "RoleArn": assumed_role_info.role_arn,
-            "RoleSessionName": assumed_role_info.role_session_name,
+            "RoleSessionName": role_session_name,
             "DurationSeconds": assumed_role_info.session_duration,
         }
 

--- a/prowler/providers/aws/lib/arguments/arguments.py
+++ b/prowler/providers/aws/lib/arguments/arguments.py
@@ -222,7 +222,7 @@ def validate_role_session_name(session_name):
             return session_name
         else:
             raise ArgumentTypeError(
-                "Role Session Name length must be at least 2 and less than 64 characters"
+                "Role Session Name length must be at least 2 and less than or equal to 64 characters"
             )
     else:
         raise ArgumentTypeError(

--- a/prowler/providers/aws/lib/arguments/arguments.py
+++ b/prowler/providers/aws/lib/arguments/arguments.py
@@ -226,5 +226,5 @@ def validate_role_session_name(session_name):
             )
     else:
         raise ArgumentTypeError(
-            "Role Session Name characters must only consist of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-"
+            "Role Session Name must only consist of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-"
         )

--- a/prowler/providers/aws/lib/arguments/arguments.py
+++ b/prowler/providers/aws/lib/arguments/arguments.py
@@ -226,5 +226,5 @@ def validate_role_session_name(session_name):
             )
     else:
         raise ArgumentTypeError(
-            "Role Session Name must characters must only consist of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-"
+            "Role Session Name characters must only consist of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-"
         )

--- a/prowler/providers/aws/lib/arguments/arguments.py
+++ b/prowler/providers/aws/lib/arguments/arguments.py
@@ -1,5 +1,5 @@
 from argparse import ArgumentTypeError, Namespace
-from re import search, fullmatch
+from re import fullmatch, search
 
 from prowler.providers.aws.aws_provider import get_aws_available_regions
 from prowler.providers.aws.lib.arn.arn import arn_type
@@ -30,8 +30,8 @@ def init_parser(self):
     aws_auth_subparser.add_argument(
         "--role-session-name",
         nargs="?",
-        default="ProwlerAsessmentSession",
-        help="An identifier for the assumed role session. Defaults to ProwlerAsessmentSession",
+        default="ProwlerAssessmentSession",
+        help="An identifier for the assumed role session. Defaults to ProwlerAssessmentSession",
         type=validate_role_session_name,
     )
     aws_auth_subparser.add_argument(

--- a/prowler/providers/aws/lib/arguments/arguments.py
+++ b/prowler/providers/aws/lib/arguments/arguments.py
@@ -218,7 +218,7 @@ def validate_role_session_name(session_name):
     Documentation: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
     """
     if search("[\w+=,.@-]*", session_name):
-        if len(session_name) > 1 and len(session_name) < 64:
+        if len(session_name) >= 2 and len(session_name) <= 64:
             return session_name
         else:
             raise ArgumentTypeError(

--- a/prowler/providers/aws/lib/arguments/arguments.py
+++ b/prowler/providers/aws/lib/arguments/arguments.py
@@ -28,6 +28,13 @@ def init_parser(self):
         # Pending ARN validation
     )
     aws_auth_subparser.add_argument(
+        "--role-session-name",
+        nargs="?",
+        default="ProwlerAsessmentSession",
+        help="An identifier for the assumed role session. Defaults to ProwlerAsessmentSession",
+        type=validate_role_session_name,
+    )
+    aws_auth_subparser.add_argument(
         "--sts-endpoint-region",
         nargs="?",
         default=None,
@@ -202,4 +209,22 @@ def validate_bucket(bucket_name):
     else:
         raise ArgumentTypeError(
             "Bucket name must be valid (https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)"
+        )
+
+
+def validate_role_session_name(session_name):
+    """
+    validates that the role session name is valid
+    Documentation: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
+    """
+    if search("[\w+=,.@-]*", session_name):
+        if len(session_name) > 1 and len(session_name) < 64:
+            return session_name
+        else:
+            raise ArgumentTypeError(
+                "Role Session Name length must be at least 2 and less than 64 characters"
+            )
+    else:
+        raise ArgumentTypeError(
+            "Role Session Name must characters must only consist of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-"
         )

--- a/prowler/providers/aws/lib/arguments/arguments.py
+++ b/prowler/providers/aws/lib/arguments/arguments.py
@@ -1,5 +1,5 @@
 from argparse import ArgumentTypeError, Namespace
-from re import search
+from re import search, fullmatch
 
 from prowler.providers.aws.aws_provider import get_aws_available_regions
 from prowler.providers.aws.lib.arn.arn import arn_type
@@ -217,14 +217,9 @@ def validate_role_session_name(session_name):
     validates that the role session name is valid
     Documentation: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
     """
-    if search("[\w+=,.@-]*", session_name):
-        if len(session_name) >= 2 and len(session_name) <= 64:
-            return session_name
-        else:
-            raise ArgumentTypeError(
-                "Role Session Name length must be at least 2 and less than or equal to 64 characters"
-            )
+    if fullmatch("[\w+=,.@-]{2,64}", session_name):
+        return session_name
     else:
         raise ArgumentTypeError(
-            "Role Session Name must only consist of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-"
+                        "Role Session Name must be 2-64 characters long and consist only of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-"
         )

--- a/prowler/providers/aws/lib/arguments/arguments.py
+++ b/prowler/providers/aws/lib/arguments/arguments.py
@@ -221,5 +221,5 @@ def validate_role_session_name(session_name):
         return session_name
     else:
         raise ArgumentTypeError(
-                        "Role Session Name must be 2-64 characters long and consist only of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-"
+            "Role Session Name must be 2-64 characters long and consist only of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-"
         )

--- a/prowler/providers/aws/lib/audit_info/audit_info.py
+++ b/prowler/providers/aws/lib/audit_info/audit_info.py
@@ -30,6 +30,7 @@ current_audit_info = AWS_Audit_Info(
         session_duration=None,
         external_id=None,
         mfa_enabled=None,
+        role_session_name=None,
     ),
     mfa_enabled=None,
     audit_resources=None,

--- a/prowler/providers/aws/lib/audit_info/models.py
+++ b/prowler/providers/aws/lib/audit_info/models.py
@@ -20,6 +20,7 @@ class AWS_Assume_Role:
     session_duration: int
     external_id: str
     mfa_enabled: bool
+    role_session_name: str
 
 
 @dataclass

--- a/prowler/providers/common/audit_info.py
+++ b/prowler/providers/common/audit_info.py
@@ -63,7 +63,7 @@ GCP Account: {Fore.YELLOW}[{profile}]{Style.RESET_ALL}  GCP Project IDs: {Fore.Y
     def print_azure_credentials(self, audit_info: Azure_Audit_Info):
         printed_subscriptions = []
         for key, value in audit_info.identity.subscriptions.items():
-            intermediate = f"{key} : {value}"
+            intermediate = key + " : " + value
             printed_subscriptions.append(intermediate)
         report = f"""
 This report is being generated using the identity below:
@@ -85,6 +85,7 @@ Azure Identity Type: {Fore.YELLOW}[{audit_info.identity.identity_type}]{Style.RE
         current_audit_info.assumed_role_info.role_arn = input_role
         input_session_duration = arguments.get("session_duration")
         input_external_id = arguments.get("external_id")
+        input_role_session_name = arguments.get("role_session_name")
 
         # STS Endpoint Region
         sts_endpoint_region = arguments.get("sts_endpoint_region")
@@ -153,6 +154,9 @@ Azure Identity Type: {Fore.YELLOW}[{audit_info.identity.identity_type}]{Style.RE
             )
             current_audit_info.assumed_role_info.external_id = input_external_id
             current_audit_info.assumed_role_info.mfa_enabled = input_mfa
+            current_audit_info.assumed_role_info.role_session_name = (
+                input_role_session_name
+            )
 
             # Check if role arn is valid
             try:

--- a/prowler/providers/common/audit_info.py
+++ b/prowler/providers/common/audit_info.py
@@ -63,7 +63,7 @@ GCP Account: {Fore.YELLOW}[{profile}]{Style.RESET_ALL}  GCP Project IDs: {Fore.Y
     def print_azure_credentials(self, audit_info: Azure_Audit_Info):
         printed_subscriptions = []
         for key, value in audit_info.identity.subscriptions.items():
-            intermediate = key + " : " + value
+            intermediate = f"{key} : {value}"
             printed_subscriptions.append(intermediate)
         report = f"""
 This report is being generated using the identity below:

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -1017,7 +1017,7 @@ class Test_Parser:
 
     def test_aws_parser_role_session_name(self):
         argument = "--role-session-name"
-        role_session_name = "ProwlerAsessmentSession"
+        role_session_name = "ProwlerAssessmentSession"
         command = [prowler_command, argument, role_session_name]
         parsed = self.parser.parse(command)
         assert parsed.role_session_name == role_session_name

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -56,6 +56,7 @@ class Test_AWS_Provider:
                 session_duration=None,
                 external_id=None,
                 mfa_enabled=False,
+                role_session_name="ProwlerAsessmentSession",
             ),
             original_session=session,
         )
@@ -75,6 +76,7 @@ class Test_AWS_Provider:
                 session_duration=None,
                 external_id=None,
                 mfa_enabled=False,
+                role_session_name="ProwlerAsessmentSession",
             )
 
     @mock_iam
@@ -103,6 +105,7 @@ class Test_AWS_Provider:
                 session_duration=None,
                 external_id=None,
                 mfa_enabled=False,
+                role_session_name="ProwlerAsessmentSession",
             ),
             original_session=session,
             profile_region=AWS_REGION_US_EAST_1,
@@ -123,6 +126,7 @@ class Test_AWS_Provider:
                 session_duration=None,
                 external_id=None,
                 mfa_enabled=False,
+                role_session_name="ProwlerAsessmentSession",
             )
 
     @mock_iam
@@ -157,6 +161,7 @@ class Test_AWS_Provider:
                 session_duration=session_duration_seconds,
                 external_id=None,
                 mfa_enabled=True,
+                role_session_name="ProwlerAsessmentSession",
             ),
             original_session=session,
             profile_region=AWS_REGION_US_EAST_1,
@@ -235,6 +240,7 @@ class Test_AWS_Provider:
                 session_duration=session_duration_seconds,
                 external_id=None,
                 mfa_enabled=False,
+                role_session_name="ProwlerAsessmentSession",
             ),
             original_session=session,
             profile_region=AWS_REGION_US_EAST_1,
@@ -307,6 +313,7 @@ class Test_AWS_Provider:
                 session_duration=session_duration_seconds,
                 external_id=None,
                 mfa_enabled=False,
+                role_session_name="ProwlerAsessmentSession",
             ),
             original_session=session,
             profile_region=AWS_REGION_US_EAST_1,

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -32,7 +32,7 @@ class Test_AWS_Provider:
     @mock_iam
     @mock_sts
     def test_aws_provider_user_without_mfa(self):
-        # sessionName = "ProwlerAsessmentSession"
+        # sessionName = "ProwlerAssessmentSession"
         # Boto 3 client to create our user
         iam_client = boto3.client("iam", region_name=AWS_REGION_US_EAST_1)
         # IAM user
@@ -56,7 +56,7 @@ class Test_AWS_Provider:
                 session_duration=None,
                 external_id=None,
                 mfa_enabled=False,
-                role_session_name="ProwlerAsessmentSession",
+                role_session_name="ProwlerAssessmentSession",
             ),
             original_session=session,
         )
@@ -76,7 +76,7 @@ class Test_AWS_Provider:
                 session_duration=None,
                 external_id=None,
                 mfa_enabled=False,
-                role_session_name="ProwlerAsessmentSession",
+                role_session_name="ProwlerAssessmentSession",
             )
 
     @mock_iam
@@ -105,7 +105,7 @@ class Test_AWS_Provider:
                 session_duration=None,
                 external_id=None,
                 mfa_enabled=False,
-                role_session_name="ProwlerAsessmentSession",
+                role_session_name="ProwlerAssessmentSession",
             ),
             original_session=session,
             profile_region=AWS_REGION_US_EAST_1,
@@ -126,7 +126,7 @@ class Test_AWS_Provider:
                 session_duration=None,
                 external_id=None,
                 mfa_enabled=False,
-                role_session_name="ProwlerAsessmentSession",
+                role_session_name="ProwlerAssessmentSession",
             )
 
     @mock_iam
@@ -136,7 +136,7 @@ class Test_AWS_Provider:
         role_name = "test-role"
         role_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:role/{role_name}"
         session_duration_seconds = 900
-        sessionName = "ProwlerAsessmentSession"
+        sessionName = "ProwlerAssessmentSession"
 
         # Boto 3 client to create our user
         iam_client = boto3.client("iam", region_name=AWS_REGION_US_EAST_1)
@@ -161,7 +161,7 @@ class Test_AWS_Provider:
                 session_duration=session_duration_seconds,
                 external_id=None,
                 mfa_enabled=True,
-                role_session_name="ProwlerAsessmentSession",
+                role_session_name="ProwlerAssessmentSession",
             ),
             original_session=session,
             profile_region=AWS_REGION_US_EAST_1,
@@ -215,7 +215,7 @@ class Test_AWS_Provider:
         role_name = "test-role"
         role_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:role/{role_name}"
         session_duration_seconds = 900
-        sessionName = "ProwlerAsessmentSession"
+        sessionName = "ProwlerAssessmentSession"
 
         # Boto 3 client to create our user
         iam_client = boto3.client("iam", region_name=AWS_REGION_US_EAST_1)
@@ -240,7 +240,7 @@ class Test_AWS_Provider:
                 session_duration=session_duration_seconds,
                 external_id=None,
                 mfa_enabled=False,
-                role_session_name="ProwlerAsessmentSession",
+                role_session_name="ProwlerAssessmentSession",
             ),
             original_session=session,
             profile_region=AWS_REGION_US_EAST_1,
@@ -288,7 +288,7 @@ class Test_AWS_Provider:
         session_duration_seconds = 900
         AWS_REGION_US_EAST_1 = AWS_REGION_EU_WEST_1
         sts_endpoint_region = AWS_REGION_US_EAST_1
-        sessionName = "ProwlerAsessmentSession"
+        sessionName = "ProwlerAssessmentSession"
 
         # Boto 3 client to create our user
         iam_client = boto3.client("iam", region_name=AWS_REGION_US_EAST_1)
@@ -313,7 +313,7 @@ class Test_AWS_Provider:
                 session_duration=session_duration_seconds,
                 external_id=None,
                 mfa_enabled=False,
-                role_session_name="ProwlerAsessmentSession",
+                role_session_name="ProwlerAssessmentSession",
             ),
             original_session=session,
             profile_region=AWS_REGION_US_EAST_1,

--- a/tests/providers/common/audit_info_test.py
+++ b/tests/providers/common/audit_info_test.py
@@ -116,7 +116,7 @@ class Test_Set_Audit_Info:
                 session_duration=None,
                 external_id=None,
                 mfa_enabled=None,
-                role_session_name="ProwlerAsessmentSession",
+                role_session_name="ProwlerAssessmentSession",
             ),
             audited_regions=["eu-west-2", "eu-west-1"],
             organizations_metadata=None,

--- a/tests/providers/common/audit_info_test.py
+++ b/tests/providers/common/audit_info_test.py
@@ -116,6 +116,7 @@ class Test_Set_Audit_Info:
                 session_duration=None,
                 external_id=None,
                 mfa_enabled=None,
+                role_session_name="ProwlerAsessmentSession",
             ),
             audited_regions=["eu-west-2", "eu-west-1"],
             organizations_metadata=None,


### PR DESCRIPTION
### Context

Added as per this request in the prowler slack: https://prowler-workspace.slack.com/archives/C0451NDLC4X/p1704113278185009


### Description

Added a parameter to specify the RoleSessionName value passed to AWS api when performing assume-role calls.

I have not tested this myself. I have requested that the requestee tests it out.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
