### PR TITLE
fix(acm): adding more details on remaining expiration days

### DIFF
--- a/prowler/providers/aws/services/acm/acm_certificates_expiration_check/acm_certificates_expiration_check.py
+++ b/prowler/providers/aws/services/acm/acm_certificates_expiration_check/acm_certificates_expiration_check.py
@@ -19,7 +19,12 @@ class acm_certificates_expiration_check(Check):
                 report.resource_tags = certificate.tags
             else:
                 report.status = "FAIL"
-                report.status_extended = f"ACM Certificate {certificate.id} for {certificate.name} is about to expire in {DAYS_TO_EXPIRE_THRESHOLD} days."
+
+                if certificate.expiration_days < 0:
+                    report.status_extended = f"ACM Certificate {certificate.id} for {certificate.name} has expired ({abs(certificate.expiration_days)} days ago)."
+                else:
+                    report.status_extended = f"ACM Certificate {certificate.id} for {certificate.name} is about to expire in {certificate.expiration_days} days."
+
                 report.resource_id = certificate.id
                 report.resource_details = certificate.name
                 report.resource_arn = certificate.arn

--- a/prowler/providers/aws/services/acm/acm_certificates_expiration_check/acm_certificates_expiration_check.py
+++ b/prowler/providers/aws/services/acm/acm_certificates_expiration_check/acm_certificates_expiration_check.py
@@ -19,7 +19,6 @@ class acm_certificates_expiration_check(Check):
                 report.resource_tags = certificate.tags
             else:
                 report.status = "FAIL"
-
                 if certificate.expiration_days < 0:
                     report.status_extended = f"ACM Certificate {certificate.id} for {certificate.name} has expired ({abs(certificate.expiration_days)} days ago)."
                 else:

--- a/tests/providers/aws/services/acm/acm_certificates_expiration_check/acm_certificates_expiration_check_test.py
+++ b/tests/providers/aws/services/acm/acm_certificates_expiration_check/acm_certificates_expiration_check_test.py
@@ -32,6 +32,7 @@ class Test_acm_certificates_expiration_check:
         certificate_arn = f"arn:aws:acm:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:certificate/{certificate_id}"
         certificate_name = "test-certificate.com"
         certificate_type = "AMAZON_ISSUED"
+        expiration_days = 5
 
         acm_client = mock.MagicMock
         acm_client.certificates = [
@@ -40,7 +41,7 @@ class Test_acm_certificates_expiration_check:
                 id=certificate_id,
                 name=certificate_name,
                 type=certificate_type,
-                expiration_days=5,
+                expiration_days=expiration_days,
                 transparency_logging=True,
                 region=AWS_REGION,
             )
@@ -62,7 +63,50 @@ class Test_acm_certificates_expiration_check:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"ACM Certificate {certificate_id} for {certificate_name} is about to expire in {DAYS_TO_EXPIRE_THRESHOLD} days."
+                == f"ACM Certificate {certificate_id} for {certificate_name} is about to expire in {expiration_days} days."
+            )
+            assert result[0].resource_id == certificate_id
+            assert result[0].resource_arn == certificate_arn
+            assert result[0].region == AWS_REGION
+            assert result[0].resource_tags == []
+
+    def test_acm_certificate_expirated_long_time(self):
+        certificate_id = str(uuid.uuid4())
+        certificate_arn = f"arn:aws:acm:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:certificate/{certificate_id}"
+        certificate_name = "test-certificate.com"
+        certificate_type = "AMAZON_ISSUED"
+        expiration_days = -400
+
+        acm_client = mock.MagicMock
+        acm_client.certificates = [
+            Certificate(
+                arn=certificate_arn,
+                id=certificate_id,
+                name=certificate_name,
+                type=certificate_type,
+                expiration_days=expiration_days,
+                transparency_logging=True,
+                region=AWS_REGION,
+            )
+        ]
+
+        with mock.patch(
+            "prowler.providers.aws.services.acm.acm_service.ACM",
+            new=acm_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.acm.acm_certificates_expiration_check.acm_certificates_expiration_check import (
+                acm_certificates_expiration_check,
+            )
+
+            check = acm_certificates_expiration_check()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"ACM Certificate {certificate_id} for {certificate_name} has expired ({abs(expiration_days)} days ago)."
             )
             assert result[0].resource_id == certificate_id
             assert result[0].resource_arn == certificate_arn


### PR DESCRIPTION
### Context

The `ACM Certificates Expiration` check produces evidence that is not very clear when the certificate is actually going to expire.

### Description

The evidence could be more clear regarding the certificates expiration days.

The current evidence looks like this

```
ACM Certificate {certificate.id} for {certificate.name} is about to expire in {DAYS_TO_EXPIRE_THRESHOLD} days.
```

The problem with this is that `DAYS_TO_EXPIRE_THRESHOLD` equals always to `7` and then the user couldn't really know from the evidence when exactly the certificate is going to expire or how many days has the certificate been expired.

My proposal is to have 2 types of evidence when the check fails:

- when the certificate is about to expire
  - `ACM Certificate blebleble for cert_name is about to expire in 6 days`
- when the certificate has expired
  - `ACM Certificate blebleble for cert_name has expired (30 days ago).`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
