### PR TITLE
feat(quick-inventory): custom output file in quick inventory

### DIFF
--- a/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
+++ b/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
@@ -211,9 +211,13 @@ def create_inventory_table(resources: list, resources_in_region: dict) -> dict:
 
 def create_output(resources: list, audit_info: AWS_Audit_Info, args):
     json_output = []
-    output_file = (
-        f"prowler-inventory-{audit_info.audited_account}-{output_file_timestamp}"
-    )
+    # Check if custom output filename was input, if not, set the default
+    if not hasattr(args, "output_filename") or args.output_filename is None:
+        output_file = (
+            f"prowler-inventory-{audit_info.audited_account}-{output_file_timestamp}"
+        )
+    else:
+        output_file = args.output_filename
 
     for item in sorted(resources, key=lambda d: d["arn"]):
         resource = {}


### PR DESCRIPTION
### Context

Solves #3305 


### Description

Support for the already existing options -F (output file) when using the quick inventory feature (-i) on AWS.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
