### PR TITLE
chore(pre-commit): remove pytest from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,12 +86,6 @@ repos:
         language: system
         stages: ["commit", "push"]
 
-      - id: pytest-check
-        name: pytest-check
-        entry: bash -c 'pytest tests -n auto'
-        language: system
-        files: '.*\.py'
-
       - id: bandit
         name: bandit
         description: "Bandit is a tool for finding common security issues in Python code"


### PR DESCRIPTION
### Context

Since the pytest command is executed inside the GitHub actions, we do not need it in the pre-commit.

### Description

Remove the pytest-check from pre-commit yaml

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
