### PR TITLE
fix(rds): handle api call error response

### DIFF
--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -237,6 +237,10 @@ class RDS(AWSService):
                 logger.warning(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
+            else:
+                logger.error(
+                    f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
         except Exception as error:
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"

--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -232,7 +232,11 @@ class RDS(AWSService):
                     for att in response["DBClusterSnapshotAttributes"]:
                         if "all" in att["AttributeValues"]:
                             snapshot.public = True
-
+        except ClientError as error:
+            if error.response["Error"]["Code"] == "DBClusterSnapshotNotFoundFault":
+                logger.warning(
+                    f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
         except Exception as error:
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"


### PR DESCRIPTION
### Context

We need to handle `DBClusterSnapshotNotFoundFault` exception


### Description

Include exception handling in `rds` service


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
