### PR TITLE
feat(azure): New Azure SQLServer related check `sqlserver_auditing_retention_90_days`

### DIFF
--- a/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.metadata.json
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.metadata.json
@@ -13,7 +13,7 @@
   "RelatedUrl": "https://docs.microsoft.com/en-us/azure/sql-database/sql-database-auditing",
   "Remediation": {
     "Code": {
-      "CLI": "Set-AzSqlServerAudit -ResourceGroupName <resource group name> -ServerName SQL_Server_name -RetentionInDays <Number of Days to retain the audit logs, should be more than 90 days> -LogAnalyticsTargetState Enabled -WorkspaceResourceId '/subscriptions/subscription_ID/resourceGroups/insights-integration/providers/Microsoft.OperationalInsights/workspaces/workspace_name'",
+      "CLI": "Set-AzSqlServerAudit -ResourceGroupName resource_group_name -ServerName SQL_Server_name -RetentionInDays 100 -LogAnalyticsTargetState Enabled -WorkspaceResourceId '/subscriptions/subscription_ID/resourceGroups/insights-integration/providers/Microsoft.OperationalInsights/workspaces/workspace_name'",
       "NativeIaC": "",
       "Other": "https://www.trendmicro.com/cloudoneconformity-staging/knowledge-base/azure/Sql/auditing-retention.html#",
       "Terraform": "https://docs.bridgecrew.io/docs/bc_azr_logging_3"

--- a/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.metadata.json
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "azure",
+  "CheckID": "sqlserver_auditing_retention_90_days",
+  "CheckTitle": "Ensure that 'Auditing' Retention is 'greater than 90 days'",
+  "CheckType": [],
+  "ServiceName": "sqlserver",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "SQLServer",
+  "Description": "SQL Server Audit Retention should be configured to be greater than 90 days.",
+  "Risk": "Audit Logs can be used to check for anomalies and give insight into suspected breaches or misuse of information and access.",
+  "RelatedUrl": "https://docs.microsoft.com/en-us/azure/sql-database/sql-database-auditing",
+  "Remediation": {
+    "Code": {
+      "CLI": "Set-AzSqlServerAudit -ResourceGroupName <resource group name> -ServerName SQL_Server_name -RetentionInDays <Number of Days to retain the audit logs, should be more than 90 days> -LogAnalyticsTargetState Enabled -WorkspaceResourceId '/subscriptions/subscription_ID/resourceGroups/insights-integration/providers/Microsoft.OperationalInsights/workspaces/workspace_name'",
+      "NativeIaC": "",
+      "Other": "https://www.trendmicro.com/cloudoneconformity-staging/knowledge-base/azure/Sql/auditing-retention.html#",
+      "Terraform": "https://docs.bridgecrew.io/docs/bc_azr_logging_3"
+    },
+    "Recommendation": {
+      "Text": "1. Go to SQL servers 2. For each server instance 3. Click on Auditing 4. If storage is selected, expand Advanced properties 5. Set the Retention (days) setting greater than 90 days or 0 for unlimited retention. 6. Select Save",
+      "Url": "https://learn.microsoft.com/en-us/purview/audit-log-retention-policies"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.py
@@ -1,0 +1,33 @@
+from prowler.lib.check.models import Check, Check_Report_Azure
+from prowler.providers.azure.services.sqlserver.sqlserver_client import sqlserver_client
+
+
+class sqlserver_auditing_retention_90_days(Check):
+    def execute(self) -> Check_Report_Azure:
+        findings = []
+        for subscription, sql_servers in sqlserver_client.sql_servers.items():
+            for sql_server in sql_servers:
+                report = Check_Report_Azure(self.metadata())
+                report.subscription = subscription
+                report.resource_name = sql_server.name
+                report.resource_id = sql_server.id
+                has_failed = False
+                for policy in sql_server.auditing_policies:
+                    if has_failed:
+                        break
+                    if policy.state == "Enabled":
+                        if policy.retention_days <= 90:
+                            report.status = "FAIL"
+                            report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has auditing retention less than 91 days."
+                            has_failed = True
+                        else:
+                            report.status = "PASS"
+                            report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has auditing retention greater than 90 days."
+                    else:
+                        report.status = "FAIL"
+                        report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has auditing disabled."
+                        has_failed = True
+
+                findings.append(report)
+
+        return findings

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -101,6 +101,20 @@ expected_packages = [
         name="prowler.providers.azure.services.sqlserver.sqlserver_tde_encryption_enabled.sqlserver_tde_encryption_enabled",
         ispkg=False,
     ),
+    ModuleInfo(
+        module_finder=FileFinder(
+            "/root_dir/prowler/providers/azure/services/sqlserver"
+        ),
+        name="prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days",
+        ispkg=True,
+    ),
+    ModuleInfo(
+        module_finder=FileFinder(
+            "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days"
+        ),
+        name="prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days.sqlserver_auditing_retention_90_days",
+        ispkg=False,
+    ),
 ]
 
 
@@ -178,6 +192,20 @@ def mock_list_modules(*_):
                 "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_tde_encryption_enabled"
             ),
             name="prowler.providers.azure.services.sqlserver.sqlserver_tde_encryption_enabled.sqlserver_tde_encryption_enabled",
+            ispkg=False,
+        ),
+        ModuleInfo(
+            module_finder=FileFinder(
+                "/root_dir/prowler/providers/azure/services/sqlserver"
+            ),
+            name="prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days",
+            ispkg=True,
+        ),
+        ModuleInfo(
+            module_finder=FileFinder(
+                "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days"
+            ),
+            name="prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days.sqlserver_auditing_retention_90_days",
             ispkg=False,
         ),
     ]
@@ -568,6 +596,10 @@ class Test_Check:
             (
                 "sqlserver_tde_encryption_enabled",
                 "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_tde_encryption_enabled",
+            ),
+            (
+                "sqlserver_auditing_retention_90_days",
+                "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days",
             ),
         ]
         returned_checks = recover_checks_from_provider(provider, service)

--- a/tests/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days_test.py
@@ -1,0 +1,150 @@
+from unittest import mock
+from uuid import uuid4
+
+from azure.mgmt.sql.models import ServerBlobAuditingPolicy
+
+from prowler.providers.azure.services.sqlserver.sqlserver_service import SQL_Server
+
+AZURE_SUSCRIPTION = str(uuid4())
+
+
+class Test_sqlserver_auditing_retention_90_days:
+    def test_no_sql_servers(self):
+        sqlserver_client = mock.MagicMock
+        sqlserver_client.sql_servers = {}
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days.sqlserver_auditing_retention_90_days.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days.sqlserver_auditing_retention_90_days import (
+                sqlserver_auditing_retention_90_days,
+            )
+
+            check = sqlserver_auditing_retention_90_days()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_sql_servers_auditing_policy_disabled(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUSCRIPTION: [
+                SQL_Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=[ServerBlobAuditingPolicy(state="Disabled")],
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days.sqlserver_auditing_retention_90_days.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days.sqlserver_auditing_retention_90_days import (
+                sqlserver_auditing_retention_90_days,
+            )
+
+            check = sqlserver_auditing_retention_90_days()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has auditing disabled."
+            )
+            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+
+    def test_sql_servers_auditing_retention_less_than_90_days(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUSCRIPTION: [
+                SQL_Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=[
+                        ServerBlobAuditingPolicy(state="Enabled", retention_days=89)
+                    ],
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days.sqlserver_auditing_retention_90_days.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days.sqlserver_auditing_retention_90_days import (
+                sqlserver_auditing_retention_90_days,
+            )
+
+            check = sqlserver_auditing_retention_90_days()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has auditing retention less than 91 days."
+            )
+            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+
+    def test_sql_servers_auditing_retention_greater_than_90_days(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUSCRIPTION: [
+                SQL_Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=[
+                        ServerBlobAuditingPolicy(state="Enabled", retention_days=91)
+                    ],
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days.sqlserver_auditing_retention_90_days.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days.sqlserver_auditing_retention_90_days import (
+                sqlserver_auditing_retention_90_days,
+            )
+
+            check = sqlserver_auditing_retention_90_days()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has auditing retention greater than 90 days."
+            )
+            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id

--- a/tests/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days_test.py
@@ -4,8 +4,7 @@ from uuid import uuid4
 from azure.mgmt.sql.models import ServerBlobAuditingPolicy
 
 from prowler.providers.azure.services.sqlserver.sqlserver_service import SQL_Server
-
-AZURE_SUSCRIPTION = str(uuid4())
+from tests.providers.azure.azure_fixtures import AZURE_SUSCRIPTION
 
 
 class Test_sqlserver_auditing_retention_90_days:
@@ -144,6 +143,96 @@ class Test_sqlserver_auditing_retention_90_days:
             assert (
                 result[0].status_extended
                 == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has auditing retention greater than 90 days."
+            )
+            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+
+    def test_sql_servers_two_auditing_policies_with_auditing_retention_greater_than_90_days(
+        self,
+    ):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUSCRIPTION: [
+                SQL_Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=[
+                        ServerBlobAuditingPolicy(state="Enabled", retention_days=91),
+                        ServerBlobAuditingPolicy(state="Enabled", retention_days=100),
+                    ],
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days.sqlserver_auditing_retention_90_days.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days.sqlserver_auditing_retention_90_days import (
+                sqlserver_auditing_retention_90_days,
+            )
+
+            check = sqlserver_auditing_retention_90_days()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has auditing retention greater than 90 days."
+            )
+            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+
+    def test_sql_servers_two_auditing_policies_with_one_auditing_retention_less_than_90_days(
+        self,
+    ):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUSCRIPTION: [
+                SQL_Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=[
+                        ServerBlobAuditingPolicy(state="Enabled", retention_days=91),
+                        ServerBlobAuditingPolicy(state="Enabled", retention_days=80),
+                    ],
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days.sqlserver_auditing_retention_90_days.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_auditing_retention_90_days.sqlserver_auditing_retention_90_days import (
+                sqlserver_auditing_retention_90_days,
+            )
+
+            check = sqlserver_auditing_retention_90_days()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has auditing retention less than 91 days."
             )
             assert result[0].subscription == AZURE_SUSCRIPTION
             assert result[0].resource_name == sql_server_name


### PR DESCRIPTION
### Context

This pr adds new check `sqlserver_auditing_retention_90_days`


### Description

This check makes the task:

- Ensure that 'Auditing' Retention is 'greater than 90 days'


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
