### PR TITLE
chore(precommit): set trufflehog as command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,9 +80,9 @@ repos:
       - id: trufflehog
         name: TruffleHog
         description: Detect secrets in your data.
-        # entry: bash -c 'trufflehog git file://. --only-verified --fail'
+        entry: bash -c 'trufflehog --no-update git file://. --only-verified --fail'
         # For running trufflehog in docker, use the following entry instead:
-        entry: bash -c 'docker run -v "$(pwd):/workdir" -i --rm trufflesecurity/trufflehog:latest git file:///workdir --only-verified --fail'
+        # entry: bash -c 'docker run -v "$(pwd):/workdir" -i --rm trufflesecurity/trufflehog:latest git file:///workdir --only-verified --fail'
         language: system
         stages: ["commit", "push"]
 


### PR DESCRIPTION
### Context

Pre-commit was launching a trufflehog container, using the command is faster and cleaner


### Description

Use trufflehog command instead of container


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
