### PR TITLE
fix(s3): add `s3:Get*` case to `s3_bucket_policy_public_write_access`

### DIFF
--- a/prowler/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access.py
@@ -46,9 +46,24 @@ class s3_bucket_policy_public_write_access(Check):
                             and "*" in str(statement["Principal"])
                         )
                         and (
-                            "s3:PutObject" in statement["Action"]
-                            or "*" in statement["Action"]
-                            or "s3:*" in statement["Action"]
+                            (
+                                isinstance(statement["Action"], list)
+                                and (
+                                    "s3:PutObject" in statement["Action"]
+                                    or "*" in statement["Action"]
+                                    or "s3:*" in statement["Action"]
+                                    or "s3:Put*" in statement["Action"]
+                                )
+                            )
+                            or (
+                                isinstance(statement["Action"], str)
+                                and (
+                                    "s3:PutObject" == statement["Action"]
+                                    or "*" == statement["Action"]
+                                    or "s3:*" == statement["Action"]
+                                    or "s3:Put*" == statement["Action"]
+                                )
+                            )
                         )
                     ):
                         report.status = "FAIL"

--- a/tests/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access_test.py
@@ -304,3 +304,64 @@ class Test_s3_bucket_policy_public_write_access:
                     == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
                 )
                 assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_bucket_public_get_asterisk_policy(self):
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name_us = "bucket_test_us"
+        s3_client_us_east_1.create_bucket(
+            Bucket=bucket_name_us, ObjectOwnership="BucketOwnerEnforced"
+        )
+        public_write_policy = '{"Version": "2012-10-17","Id": "GetObjPolicy","Statement": [{"Sid": "PublicWritePolicy","Effect": "Allow","Principal": "*","Action": "s3:Get*","Resource": "arn:aws:s3:::bucket_test_us/*"}]}'
+        s3_client_us_east_1.put_bucket_policy(
+            Bucket=bucket_name_us,
+            Policy=public_write_policy,
+        )
+
+        # Generate S3Control Client
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
+        s3control_client.put_public_access_block(
+            AccountId=AWS_ACCOUNT_NUMBER,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+
+        from prowler.providers.aws.services.s3.s3_service import S3, S3Control
+
+        audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.aws.lib.audit_info.audit_info.current_audit_info",
+            new=audit_info,
+        ), mock.patch(
+            "prowler.providers.aws.services.s3.s3_bucket_policy_public_write_access.s3_bucket_policy_public_write_access.s3control_client",
+            new=S3Control(audit_info),
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_bucket_policy_public_write_access.s3_bucket_policy_public_write_access.s3_client",
+                new=S3(audit_info),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.s3.s3_bucket_policy_public_write_access.s3_bucket_policy_public_write_access import (
+                    s3_bucket_policy_public_write_access,
+                )
+
+                check = s3_bucket_policy_public_write_access()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == f"S3 Bucket {bucket_name_us} does not allow public write access in the bucket policy."
+                )
+                assert result[0].resource_id == bucket_name_us
+                assert (
+                    result[0].resource_arn
+                    == f"arn:{audit_info.audited_partition}:s3:::{bucket_name_us}"
+                )
+                assert result[0].region == AWS_REGION_US_EAST_1


### PR DESCRIPTION
### Context

When scanning a public s3 bucket with an bucket policy like the following, prowler alerts for possible write access.
`{ "Version": "2012-10-17", "Statement": [ { "Sid": "Statement", "Effect": "Allow", "Principal": "*", "Action": "s3:Get*", "Resource": "arn:aws:s3:::redacted-bucket-name/*" } ] }`

### Description

Improve the check's logic by verifying `s3:Get*` Action.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
