### PR TITLE
fix(fms): handle list compliance status error

### DIFF
--- a/prowler/providers/aws/services/fms/fms_policy_compliant/fms_policy_compliant.py
+++ b/prowler/providers/aws/services/fms/fms_policy_compliant/fms_policy_compliant.py
@@ -16,7 +16,10 @@ class fms_policy_compliant(Check):
             if fms_client.fms_policies:
                 for policy in fms_client.fms_policies:
                     for policy_to_account in policy.compliance_status:
-                        if policy_to_account.status == "NON_COMPLIANT":
+                        if (
+                            policy_to_account.status == "NON_COMPLIANT"
+                            or not policy_to_account.status
+                        ):
                             report.status = "FAIL"
                             report.status_extended = f"FMS with non-compliant policy {policy.name} for account {policy_to_account.account_id}."
                             report.resource_id = policy.id

--- a/prowler/providers/aws/services/fms/fms_service.py
+++ b/prowler/providers/aws/services/fms/fms_service.py
@@ -69,7 +69,7 @@ class FMS(AWSService):
                     for fms_compliance_status in page.get(
                         "PolicyComplianceStatusList", []
                     ):
-                        compliance_status = ""
+                        compliance_status = None
                         if fms_compliance_status.get("EvaluationResults"):
                             compliance_status = fms_compliance_status.get(
                                 "EvaluationResults"

--- a/prowler/providers/aws/services/fms/fms_service.py
+++ b/prowler/providers/aws/services/fms/fms_service.py
@@ -69,11 +69,11 @@ class FMS(AWSService):
                     for fms_compliance_status in page.get(
                         "PolicyComplianceStatusList", []
                     ):
-                        compliance_status = None
+                        compliance_status = ""
                         if fms_compliance_status.get("EvaluationResults"):
                             compliance_status = fms_compliance_status.get(
                                 "EvaluationResults"
-                            )[0].get("ComplianceStatus")
+                            )[0].get("ComplianceStatus", "")
                         fms_policy.compliance_status.append(
                             PolicyAccountComplianceStatus(
                                 account_id=fms_compliance_status.get("MemberAccount"),

--- a/prowler/providers/aws/services/fms/fms_service.py
+++ b/prowler/providers/aws/services/fms/fms_service.py
@@ -69,13 +69,16 @@ class FMS(AWSService):
                     for fms_compliance_status in page.get(
                         "PolicyComplianceStatusList", []
                     ):
+                        compliance_status = ""
+                        if fms_compliance_status.get("EvaluationResults"):
+                            compliance_status = fms_compliance_status.get(
+                                "EvaluationResults"
+                            )[0].get("ComplianceStatus")
                         fms_policy.compliance_status.append(
                             PolicyAccountComplianceStatus(
                                 account_id=fms_compliance_status.get("MemberAccount"),
                                 policy_id=fms_compliance_status.get("PolicyId"),
-                                status=fms_compliance_status.get("EvaluationResults")[
-                                    0
-                                ].get("ComplianceStatus"),
+                                status=compliance_status,
                             )
                         )
 

--- a/tests/providers/aws/services/fms/fms_policy_compliant/fms_policy_compliant_test.py
+++ b/tests/providers/aws/services/fms/fms_policy_compliant/fms_policy_compliant_test.py
@@ -199,3 +199,49 @@ class Test_fms_policy_compliant:
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert result[0].resource_arn == fms_client.audited_account_arn
             assert result[0].region == AWS_REGION_US_EAST_1
+
+    def test_fms_admin_with_policy_with_null_status(self):
+        fms_client = mock.MagicMock
+        fms_client.audited_account = AWS_ACCOUNT_NUMBER
+        fms_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+        fms_client.region = AWS_REGION_US_EAST_1
+        fms_client.fms_admin_account = True
+        fms_client.fms_policies = [
+            Policy(
+                arn="arn:aws:fms:us-east-1:12345678901",
+                id="12345678901",
+                name="test",
+                resource_type="AWS::EC2::Instance",
+                service_type="WAF",
+                remediation_enabled=True,
+                delete_unused_managed_resources=True,
+                compliance_status=[
+                    PolicyAccountComplianceStatus(
+                        account_id="12345678901",
+                        policy_id="12345678901",
+                        status="",
+                    ),
+                ],
+            )
+        ]
+        with mock.patch(
+            "prowler.providers.aws.services.fms.fms_service.FMS",
+            new=fms_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.fms.fms_policy_compliant.fms_policy_compliant import (
+                fms_policy_compliant,
+            )
+
+            check = fms_policy_compliant()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"FMS with non-compliant policy {fms_client.fms_policies[0].name} for account {fms_client.fms_policies[0].compliance_status[0].account_id}."
+            )
+            assert result[0].resource_id == "12345678901"
+            assert result[0].resource_arn == "arn:aws:fms:us-east-1:12345678901"
+            assert result[0].region == AWS_REGION_US_EAST_1


### PR DESCRIPTION
### Context

In `fms` service we were not handling correctly response parsing of `list_compliance_status` api call


### Description

Ensure `EvaluationResults` key exists in api call answer and contains a non-empty list prior trying to access its items


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
