### PR TITLE
fix(azure): Fix check `sqlserver_auditing_retention_90_days`

### DIFF
--- a/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.py
@@ -7,12 +7,7 @@ class sqlserver_auditing_retention_90_days(Check):
         findings = []
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
-                auditing_policies = (
-                    sql_server.auditing_policies
-                    if sql_server.auditing_policies is not None
-                    else []
-                )
-                if len(auditing_policies) > 0:
+                if sql_server.auditing_policies is not None:
                     report = Check_Report_Azure(self.metadata())
                     report.subscription = subscription
                     report.resource_name = sql_server.name

--- a/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.py
@@ -7,13 +7,14 @@ class sqlserver_auditing_retention_90_days(Check):
         findings = []
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
-                if sql_server.auditing_policies is not None:
+                auditing_policies_list = list(sql_server.auditing_policies)
+                if auditing_policies_list != []:
                     report = Check_Report_Azure(self.metadata())
                     report.subscription = subscription
                     report.resource_name = sql_server.name
                     report.resource_id = sql_server.id
                     has_failed = False
-                    for policy in sql_server.auditing_policies:
+                    for policy in auditing_policies_list:
                         if has_failed:
                             break
                         if policy.state == "Enabled":

--- a/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.py
@@ -7,27 +7,33 @@ class sqlserver_auditing_retention_90_days(Check):
         findings = []
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
-                report = Check_Report_Azure(self.metadata())
-                report.subscription = subscription
-                report.resource_name = sql_server.name
-                report.resource_id = sql_server.id
-                has_failed = False
-                for policy in sql_server.auditing_policies:
-                    if has_failed:
-                        break
-                    if policy.state == "Enabled":
-                        if policy.retention_days <= 90:
-                            report.status = "FAIL"
-                            report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has auditing retention less than 91 days."
-                            has_failed = True
+                auditing_policies = (
+                    sql_server.auditing_policies
+                    if sql_server.auditing_policies is not None
+                    else []
+                )
+                if len(auditing_policies) > 0:
+                    report = Check_Report_Azure(self.metadata())
+                    report.subscription = subscription
+                    report.resource_name = sql_server.name
+                    report.resource_id = sql_server.id
+                    has_failed = False
+                    for policy in sql_server.auditing_policies:
+                        if has_failed:
+                            break
+                        if policy.state == "Enabled":
+                            if policy.retention_days <= 90:
+                                report.status = "FAIL"
+                                report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has auditing retention less than 91 days."
+                                has_failed = True
+                            else:
+                                report.status = "PASS"
+                                report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has auditing retention greater than 90 days."
                         else:
-                            report.status = "PASS"
-                            report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has auditing retention greater than 90 days."
-                    else:
-                        report.status = "FAIL"
-                        report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has auditing disabled."
-                        has_failed = True
+                            report.status = "FAIL"
+                            report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has auditing disabled."
+                            has_failed = True
 
-                findings.append(report)
+                    findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.py
@@ -7,29 +7,29 @@ class sqlserver_auditing_retention_90_days(Check):
         findings = []
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
-                auditing_policies_list = list(sql_server.auditing_policies)
-                if auditing_policies_list != []:
-                    report = Check_Report_Azure(self.metadata())
-                    report.subscription = subscription
-                    report.resource_name = sql_server.name
-                    report.resource_id = sql_server.id
-                    has_failed = False
-                    for policy in auditing_policies_list:
-                        if has_failed:
-                            break
-                        if policy.state == "Enabled":
-                            if policy.retention_days <= 90:
-                                report.status = "FAIL"
-                                report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has auditing retention less than 91 days."
-                                has_failed = True
-                            else:
-                                report.status = "PASS"
-                                report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has auditing retention greater than 90 days."
-                        else:
+                report = Check_Report_Azure(self.metadata())
+                report.subscription = subscription
+                report.resource_name = sql_server.name
+                report.resource_id = sql_server.id
+                has_failed = False
+                has_policy = False
+                for policy in sql_server.auditing_policies:
+                    has_policy = True
+                    if has_failed:
+                        break
+                    if policy.state == "Enabled":
+                        if policy.retention_days <= 90:
                             report.status = "FAIL"
-                            report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has auditing disabled."
+                            report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has auditing retention less than 91 days."
                             has_failed = True
-
+                        else:
+                            report.status = "PASS"
+                            report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has auditing retention greater than 90 days."
+                    else:
+                        report.status = "FAIL"
+                        report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has auditing disabled."
+                        has_failed = True
+                if has_policy:
                     findings.append(report)
 
         return findings


### PR DESCRIPTION
### Context

Fix check sqlserver_auditing_retention_90_days


### Description

In te previous version, when auditing_policies was empty the check got an error. In the new version this case is handled


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
