### PR TITLE
refactor(azure): Change class names from azure services and fix typing error

### DIFF
--- a/prowler/providers/azure/services/defender/defender_service.py
+++ b/prowler/providers/azure/services/defender/defender_service.py
@@ -26,7 +26,7 @@ class Defender(AzureService):
                 for pricing in pricings_list.value:
                     pricings[subscription_name].update(
                         {
-                            pricing.name: Defender_Pricing(
+                            pricing.name: Pricing(
                                 resource_id=pricing.id,
                                 pricing_tier=pricing.pricing_tier,
                                 free_trial_remaining_time=pricing.free_trial_remaining_time,
@@ -76,7 +76,7 @@ class Defender(AzureService):
                 for assessment in assessments_list:
                     assessments[subscription_name].update(
                         {
-                            assessment.display_name: Defender_Assessments(
+                            assessment.display_name: Assesment(
                                 resource_id=assessment.id,
                                 resource_name=assessment.name,
                                 status=assessment.status.code,
@@ -90,7 +90,7 @@ class Defender(AzureService):
         return assessments
 
 
-class Defender_Pricing(BaseModel):
+class Pricing(BaseModel):
     resource_id: str
     pricing_tier: str
     free_trial_remaining_time: timedelta
@@ -103,7 +103,7 @@ class AutoProvisioningSetting(BaseModel):
     auto_provision: str
 
 
-class Defender_Assessments(BaseModel):
+class Assesment(BaseModel):
     resource_id: str
     resource_name: str
     status: str

--- a/prowler/providers/azure/services/sqlserver/sqlserver_service.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_service.py
@@ -45,7 +45,7 @@ class SQLServer(AzureService):
                         subscription, resource_group, sql_server.name
                     )
                     sql_servers[subscription].append(
-                        SQL_Server(
+                        Server(
                             id=sql_server.id,
                             name=sql_server.name,
                             public_network_access=sql_server.public_network_access,
@@ -105,7 +105,7 @@ class SQLServer(AzureService):
                     subscription, resource_group, server_name, database.name
                 )
                 databases.append(
-                    DatabaseServer(
+                    Database(
                         id=database.id,
                         name=database.name,
                         type=database.type,
@@ -133,7 +133,7 @@ class SQLServer(AzureService):
 
 
 @dataclass
-class DatabaseServer:
+class Database:
     id: str
     name: str
     type: str
@@ -143,7 +143,7 @@ class DatabaseServer:
 
 
 @dataclass
-class SQL_Server:
+class Server:
     id: str
     name: str
     public_network_access: str
@@ -152,5 +152,5 @@ class SQL_Server:
     auditing_policies: ServerBlobAuditingPolicy
     firewall_rules: FirewallRule
     encryption_protector: EncryptionProtector = None
-    databases: list[DatabaseServer] = None
+    databases: list[Database] = None
     vulnerability_assessment: ServerVulnerabilityAssessment = None

--- a/prowler/providers/azure/services/storage/storage_service.py
+++ b/prowler/providers/azure/services/storage/storage_service.py
@@ -33,7 +33,7 @@ class Storage(AzureService):
                     else:
                         resouce_group_name = None
                     storage_accounts[subscription].append(
-                        Storage_Account(
+                        Account(
                             id=storage_account.id,
                             name=storage_account.name,
                             resouce_group_name=resouce_group_name,
@@ -62,7 +62,7 @@ class Storage(AzureService):
                     properties = client.blob_services.get_service_properties(
                         account.resouce_group_name, account.name
                     )
-                    account.blob_properties = Blob_Properties(
+                    account.blob_properties = BlobProperties(
                         id=properties.id,
                         name=properties.name,
                         type=properties.type,
@@ -76,7 +76,7 @@ class Storage(AzureService):
 
 
 @dataclass
-class Blob_Properties:
+class BlobProperties:
     id: str
     name: str
     type: str
@@ -85,7 +85,7 @@ class Blob_Properties:
 
 
 @dataclass
-class Storage_Account:
+class Account:
     id: str
     name: str
     resouce_group_name: str
@@ -97,4 +97,4 @@ class Storage_Account:
     minimum_tls_version: str
     private_endpoint_connections: PrivateEndpointConnection
     key_expiration_period_in_days: str
-    blob_properties: Blob_Properties = None
+    blob_properties: BlobProperties = None

--- a/tests/providers/azure/azure_fixtures.py
+++ b/tests/providers/azure/azure_fixtures.py
@@ -8,7 +8,7 @@ from prowler.providers.azure.lib.audit_info.models import (
     Azure_Region_Config,
 )
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 # Azure Identity
 IDENTITY_ID = "00000000-0000-0000-0000-000000000000"
@@ -25,7 +25,7 @@ def set_mocked_azure_audit_info(
         identity_type=IDENTITY_TYPE,
         tenant_ids=TENANT_IDS,
         domain=DOMAIN,
-        subscriptions={AZURE_SUSCRIPTION: "id_subscription"},
+        subscriptions={AZURE_SUBSCRIPTION: "id_subscription"},
     ),
     audit_config: dict = None,
     azure_region_config: Azure_Region_Config = Azure_Region_Config(),

--- a/tests/providers/azure/services/defender/defender_auto_provisioning_log_analytics_agent_vms_on/defender_auto_provisioning_log_analytics_agent_vms_on_test.py
+++ b/tests/providers/azure/services/defender/defender_auto_provisioning_log_analytics_agent_vms_on/defender_auto_provisioning_log_analytics_agent_vms_on_test.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 from prowler.providers.azure.services.defender.defender_service import (
     AutoProvisioningSetting,
 )
-from tests.providers.azure.azure_fixtures import AZURE_SUSCRIPTION
+from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_defender_auto_provisioning_log_analytics_agent_vms_on:
@@ -28,7 +28,7 @@ class Test_defender_auto_provisioning_log_analytics_agent_vms_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.auto_provisioning_settings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "default": AutoProvisioningSetting(
                     resource_id=resource_id,
                     resource_name="default",
@@ -52,9 +52,9 @@ class Test_defender_auto_provisioning_log_analytics_agent_vms_on:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Defender Auto Provisioning Log Analytics Agents from subscription {AZURE_SUSCRIPTION} is set to OFF."
+                == f"Defender Auto Provisioning Log Analytics Agents from subscription {AZURE_SUBSCRIPTION} is set to OFF."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "default"
             assert result[0].resource_id == resource_id
 
@@ -62,7 +62,7 @@ class Test_defender_auto_provisioning_log_analytics_agent_vms_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.auto_provisioning_settings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "default": AutoProvisioningSetting(
                     resource_id=resource_id,
                     resource_name="default",
@@ -86,9 +86,9 @@ class Test_defender_auto_provisioning_log_analytics_agent_vms_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Defender Auto Provisioning Log Analytics Agents from subscription {AZURE_SUSCRIPTION} is set to ON."
+                == f"Defender Auto Provisioning Log Analytics Agents from subscription {AZURE_SUBSCRIPTION} is set to ON."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "default"
             assert result[0].resource_id == resource_id
 
@@ -96,7 +96,7 @@ class Test_defender_auto_provisioning_log_analytics_agent_vms_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.auto_provisioning_settings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "default": AutoProvisioningSetting(
                     resource_id=resource_id,
                     resource_name="default",
@@ -126,17 +126,17 @@ class Test_defender_auto_provisioning_log_analytics_agent_vms_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Defender Auto Provisioning Log Analytics Agents from subscription {AZURE_SUSCRIPTION} is set to ON."
+                == f"Defender Auto Provisioning Log Analytics Agents from subscription {AZURE_SUBSCRIPTION} is set to ON."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "default"
             assert result[0].resource_id == resource_id
 
             assert result[1].status == "FAIL"
             assert (
                 result[1].status_extended
-                == f"Defender Auto Provisioning Log Analytics Agents from subscription {AZURE_SUSCRIPTION} is set to OFF."
+                == f"Defender Auto Provisioning Log Analytics Agents from subscription {AZURE_SUBSCRIPTION} is set to OFF."
             )
-            assert result[1].subscription == AZURE_SUSCRIPTION
+            assert result[1].subscription == AZURE_SUBSCRIPTION
             assert result[1].resource_name == "default2"
             assert result[1].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_auto_provisioning_vulnerabilty_assessments_machines_on/defender_auto_provisioning_vulnerabilty_assessments_machines_on_test.py
+++ b/tests/providers/azure/services/defender/defender_auto_provisioning_vulnerabilty_assessments_machines_on/defender_auto_provisioning_vulnerabilty_assessments_machines_on_test.py
@@ -2,7 +2,7 @@ from unittest import mock
 from uuid import uuid4
 
 from prowler.providers.azure.services.defender.defender_service import Assesment
-from tests.providers.azure.azure_fixtures import AZURE_SUSCRIPTION
+from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_defender_auto_provisioning_vulnerabilty_assessments_machines_on:
@@ -26,7 +26,7 @@ class Test_defender_auto_provisioning_vulnerabilty_assessments_machines_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.assessments = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "Machines should have a vulnerability assessment solution": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
@@ -49,9 +49,9 @@ class Test_defender_auto_provisioning_vulnerabilty_assessments_machines_on:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Vulnerability assessment is not set up in all VMs in subscription {AZURE_SUSCRIPTION}."
+                == f"Vulnerability assessment is not set up in all VMs in subscription {AZURE_SUBSCRIPTION}."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "vm1"
             assert result[0].resource_id == resource_id
 
@@ -59,7 +59,7 @@ class Test_defender_auto_provisioning_vulnerabilty_assessments_machines_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.assessments = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "Machines should have a vulnerability assessment solution": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
@@ -82,8 +82,8 @@ class Test_defender_auto_provisioning_vulnerabilty_assessments_machines_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Vulnerability assessment is set up in all VMs in subscription {AZURE_SUSCRIPTION}."
+                == f"Vulnerability assessment is set up in all VMs in subscription {AZURE_SUBSCRIPTION}."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "vm1"
             assert result[0].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_auto_provisioning_vulnerabilty_assessments_machines_on/defender_auto_provisioning_vulnerabilty_assessments_machines_on_test.py
+++ b/tests/providers/azure/services/defender/defender_auto_provisioning_vulnerabilty_assessments_machines_on/defender_auto_provisioning_vulnerabilty_assessments_machines_on_test.py
@@ -1,9 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.defender.defender_service import (
-    Defender_Assessments,
-)
+from prowler.providers.azure.services.defender.defender_service import Assesment
 from tests.providers.azure.azure_fixtures import AZURE_SUSCRIPTION
 
 
@@ -29,7 +27,7 @@ class Test_defender_auto_provisioning_vulnerabilty_assessments_machines_on:
         defender_client = mock.MagicMock
         defender_client.assessments = {
             AZURE_SUSCRIPTION: {
-                "Machines should have a vulnerability assessment solution": Defender_Assessments(
+                "Machines should have a vulnerability assessment solution": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
                     status="Unhealthy",
@@ -62,7 +60,7 @@ class Test_defender_auto_provisioning_vulnerabilty_assessments_machines_on:
         defender_client = mock.MagicMock
         defender_client.assessments = {
             AZURE_SUSCRIPTION: {
-                "Machines should have a vulnerability assessment solution": Defender_Assessments(
+                "Machines should have a vulnerability assessment solution": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
                     status="Healthy",

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_app_services_is_on/defender_ensure_defender_for_app_services_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_app_services_is_on/defender_ensure_defender_for_app_services_is_on_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.defender.defender_service import Pricing
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_defender_ensure_defender_for_app_services_is_on:
@@ -27,7 +27,7 @@ class Test_defender_ensure_defender_for_app_services_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "AppServices": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
@@ -50,9 +50,9 @@ class Test_defender_ensure_defender_for_app_services_is_on:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for App Services from subscription {AZURE_SUSCRIPTION} is set to OFF (pricing tier not standard)."
+                == f"Defender plan Defender for App Services from subscription {AZURE_SUBSCRIPTION} is set to OFF (pricing tier not standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan App Services"
             assert result[0].resource_id == resource_id
 
@@ -60,7 +60,7 @@ class Test_defender_ensure_defender_for_app_services_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "AppServices": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -83,8 +83,8 @@ class Test_defender_ensure_defender_for_app_services_is_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for App Services from subscription {AZURE_SUSCRIPTION} is set to ON (pricing tier standard)."
+                == f"Defender plan Defender for App Services from subscription {AZURE_SUBSCRIPTION} is set to ON (pricing tier standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan App Services"
             assert result[0].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_app_services_is_on/defender_ensure_defender_for_app_services_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_app_services_is_on/defender_ensure_defender_for_app_services_is_on_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.defender.defender_service import Defender_Pricing
+from prowler.providers.azure.services.defender.defender_service import Pricing
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -28,7 +28,7 @@ class Test_defender_ensure_defender_for_app_services_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "AppServices": Defender_Pricing(
+                "AppServices": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
@@ -61,7 +61,7 @@ class Test_defender_ensure_defender_for_app_services_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "AppServices": Defender_Pricing(
+                "AppServices": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_arm_is_on/defender_ensure_defender_for_arm_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_arm_is_on/defender_ensure_defender_for_arm_is_on_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.defender.defender_service import Pricing
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_defender_ensure_defender_for_arm_is_on:
@@ -27,7 +27,7 @@ class Test_defender_ensure_defender_for_arm_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "Arm": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
@@ -50,9 +50,9 @@ class Test_defender_ensure_defender_for_arm_is_on:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for ARM from subscription {AZURE_SUSCRIPTION} is set to OFF (pricing tier not standard)."
+                == f"Defender plan Defender for ARM from subscription {AZURE_SUBSCRIPTION} is set to OFF (pricing tier not standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan ARM"
             assert result[0].resource_id == resource_id
 
@@ -60,7 +60,7 @@ class Test_defender_ensure_defender_for_arm_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "Arm": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -83,8 +83,8 @@ class Test_defender_ensure_defender_for_arm_is_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for ARM from subscription {AZURE_SUSCRIPTION} is set to ON (pricing tier standard)."
+                == f"Defender plan Defender for ARM from subscription {AZURE_SUBSCRIPTION} is set to ON (pricing tier standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan ARM"
             assert result[0].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_arm_is_on/defender_ensure_defender_for_arm_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_arm_is_on/defender_ensure_defender_for_arm_is_on_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.defender.defender_service import Defender_Pricing
+from prowler.providers.azure.services.defender.defender_service import Pricing
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -28,7 +28,7 @@ class Test_defender_ensure_defender_for_arm_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "Arm": Defender_Pricing(
+                "Arm": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
@@ -61,7 +61,7 @@ class Test_defender_ensure_defender_for_arm_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "Arm": Defender_Pricing(
+                "Arm": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_azure_sql_databases_is_on/defender_ensure_defender_for_azure_sql_databases_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_azure_sql_databases_is_on/defender_ensure_defender_for_azure_sql_databases_is_on_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.defender.defender_service import Defender_Pricing
+from prowler.providers.azure.services.defender.defender_service import Pricing
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -28,7 +28,7 @@ class Test_defender_ensure_defender_for_azure_sql_databases_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "SqlServers": Defender_Pricing(
+                "SqlServers": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
@@ -61,7 +61,7 @@ class Test_defender_ensure_defender_for_azure_sql_databases_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "SqlServers": Defender_Pricing(
+                "SqlServers": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_azure_sql_databases_is_on/defender_ensure_defender_for_azure_sql_databases_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_azure_sql_databases_is_on/defender_ensure_defender_for_azure_sql_databases_is_on_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.defender.defender_service import Pricing
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_defender_ensure_defender_for_azure_sql_databases_is_on:
@@ -27,7 +27,7 @@ class Test_defender_ensure_defender_for_azure_sql_databases_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "SqlServers": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
@@ -50,9 +50,9 @@ class Test_defender_ensure_defender_for_azure_sql_databases_is_on:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for Azure SQL DB Servers from subscription {AZURE_SUSCRIPTION} is set to OFF (pricing tier not standard)."
+                == f"Defender plan Defender for Azure SQL DB Servers from subscription {AZURE_SUBSCRIPTION} is set to OFF (pricing tier not standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan Azure SQL DB Servers"
             assert result[0].resource_id == resource_id
 
@@ -60,7 +60,7 @@ class Test_defender_ensure_defender_for_azure_sql_databases_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "SqlServers": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -83,8 +83,8 @@ class Test_defender_ensure_defender_for_azure_sql_databases_is_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for Azure SQL DB Servers from subscription {AZURE_SUSCRIPTION} is set to ON (pricing tier standard)."
+                == f"Defender plan Defender for Azure SQL DB Servers from subscription {AZURE_SUBSCRIPTION} is set to ON (pricing tier standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan Azure SQL DB Servers"
             assert result[0].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_containers_is_on/defender_ensure_defender_for_containers_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_containers_is_on/defender_ensure_defender_for_containers_is_on_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.defender.defender_service import Pricing
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_defender_ensure_defender_for_containers_is_on:
@@ -27,7 +27,7 @@ class Test_defender_ensure_defender_for_containers_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "Containers": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
@@ -50,9 +50,9 @@ class Test_defender_ensure_defender_for_containers_is_on:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for Containers from subscription {AZURE_SUSCRIPTION} is set to OFF (pricing tier not standard)."
+                == f"Defender plan Defender for Containers from subscription {AZURE_SUBSCRIPTION} is set to OFF (pricing tier not standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan Container Registries"
             assert result[0].resource_id == resource_id
 
@@ -60,7 +60,7 @@ class Test_defender_ensure_defender_for_containers_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "Containers": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -83,8 +83,8 @@ class Test_defender_ensure_defender_for_containers_is_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for Containers from subscription {AZURE_SUSCRIPTION} is set to ON (pricing tier standard)."
+                == f"Defender plan Defender for Containers from subscription {AZURE_SUBSCRIPTION} is set to ON (pricing tier standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan Container Registries"
             assert result[0].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_containers_is_on/defender_ensure_defender_for_containers_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_containers_is_on/defender_ensure_defender_for_containers_is_on_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.defender.defender_service import Defender_Pricing
+from prowler.providers.azure.services.defender.defender_service import Pricing
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -28,7 +28,7 @@ class Test_defender_ensure_defender_for_containers_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "Containers": Defender_Pricing(
+                "Containers": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
@@ -61,7 +61,7 @@ class Test_defender_ensure_defender_for_containers_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "Containers": Defender_Pricing(
+                "Containers": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_cosmosdb_is_on/defender_ensure_defender_for_cosmosdb_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_cosmosdb_is_on/defender_ensure_defender_for_cosmosdb_is_on_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.defender.defender_service import Defender_Pricing
+from prowler.providers.azure.services.defender.defender_service import Pricing
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -28,7 +28,7 @@ class Test_defender_ensure_defender_for_cosmosdb_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "CosmosDbs": Defender_Pricing(
+                "CosmosDbs": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
@@ -61,7 +61,7 @@ class Test_defender_ensure_defender_for_cosmosdb_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "CosmosDbs": Defender_Pricing(
+                "CosmosDbs": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_cosmosdb_is_on/defender_ensure_defender_for_cosmosdb_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_cosmosdb_is_on/defender_ensure_defender_for_cosmosdb_is_on_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.defender.defender_service import Pricing
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_defender_ensure_defender_for_cosmosdb_is_on:
@@ -27,7 +27,7 @@ class Test_defender_ensure_defender_for_cosmosdb_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "CosmosDbs": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
@@ -50,9 +50,9 @@ class Test_defender_ensure_defender_for_cosmosdb_is_on:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for Cosmos DB from subscription {AZURE_SUSCRIPTION} is set to OFF (pricing tier not standard)."
+                == f"Defender plan Defender for Cosmos DB from subscription {AZURE_SUBSCRIPTION} is set to OFF (pricing tier not standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan Cosmos DB"
             assert result[0].resource_id == resource_id
 
@@ -60,7 +60,7 @@ class Test_defender_ensure_defender_for_cosmosdb_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "CosmosDbs": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -83,8 +83,8 @@ class Test_defender_ensure_defender_for_cosmosdb_is_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for Cosmos DB from subscription {AZURE_SUSCRIPTION} is set to ON (pricing tier standard)."
+                == f"Defender plan Defender for Cosmos DB from subscription {AZURE_SUBSCRIPTION} is set to ON (pricing tier standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan Cosmos DB"
             assert result[0].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_databases_is_on/defender_ensure_defender_for_databases_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_databases_is_on/defender_ensure_defender_for_databases_is_on_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.defender.defender_service import Pricing
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_defender_ensure_defender_for_databases_is_on:
@@ -27,7 +27,7 @@ class Test_defender_ensure_defender_for_databases_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "SqlServers": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -52,7 +52,7 @@ class Test_defender_ensure_defender_for_databases_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "SqlServerVirtualMachines": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -77,7 +77,7 @@ class Test_defender_ensure_defender_for_databases_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "OpenSourceRelationalDatabases": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -102,7 +102,7 @@ class Test_defender_ensure_defender_for_databases_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "CosmosDbs": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -127,7 +127,7 @@ class Test_defender_ensure_defender_for_databases_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "SqlServers": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -165,9 +165,9 @@ class Test_defender_ensure_defender_for_databases_is_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for Databases from subscription {AZURE_SUSCRIPTION} is set to ON (pricing tier standard)."
+                == f"Defender plan Defender for Databases from subscription {AZURE_SUBSCRIPTION} is set to ON (pricing tier standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan Databases"
             assert result[0].resource_id == resource_id
 
@@ -175,7 +175,7 @@ class Test_defender_ensure_defender_for_databases_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "SqlServers": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -213,8 +213,8 @@ class Test_defender_ensure_defender_for_databases_is_on:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for Databases from subscription {AZURE_SUSCRIPTION} is set to OFF (pricing tier not standard)."
+                == f"Defender plan Defender for Databases from subscription {AZURE_SUBSCRIPTION} is set to OFF (pricing tier not standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan Databases"
             assert result[0].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_databases_is_on/defender_ensure_defender_for_databases_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_databases_is_on/defender_ensure_defender_for_databases_is_on_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.defender.defender_service import Defender_Pricing
+from prowler.providers.azure.services.defender.defender_service import Pricing
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -28,7 +28,7 @@ class Test_defender_ensure_defender_for_databases_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "SqlServers": Defender_Pricing(
+                "SqlServers": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
@@ -53,7 +53,7 @@ class Test_defender_ensure_defender_for_databases_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "SqlServerVirtualMachines": Defender_Pricing(
+                "SqlServerVirtualMachines": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
@@ -78,7 +78,7 @@ class Test_defender_ensure_defender_for_databases_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "OpenSourceRelationalDatabases": Defender_Pricing(
+                "OpenSourceRelationalDatabases": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
@@ -103,7 +103,7 @@ class Test_defender_ensure_defender_for_databases_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "CosmosDbs": Defender_Pricing(
+                "CosmosDbs": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
@@ -128,22 +128,22 @@ class Test_defender_ensure_defender_for_databases_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "SqlServers": Defender_Pricing(
+                "SqlServers": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 ),
-                "SqlServerVirtualMachines": Defender_Pricing(
+                "SqlServerVirtualMachines": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 ),
-                "OpenSourceRelationalDatabases": Defender_Pricing(
+                "OpenSourceRelationalDatabases": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 ),
-                "CosmosDbs": Defender_Pricing(
+                "CosmosDbs": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
@@ -176,22 +176,22 @@ class Test_defender_ensure_defender_for_databases_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "SqlServers": Defender_Pricing(
+                "SqlServers": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 ),
-                "SqlServerVirtualMachines": Defender_Pricing(
+                "SqlServerVirtualMachines": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 ),
-                "OpenSourceRelationalDatabases": Defender_Pricing(
+                "OpenSourceRelationalDatabases": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 ),
-                "CosmosDbs": Defender_Pricing(
+                "CosmosDbs": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_dns_is_on/defender_ensure_defender_for_dns_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_dns_is_on/defender_ensure_defender_for_dns_is_on_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.defender.defender_service import Defender_Pricing
+from prowler.providers.azure.services.defender.defender_service import Pricing
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -28,7 +28,7 @@ class Test_defender_ensure_defender_for_dns_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "Dns": Defender_Pricing(
+                "Dns": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
@@ -61,7 +61,7 @@ class Test_defender_ensure_defender_for_dns_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "Dns": Defender_Pricing(
+                "Dns": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_dns_is_on/defender_ensure_defender_for_dns_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_dns_is_on/defender_ensure_defender_for_dns_is_on_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.defender.defender_service import Pricing
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_defender_ensure_defender_for_dns_is_on:
@@ -27,7 +27,7 @@ class Test_defender_ensure_defender_for_dns_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "Dns": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
@@ -50,9 +50,9 @@ class Test_defender_ensure_defender_for_dns_is_on:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for DNS from subscription {AZURE_SUSCRIPTION} is set to OFF (pricing tier not standard)."
+                == f"Defender plan Defender for DNS from subscription {AZURE_SUBSCRIPTION} is set to OFF (pricing tier not standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan DNS"
             assert result[0].resource_id == resource_id
 
@@ -60,7 +60,7 @@ class Test_defender_ensure_defender_for_dns_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "Dns": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -83,8 +83,8 @@ class Test_defender_ensure_defender_for_dns_is_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for DNS from subscription {AZURE_SUSCRIPTION} is set to ON (pricing tier standard)."
+                == f"Defender plan Defender for DNS from subscription {AZURE_SUBSCRIPTION} is set to ON (pricing tier standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan DNS"
             assert result[0].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_keyvault_is_on/defender_ensure_defender_for_keyvault_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_keyvault_is_on/defender_ensure_defender_for_keyvault_is_on_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.defender.defender_service import Defender_Pricing
+from prowler.providers.azure.services.defender.defender_service import Pricing
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -28,7 +28,7 @@ class Test_defender_ensure_defender_for_keyvault_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "KeyVaults": Defender_Pricing(
+                "KeyVaults": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
@@ -61,7 +61,7 @@ class Test_defender_ensure_defender_for_keyvault_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "KeyVaults": Defender_Pricing(
+                "KeyVaults": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_keyvault_is_on/defender_ensure_defender_for_keyvault_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_keyvault_is_on/defender_ensure_defender_for_keyvault_is_on_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.defender.defender_service import Pricing
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_defender_ensure_defender_for_keyvault_is_on:
@@ -27,7 +27,7 @@ class Test_defender_ensure_defender_for_keyvault_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "KeyVaults": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
@@ -50,9 +50,9 @@ class Test_defender_ensure_defender_for_keyvault_is_on:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for KeyVaults from subscription {AZURE_SUSCRIPTION} is set to OFF (pricing tier not standard)."
+                == f"Defender plan Defender for KeyVaults from subscription {AZURE_SUBSCRIPTION} is set to OFF (pricing tier not standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan KeyVaults"
             assert result[0].resource_id == resource_id
 
@@ -60,7 +60,7 @@ class Test_defender_ensure_defender_for_keyvault_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "KeyVaults": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -83,8 +83,8 @@ class Test_defender_ensure_defender_for_keyvault_is_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for KeyVaults from subscription {AZURE_SUSCRIPTION} is set to ON (pricing tier standard)."
+                == f"Defender plan Defender for KeyVaults from subscription {AZURE_SUBSCRIPTION} is set to ON (pricing tier standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan KeyVaults"
             assert result[0].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_os_relational_databases_is_on/defender_ensure_defender_for_os_relational_databases_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_os_relational_databases_is_on/defender_ensure_defender_for_os_relational_databases_is_on_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.defender.defender_service import Defender_Pricing
+from prowler.providers.azure.services.defender.defender_service import Pricing
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -28,7 +28,7 @@ class Test_defender_ensure_defender_for_os_relational_databases_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "OpenSourceRelationalDatabases": Defender_Pricing(
+                "OpenSourceRelationalDatabases": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
@@ -64,7 +64,7 @@ class Test_defender_ensure_defender_for_os_relational_databases_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "OpenSourceRelationalDatabases": Defender_Pricing(
+                "OpenSourceRelationalDatabases": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_os_relational_databases_is_on/defender_ensure_defender_for_os_relational_databases_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_os_relational_databases_is_on/defender_ensure_defender_for_os_relational_databases_is_on_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.defender.defender_service import Pricing
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_defender_ensure_defender_for_os_relational_databases_is_on:
@@ -27,7 +27,7 @@ class Test_defender_ensure_defender_for_os_relational_databases_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "OpenSourceRelationalDatabases": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
@@ -50,9 +50,9 @@ class Test_defender_ensure_defender_for_os_relational_databases_is_on:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for Open-Source Relational Databases from subscription {AZURE_SUSCRIPTION} is set to OFF (pricing tier not standard)."
+                == f"Defender plan Defender for Open-Source Relational Databases from subscription {AZURE_SUBSCRIPTION} is set to OFF (pricing tier not standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert (
                 result[0].resource_name
                 == "Defender plan Open-Source Relational Databases"
@@ -63,7 +63,7 @@ class Test_defender_ensure_defender_for_os_relational_databases_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "OpenSourceRelationalDatabases": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -86,9 +86,9 @@ class Test_defender_ensure_defender_for_os_relational_databases_is_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for Open-Source Relational Databases from subscription {AZURE_SUSCRIPTION} is set to ON (pricing tier standard)."
+                == f"Defender plan Defender for Open-Source Relational Databases from subscription {AZURE_SUBSCRIPTION} is set to ON (pricing tier standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert (
                 result[0].resource_name
                 == "Defender plan Open-Source Relational Databases"

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_server_is_on/defender_ensure_defender_for_server_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_server_is_on/defender_ensure_defender_for_server_is_on_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.defender.defender_service import Pricing
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_defender_ensure_defender_for_server_is_on:
@@ -27,7 +27,7 @@ class Test_defender_ensure_defender_for_server_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "VirtualMachines": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
@@ -50,9 +50,9 @@ class Test_defender_ensure_defender_for_server_is_on:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for Servers from subscription {AZURE_SUSCRIPTION} is set to OFF (pricing tier not standard)."
+                == f"Defender plan Defender for Servers from subscription {AZURE_SUBSCRIPTION} is set to OFF (pricing tier not standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan Servers"
             assert result[0].resource_id == resource_id
 
@@ -60,7 +60,7 @@ class Test_defender_ensure_defender_for_server_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "VirtualMachines": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -83,8 +83,8 @@ class Test_defender_ensure_defender_for_server_is_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for Servers from subscription {AZURE_SUSCRIPTION} is set to ON (pricing tier standard)."
+                == f"Defender plan Defender for Servers from subscription {AZURE_SUBSCRIPTION} is set to ON (pricing tier standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan Servers"
             assert result[0].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_server_is_on/defender_ensure_defender_for_server_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_server_is_on/defender_ensure_defender_for_server_is_on_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.defender.defender_service import Defender_Pricing
+from prowler.providers.azure.services.defender.defender_service import Pricing
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -28,7 +28,7 @@ class Test_defender_ensure_defender_for_server_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "VirtualMachines": Defender_Pricing(
+                "VirtualMachines": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
@@ -61,7 +61,7 @@ class Test_defender_ensure_defender_for_server_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "VirtualMachines": Defender_Pricing(
+                "VirtualMachines": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_sql_servers_is_on/defender_ensure_defender_for_sql_servers_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_sql_servers_is_on/defender_ensure_defender_for_sql_servers_is_on_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.defender.defender_service import Pricing
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_defender_ensure_defender_for_sql_servers_is_on:
@@ -27,7 +27,7 @@ class Test_defender_ensure_defender_for_sql_servers_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "SqlServerVirtualMachines": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
@@ -50,9 +50,9 @@ class Test_defender_ensure_defender_for_sql_servers_is_on:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for SQL Server VMs from subscription {AZURE_SUSCRIPTION} is set to OFF (pricing tier not standard)."
+                == f"Defender plan Defender for SQL Server VMs from subscription {AZURE_SUBSCRIPTION} is set to OFF (pricing tier not standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan SQL Server VMs"
             assert result[0].resource_id == resource_id
 
@@ -60,7 +60,7 @@ class Test_defender_ensure_defender_for_sql_servers_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "SqlServerVirtualMachines": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -83,8 +83,8 @@ class Test_defender_ensure_defender_for_sql_servers_is_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for SQL Server VMs from subscription {AZURE_SUSCRIPTION} is set to ON (pricing tier standard)."
+                == f"Defender plan Defender for SQL Server VMs from subscription {AZURE_SUBSCRIPTION} is set to ON (pricing tier standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan SQL Server VMs"
             assert result[0].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_sql_servers_is_on/defender_ensure_defender_for_sql_servers_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_sql_servers_is_on/defender_ensure_defender_for_sql_servers_is_on_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.defender.defender_service import Defender_Pricing
+from prowler.providers.azure.services.defender.defender_service import Pricing
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -28,7 +28,7 @@ class Test_defender_ensure_defender_for_sql_servers_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "SqlServerVirtualMachines": Defender_Pricing(
+                "SqlServerVirtualMachines": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
@@ -61,7 +61,7 @@ class Test_defender_ensure_defender_for_sql_servers_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "SqlServerVirtualMachines": Defender_Pricing(
+                "SqlServerVirtualMachines": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_storage_is_on/defender_ensure_defender_for_storage_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_storage_is_on/defender_ensure_defender_for_storage_is_on_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.defender.defender_service import Defender_Pricing
+from prowler.providers.azure.services.defender.defender_service import Pricing
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -28,7 +28,7 @@ class Test_defender_ensure_defender_for_storage_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "StorageAccounts": Defender_Pricing(
+                "StorageAccounts": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
@@ -61,7 +61,7 @@ class Test_defender_ensure_defender_for_storage_is_on:
         defender_client = mock.MagicMock
         defender_client.pricings = {
             AZURE_SUSCRIPTION: {
-                "StorageAccounts": Defender_Pricing(
+                "StorageAccounts": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_storage_is_on/defender_ensure_defender_for_storage_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_storage_is_on/defender_ensure_defender_for_storage_is_on_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.defender.defender_service import Pricing
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_defender_ensure_defender_for_storage_is_on:
@@ -27,7 +27,7 @@ class Test_defender_ensure_defender_for_storage_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "StorageAccounts": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Not Standard",
@@ -50,9 +50,9 @@ class Test_defender_ensure_defender_for_storage_is_on:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for Storage Accounts from subscription {AZURE_SUSCRIPTION} is set to OFF (pricing tier not standard)."
+                == f"Defender plan Defender for Storage Accounts from subscription {AZURE_SUBSCRIPTION} is set to OFF (pricing tier not standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan Storage Accounts"
             assert result[0].resource_id == resource_id
 
@@ -60,7 +60,7 @@ class Test_defender_ensure_defender_for_storage_is_on:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.pricings = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "StorageAccounts": Pricing(
                     resource_id=resource_id,
                     pricing_tier="Standard",
@@ -83,8 +83,8 @@ class Test_defender_ensure_defender_for_storage_is_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Defender plan Defender for Storage Accounts from subscription {AZURE_SUSCRIPTION} is set to ON (pricing tier standard)."
+                == f"Defender plan Defender for Storage Accounts from subscription {AZURE_SUBSCRIPTION} is set to ON (pricing tier standard)."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "Defender plan Storage Accounts"
             assert result[0].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_ensure_system_updates_are_applied/defender_ensure_system_updates_are_applied_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_system_updates_are_applied/defender_ensure_system_updates_are_applied_test.py
@@ -2,7 +2,7 @@ from unittest import mock
 from uuid import uuid4
 
 from prowler.providers.azure.services.defender.defender_service import Assesment
-from tests.providers.azure.azure_fixtures import AZURE_SUSCRIPTION
+from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_defender_ensure_system_updates_are_applied:
@@ -26,7 +26,7 @@ class Test_defender_ensure_system_updates_are_applied:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.assessments = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "Log Analytics agent should be installed on virtual machines": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
@@ -59,9 +59,9 @@ class Test_defender_ensure_system_updates_are_applied:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"System updates are not applied for all the VMs in the subscription {AZURE_SUSCRIPTION}."
+                == f"System updates are not applied for all the VMs in the subscription {AZURE_SUBSCRIPTION}."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "vm1"
             assert result[0].resource_id == resource_id
 
@@ -71,7 +71,7 @@ class Test_defender_ensure_system_updates_are_applied:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.assessments = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "Log Analytics agent should be installed on virtual machines": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
@@ -104,9 +104,9 @@ class Test_defender_ensure_system_updates_are_applied:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"System updates are not applied for all the VMs in the subscription {AZURE_SUSCRIPTION}."
+                == f"System updates are not applied for all the VMs in the subscription {AZURE_SUBSCRIPTION}."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "vm1"
             assert result[0].resource_id == resource_id
 
@@ -114,7 +114,7 @@ class Test_defender_ensure_system_updates_are_applied:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.assessments = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "Log Analytics agent should be installed on virtual machines": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
@@ -147,9 +147,9 @@ class Test_defender_ensure_system_updates_are_applied:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"System updates are not applied for all the VMs in the subscription {AZURE_SUSCRIPTION}."
+                == f"System updates are not applied for all the VMs in the subscription {AZURE_SUBSCRIPTION}."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "vm1"
             assert result[0].resource_id == resource_id
 
@@ -159,7 +159,7 @@ class Test_defender_ensure_system_updates_are_applied:
         resource_id = str(uuid4())
         defender_client = mock.MagicMock
         defender_client.assessments = {
-            AZURE_SUSCRIPTION: {
+            AZURE_SUBSCRIPTION: {
                 "Log Analytics agent should be installed on virtual machines": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
@@ -192,8 +192,8 @@ class Test_defender_ensure_system_updates_are_applied:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"System updates are applied for all the VMs in the subscription {AZURE_SUSCRIPTION}."
+                == f"System updates are applied for all the VMs in the subscription {AZURE_SUBSCRIPTION}."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == "vm1"
             assert result[0].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_ensure_system_updates_are_applied/defender_ensure_system_updates_are_applied_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_system_updates_are_applied/defender_ensure_system_updates_are_applied_test.py
@@ -1,9 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.defender.defender_service import (
-    Defender_Assessments,
-)
+from prowler.providers.azure.services.defender.defender_service import Assesment
 from tests.providers.azure.azure_fixtures import AZURE_SUSCRIPTION
 
 
@@ -29,17 +27,17 @@ class Test_defender_ensure_system_updates_are_applied:
         defender_client = mock.MagicMock
         defender_client.assessments = {
             AZURE_SUSCRIPTION: {
-                "Log Analytics agent should be installed on virtual machines": Defender_Assessments(
+                "Log Analytics agent should be installed on virtual machines": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
                     status="Unhealthy",
                 ),
-                "Machines should be configured to periodically check for missing system updates": Defender_Assessments(
+                "Machines should be configured to periodically check for missing system updates": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
                     status="Healthy",
                 ),
-                "System updates should be installed on your machines": Defender_Assessments(
+                "System updates should be installed on your machines": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
                     status="Healthy",
@@ -74,17 +72,17 @@ class Test_defender_ensure_system_updates_are_applied:
         defender_client = mock.MagicMock
         defender_client.assessments = {
             AZURE_SUSCRIPTION: {
-                "Log Analytics agent should be installed on virtual machines": Defender_Assessments(
+                "Log Analytics agent should be installed on virtual machines": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
                     status="Healthy",
                 ),
-                "Machines should be configured to periodically check for missing system updates": Defender_Assessments(
+                "Machines should be configured to periodically check for missing system updates": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
                     status="Unhealthy",
                 ),
-                "System updates should be installed on your machines": Defender_Assessments(
+                "System updates should be installed on your machines": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
                     status="Healthy",
@@ -117,17 +115,17 @@ class Test_defender_ensure_system_updates_are_applied:
         defender_client = mock.MagicMock
         defender_client.assessments = {
             AZURE_SUSCRIPTION: {
-                "Log Analytics agent should be installed on virtual machines": Defender_Assessments(
+                "Log Analytics agent should be installed on virtual machines": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
                     status="Healthy",
                 ),
-                "Machines should be configured to periodically check for missing system updates": Defender_Assessments(
+                "Machines should be configured to periodically check for missing system updates": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
                     status="Healthy",
                 ),
-                "System updates should be installed on your machines": Defender_Assessments(
+                "System updates should be installed on your machines": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
                     status="Unhealthy",
@@ -162,17 +160,17 @@ class Test_defender_ensure_system_updates_are_applied:
         defender_client = mock.MagicMock
         defender_client.assessments = {
             AZURE_SUSCRIPTION: {
-                "Log Analytics agent should be installed on virtual machines": Defender_Assessments(
+                "Log Analytics agent should be installed on virtual machines": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
                     status="Healthy",
                 ),
-                "Machines should be configured to periodically check for missing system updates": Defender_Assessments(
+                "Machines should be configured to periodically check for missing system updates": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
                     status="Healthy",
                 ),
-                "System updates should be installed on your machines": Defender_Assessments(
+                "System updates should be installed on your machines": Assesment(
                     resource_id=resource_id,
                     resource_name="vm1",
                     status="Healthy",

--- a/tests/providers/azure/services/defender/defender_service_test.py
+++ b/tests/providers/azure/services/defender/defender_service_test.py
@@ -2,10 +2,10 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from prowler.providers.azure.services.defender.defender_service import (
+    Assesment,
     AutoProvisioningSetting,
     Defender,
-    Defender_Assessments,
-    Defender_Pricing,
+    Pricing,
 )
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUSCRIPTION,
@@ -16,7 +16,7 @@ from tests.providers.azure.azure_fixtures import (
 def mock_defender_get_pricings(_):
     return {
         AZURE_SUSCRIPTION: {
-            "Standard": Defender_Pricing(
+            "Standard": Pricing(
                 resource_id="resource_id",
                 pricing_tier="pricing_tier",
                 free_trial_remaining_time=timedelta(days=1),
@@ -41,7 +41,7 @@ def mock_defender_get_auto_provisioning_settings(_):
 def mock_defender_get_assessments(_):
     return {
         AZURE_SUSCRIPTION: {
-            "default": Defender_Assessments(
+            "default": Assesment(
                 resource_id="/subscriptions/resource_id",
                 resource_name="default",
                 status="Healthy",

--- a/tests/providers/azure/services/defender/defender_service_test.py
+++ b/tests/providers/azure/services/defender/defender_service_test.py
@@ -8,14 +8,14 @@ from prowler.providers.azure.services.defender.defender_service import (
     Pricing,
 )
 from tests.providers.azure.azure_fixtures import (
-    AZURE_SUSCRIPTION,
+    AZURE_SUBSCRIPTION,
     set_mocked_azure_audit_info,
 )
 
 
 def mock_defender_get_pricings(_):
     return {
-        AZURE_SUSCRIPTION: {
+        AZURE_SUBSCRIPTION: {
             "Standard": Pricing(
                 resource_id="resource_id",
                 pricing_tier="pricing_tier",
@@ -27,7 +27,7 @@ def mock_defender_get_pricings(_):
 
 def mock_defender_get_auto_provisioning_settings(_):
     return {
-        AZURE_SUSCRIPTION: {
+        AZURE_SUBSCRIPTION: {
             "default": AutoProvisioningSetting(
                 resource_id="/subscriptions/resource_id",
                 resource_name="default",
@@ -40,7 +40,7 @@ def mock_defender_get_auto_provisioning_settings(_):
 
 def mock_defender_get_assessments(_):
     return {
-        AZURE_SUSCRIPTION: {
+        AZURE_SUBSCRIPTION: {
             "default": Assesment(
                 resource_id="/subscriptions/resource_id",
                 resource_name="default",
@@ -66,7 +66,7 @@ class Test_Defender_Service:
     def test__get_client__(self):
         defender = Defender(set_mocked_azure_audit_info())
         assert (
-            defender.clients[AZURE_SUSCRIPTION].__class__.__name__ == "SecurityCenter"
+            defender.clients[AZURE_SUBSCRIPTION].__class__.__name__ == "SecurityCenter"
         )
 
     def test__get_subscriptions__(self):
@@ -78,14 +78,14 @@ class Test_Defender_Service:
         defender = Defender(set_mocked_azure_audit_info())
         assert len(defender.pricings) == 1
         assert (
-            defender.pricings[AZURE_SUSCRIPTION]["Standard"].resource_id
+            defender.pricings[AZURE_SUBSCRIPTION]["Standard"].resource_id
             == "resource_id"
         )
         assert (
-            defender.pricings[AZURE_SUSCRIPTION]["Standard"].pricing_tier
+            defender.pricings[AZURE_SUBSCRIPTION]["Standard"].pricing_tier
             == "pricing_tier"
         )
-        assert defender.pricings[AZURE_SUSCRIPTION][
+        assert defender.pricings[AZURE_SUBSCRIPTION][
             "Standard"
         ].free_trial_remaining_time == timedelta(days=1)
 
@@ -93,25 +93,25 @@ class Test_Defender_Service:
         defender = Defender(set_mocked_azure_audit_info())
         assert len(defender.auto_provisioning_settings) == 1
         assert (
-            defender.auto_provisioning_settings[AZURE_SUSCRIPTION][
+            defender.auto_provisioning_settings[AZURE_SUBSCRIPTION][
                 "default"
             ].resource_id
             == "/subscriptions/resource_id"
         )
         assert (
-            defender.auto_provisioning_settings[AZURE_SUSCRIPTION][
+            defender.auto_provisioning_settings[AZURE_SUBSCRIPTION][
                 "default"
             ].resource_name
             == "default"
         )
         assert (
-            defender.auto_provisioning_settings[AZURE_SUSCRIPTION][
+            defender.auto_provisioning_settings[AZURE_SUBSCRIPTION][
                 "default"
             ].resource_type
             == "Microsoft.Security/autoProvisioningSettings"
         )
         assert (
-            defender.auto_provisioning_settings[AZURE_SUSCRIPTION][
+            defender.auto_provisioning_settings[AZURE_SUBSCRIPTION][
                 "default"
             ].auto_provision
             == "On"
@@ -121,11 +121,11 @@ class Test_Defender_Service:
         defender = Defender(set_mocked_azure_audit_info())
         assert len(defender.assessments) == 1
         assert (
-            defender.assessments[AZURE_SUSCRIPTION]["default"].resource_id
+            defender.assessments[AZURE_SUBSCRIPTION]["default"].resource_id
             == "/subscriptions/resource_id"
         )
         assert (
-            defender.assessments[AZURE_SUSCRIPTION]["default"].resource_name
+            defender.assessments[AZURE_SUBSCRIPTION]["default"].resource_name
             == "default"
         )
-        assert defender.assessments[AZURE_SUSCRIPTION]["default"].status == "Healthy"
+        assert defender.assessments[AZURE_SUBSCRIPTION]["default"].status == "Healthy"

--- a/tests/providers/azure/services/iam/iam_custom_role_has_permissions_to_administer_resource_locks/iam_custom_role_has_permissions_to_administer_resource_locks_test.py
+++ b/tests/providers/azure/services/iam/iam_custom_role_has_permissions_to_administer_resource_locks/iam_custom_role_has_permissions_to_administer_resource_locks_test.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 from azure.mgmt.authorization.v2022_04_01.models import Permission
 
 from prowler.providers.azure.services.iam.iam_service import Role
-from tests.providers.azure.azure_fixtures import AZURE_SUSCRIPTION
+from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_iam_custom_role_has_permissions_to_administer_resource_locks:
@@ -30,7 +30,7 @@ class Test_iam_custom_role_has_permissions_to_administer_resource_locks:
         defender_client = mock.MagicMock
         role_name = "test-role"
         defender_client.custom_roles = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Role(
                     id=str(uuid4()),
                     name=role_name,
@@ -62,12 +62,12 @@ class Test_iam_custom_role_has_permissions_to_administer_resource_locks:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Role {role_name} from subscription {AZURE_SUSCRIPTION} has permission to administer resource locks."
+                == f"Role {role_name} from subscription {AZURE_SUBSCRIPTION} has permission to administer resource locks."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert (
                 result[0].resource_id
-                == defender_client.custom_roles[AZURE_SUSCRIPTION][0].id
+                == defender_client.custom_roles[AZURE_SUBSCRIPTION][0].id
             )
             assert result[0].resource_name == role_name
 
@@ -77,7 +77,7 @@ class Test_iam_custom_role_has_permissions_to_administer_resource_locks:
         defender_client = mock.MagicMock
         role_name = "test-role"
         defender_client.custom_roles = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Role(
                     id=str(uuid4()),
                     name=role_name,
@@ -102,11 +102,11 @@ class Test_iam_custom_role_has_permissions_to_administer_resource_locks:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Role {role_name} from subscription {AZURE_SUSCRIPTION} has no permission to administer resource locks."
+                == f"Role {role_name} from subscription {AZURE_SUBSCRIPTION} has no permission to administer resource locks."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert (
                 result[0].resource_id
-                == defender_client.custom_roles[AZURE_SUSCRIPTION][0].id
+                == defender_client.custom_roles[AZURE_SUBSCRIPTION][0].id
             )
             assert result[0].resource_name == role_name

--- a/tests/providers/azure/services/iam/iam_subscription_roles_owner_custom_not_created/iam_subscription_roles_owner_custom_not_created_test.py
+++ b/tests/providers/azure/services/iam/iam_subscription_roles_owner_custom_not_created/iam_subscription_roles_owner_custom_not_created_test.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 from azure.mgmt.authorization.v2022_04_01.models import Permission
 
 from prowler.providers.azure.services.iam.iam_service import Role
-from tests.providers.azure.azure_fixtures import AZURE_SUSCRIPTION
+from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_iam_subscription_roles_owner_custom_not_created:
@@ -28,7 +28,7 @@ class Test_iam_subscription_roles_owner_custom_not_created:
         defender_client = mock.MagicMock
         role_name = "test-role"
         defender_client.custom_roles = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Role(
                     id=str(uuid4()),
                     name=role_name,
@@ -53,12 +53,12 @@ class Test_iam_subscription_roles_owner_custom_not_created:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Role {role_name} from subscription {AZURE_SUSCRIPTION} is a custom owner role."
+                == f"Role {role_name} from subscription {AZURE_SUBSCRIPTION} is a custom owner role."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert (
                 result[0].resource_id
-                == defender_client.custom_roles[AZURE_SUSCRIPTION][0].id
+                == defender_client.custom_roles[AZURE_SUBSCRIPTION][0].id
             )
             assert result[0].resource_name == role_name
 
@@ -66,7 +66,7 @@ class Test_iam_subscription_roles_owner_custom_not_created:
         defender_client = mock.MagicMock
         role_name = "test-role"
         defender_client.custom_roles = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Role(
                     id=str(uuid4()),
                     name=role_name,
@@ -91,11 +91,11 @@ class Test_iam_subscription_roles_owner_custom_not_created:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Role {role_name} from subscription {AZURE_SUSCRIPTION} is not a custom owner role."
+                == f"Role {role_name} from subscription {AZURE_SUBSCRIPTION} is not a custom owner role."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert (
                 result[0].resource_id
-                == defender_client.custom_roles[AZURE_SUSCRIPTION][0].id
+                == defender_client.custom_roles[AZURE_SUBSCRIPTION][0].id
             )
             assert result[0].resource_name == role_name

--- a/tests/providers/azure/services/sqlserver/sqlserver_auditing_enabled/sqlserver_auditing_enabled_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_auditing_enabled/sqlserver_auditing_enabled_test.py
@@ -8,7 +8,7 @@ from azure.mgmt.sql.models import (
 )
 
 from prowler.providers.azure.services.sqlserver.sqlserver_service import Server
-from tests.providers.azure.azure_fixtures import AZURE_SUSCRIPTION
+from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_sqlserver_auditing_enabled:
@@ -33,7 +33,7 @@ class Test_sqlserver_auditing_enabled:
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -60,9 +60,9 @@ class Test_sqlserver_auditing_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} does not have any auditing policy configured."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} does not have any auditing policy configured."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id
 
@@ -71,7 +71,7 @@ class Test_sqlserver_auditing_enabled:
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -98,8 +98,8 @@ class Test_sqlserver_auditing_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has a auditing policy configured."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has a auditing policy configured."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id

--- a/tests/providers/azure/services/sqlserver/sqlserver_auditing_enabled/sqlserver_auditing_enabled_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_auditing_enabled/sqlserver_auditing_enabled_test.py
@@ -7,7 +7,7 @@ from azure.mgmt.sql.models import (
     ServerExternalAdministrator,
 )
 
-from prowler.providers.azure.services.sqlserver.sqlserver_service import SQL_Server
+from prowler.providers.azure.services.sqlserver.sqlserver_service import Server
 from tests.providers.azure.azure_fixtures import AZURE_SUSCRIPTION
 
 
@@ -34,7 +34,7 @@ class Test_sqlserver_auditing_enabled:
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",
@@ -72,7 +72,7 @@ class Test_sqlserver_auditing_enabled:
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",

--- a/tests/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from azure.mgmt.sql.models import ServerBlobAuditingPolicy
 
-from prowler.providers.azure.services.sqlserver.sqlserver_service import SQL_Server
+from prowler.providers.azure.services.sqlserver.sqlserver_service import Server
 from tests.providers.azure.azure_fixtures import AZURE_SUSCRIPTION
 
 
@@ -30,7 +30,7 @@ class Test_sqlserver_auditing_retention_90_days:
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",
@@ -70,7 +70,7 @@ class Test_sqlserver_auditing_retention_90_days:
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",
@@ -112,7 +112,7 @@ class Test_sqlserver_auditing_retention_90_days:
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",
@@ -156,7 +156,7 @@ class Test_sqlserver_auditing_retention_90_days:
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",
@@ -201,7 +201,7 @@ class Test_sqlserver_auditing_retention_90_days:
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",

--- a/tests/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days_test.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 from azure.mgmt.sql.models import ServerBlobAuditingPolicy
 
 from prowler.providers.azure.services.sqlserver.sqlserver_service import Server
-from tests.providers.azure.azure_fixtures import AZURE_SUSCRIPTION
+from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_sqlserver_auditing_retention_90_days:
@@ -29,7 +29,7 @@ class Test_sqlserver_auditing_retention_90_days:
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -58,9 +58,9 @@ class Test_sqlserver_auditing_retention_90_days:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has auditing disabled."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has auditing disabled."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id
 
@@ -69,7 +69,7 @@ class Test_sqlserver_auditing_retention_90_days:
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -100,9 +100,9 @@ class Test_sqlserver_auditing_retention_90_days:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has auditing retention less than 91 days."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has auditing retention less than 91 days."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id
 
@@ -111,7 +111,7 @@ class Test_sqlserver_auditing_retention_90_days:
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -142,9 +142,9 @@ class Test_sqlserver_auditing_retention_90_days:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has auditing retention greater than 90 days."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has auditing retention greater than 90 days."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id
 
@@ -155,7 +155,7 @@ class Test_sqlserver_auditing_retention_90_days:
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -187,9 +187,9 @@ class Test_sqlserver_auditing_retention_90_days:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has auditing retention greater than 90 days."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has auditing retention greater than 90 days."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id
 
@@ -200,7 +200,7 @@ class Test_sqlserver_auditing_retention_90_days:
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -232,8 +232,8 @@ class Test_sqlserver_auditing_retention_90_days:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has auditing retention less than 91 days."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has auditing retention less than 91 days."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id

--- a/tests/providers/azure/services/sqlserver/sqlserver_azuread_administrator_enabled/sqlserver_azuread_administrator_enabled_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_azuread_administrator_enabled/sqlserver_azuread_administrator_enabled_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from azure.mgmt.sql.models import ServerExternalAdministrator
 
-from prowler.providers.azure.services.sqlserver.sqlserver_service import SQL_Server
+from prowler.providers.azure.services.sqlserver.sqlserver_service import Server
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -31,7 +31,7 @@ class Test_sqlserver_azuread_administrator_enabled:
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",
@@ -69,7 +69,7 @@ class Test_sqlserver_azuread_administrator_enabled:
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",
@@ -109,7 +109,7 @@ class Test_sqlserver_azuread_administrator_enabled:
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",

--- a/tests/providers/azure/services/sqlserver/sqlserver_azuread_administrator_enabled/sqlserver_azuread_administrator_enabled_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_azuread_administrator_enabled/sqlserver_azuread_administrator_enabled_test.py
@@ -5,7 +5,7 @@ from azure.mgmt.sql.models import ServerExternalAdministrator
 
 from prowler.providers.azure.services.sqlserver.sqlserver_service import Server
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_sqlserver_azuread_administrator_enabled:
@@ -30,7 +30,7 @@ class Test_sqlserver_azuread_administrator_enabled:
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -57,9 +57,9 @@ class Test_sqlserver_azuread_administrator_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} does not have an Active Directory administrator."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} does not have an Active Directory administrator."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id
 
@@ -68,7 +68,7 @@ class Test_sqlserver_azuread_administrator_enabled:
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -97,9 +97,9 @@ class Test_sqlserver_azuread_administrator_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} does not have an Active Directory administrator."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} does not have an Active Directory administrator."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id
 
@@ -108,7 +108,7 @@ class Test_sqlserver_azuread_administrator_enabled:
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -137,8 +137,8 @@ class Test_sqlserver_azuread_administrator_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has an Active Directory administrator."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has an Active Directory administrator."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id

--- a/tests/providers/azure/services/sqlserver/sqlserver_service_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_service_test.py
@@ -7,8 +7,8 @@ from azure.mgmt.sql.models import (
 )
 
 from prowler.providers.azure.services.sqlserver.sqlserver_service import (
-    DatabaseServer,
-    SQL_Server,
+    Database,
+    Server,
     SQLServer,
 )
 from tests.providers.azure.azure_fixtures import (
@@ -18,7 +18,7 @@ from tests.providers.azure.azure_fixtures import (
 
 
 def mock_sqlserver_get_sql_servers(_):
-    database = DatabaseServer(
+    database = Database(
         id="id",
         name="name",
         type="type",
@@ -28,7 +28,7 @@ def mock_sqlserver_get_sql_servers(_):
     )
     return {
         AZURE_SUSCRIPTION: [
-            SQL_Server(
+            Server(
                 id="id",
                 name="name",
                 public_network_access="public_network_access",
@@ -61,7 +61,7 @@ class Test_SqlServer_Service:
         )
 
     def test__get_sql_servers__(self):
-        database = DatabaseServer(
+        database = Database(
             id="id",
             name="name",
             type="type",
@@ -71,8 +71,7 @@ class Test_SqlServer_Service:
         )
         sql_server = SQLServer(set_mocked_azure_audit_info())
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][0].__class__.__name__
-            == "SQL_Server"
+            sql_server.sql_servers[AZURE_SUSCRIPTION][0].__class__.__name__ == "Server"
         )
         assert sql_server.sql_servers[AZURE_SUSCRIPTION][0].id == "id"
         assert sql_server.sql_servers[AZURE_SUSCRIPTION][0].name == "name"
@@ -105,7 +104,7 @@ class Test_SqlServer_Service:
         sql_server = SQLServer(set_mocked_azure_audit_info())
         assert (
             sql_server.sql_servers[AZURE_SUSCRIPTION][0].databases[0].__class__.__name__
-            == "DatabaseServer"
+            == "Database"
         )
         assert sql_server.sql_servers[AZURE_SUSCRIPTION][0].databases[0].id == "id"
         assert sql_server.sql_servers[AZURE_SUSCRIPTION][0].databases[0].name == "name"

--- a/tests/providers/azure/services/sqlserver/sqlserver_service_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_service_test.py
@@ -12,7 +12,7 @@ from prowler.providers.azure.services.sqlserver.sqlserver_service import (
     SQLServer,
 )
 from tests.providers.azure.azure_fixtures import (
-    AZURE_SUSCRIPTION,
+    AZURE_SUBSCRIPTION,
     set_mocked_azure_audit_info,
 )
 
@@ -27,7 +27,7 @@ def mock_sqlserver_get_sql_servers(_):
         tde_encryption=TransparentDataEncryption(status="Disabled"),
     )
     return {
-        AZURE_SUSCRIPTION: [
+        AZURE_SUBSCRIPTION: [
             Server(
                 id="id",
                 name="name",
@@ -56,7 +56,7 @@ class Test_SqlServer_Service:
     def test__get_client__(self):
         sql_server = SQLServer(set_mocked_azure_audit_info())
         assert (
-            sql_server.clients[AZURE_SUSCRIPTION].__class__.__name__
+            sql_server.clients[AZURE_SUBSCRIPTION].__class__.__name__
             == "SqlManagementClient"
         )
 
@@ -71,30 +71,30 @@ class Test_SqlServer_Service:
         )
         sql_server = SQLServer(set_mocked_azure_audit_info())
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][0].__class__.__name__ == "Server"
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][0].__class__.__name__ == "Server"
         )
-        assert sql_server.sql_servers[AZURE_SUSCRIPTION][0].id == "id"
-        assert sql_server.sql_servers[AZURE_SUSCRIPTION][0].name == "name"
+        assert sql_server.sql_servers[AZURE_SUBSCRIPTION][0].id == "id"
+        assert sql_server.sql_servers[AZURE_SUBSCRIPTION][0].name == "name"
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][0].public_network_access
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][0].public_network_access
             == "public_network_access"
         )
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][0].minimal_tls_version
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][0].minimal_tls_version
             == "minimal_tls_version"
         )
-        assert sql_server.sql_servers[AZURE_SUSCRIPTION][0].administrators is None
-        assert sql_server.sql_servers[AZURE_SUSCRIPTION][0].auditing_policies is None
-        assert sql_server.sql_servers[AZURE_SUSCRIPTION][0].firewall_rules is None
+        assert sql_server.sql_servers[AZURE_SUBSCRIPTION][0].administrators is None
+        assert sql_server.sql_servers[AZURE_SUBSCRIPTION][0].auditing_policies is None
+        assert sql_server.sql_servers[AZURE_SUBSCRIPTION][0].firewall_rules is None
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][
                 0
             ].encryption_protector.__class__.__name__
             == "EncryptionProtector"
         )
-        assert sql_server.sql_servers[AZURE_SUSCRIPTION][0].databases == [database]
+        assert sql_server.sql_servers[AZURE_SUBSCRIPTION][0].databases == [database]
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][
                 0
             ].vulnerability_assessment.__class__.__name__
             == "ServerVulnerabilityAssessment"
@@ -103,22 +103,24 @@ class Test_SqlServer_Service:
     def test__get_databases__(self):
         sql_server = SQLServer(set_mocked_azure_audit_info())
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][0].databases[0].__class__.__name__
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][0]
+            .databases[0]
+            .__class__.__name__
             == "Database"
         )
-        assert sql_server.sql_servers[AZURE_SUSCRIPTION][0].databases[0].id == "id"
-        assert sql_server.sql_servers[AZURE_SUSCRIPTION][0].databases[0].name == "name"
-        assert sql_server.sql_servers[AZURE_SUSCRIPTION][0].databases[0].type == "type"
+        assert sql_server.sql_servers[AZURE_SUBSCRIPTION][0].databases[0].id == "id"
+        assert sql_server.sql_servers[AZURE_SUBSCRIPTION][0].databases[0].name == "name"
+        assert sql_server.sql_servers[AZURE_SUBSCRIPTION][0].databases[0].type == "type"
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][0].databases[0].location
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][0].databases[0].location
             == "location"
         )
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][0].databases[0].managed_by
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][0].databases[0].managed_by
             == "managed_by"
         )
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][0]
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][0]
             .databases[0]
             .tde_encryption.__class__.__name__
             == "TransparentDataEncryption"
@@ -127,13 +129,13 @@ class Test_SqlServer_Service:
     def test__get_transparent_data_encryption__(self):
         sql_server = SQLServer(set_mocked_azure_audit_info())
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][0]
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][0]
             .databases[0]
             .tde_encryption.__class__.__name__
             == "TransparentDataEncryption"
         )
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][0]
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][0]
             .databases[0]
             .tde_encryption.status
             == "Disabled"
@@ -142,13 +144,13 @@ class Test_SqlServer_Service:
     def test__get_encryption_protectors__(self):
         sql_server = SQLServer(set_mocked_azure_audit_info())
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][
                 0
             ].encryption_protector.__class__.__name__
             == "EncryptionProtector"
         )
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][
                 0
             ].encryption_protector.server_key_type
             == "AzureKeyVault"
@@ -163,13 +165,13 @@ class Test_SqlServer_Service:
         sql_server = SQLServer(set_mocked_azure_audit_info())
         storage_container_path = "/subcription_id/resource_group/sql_server"
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][
                 0
             ].vulnerability_assessment.__class__.__name__
             == "ServerVulnerabilityAssessment"
         )
         assert (
-            sql_server.sql_servers[AZURE_SUSCRIPTION][
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][
                 0
             ].vulnerability_assessment.storage_container_path
             == storage_container_path

--- a/tests/providers/azure/services/sqlserver/sqlserver_tde_encrypted_with_cmk/sqlserver_tde_encrypted_with_cmk_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_tde_encrypted_with_cmk/sqlserver_tde_encrypted_with_cmk_test.py
@@ -4,8 +4,8 @@ from uuid import uuid4
 from azure.mgmt.sql.models import EncryptionProtector, TransparentDataEncryption
 
 from prowler.providers.azure.services.sqlserver.sqlserver_service import (
-    DatabaseServer,
-    SQL_Server,
+    Database,
+    Server,
 )
 
 AZURE_SUSCRIPTION = str(uuid4())
@@ -34,7 +34,7 @@ class Test_sqlserver_tde_encrypted_with_cmk:
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",
@@ -63,7 +63,7 @@ class Test_sqlserver_tde_encrypted_with_cmk:
         sqlserver_client = mock.MagicMock
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
-        database = DatabaseServer(
+        database = Database(
             id="id",
             name="name",
             type="type",
@@ -73,7 +73,7 @@ class Test_sqlserver_tde_encrypted_with_cmk:
         )
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",
@@ -113,7 +113,7 @@ class Test_sqlserver_tde_encrypted_with_cmk:
         sqlserver_client = mock.MagicMock
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
-        database = DatabaseServer(
+        database = Database(
             id="id",
             name="name",
             type="type",
@@ -123,7 +123,7 @@ class Test_sqlserver_tde_encrypted_with_cmk:
         )
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",
@@ -163,7 +163,7 @@ class Test_sqlserver_tde_encrypted_with_cmk:
         sqlserver_client = mock.MagicMock
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
-        database = DatabaseServer(
+        database = Database(
             id="id",
             name="name",
             type="type",
@@ -173,7 +173,7 @@ class Test_sqlserver_tde_encrypted_with_cmk:
         )
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",

--- a/tests/providers/azure/services/sqlserver/sqlserver_tde_encrypted_with_cmk/sqlserver_tde_encrypted_with_cmk_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_tde_encrypted_with_cmk/sqlserver_tde_encrypted_with_cmk_test.py
@@ -8,7 +8,7 @@ from prowler.providers.azure.services.sqlserver.sqlserver_service import (
     Server,
 )
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_sqlserver_tde_encrypted_with_cmk:
@@ -33,7 +33,7 @@ class Test_sqlserver_tde_encrypted_with_cmk:
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -72,7 +72,7 @@ class Test_sqlserver_tde_encrypted_with_cmk:
             tde_encryption=None,
         )
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -103,9 +103,9 @@ class Test_sqlserver_tde_encrypted_with_cmk:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has TDE disabled without CMK."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has TDE disabled without CMK."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id
 
@@ -122,7 +122,7 @@ class Test_sqlserver_tde_encrypted_with_cmk:
             tde_encryption=TransparentDataEncryption(status="Disabled"),
         )
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -153,9 +153,9 @@ class Test_sqlserver_tde_encrypted_with_cmk:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has TDE disabled with CMK."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has TDE disabled with CMK."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id
 
@@ -172,7 +172,7 @@ class Test_sqlserver_tde_encrypted_with_cmk:
             tde_encryption=TransparentDataEncryption(status="Enabled"),
         )
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -203,8 +203,8 @@ class Test_sqlserver_tde_encrypted_with_cmk:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has TDE enabled with CMK."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has TDE enabled with CMK."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id

--- a/tests/providers/azure/services/sqlserver/sqlserver_tde_encryption_enabled/sqlserver_tde_encryption_enabled_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_tde_encryption_enabled/sqlserver_tde_encryption_enabled_test.py
@@ -4,8 +4,8 @@ from uuid import uuid4
 from azure.mgmt.sql.models import TransparentDataEncryption
 
 from prowler.providers.azure.services.sqlserver.sqlserver_service import (
-    DatabaseServer,
-    SQL_Server,
+    Database,
+    Server,
 )
 
 AZURE_SUSCRIPTION = str(uuid4())
@@ -34,7 +34,7 @@ class Test_sqlserver_tde_encryption_enabled:
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",
@@ -65,7 +65,7 @@ class Test_sqlserver_tde_encryption_enabled:
         sql_server_id = str(uuid4())
         database_name = "Database Name"
         database_id = str(uuid4())
-        database = DatabaseServer(
+        database = Database(
             id=database_id,
             name=database_name,
             type="type",
@@ -75,7 +75,7 @@ class Test_sqlserver_tde_encryption_enabled:
         )
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",
@@ -115,7 +115,7 @@ class Test_sqlserver_tde_encryption_enabled:
         sql_server_id = str(uuid4())
         database_name = "Database Name"
         database_id = str(uuid4())
-        database = DatabaseServer(
+        database = Database(
             id=database_id,
             name=database_name,
             type="type",
@@ -125,7 +125,7 @@ class Test_sqlserver_tde_encryption_enabled:
         )
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",

--- a/tests/providers/azure/services/sqlserver/sqlserver_tde_encryption_enabled/sqlserver_tde_encryption_enabled_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_tde_encryption_enabled/sqlserver_tde_encryption_enabled_test.py
@@ -8,7 +8,7 @@ from prowler.providers.azure.services.sqlserver.sqlserver_service import (
     Server,
 )
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_sqlserver_tde_encryption_enabled:
@@ -33,7 +33,7 @@ class Test_sqlserver_tde_encryption_enabled:
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -74,7 +74,7 @@ class Test_sqlserver_tde_encryption_enabled:
             tde_encryption=TransparentDataEncryption(status="Disabled"),
         )
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -103,9 +103,9 @@ class Test_sqlserver_tde_encryption_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Database {database_name} from SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has TDE disabled"
+                == f"Database {database_name} from SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has TDE disabled"
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == database_name
             assert result[0].resource_id == database_id
 
@@ -124,7 +124,7 @@ class Test_sqlserver_tde_encryption_enabled:
             tde_encryption=TransparentDataEncryption(status="Enabled"),
         )
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -153,8 +153,8 @@ class Test_sqlserver_tde_encryption_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Database {database_name} from SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has TDE enabled"
+                == f"Database {database_name} from SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has TDE enabled"
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == database_name
             assert result[0].resource_id == database_id

--- a/tests/providers/azure/services/sqlserver/sqlserver_unrestricted_inbound_access/sqlserver_unrestricted_inbound_access_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_unrestricted_inbound_access/sqlserver_unrestricted_inbound_access_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from azure.mgmt.sql.models import FirewallRule
 
-from prowler.providers.azure.services.sqlserver.sqlserver_service import SQL_Server
+from prowler.providers.azure.services.sqlserver.sqlserver_service import Server
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -31,7 +31,7 @@ class Test_sqlserver_unrestricted_inbound_access:
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",
@@ -73,7 +73,7 @@ class Test_sqlserver_unrestricted_inbound_access:
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",

--- a/tests/providers/azure/services/sqlserver/sqlserver_unrestricted_inbound_access/sqlserver_unrestricted_inbound_access_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_unrestricted_inbound_access/sqlserver_unrestricted_inbound_access_test.py
@@ -5,7 +5,7 @@ from azure.mgmt.sql.models import FirewallRule
 
 from prowler.providers.azure.services.sqlserver.sqlserver_service import Server
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_sqlserver_unrestricted_inbound_access:
@@ -30,7 +30,7 @@ class Test_sqlserver_unrestricted_inbound_access:
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -61,9 +61,9 @@ class Test_sqlserver_unrestricted_inbound_access:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has firewall rules allowing 0.0.0.0-255.255.255.255."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has firewall rules allowing 0.0.0.0-255.255.255.255."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id
 
@@ -72,7 +72,7 @@ class Test_sqlserver_unrestricted_inbound_access:
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -103,8 +103,8 @@ class Test_sqlserver_unrestricted_inbound_access:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} does not have firewall rules allowing 0.0.0.0-255.255.255.255."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} does not have firewall rules allowing 0.0.0.0-255.255.255.255."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id

--- a/tests/providers/azure/services/sqlserver/sqlserver_vulnerability_assessment_enabled/sqlserver_vulnerability_assessment_enabled_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_vulnerability_assessment_enabled/sqlserver_vulnerability_assessment_enabled_test.py
@@ -12,7 +12,7 @@ from prowler.providers.azure.services.sqlserver.sqlserver_service import (
     Server,
 )
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_sqlserver_vulnerability_assessment_enabled:
@@ -45,7 +45,7 @@ class Test_sqlserver_vulnerability_assessment_enabled:
             tde_encryption=None,
         )
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -77,9 +77,9 @@ class Test_sqlserver_vulnerability_assessment_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has vulnerability assessment disabled."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has vulnerability assessment disabled."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id
 
@@ -96,7 +96,7 @@ class Test_sqlserver_vulnerability_assessment_enabled:
             tde_encryption=TransparentDataEncryption(status="Disabled"),
         )
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -130,9 +130,9 @@ class Test_sqlserver_vulnerability_assessment_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has vulnerability assessment disabled."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has vulnerability assessment disabled."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id
 
@@ -149,7 +149,7 @@ class Test_sqlserver_vulnerability_assessment_enabled:
             tde_encryption=TransparentDataEncryption(status="Enabled"),
         )
         sqlserver_client.sql_servers = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Server(
                     id=sql_server_id,
                     name=sql_server_name,
@@ -183,8 +183,8 @@ class Test_sqlserver_vulnerability_assessment_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"SQL Server {sql_server_name} from subscription {AZURE_SUSCRIPTION} has vulnerability assessment enabled."
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has vulnerability assessment enabled."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id

--- a/tests/providers/azure/services/sqlserver/sqlserver_vulnerability_assessment_enabled/sqlserver_vulnerability_assessment_enabled_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_vulnerability_assessment_enabled/sqlserver_vulnerability_assessment_enabled_test.py
@@ -8,8 +8,8 @@ from azure.mgmt.sql.models import (
 )
 
 from prowler.providers.azure.services.sqlserver.sqlserver_service import (
-    DatabaseServer,
-    SQL_Server,
+    Database,
+    Server,
 )
 
 AZURE_SUSCRIPTION = str(uuid4())
@@ -36,7 +36,7 @@ class Test_sqlserver_vulnerability_assessment_enabled:
         sqlserver_client = mock.MagicMock
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
-        database = DatabaseServer(
+        database = Database(
             id="id",
             name="name",
             type="type",
@@ -46,7 +46,7 @@ class Test_sqlserver_vulnerability_assessment_enabled:
         )
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",
@@ -87,7 +87,7 @@ class Test_sqlserver_vulnerability_assessment_enabled:
         sqlserver_client = mock.MagicMock
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
-        database = DatabaseServer(
+        database = Database(
             id="id",
             name="name",
             type="type",
@@ -97,7 +97,7 @@ class Test_sqlserver_vulnerability_assessment_enabled:
         )
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",
@@ -140,7 +140,7 @@ class Test_sqlserver_vulnerability_assessment_enabled:
         sqlserver_client = mock.MagicMock
         sql_server_name = "SQL Server Name"
         sql_server_id = str(uuid4())
-        database = DatabaseServer(
+        database = Database(
             id="id",
             name="name",
             type="type",
@@ -150,7 +150,7 @@ class Test_sqlserver_vulnerability_assessment_enabled:
         )
         sqlserver_client.sql_servers = {
             AZURE_SUSCRIPTION: [
-                SQL_Server(
+                Server(
                     id=sql_server_id,
                     name=sql_server_name,
                     public_network_access="",

--- a/tests/providers/azure/services/storage/storage_blob_public_access_level_is_disabled/storage_blob_public_access_level_is_disabled_test.py
+++ b/tests/providers/azure/services/storage/storage_blob_public_access_level_is_disabled/storage_blob_public_access_level_is_disabled_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.storage.storage_service import Storage_Account
+from prowler.providers.azure.services.storage.storage_service import Account
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -29,7 +29,7 @@ class Test_storage_blob_public_access_level_is_disabled:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,
@@ -71,7 +71,7 @@ class Test_storage_blob_public_access_level_is_disabled:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,

--- a/tests/providers/azure/services/storage/storage_blob_public_access_level_is_disabled/storage_blob_public_access_level_is_disabled_test.py
+++ b/tests/providers/azure/services/storage/storage_blob_public_access_level_is_disabled/storage_blob_public_access_level_is_disabled_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.storage.storage_service import Account
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_storage_blob_public_access_level_is_disabled:
@@ -28,7 +28,7 @@ class Test_storage_blob_public_access_level_is_disabled:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -59,9 +59,9 @@ class Test_storage_blob_public_access_level_is_disabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} has allow blob public access enabled."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} has allow blob public access enabled."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id
 
@@ -70,7 +70,7 @@ class Test_storage_blob_public_access_level_is_disabled:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -101,8 +101,8 @@ class Test_storage_blob_public_access_level_is_disabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} has allow blob public access disabled."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} has allow blob public access disabled."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id

--- a/tests/providers/azure/services/storage/storage_default_network_access_rule_is_denied/storage_default_network_access_rule_is_denied_test.py
+++ b/tests/providers/azure/services/storage/storage_default_network_access_rule_is_denied/storage_default_network_access_rule_is_denied_test.py
@@ -5,7 +5,7 @@ from azure.mgmt.storage.v2022_09_01.models import NetworkRuleSet
 
 from prowler.providers.azure.services.storage.storage_service import Account
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_storage_default_network_access_rule_is_denied:
@@ -30,7 +30,7 @@ class Test_storage_default_network_access_rule_is_denied:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -61,9 +61,9 @@ class Test_storage_default_network_access_rule_is_denied:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} has network access rule set to Allow."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} has network access rule set to Allow."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id
 
@@ -72,7 +72,7 @@ class Test_storage_default_network_access_rule_is_denied:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -103,8 +103,8 @@ class Test_storage_default_network_access_rule_is_denied:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} has network access rule set to Deny."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} has network access rule set to Deny."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id

--- a/tests/providers/azure/services/storage/storage_default_network_access_rule_is_denied/storage_default_network_access_rule_is_denied_test.py
+++ b/tests/providers/azure/services/storage/storage_default_network_access_rule_is_denied/storage_default_network_access_rule_is_denied_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from azure.mgmt.storage.v2022_09_01.models import NetworkRuleSet
 
-from prowler.providers.azure.services.storage.storage_service import Storage_Account
+from prowler.providers.azure.services.storage.storage_service import Account
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -31,7 +31,7 @@ class Test_storage_default_network_access_rule_is_denied:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,
@@ -73,7 +73,7 @@ class Test_storage_default_network_access_rule_is_denied:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,

--- a/tests/providers/azure/services/storage/storage_ensure_azure_services_are_trusted_to_access_is_enabled/storage_ensure_azure_services_are_trusted_to_access_is_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_azure_services_are_trusted_to_access_is_enabled/storage_ensure_azure_services_are_trusted_to_access_is_enabled_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from azure.mgmt.storage.v2022_09_01.models import NetworkRuleSet
 
-from prowler.providers.azure.services.storage.storage_service import Storage_Account
+from prowler.providers.azure.services.storage.storage_service import Account
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -31,7 +31,7 @@ class Test_storage_ensure_azure_services_are_trusted_to_access_is_enabled:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,
@@ -73,7 +73,7 @@ class Test_storage_ensure_azure_services_are_trusted_to_access_is_enabled:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,

--- a/tests/providers/azure/services/storage/storage_ensure_azure_services_are_trusted_to_access_is_enabled/storage_ensure_azure_services_are_trusted_to_access_is_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_azure_services_are_trusted_to_access_is_enabled/storage_ensure_azure_services_are_trusted_to_access_is_enabled_test.py
@@ -5,7 +5,7 @@ from azure.mgmt.storage.v2022_09_01.models import NetworkRuleSet
 
 from prowler.providers.azure.services.storage.storage_service import Account
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_storage_ensure_azure_services_are_trusted_to_access_is_enabled:
@@ -30,7 +30,7 @@ class Test_storage_ensure_azure_services_are_trusted_to_access_is_enabled:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -61,9 +61,9 @@ class Test_storage_ensure_azure_services_are_trusted_to_access_is_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} does not allow trusted Microsoft services to access this storage account."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} does not allow trusted Microsoft services to access this storage account."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id
 
@@ -72,7 +72,7 @@ class Test_storage_ensure_azure_services_are_trusted_to_access_is_enabled:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -103,8 +103,8 @@ class Test_storage_ensure_azure_services_are_trusted_to_access_is_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} allows trusted Microsoft services to access this storage account."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} allows trusted Microsoft services to access this storage account."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id

--- a/tests/providers/azure/services/storage/storage_ensure_encryption_with_customer_managed_keys/storage_ensure_encryption_with_customer_managed_keys_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_encryption_with_customer_managed_keys/storage_ensure_encryption_with_customer_managed_keys_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.storage.storage_service import Storage_Account
+from prowler.providers.azure.services.storage.storage_service import Account
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -29,7 +29,7 @@ class Test_storage_ensure_encryption_with_customer_managed_keys:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,
@@ -71,7 +71,7 @@ class Test_storage_ensure_encryption_with_customer_managed_keys:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,

--- a/tests/providers/azure/services/storage/storage_ensure_encryption_with_customer_managed_keys/storage_ensure_encryption_with_customer_managed_keys_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_encryption_with_customer_managed_keys/storage_ensure_encryption_with_customer_managed_keys_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.storage.storage_service import Account
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_storage_ensure_encryption_with_customer_managed_keys:
@@ -28,7 +28,7 @@ class Test_storage_ensure_encryption_with_customer_managed_keys:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -59,9 +59,9 @@ class Test_storage_ensure_encryption_with_customer_managed_keys:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} does not encrypt with CMKs."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} does not encrypt with CMKs."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id
 
@@ -70,7 +70,7 @@ class Test_storage_ensure_encryption_with_customer_managed_keys:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -101,8 +101,8 @@ class Test_storage_ensure_encryption_with_customer_managed_keys:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} encrypts with CMKs."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} encrypts with CMKs."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id

--- a/tests/providers/azure/services/storage/storage_ensure_minimum_tls_version_12/storage_ensure_minimum_tls_version_12_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_minimum_tls_version_12/storage_ensure_minimum_tls_version_12_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.storage.storage_service import Account
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_storage_ensure_minimum_tls_version_12:
@@ -28,7 +28,7 @@ class Test_storage_ensure_minimum_tls_version_12:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -59,9 +59,9 @@ class Test_storage_ensure_minimum_tls_version_12:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} does not have TLS version set to 1.2."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} does not have TLS version set to 1.2."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id
 
@@ -70,7 +70,7 @@ class Test_storage_ensure_minimum_tls_version_12:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -101,8 +101,8 @@ class Test_storage_ensure_minimum_tls_version_12:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} has TLS version set to 1.2."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} has TLS version set to 1.2."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id

--- a/tests/providers/azure/services/storage/storage_ensure_minimum_tls_version_12/storage_ensure_minimum_tls_version_12_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_minimum_tls_version_12/storage_ensure_minimum_tls_version_12_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.storage.storage_service import Storage_Account
+from prowler.providers.azure.services.storage.storage_service import Account
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -29,7 +29,7 @@ class Test_storage_ensure_minimum_tls_version_12:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,
@@ -71,7 +71,7 @@ class Test_storage_ensure_minimum_tls_version_12:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,

--- a/tests/providers/azure/services/storage/storage_ensure_private_endpoints_in_storage_accounts/storage_ensure_private_endpoints_in_storage_accounts_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_private_endpoints_in_storage_accounts/storage_ensure_private_endpoints_in_storage_accounts_test.py
@@ -5,7 +5,7 @@ from azure.mgmt.storage.v2023_01_01.models import PrivateEndpointConnection
 
 from prowler.providers.azure.services.storage.storage_service import Account
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_storage_ensure_private_endpoints_in_storage_accounts:
@@ -32,7 +32,7 @@ class Test_storage_ensure_private_endpoints_in_storage_accounts:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -63,9 +63,9 @@ class Test_storage_ensure_private_endpoints_in_storage_accounts:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} does not have private endpoint connections."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} does not have private endpoint connections."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id
 
@@ -76,7 +76,7 @@ class Test_storage_ensure_private_endpoints_in_storage_accounts:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -107,8 +107,8 @@ class Test_storage_ensure_private_endpoints_in_storage_accounts:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} has private endpoint connections."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} has private endpoint connections."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id

--- a/tests/providers/azure/services/storage/storage_ensure_private_endpoints_in_storage_accounts/storage_ensure_private_endpoints_in_storage_accounts_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_private_endpoints_in_storage_accounts/storage_ensure_private_endpoints_in_storage_accounts_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from azure.mgmt.storage.v2023_01_01.models import PrivateEndpointConnection
 
-from prowler.providers.azure.services.storage.storage_service import Storage_Account
+from prowler.providers.azure.services.storage.storage_service import Account
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -33,7 +33,7 @@ class Test_storage_ensure_private_endpoints_in_storage_accounts:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,
@@ -77,7 +77,7 @@ class Test_storage_ensure_private_endpoints_in_storage_accounts:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,

--- a/tests/providers/azure/services/storage/storage_ensure_soft_delete_is_enabled/storage_ensure_soft_delete_is_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_soft_delete_is_enabled/storage_ensure_soft_delete_is_enabled_test.py
@@ -8,7 +8,7 @@ from prowler.providers.azure.services.storage.storage_service import (
     BlobProperties,
 )
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_storage_ensure_soft_delete_is_enabled:
@@ -34,7 +34,7 @@ class Test_storage_ensure_soft_delete_is_enabled:
         storage_client = mock.MagicMock
         storage_account_blob_properties = None
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -78,7 +78,7 @@ class Test_storage_ensure_soft_delete_is_enabled:
             container_delete_retention_policy=DeleteRetentionPolicy(enabled=False),
         )
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -110,9 +110,9 @@ class Test_storage_ensure_soft_delete_is_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} has soft delete disabled."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} has soft delete disabled."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id
 
@@ -130,7 +130,7 @@ class Test_storage_ensure_soft_delete_is_enabled:
             container_delete_retention_policy=DeleteRetentionPolicy(enabled=True),
         )
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -162,8 +162,8 @@ class Test_storage_ensure_soft_delete_is_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} has soft delete enabled."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} has soft delete enabled."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id

--- a/tests/providers/azure/services/storage/storage_ensure_soft_delete_is_enabled/storage_ensure_soft_delete_is_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_soft_delete_is_enabled/storage_ensure_soft_delete_is_enabled_test.py
@@ -4,8 +4,8 @@ from uuid import uuid4
 from azure.mgmt.storage.v2023_01_01.models import DeleteRetentionPolicy
 
 from prowler.providers.azure.services.storage.storage_service import (
-    Blob_Properties,
-    Storage_Account,
+    Account,
+    BlobProperties,
 )
 
 AZURE_SUSCRIPTION = str(uuid4())
@@ -35,7 +35,7 @@ class Test_storage_ensure_soft_delete_is_enabled:
         storage_account_blob_properties = None
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,
@@ -70,7 +70,7 @@ class Test_storage_ensure_soft_delete_is_enabled:
         storage_account_id = str(uuid4())
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
-        storage_account_blob_properties = Blob_Properties(
+        storage_account_blob_properties = BlobProperties(
             id=None,
             name=None,
             type=None,
@@ -79,7 +79,7 @@ class Test_storage_ensure_soft_delete_is_enabled:
         )
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,
@@ -122,7 +122,7 @@ class Test_storage_ensure_soft_delete_is_enabled:
         storage_account_id = str(uuid4())
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
-        storage_account_blob_properties = Blob_Properties(
+        storage_account_blob_properties = BlobProperties(
             id=None,
             name=None,
             type=None,
@@ -131,7 +131,7 @@ class Test_storage_ensure_soft_delete_is_enabled:
         )
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,

--- a/tests/providers/azure/services/storage/storage_infrastructure_encryption_is_enabled/storage_infrastructure_encryption_is_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_infrastructure_encryption_is_enabled/storage_infrastructure_encryption_is_enabled_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.storage.storage_service import Account
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_storage_infrastructure_encryption_is_enabled:
@@ -28,7 +28,7 @@ class Test_storage_infrastructure_encryption_is_enabled:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -59,9 +59,9 @@ class Test_storage_infrastructure_encryption_is_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} has infrastructure encryption disabled."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} has infrastructure encryption disabled."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id
 
@@ -70,7 +70,7 @@ class Test_storage_infrastructure_encryption_is_enabled:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -101,8 +101,8 @@ class Test_storage_infrastructure_encryption_is_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} has infrastructure encryption enabled."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} has infrastructure encryption enabled."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id

--- a/tests/providers/azure/services/storage/storage_infrastructure_encryption_is_enabled/storage_infrastructure_encryption_is_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_infrastructure_encryption_is_enabled/storage_infrastructure_encryption_is_enabled_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.storage.storage_service import Storage_Account
+from prowler.providers.azure.services.storage.storage_service import Account
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -29,7 +29,7 @@ class Test_storage_infrastructure_encryption_is_enabled:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,
@@ -71,7 +71,7 @@ class Test_storage_infrastructure_encryption_is_enabled:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,

--- a/tests/providers/azure/services/storage/storage_key_rotation_90_days/storage_key_rotation_90_days_test.py
+++ b/tests/providers/azure/services/storage/storage_key_rotation_90_days/storage_key_rotation_90_days_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.storage.storage_service import Storage_Account
+from prowler.providers.azure.services.storage.storage_service import Account
 from tests.providers.azure.azure_fixtures import AZURE_SUSCRIPTION
 
 
@@ -29,7 +29,7 @@ class Test_storage_key_rotation_90_dayss:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,
@@ -72,7 +72,7 @@ class Test_storage_key_rotation_90_dayss:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,
@@ -114,7 +114,7 @@ class Test_storage_key_rotation_90_dayss:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,

--- a/tests/providers/azure/services/storage/storage_key_rotation_90_days/storage_key_rotation_90_days_test.py
+++ b/tests/providers/azure/services/storage/storage_key_rotation_90_days/storage_key_rotation_90_days_test.py
@@ -2,7 +2,7 @@ from unittest import mock
 from uuid import uuid4
 
 from prowler.providers.azure.services.storage.storage_service import Account
-from tests.providers.azure.azure_fixtures import AZURE_SUSCRIPTION
+from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_storage_key_rotation_90_dayss:
@@ -28,7 +28,7 @@ class Test_storage_key_rotation_90_dayss:
         expiration_days = 91
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -59,9 +59,9 @@ class Test_storage_key_rotation_90_dayss:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} has an invalid key expiration period of {expiration_days} days."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} has an invalid key expiration period of {expiration_days} days."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id
 
@@ -71,7 +71,7 @@ class Test_storage_key_rotation_90_dayss:
         expiration_days = 90
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -102,9 +102,9 @@ class Test_storage_key_rotation_90_dayss:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} has a key expiration period of {expiration_days} days."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} has a key expiration period of {expiration_days} days."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id
 
@@ -113,7 +113,7 @@ class Test_storage_key_rotation_90_dayss:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -144,8 +144,8 @@ class Test_storage_key_rotation_90_dayss:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} has no key expiration period set."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} has no key expiration period set."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id

--- a/tests/providers/azure/services/storage/storage_secure_transfer_required_is_enabled/storage_secure_transfer_required_is_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_secure_transfer_required_is_enabled/storage_secure_transfer_required_is_enabled_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.storage.storage_service import Storage_Account
+from prowler.providers.azure.services.storage.storage_service import Account
 
 AZURE_SUSCRIPTION = str(uuid4())
 
@@ -29,7 +29,7 @@ class Test_storage_secure_transfer_required_is_enabled:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,
@@ -71,7 +71,7 @@ class Test_storage_secure_transfer_required_is_enabled:
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
             AZURE_SUSCRIPTION: [
-                Storage_Account(
+                Account(
                     id=storage_account_id,
                     name=storage_account_name,
                     resouce_group_name=None,

--- a/tests/providers/azure/services/storage/storage_secure_transfer_required_is_enabled/storage_secure_transfer_required_is_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_secure_transfer_required_is_enabled/storage_secure_transfer_required_is_enabled_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.storage.storage_service import Account
 
-AZURE_SUSCRIPTION = str(uuid4())
+AZURE_SUBSCRIPTION = str(uuid4())
 
 
 class Test_storage_secure_transfer_required_is_enabled:
@@ -28,7 +28,7 @@ class Test_storage_secure_transfer_required_is_enabled:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -59,9 +59,9 @@ class Test_storage_secure_transfer_required_is_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} has secure transfer required disabled."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} has secure transfer required disabled."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id
 
@@ -70,7 +70,7 @@ class Test_storage_secure_transfer_required_is_enabled:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_client.storage_accounts = {
-            AZURE_SUSCRIPTION: [
+            AZURE_SUBSCRIPTION: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
@@ -101,8 +101,8 @@ class Test_storage_secure_transfer_required_is_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Storage account {storage_account_name} from subscription {AZURE_SUSCRIPTION} has secure transfer required enabled."
+                == f"Storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION} has secure transfer required enabled."
             )
-            assert result[0].subscription == AZURE_SUSCRIPTION
+            assert result[0].subscription == AZURE_SUBSCRIPTION
             assert result[0].resource_name == storage_account_name
             assert result[0].resource_id == storage_account_id

--- a/tests/providers/azure/services/storage/storage_service_test.py
+++ b/tests/providers/azure/services/storage/storage_service_test.py
@@ -6,7 +6,7 @@ from prowler.providers.azure.services.storage.storage_service import (
     Storage,
 )
 from tests.providers.azure.azure_fixtures import (
-    AZURE_SUSCRIPTION,
+    AZURE_SUBSCRIPTION,
     set_mocked_azure_audit_info,
 )
 
@@ -20,7 +20,7 @@ def mock_storage_get_storage_accounts(_):
         container_delete_retention_policy=None,
     )
     return {
-        AZURE_SUSCRIPTION: [
+        AZURE_SUBSCRIPTION: [
             Account(
                 id="id",
                 name="name",
@@ -47,45 +47,49 @@ class Test_Storage_Service:
     def test__get_client__(self):
         storage = Storage(set_mocked_azure_audit_info())
         assert (
-            storage.clients[AZURE_SUSCRIPTION].__class__.__name__
+            storage.clients[AZURE_SUBSCRIPTION].__class__.__name__
             == "StorageManagementClient"
         )
 
     def test__get_storage_accounts__(self):
         storage = Storage(set_mocked_azure_audit_info())
         assert (
-            storage.storage_accounts[AZURE_SUSCRIPTION][0].__class__.__name__
+            storage.storage_accounts[AZURE_SUBSCRIPTION][0].__class__.__name__
             == "Account"
         )
-        assert storage.storage_accounts[AZURE_SUSCRIPTION][0].id == "id"
-        assert storage.storage_accounts[AZURE_SUSCRIPTION][0].name == "name"
-        assert storage.storage_accounts[AZURE_SUSCRIPTION][0].resouce_group_name is None
+        assert storage.storage_accounts[AZURE_SUBSCRIPTION][0].id == "id"
+        assert storage.storage_accounts[AZURE_SUBSCRIPTION][0].name == "name"
         assert (
-            storage.storage_accounts[AZURE_SUSCRIPTION][0].enable_https_traffic_only
+            storage.storage_accounts[AZURE_SUBSCRIPTION][0].resouce_group_name is None
+        )
+        assert (
+            storage.storage_accounts[AZURE_SUBSCRIPTION][0].enable_https_traffic_only
             is False
         )
         assert (
-            storage.storage_accounts[AZURE_SUSCRIPTION][0].infrastructure_encryption
+            storage.storage_accounts[AZURE_SUBSCRIPTION][0].infrastructure_encryption
             is False
         )
         assert (
-            storage.storage_accounts[AZURE_SUSCRIPTION][0].allow_blob_public_access
+            storage.storage_accounts[AZURE_SUBSCRIPTION][0].allow_blob_public_access
             is None
         )
-        assert storage.storage_accounts[AZURE_SUSCRIPTION][0].network_rule_set is None
-        assert storage.storage_accounts[AZURE_SUSCRIPTION][0].encryption_type == "None"
+        assert storage.storage_accounts[AZURE_SUBSCRIPTION][0].network_rule_set is None
+        assert storage.storage_accounts[AZURE_SUBSCRIPTION][0].encryption_type == "None"
         assert (
-            storage.storage_accounts[AZURE_SUSCRIPTION][0].minimum_tls_version is None
+            storage.storage_accounts[AZURE_SUBSCRIPTION][0].minimum_tls_version is None
         )
         assert (
-            storage.storage_accounts[AZURE_SUSCRIPTION][0].key_expiration_period_in_days
+            storage.storage_accounts[AZURE_SUBSCRIPTION][
+                0
+            ].key_expiration_period_in_days
             is None
         )
         assert (
-            storage.storage_accounts[AZURE_SUSCRIPTION][0].private_endpoint_connections
+            storage.storage_accounts[AZURE_SUBSCRIPTION][0].private_endpoint_connections
             is None
         )
-        assert storage.storage_accounts[AZURE_SUSCRIPTION][
+        assert storage.storage_accounts[AZURE_SUBSCRIPTION][
             0
         ].blob_properties == BlobProperties(
             id="id",
@@ -98,28 +102,30 @@ class Test_Storage_Service:
     def test__get_blob_properties__(self):
         storage = Storage(set_mocked_azure_audit_info())
         assert (
-            storage.storage_accounts[AZURE_SUSCRIPTION][
+            storage.storage_accounts[AZURE_SUBSCRIPTION][
                 0
             ].blob_properties.__class__.__name__
             == "BlobProperties"
         )
-        assert storage.storage_accounts[AZURE_SUSCRIPTION][0].blob_properties.id == "id"
         assert (
-            storage.storage_accounts[AZURE_SUSCRIPTION][0].blob_properties.name
+            storage.storage_accounts[AZURE_SUBSCRIPTION][0].blob_properties.id == "id"
+        )
+        assert (
+            storage.storage_accounts[AZURE_SUBSCRIPTION][0].blob_properties.name
             == "name"
         )
         assert (
-            storage.storage_accounts[AZURE_SUSCRIPTION][0].blob_properties.type
+            storage.storage_accounts[AZURE_SUBSCRIPTION][0].blob_properties.type
             == "type"
         )
         assert (
-            storage.storage_accounts[AZURE_SUSCRIPTION][
+            storage.storage_accounts[AZURE_SUBSCRIPTION][
                 0
             ].blob_properties.default_service_version
             is None
         )
         assert (
-            storage.storage_accounts[AZURE_SUSCRIPTION][
+            storage.storage_accounts[AZURE_SUBSCRIPTION][
                 0
             ].blob_properties.container_delete_retention_policy
             is None

--- a/tests/providers/azure/services/storage/storage_service_test.py
+++ b/tests/providers/azure/services/storage/storage_service_test.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch
 
 from prowler.providers.azure.services.storage.storage_service import (
-    Blob_Properties,
+    Account,
+    BlobProperties,
     Storage,
-    Storage_Account,
 )
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUSCRIPTION,
@@ -12,7 +12,7 @@ from tests.providers.azure.azure_fixtures import (
 
 
 def mock_storage_get_storage_accounts(_):
-    blob_properties = Blob_Properties(
+    blob_properties = BlobProperties(
         id="id",
         name="name",
         type="type",
@@ -21,7 +21,7 @@ def mock_storage_get_storage_accounts(_):
     )
     return {
         AZURE_SUSCRIPTION: [
-            Storage_Account(
+            Account(
                 id="id",
                 name="name",
                 resouce_group_name=None,
@@ -55,7 +55,7 @@ class Test_Storage_Service:
         storage = Storage(set_mocked_azure_audit_info())
         assert (
             storage.storage_accounts[AZURE_SUSCRIPTION][0].__class__.__name__
-            == "Storage_Account"
+            == "Account"
         )
         assert storage.storage_accounts[AZURE_SUSCRIPTION][0].id == "id"
         assert storage.storage_accounts[AZURE_SUSCRIPTION][0].name == "name"
@@ -87,7 +87,7 @@ class Test_Storage_Service:
         )
         assert storage.storage_accounts[AZURE_SUSCRIPTION][
             0
-        ].blob_properties == Blob_Properties(
+        ].blob_properties == BlobProperties(
             id="id",
             name="name",
             type="type",
@@ -101,7 +101,7 @@ class Test_Storage_Service:
             storage.storage_accounts[AZURE_SUSCRIPTION][
                 0
             ].blob_properties.__class__.__name__
-            == "Blob_Properties"
+            == "BlobProperties"
         )
         assert storage.storage_accounts[AZURE_SUSCRIPTION][0].blob_properties.id == "id"
         assert (


### PR DESCRIPTION
### Context

This pr changes class names from azure services and fix typing error AZURE_SUSCRIPTION -> AZURE_SUBSCRIPTION


### Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
