### PR TITLE
fix(apigatewayv2_api_access_logging_enabled): Finding ID should be unique

### DIFF
--- a/prowler/providers/aws/services/apigatewayv2/apigatewayv2_api_access_logging_enabled/apigatewayv2_api_access_logging_enabled.py
+++ b/prowler/providers/aws/services/apigatewayv2/apigatewayv2_api_access_logging_enabled/apigatewayv2_api_access_logging_enabled.py
@@ -14,13 +14,13 @@ class apigatewayv2_api_access_logging_enabled(Check):
                 if stage.logging:
                     report.status = "PASS"
                     report.status_extended = f"API Gateway V2 {api.name} ID {api.id} in stage {stage.name} has access logging enabled."
-                    report.resource_id = api.name
+                    report.resource_id = f"{api.name}-{stage.name}"
                     report.resource_arn = api.arn
                     report.resource_tags = api.tags
                 else:
                     report.status = "FAIL"
                     report.status_extended = f"API Gateway V2 {api.name} ID {api.id} in stage {stage.name} has access logging disabled."
-                    report.resource_id = api.name
+                    report.resource_id = f"{api.name}-{stage.name}"
                     report.resource_arn = api.arn
                     report.resource_tags = api.tags
                 findings.append(report)

--- a/tests/providers/aws/services/apigatewayv2/apigatewayv2_access_logging_enabled/apigatewayv2_access_logging_enabled_test.py
+++ b/tests/providers/aws/services/apigatewayv2/apigatewayv2_access_logging_enabled/apigatewayv2_access_logging_enabled_test.py
@@ -72,6 +72,7 @@ class Test_apigatewayv2_api_access_logging_enabled:
         apigatewayv2_client = client("apigatewayv2", region_name=AWS_REGION_US_EAST_1)
         # Create ApiGatewayV2 API
         api = apigatewayv2_client.create_api(Name="test-api", ProtocolType="HTTP")
+        api_id = api["ApiId"]
         # Get stages mock with stage with logging
         from prowler.providers.aws.services.apigatewayv2.apigatewayv2_service import (
             ApiGatewayV2,
@@ -100,13 +101,13 @@ class Test_apigatewayv2_api_access_logging_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"API Gateway V2 test-api ID {api['ApiId']} in stage test-stage has access logging enabled."
+                == f"API Gateway V2 test-api ID {api_id} in stage test-stage has access logging enabled."
             )
 
-            assert result[0].resource_id == "test-api"
+            assert result[0].resource_id == "test-api-test-stage"
             assert (
                 result[0].resource_arn
-                == f"arn:aws:apigateway:{AWS_REGION_US_EAST_1}::apis/{api['ApiId']}"
+                == f"arn:aws:apigateway:{AWS_REGION_US_EAST_1}::apis/{api_id}"
             )
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [{}]


### PR DESCRIPTION
### Description

Finding ID should be unique, changed from `{api.name}` to `{api.name}-{stage.name}`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
