### PR TITLE
fix(organizations_scp_check_deny_regions): enhance check logic

### DIFF
--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -69,8 +69,8 @@ aws:
   # AWS Organizations
   # organizations_scp_check_deny_regions
   # organizations_enabled_regions: [
-  #   'eu-central-1',
-  #   'eu-west-1',
+  #   "eu-central-1",
+  #   "eu-west-1",
   #   "us-east-1"
   # ]
   organizations_enabled_regions: []

--- a/prowler/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions.py
+++ b/prowler/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions.py
@@ -48,11 +48,12 @@ class organizations_scp_check_deny_regions(Check):
                                 and "aws:RequestedRegion"
                                 in statement["Condition"]["StringNotEquals"]
                             ):
-                                if (
-                                    organizations_enabled_regions
-                                    == statement["Condition"]["StringNotEquals"][
+                                if all(
+                                    region
+                                    in statement["Condition"]["StringNotEquals"][
                                         "aws:RequestedRegion"
                                     ]
+                                    for region in organizations_enabled_regions
                                 ):
                                     # All defined regions are restricted, we exit here, no need to continue.
                                     report.status = "PASS"
@@ -73,11 +74,12 @@ class organizations_scp_check_deny_regions(Check):
                                 and "aws:RequestedRegion"
                                 in statement["Condition"]["StringEquals"]
                             ):
-                                if (
-                                    organizations_enabled_regions
-                                    == statement["Condition"]["StringEquals"][
+                                if all(
+                                    region
+                                    in statement["Condition"]["StringEquals"][
                                         "aws:RequestedRegion"
                                     ]
+                                    for region in organizations_enabled_regions
                                 ):
                                     # All defined regions are restricted, we exit here, no need to continue.
                                     report.status = "PASS"

--- a/tests/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions_test.py
+++ b/tests/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions_test.py
@@ -9,13 +9,14 @@ from prowler.providers.aws.services.organizations.organizations_service import (
 )
 from tests.providers.aws.audit_info_utils import (
     AWS_ACCOUNT_ARN,
+    AWS_REGION_EU_CENTRAL_1,
     AWS_REGION_EU_WEST_1,
     set_mocked_aws_audit_info,
 )
 
 
 def scp_restrict_regions_with_deny():
-    return '{"Version":"2012-10-17","Statement":{"Effect":"Deny","NotAction":"s3:*","Resource":"*","Condition":{"StringNotEquals":{"aws:RequestedRegion":["eu-central-1"]}}}}'
+    return '{"Version":"2012-10-17","Statement":{"Effect":"Deny","NotAction":"s3:*","Resource":"*","Condition":{"StringNotEquals":{"aws:RequestedRegion":["eu-central-1","eu-west-1"]}}}}'
 
 
 class Test_organizations_scp_check_deny_regions:
@@ -172,6 +173,55 @@ class Test_organizations_scp_check_deny_regions:
                 assert result[0].resource_arn == response["Organization"]["Arn"]
                 assert search(
                     "restricting some AWS Regions, but not all the configured ones, please check config.",
+                    result[0].status_extended,
+                )
+                assert result[0].region == AWS_REGION_EU_WEST_1
+
+    @mock_organizations
+    def test_organization_with_scp_deny_all_regions_valid(self):
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_EU_WEST_1])
+        audit_info.audit_config = {
+            "organizations_enabled_regions": [
+                AWS_REGION_EU_WEST_1,
+                AWS_REGION_EU_CENTRAL_1,
+            ]
+        }
+        # Create Organization
+        conn = client("organizations", region_name=AWS_REGION_EU_WEST_1)
+        response = conn.create_organization()
+        # Create Policy
+        conn.create_policy(
+            Content=scp_restrict_regions_with_deny(),
+            Description="Test",
+            Name="Test",
+            Type="SERVICE_CONTROL_POLICY",
+        )
+
+        # Set config variable
+        audit_info.audit_config = {"organizations_enabled_regions": ["eu-central-1"]}
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=audit_info,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.organizations.organizations_scp_check_deny_regions.organizations_scp_check_deny_regions.organizations_client",
+                new=Organizations(audit_info),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.organizations.organizations_scp_check_deny_regions.organizations_scp_check_deny_regions import (
+                    organizations_scp_check_deny_regions,
+                )
+
+                check = organizations_scp_check_deny_regions()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert result[0].resource_id == response["Organization"]["Id"]
+                assert result[0].resource_arn == response["Organization"]["Arn"]
+                assert search(
+                    "restricting all configured regions found",
                     result[0].status_extended,
                 )
                 assert result[0].region == AWS_REGION_EU_WEST_1


### PR DESCRIPTION
### Context

Enhance `organizations_scp_check_deny_regions` logic so not all the restricted regions in the SCP has to be in the config variable.

### Description

Only check that the regions in the config variable are in the SCP restrictions.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
