### PR TITLE
feat(Azure): Add 4 new checks related to SQLServer and Vulnerability Assessment

### DIFF
--- a/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.metadata.json
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.metadata.json
@@ -10,7 +10,7 @@
   "ResourceType": "SQLServer",
   "Description": "Ensure that Microsoft Defender for SQL is set to 'On' for critical SQL Servers",
   "Risk": "Microsoft Defender for SQL is a unified package for advanced SQL security capabilities. Microsoft Defender is available for Azure SQL Database, Azure SQL Managed  classifying sensitive data, surfacing and mitigating potential database vulnerabilities, and detecting anomalous activities that could indicate a threat to your database. It provides a single go-to location for enabling and managing these capabilities.",
-  "RelatedUrl": " https://docs.microsoft.com/en-us/azure/azure-sql/database/azure-defender-for-sql?view=azuresql",
+  "RelatedUrl": "https://docs.microsoft.com/en-us/azure/azure-sql/database/azure-defender-for-sql?view=azuresql",
   "Remediation": {
     "Code": {
       "CLI": "",

--- a/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.metadata.json
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.metadata.json
@@ -16,7 +16,7 @@
       "CLI": "",
       "NativeIaC": "",
       "Other": "https://www.trendmicro.com/cloudoneconformity-staging/knowledge-base/azure/SecurityCenter/defender-azure-sql.html",
-      "Terraform": "https://docs.bridgecrew.io/docs/ensure-that-azure-defender-is-set-to-on-for-azure-sql-database-servers"
+      "Terraform": ""
     },
     "Recommendation": {
       "Text": "1. Go to SQL servers For each production SQL server instance: 2. Click Microsoft Defender for Cloud 3. Click Enable Microsoft Defender for SQL",

--- a/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.metadata.json
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.metadata.json
@@ -10,21 +10,21 @@
   "ResourceType": "SQLServer",
   "Description": "Ensure that Microsoft Defender for SQL is set to 'On' for critical SQL Servers",
   "Risk": "Microsoft Defender for SQL is a unified package for advanced SQL security capabilities. Microsoft Defender is available for Azure SQL Database, Azure SQL Managed  classifying sensitive data, surfacing and mitigating potential database vulnerabilities, and detecting anomalous activities that could indicate a threat to your database. It provides a single go-to location for enabling and managing these capabilities.",
-  "RelatedUrl": "https://docs.microsoft.com/en-us/azure/sql-database/sql-database-aad-authentication",
+  "RelatedUrl": " https://docs.microsoft.com/en-us/azure/azure-sql/database/azure-defender-for-sql?view=azuresql",
   "Remediation": {
     "Code": {
-      "CLI": "az sql server ad-admin create --resource-group resource_group_name --server server_name --display-name display_name --object-id user_object_id",
+      "CLI": "",
       "NativeIaC": "",
       "Other": "https://www.trendmicro.com/cloudoneconformity-staging/knowledge-base/azure/SecurityCenter/defender-azure-sql.html",
       "Terraform": "https://docs.bridgecrew.io/docs/ensure-that-azure-defender-is-set-to-on-for-azure-sql-database-servers"
     },
     "Recommendation": {
       "Text": "1. Go to SQL servers For each production SQL server instance: 2. Click Microsoft Defender for Cloud 3. Click Enable Microsoft Defender for SQL",
-      "Url": ""
+      "Url": "https://learn.microsoft.com/en-us/azure/defender-for-cloud/defender-for-sql-usage"
     }
   },
   "Categories": [],
   "DependsOn": [],
   "RelatedTo": [],
-  "Notes": ""
+  "Notes": "Microsoft Defender for SQL is a paid feature and will incur additional cost for each SQL server."
 }

--- a/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.metadata.json
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "azure",
+  "CheckID": "sqlserver_microsoft_defender_enabled",
+  "CheckTitle": "Ensure that Microsoft Defender for SQL is set to 'On' for critical SQL Servers",
+  "CheckType": [],
+  "ServiceName": "sqlserver",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "SQLServer",
+  "Description": "Ensure that Microsoft Defender for SQL is set to 'On' for critical SQL Servers",
+  "Risk": "Microsoft Defender for SQL is a unified package for advanced SQL security capabilities. Microsoft Defender is available for Azure SQL Database, Azure SQL Managed  classifying sensitive data, surfacing and mitigating potential database vulnerabilities, and detecting anomalous activities that could indicate a threat to your database. It provides a single go-to location for enabling and managing these capabilities.",
+  "RelatedUrl": "https://docs.microsoft.com/en-us/azure/sql-database/sql-database-aad-authentication",
+  "Remediation": {
+    "Code": {
+      "CLI": "az sql server ad-admin create --resource-group resource_group_name --server server_name --display-name display_name --object-id user_object_id",
+      "NativeIaC": "",
+      "Other": "https://www.trendmicro.com/cloudoneconformity-staging/knowledge-base/azure/SecurityCenter/defender-azure-sql.html",
+      "Terraform": "https://docs.bridgecrew.io/docs/ensure-that-azure-defender-is-set-to-on-for-azure-sql-database-servers"
+    },
+    "Recommendation": {
+      "Text": "1. Go to SQL servers For each production SQL server instance: 2. Click Microsoft Defender for Cloud 3. Click Enable Microsoft Defender for SQL",
+      "Url": ""
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.py
@@ -7,20 +7,16 @@ class sqlserver_microsoft_defender_enabled(Check):
         findings = []
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
-                report = Check_Report_Azure(self.metadata())
-                report.subscription = subscription
-                report.status = "PASS"
-                report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has an Active Directory administrator."
-                report.resource_name = sql_server.name
-                report.resource_id = sql_server.id
-
-                if (
-                    sql_server.administrators is None
-                    or sql_server.administrators.administrator_type != "ActiveDirectory"
-                ):
+                if sql_server.security_alert_policies is not None:
+                    report = Check_Report_Azure(self.metadata())
+                    report.subscription = subscription
+                    report.resource_name = sql_server.name
+                    report.resource_id = sql_server.id
                     report.status = "FAIL"
-                    report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} does not have an Active Directory administrator."
-
-                findings.append(report)
+                    report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has microsoft defender disabled."
+                    if sql_server.security_alert_policies.state == "Enabled":
+                        report.status = "PASS"
+                        report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has microsoft defender enabled."
+                    findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.py
@@ -1,0 +1,26 @@
+from prowler.lib.check.models import Check, Check_Report_Azure
+from prowler.providers.azure.services.sqlserver.sqlserver_client import sqlserver_client
+
+
+class sqlserver_microsoft_defender_enabled(Check):
+    def execute(self) -> Check_Report_Azure:
+        findings = []
+        for subscription, sql_servers in sqlserver_client.sql_servers.items():
+            for sql_server in sql_servers:
+                report = Check_Report_Azure(self.metadata())
+                report.subscription = subscription
+                report.status = "PASS"
+                report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has an Active Directory administrator."
+                report.resource_name = sql_server.name
+                report.resource_id = sql_server.id
+
+                if (
+                    sql_server.administrators is None
+                    or sql_server.administrators.administrator_type != "ActiveDirectory"
+                ):
+                    report.status = "FAIL"
+                    report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} does not have an Active Directory administrator."
+
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.py
@@ -7,7 +7,7 @@ class sqlserver_microsoft_defender_enabled(Check):
         findings = []
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
-                if sql_server.security_alert_policies is not None:
+                if sql_server.security_alert_policies:
                     report = Check_Report_Azure(self.metadata())
                     report.subscription = subscription
                     report.resource_name = sql_server.name

--- a/prowler/providers/azure/services/sqlserver/sqlserver_periodic_recurring_scans_enabled/sqlserver_periodic_recurring_scans_enabled.metadata.json
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_periodic_recurring_scans_enabled/sqlserver_periodic_recurring_scans_enabled.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "azure",
+  "CheckID": "sqlserver_periodic_recurring_scans_enabled",
+  "CheckTitle": "Ensure that Vulnerability Assessment (VA) setting 'Periodic recurring scans' is set to 'on' for each SQL server",
+  "CheckType": [],
+  "ServiceName": "sqlserver",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "SQLServer",
+  "Description": "Enable Vulnerability Assessment (VA) Periodic recurring scans for critical SQL servers and corresponding SQL databases.",
+  "Risk": "VA setting 'Periodic recurring scans' schedules periodic (weekly) vulnerability scanning for the SQL server and corresponding Databases. Periodic and regular vulnerability scanning provides risk visibility based on updated known vulnerability signatures and best practices.",
+  "RelatedUrl": "https://docs.microsoft.com/en-us/azure/sql-database/sql-vulnerability-assessment",
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "https://www.trendmicro.com/cloudoneconformity-staging/knowledge-base/azure/Sql/periodic-vulnerability-scans.html#",
+      "Terraform": "https://docs.bridgecrew.io/docs/ensure-that-va-setting-periodic-recurring-scans-is-enabled-on-a-sql-server"
+    },
+    "Recommendation": {
+      "Text": "1. Go to SQL servers 2. For each server instance 3. Click on Security Center 4. In Section Vulnerability Assessment Settings, set Storage Account if not already 5. Toggle 'Periodic recurring scans' to ON. 6. Click Save",
+      "Url": "https://learn.microsoft.com/en-us/azure/defender-for-cloud/sql-azure-vulnerability-assessment-enable"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "Enabling the Azure Defender for SQL feature will incur additional costs for each SQL server."
+}

--- a/prowler/providers/azure/services/sqlserver/sqlserver_periodic_recurring_scans_enabled/sqlserver_periodic_recurring_scans_enabled.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_periodic_recurring_scans_enabled/sqlserver_periodic_recurring_scans_enabled.py
@@ -1,0 +1,27 @@
+from prowler.lib.check.models import Check, Check_Report_Azure
+from prowler.providers.azure.services.sqlserver.sqlserver_client import sqlserver_client
+
+
+class sqlserver_periodic_recurring_scans_enabled(Check):
+    def execute(self) -> Check_Report_Azure:
+        findings = []
+        for subscription, sql_servers in sqlserver_client.sql_servers.items():
+            for sql_server in sql_servers:
+                report = Check_Report_Azure(self.metadata())
+                report.subscription = subscription
+                report.resource_name = sql_server.name
+                report.resource_id = sql_server.id
+                report.status = "FAIL"
+                report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment disabled."
+                if (
+                    sql_server.vulnerability_assessment
+                    and sql_server.vulnerability_assessment.storage_container_path
+                    is not None
+                ):
+                    report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment enabled but no recurring scans."
+                    if sql_server.vulnerability_assessment.recurring_scans.is_enabled:
+                        report.status = "PASS"
+                        report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has periodic recurring scans enabled."
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/azure/services/sqlserver/sqlserver_service.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_service.py
@@ -161,4 +161,4 @@ class Server:
     encryption_protector: EncryptionProtector = None
     databases: list[Database] = None
     vulnerability_assessment: ServerVulnerabilityAssessment = None
-    security_alert_policies: ServerSecurityAlertPolicy
+    security_alert_policies: ServerSecurityAlertPolicy = None

--- a/prowler/providers/azure/services/sqlserver/sqlserver_service.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_service.py
@@ -6,6 +6,7 @@ from azure.mgmt.sql.models import (
     FirewallRule,
     ServerBlobAuditingPolicy,
     ServerExternalAdministrator,
+    ServerSecurityAlertPolicy,
     ServerVulnerabilityAssessment,
     TransparentDataEncryption,
 )
@@ -44,6 +45,11 @@ class SQLServer(AzureService):
                     vulnerability_assessment = self.__get_vulnerability_assesments__(
                         subscription, resource_group, sql_server.name
                     )
+                    security_alert_policies = client.server_security_alert_policies.get(
+                        resource_group_name=resource_group,
+                        server_name=sql_server.name,
+                        security_alert_policy_name="default",
+                    )
                     sql_servers[subscription].append(
                         Server(
                             id=sql_server.id,
@@ -58,6 +64,7 @@ class SQLServer(AzureService):
                                 subscription, resource_group, sql_server.name
                             ),
                             vulnerability_assessment=vulnerability_assessment,
+                            security_alert_policies=security_alert_policies,
                         )
                     )
             except Exception as error:
@@ -154,3 +161,4 @@ class Server:
     encryption_protector: EncryptionProtector = None
     databases: list[Database] = None
     vulnerability_assessment: ServerVulnerabilityAssessment = None
+    security_alert_policies: ServerSecurityAlertPolicy

--- a/prowler/providers/azure/services/sqlserver/sqlserver_service.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_service.py
@@ -30,14 +30,11 @@ class SQLServer(AzureService):
                 sql_servers_list = client.servers.list()
                 for sql_server in sql_servers_list:
                     resource_group = self.__get_resource_group__(sql_server.id)
-                    auditing_policies = (
-                        client.server_blob_auditing_policies.list_by_server(
-                            resource_group_name=resource_group,
-                            server_name=sql_server.name,
-                        )
+                    auditing_policies = self.__get_server_blob_auditing_policies__(
+                        subscription, resource_group, sql_server.name
                     )
-                    firewall_rules = client.firewall_rules.list_by_server(
-                        resource_group_name=resource_group, server_name=sql_server.name
+                    firewall_rules = self.__get_firewall_rules__(
+                        subscription, resource_group, sql_server.name
                     )
                     encryption_protector = self.__get_enctyption_protectors__(
                         subscription, resource_group, sql_server.name
@@ -45,10 +42,10 @@ class SQLServer(AzureService):
                     vulnerability_assessment = self.__get_vulnerability_assesments__(
                         subscription, resource_group, sql_server.name
                     )
-                    security_alert_policies = client.server_security_alert_policies.get(
-                        resource_group_name=resource_group,
-                        server_name=sql_server.name,
-                        security_alert_policy_name="default",
+                    security_alert_policies = (
+                        self.__get_server_security_alert_policies__(
+                            subscription, resource_group, sql_server.name
+                        )
                     )
                     sql_servers[subscription].append(
                         Server(
@@ -137,6 +134,34 @@ class SQLServer(AzureService):
             vulnerability_assessment_name="default",
         )
         return vulnerability_assessment
+
+    def __get_server_blob_auditing_policies__(
+        self, subscription, resource_group, server_name
+    ):
+        client = self.clients[subscription]
+        auditing_policies = client.server_blob_auditing_policies.list_by_server(
+            resource_group_name=resource_group,
+            server_name=server_name,
+        )
+        return auditing_policies
+
+    def __get_firewall_rules__(self, subscription, resource_group, server_name):
+        client = self.clients[subscription]
+        firewall_rules = client.firewall_rules.list_by_server(
+            resource_group_name=resource_group, server_name=server_name
+        )
+        return firewall_rules
+
+    def __get_server_security_alert_policies__(
+        self, subscription, resource_group, server_name
+    ):
+        client = self.clients[subscription]
+        security_alert_policies = client.server_security_alert_policies.get(
+            resource_group_name=resource_group,
+            server_name=server_name,
+            security_alert_policy_name="default",
+        )
+        return security_alert_policies
 
 
 @dataclass

--- a/prowler/providers/azure/services/sqlserver/sqlserver_tde_encryption_enabled/sqlserver_tde_encryption_enabled.metadata.json
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_tde_encryption_enabled/sqlserver_tde_encryption_enabled.metadata.json
@@ -1,6 +1,6 @@
 {
   "Provider": "azure",
-  "CheckID": "sqlserver_tde_encrypted",
+  "CheckID": "sqlserver_tde_encryption_enabled",
   "CheckTitle": "Ensure SQL server's Transparent Data Encryption (TDE) protector is encrypted",
   "CheckType": [],
   "ServiceName": "sqlserver",

--- a/prowler/providers/azure/services/sqlserver/sqlserver_va_emails_notifications_admins_enabled/sqlserver_va_emails_notifications_admins_enabled.metadata.json
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_va_emails_notifications_admins_enabled/sqlserver_va_emails_notifications_admins_enabled.metadata.json
@@ -15,8 +15,8 @@
     "Code": {
       "CLI": "",
       "NativeIaC": "",
-      "Other": "https://www.tenable.com/audits/items/CIS_Microsoft_Azure_Foundations_L2_v1.3.1.audit:c4e2d4019a12b8410b55a6cf2d838d7b",
-      "Terraform": "https://docs.bridgecrew.io/docs/ensure-that-va-setting-also-send-email-notifications-to-admins-and-subscription-owners-is-set-for-an-sql-server"
+      "Other": "",
+      "Terraform": "https://docs.bridgecrew.io/docs/ensure-that-va-setting-also-send-email-notifications-to-admins-and-subscription-owners-is-set-for-an-sql-server#terraform"
     },
     "Recommendation": {
       "Text": "1. Go to SQL servers 2. Select a server instance 3. Click on Security Center 4. Select Configure next to Enabled at subscription-level 5. In Section Vulnerability Assessment Settings, configure Storage Accounts if not already 6. Check/enable 'Also send email notifications to admins and subscription owners' 7. Click Save",

--- a/prowler/providers/azure/services/sqlserver/sqlserver_va_emails_notifications_admins_enabled/sqlserver_va_emails_notifications_admins_enabled.metadata.json
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_va_emails_notifications_admins_enabled/sqlserver_va_emails_notifications_admins_enabled.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "azure",
+  "CheckID": "sqlserver_va_emails_notifications_admins_enabled",
+  "CheckTitle": "Ensure that Vulnerability Assessment (VA) setting 'Also send email notifications to admins and subscription owners' is set for each SQL Server",
+  "CheckType": [],
+  "ServiceName": "sqlserver",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "SQLServer",
+  "Description": "Enable Vulnerability Assessment (VA) setting 'Also send email notifications to admins and subscription owners'.",
+  "Risk": "VA scan reports and alerts will be sent to admins and subscription owners by enabling setting 'Also send email notifications to admins and subscription owners'. This may help in reducing time required for identifying risks and taking corrective measures.",
+  "RelatedUrl": "https://docs.microsoft.com/en-us/azure/sql-database/sql-vulnerability-assessment",
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "https://www.tenable.com/audits/items/CIS_Microsoft_Azure_Foundations_L2_v1.3.1.audit:c4e2d4019a12b8410b55a6cf2d838d7b",
+      "Terraform": "https://docs.bridgecrew.io/docs/ensure-that-va-setting-also-send-email-notifications-to-admins-and-subscription-owners-is-set-for-an-sql-server"
+    },
+    "Recommendation": {
+      "Text": "1. Go to SQL servers 2. Select a server instance 3. Click on Security Center 4. Select Configure next to Enabled at subscription-level 5. In Section Vulnerability Assessment Settings, configure Storage Accounts if not already 6. Check/enable 'Also send email notifications to admins and subscription owners' 7. Click Save",
+      "Url": "https://learn.microsoft.com/en-us/azure/defender-for-cloud/sql-azure-vulnerability-assessment-enable"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "Enabling the Microsoft Defender for SQL features will incur additional costs for each SQL server."
+}

--- a/prowler/providers/azure/services/sqlserver/sqlserver_va_emails_notifications_admins_enabled/sqlserver_va_emails_notifications_admins_enabled.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_va_emails_notifications_admins_enabled/sqlserver_va_emails_notifications_admins_enabled.py
@@ -1,0 +1,31 @@
+from prowler.lib.check.models import Check, Check_Report_Azure
+from prowler.providers.azure.services.sqlserver.sqlserver_client import sqlserver_client
+
+
+class sqlserver_va_emails_notifications_admins_enabled(Check):
+    def execute(self) -> Check_Report_Azure:
+        findings = []
+        for subscription, sql_servers in sqlserver_client.sql_servers.items():
+            for sql_server in sql_servers:
+                report = Check_Report_Azure(self.metadata())
+                report.subscription = subscription
+                report.resource_name = sql_server.name
+                report.resource_id = sql_server.id
+                report.status = "FAIL"
+                report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment disabled."
+                if (
+                    sql_server.vulnerability_assessment
+                    and sql_server.vulnerability_assessment.storage_container_path
+                    is not None
+                ):
+                    report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment enabled but no scan reports configured for subscription admins."
+                    if (
+                        sql_server.vulnerability_assessment.recurring_scans.email_subscription_admins
+                        is not None
+                        and sql_server.vulnerability_assessment.recurring_scans.email_subscription_admins
+                    ):
+                        report.status = "PASS"
+                        report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment enabled and scan reports configured for subscription admins."
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/azure/services/sqlserver/sqlserver_va_emails_notifications_admins_enabled/sqlserver_va_emails_notifications_admins_enabled.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_va_emails_notifications_admins_enabled/sqlserver_va_emails_notifications_admins_enabled.py
@@ -16,12 +16,10 @@ class sqlserver_va_emails_notifications_admins_enabled(Check):
                 if (
                     sql_server.vulnerability_assessment
                     and sql_server.vulnerability_assessment.storage_container_path
-                    is not None
                 ):
                     report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment enabled but no scan reports configured for subscription admins."
                     if (
-                        sql_server.vulnerability_assessment.recurring_scans.email_subscription_admins
-                        is not None
+                        sql_server.vulnerability_assessment.recurring_scans
                         and sql_server.vulnerability_assessment.recurring_scans.email_subscription_admins
                     ):
                         report.status = "PASS"

--- a/prowler/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled/sqlserver_va_periodic_recurring_scans_enabled.metadata.json
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled/sqlserver_va_periodic_recurring_scans_enabled.metadata.json
@@ -1,6 +1,6 @@
 {
   "Provider": "azure",
-  "CheckID": "sqlserver_periodic_recurring_scans_enabled",
+  "CheckID": "sqlserver_va_periodic_recurring_scans_enabled",
   "CheckTitle": "Ensure that Vulnerability Assessment (VA) setting 'Periodic recurring scans' is set to 'on' for each SQL server",
   "CheckType": [],
   "ServiceName": "sqlserver",

--- a/prowler/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled/sqlserver_va_periodic_recurring_scans_enabled.metadata.json
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled/sqlserver_va_periodic_recurring_scans_enabled.metadata.json
@@ -16,7 +16,7 @@
       "CLI": "",
       "NativeIaC": "",
       "Other": "https://www.trendmicro.com/cloudoneconformity-staging/knowledge-base/azure/Sql/periodic-vulnerability-scans.html#",
-      "Terraform": "https://docs.bridgecrew.io/docs/ensure-that-va-setting-periodic-recurring-scans-is-enabled-on-a-sql-server"
+      "Terraform": "https://docs.bridgecrew.io/docs/ensure-that-va-setting-periodic-recurring-scans-is-enabled-on-a-sql-server#terraform"
     },
     "Recommendation": {
       "Text": "1. Go to SQL servers 2. For each server instance 3. Click on Security Center 4. In Section Vulnerability Assessment Settings, set Storage Account if not already 5. Toggle 'Periodic recurring scans' to ON. 6. Click Save",

--- a/prowler/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled/sqlserver_va_periodic_recurring_scans_enabled.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled/sqlserver_va_periodic_recurring_scans_enabled.py
@@ -2,7 +2,7 @@ from prowler.lib.check.models import Check, Check_Report_Azure
 from prowler.providers.azure.services.sqlserver.sqlserver_client import sqlserver_client
 
 
-class sqlserver_periodic_recurring_scans_enabled(Check):
+class sqlserver_va_periodic_recurring_scans_enabled(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
         for subscription, sql_servers in sqlserver_client.sql_servers.items():

--- a/prowler/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled/sqlserver_va_periodic_recurring_scans_enabled.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled/sqlserver_va_periodic_recurring_scans_enabled.py
@@ -16,10 +16,12 @@ class sqlserver_va_periodic_recurring_scans_enabled(Check):
                 if (
                     sql_server.vulnerability_assessment
                     and sql_server.vulnerability_assessment.storage_container_path
-                    is not None
                 ):
                     report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment enabled but no recurring scans."
-                    if sql_server.vulnerability_assessment.recurring_scans.is_enabled:
+                    if (
+                        sql_server.vulnerability_assessment.recurring_scans
+                        and sql_server.vulnerability_assessment.recurring_scans.is_enabled
+                    ):
                         report.status = "PASS"
                         report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has periodic recurring scans enabled."
                 findings.append(report)

--- a/prowler/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured/sqlserver_va_scan_reports_configured.metadata.json
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured/sqlserver_va_scan_reports_configured.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "azure",
+  "CheckID": "sqlserver_va_scan_reports_configured",
+  "CheckTitle": "Ensure that Vulnerability Assessment (VA) setting 'Send scan reports to' is configured for a SQL server",
+  "CheckType": [],
+  "ServiceName": "sqlserver",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "SQLServer",
+  "Description": "Configure 'Send scan reports to' with email addresses of concerned data owners/stakeholders for a critical SQL servers.",
+  "Risk": "Vulnerability Assessment (VA) scan reports and alerts will be sent to email addresses configured at 'Send scan reports to'. This may help in reducing time required for identifying risks and taking corrective measures",
+  "RelatedUrl": "https://docs.microsoft.com/en-us/azure/sql-database/sql-vulnerability-assessment",
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "https://www.tenable.com/audits/items/CIS_Microsoft_Azure_Foundations_L2_v1.3.1.audit:7a3f11f12c52122fc23badc7c808ebe9",
+      "Terraform": "https://docs.bridgecrew.io/docs/ensure-that-va-setting-send-scan-reports-to-is-configured-for-a-sql-server"
+    },
+    "Recommendation": {
+      "Text": "1. Go to SQL servers 2. Select a server instance 3. Select Microsoft Defender for Cloud 4. Select Configure next to Enablement status 5. Set Microsoft Defender for SQL to On 6. Under Vulnerability Assessment Settings, select a Storage Account 7. Set Periodic recurring scans to On 8. Under Send scan reports to, provide email addresses for data owners and stakeholders 9. Click Save",
+      "Url": "https://learn.microsoft.com/en-us/azure/defender-for-cloud/sql-azure-vulnerability-assessment-enable"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "Enabling the Microsoft Defender for SQL features will incur additional costs for each SQL server."
+}

--- a/prowler/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured/sqlserver_va_scan_reports_configured.metadata.json
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured/sqlserver_va_scan_reports_configured.metadata.json
@@ -15,8 +15,8 @@
     "Code": {
       "CLI": "",
       "NativeIaC": "",
-      "Other": "https://www.tenable.com/audits/items/CIS_Microsoft_Azure_Foundations_L2_v1.3.1.audit:7a3f11f12c52122fc23badc7c808ebe9",
-      "Terraform": "https://docs.bridgecrew.io/docs/ensure-that-va-setting-send-scan-reports-to-is-configured-for-a-sql-server"
+      "Other": "",
+      "Terraform": "https://docs.bridgecrew.io/docs/ensure-that-va-setting-send-scan-reports-to-is-configured-for-a-sql-server#terraform"
     },
     "Recommendation": {
       "Text": "1. Go to SQL servers 2. Select a server instance 3. Select Microsoft Defender for Cloud 4. Select Configure next to Enablement status 5. Set Microsoft Defender for SQL to On 6. Under Vulnerability Assessment Settings, select a Storage Account 7. Set Periodic recurring scans to On 8. Under Send scan reports to, provide email addresses for data owners and stakeholders 9. Click Save",

--- a/prowler/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured/sqlserver_va_scan_reports_configured.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured/sqlserver_va_scan_reports_configured.py
@@ -1,0 +1,38 @@
+from prowler.lib.check.models import Check, Check_Report_Azure
+from prowler.providers.azure.services.sqlserver.sqlserver_client import sqlserver_client
+
+
+class sqlserver_va_scan_reports_configured(Check):
+    def execute(self) -> Check_Report_Azure:
+        findings = []
+        for subscription, sql_servers in sqlserver_client.sql_servers.items():
+            for sql_server in sql_servers:
+                report = Check_Report_Azure(self.metadata())
+                report.subscription = subscription
+                report.resource_name = sql_server.name
+                report.resource_id = sql_server.id
+                report.status = "FAIL"
+                report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment disabled."
+                if (
+                    sql_server.vulnerability_assessment
+                    and sql_server.vulnerability_assessment.storage_container_path
+                    is not None
+                ):
+                    report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment enabled but no scan reports configured."
+                    if (
+                        sql_server.vulnerability_assessment.recurring_scans.email_subscription_admins
+                        is not None
+                        and sql_server.vulnerability_assessment.recurring_scans.email_subscription_admins
+                    ) or (
+                        sql_server.vulnerability_assessment.recurring_scans.emails
+                        is not None
+                        and len(
+                            sql_server.vulnerability_assessment.recurring_scans.emails
+                        )
+                        > 0
+                    ):
+                        report.status = "PASS"
+                        report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment enabled and scan reports configured."
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured/sqlserver_va_scan_reports_configured.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured/sqlserver_va_scan_reports_configured.py
@@ -16,20 +16,19 @@ class sqlserver_va_scan_reports_configured(Check):
                 if (
                     sql_server.vulnerability_assessment
                     and sql_server.vulnerability_assessment.storage_container_path
-                    is not None
                 ):
                     report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment enabled but no scan reports configured."
-                    if (
-                        sql_server.vulnerability_assessment.recurring_scans.email_subscription_admins
-                        is not None
-                        and sql_server.vulnerability_assessment.recurring_scans.email_subscription_admins
-                    ) or (
-                        sql_server.vulnerability_assessment.recurring_scans.emails
-                        is not None
-                        and len(
-                            sql_server.vulnerability_assessment.recurring_scans.emails
+                    if sql_server.vulnerability_assessment.recurring_scans and (
+                        (
+                            sql_server.vulnerability_assessment.recurring_scans.email_subscription_admins
                         )
-                        > 0
+                        or (
+                            sql_server.vulnerability_assessment.recurring_scans.emails
+                            and len(
+                                sql_server.vulnerability_assessment.recurring_scans.emails
+                            )
+                            > 0
+                        )
                     ):
                         report.status = "PASS"
                         report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment enabled and scan reports configured."

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -143,6 +143,20 @@ expected_packages = [
         name="prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_va_periodic_recurring_scans_enabled",
         ispkg=False,
     ),
+    ModuleInfo(
+        module_finder=FileFinder(
+            "/root_dir/prowler/providers/azure/services/sqlserver"
+        ),
+        name="prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured",
+        ispkg=True,
+    ),
+    ModuleInfo(
+        module_finder=FileFinder(
+            "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured"
+        ),
+        name="prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured",
+        ispkg=False,
+    ),
 ]
 
 
@@ -262,6 +276,20 @@ def mock_list_modules(*_):
                 "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled"
             ),
             name="prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_va_periodic_recurring_scans_enabled",
+            ispkg=False,
+        ),
+        ModuleInfo(
+            module_finder=FileFinder(
+                "/root_dir/prowler/providers/azure/services/sqlserver"
+            ),
+            name="prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured",
+            ispkg=True,
+        ),
+        ModuleInfo(
+            module_finder=FileFinder(
+                "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured"
+            ),
+            name="prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured",
             ispkg=False,
         ),
     ]
@@ -664,6 +692,10 @@ class Test_Check:
             (
                 "sqlserver_va_periodic_recurring_scans_enabled",
                 "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled",
+            ),
+            (
+                "sqlserver_va_scan_reports_configured",
+                "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured",
             ),
         ]
         returned_checks = recover_checks_from_provider(provider, service)

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -129,6 +129,20 @@ expected_packages = [
         name="prowler.providers.azure.services.sqlserver.sqlserver_vulnerability_assessment_enabled.sqlserver_vulnerability_assessment_enabled",
         ispkg=False,
     ),
+    ModuleInfo(
+        module_finder=FileFinder(
+            "/root_dir/prowler/providers/azure/services/sqlserver"
+        ),
+        name="prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled",
+        ispkg=True,
+    ),
+    ModuleInfo(
+        module_finder=FileFinder(
+            "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_periodic_recurring_scans_enabled"
+        ),
+        name="prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled",
+        ispkg=False,
+    ),
 ]
 
 
@@ -234,6 +248,20 @@ def mock_list_modules(*_):
                 "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_vulnerability_assessment_enabled"
             ),
             name="prowler.providers.azure.services.sqlserver.sqlserver_vulnerability_assessment_enabled.sqlserver_vulnerability_assessment_enabled",
+            ispkg=False,
+        ),
+        ModuleInfo(
+            module_finder=FileFinder(
+                "/root_dir/prowler/providers/azure/services/sqlserver"
+            ),
+            name="prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled",
+            ispkg=True,
+        ),
+        ModuleInfo(
+            module_finder=FileFinder(
+                "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_periodic_recurring_scans_enabled"
+            ),
+            name="prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled",
             ispkg=False,
         ),
     ]
@@ -632,6 +660,10 @@ class Test_Check:
             (
                 "sqlserver_vulnerability_assessment_enabled",
                 "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_vulnerability_assessment_enabled",
+            ),
+            (
+                "sqlserver_periodic_recurring_scans_enabled",
+                "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_periodic_recurring_scans_enabled",
             ),
         ]
         returned_checks = recover_checks_from_provider(provider, service)

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -157,6 +157,20 @@ expected_packages = [
         name="prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured",
         ispkg=False,
     ),
+    ModuleInfo(
+        module_finder=FileFinder(
+            "/root_dir/prowler/providers/azure/services/sqlserver"
+        ),
+        name="prowler.providers.azure.services.sqlserver.sqlserver_va_emails_notifications_admins_enabled",
+        ispkg=True,
+    ),
+    ModuleInfo(
+        module_finder=FileFinder(
+            "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_va_emails_notifications_admins_enabled"
+        ),
+        name="prowler.providers.azure.services.sqlserver.sqlserver_va_emails_notifications_admins_enabled.sqlserver_va_emails_notifications_admins_enabled",
+        ispkg=False,
+    ),
 ]
 
 
@@ -290,6 +304,20 @@ def mock_list_modules(*_):
                 "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured"
             ),
             name="prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured",
+            ispkg=False,
+        ),
+        ModuleInfo(
+            module_finder=FileFinder(
+                "/root_dir/prowler/providers/azure/services/sqlserver"
+            ),
+            name="prowler.providers.azure.services.sqlserver.sqlserver_va_emails_notifications_admins_enabled",
+            ispkg=True,
+        ),
+        ModuleInfo(
+            module_finder=FileFinder(
+                "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_va_emails_notifications_admins_enabled"
+            ),
+            name="prowler.providers.azure.services.sqlserver.sqlserver_va_emails_notifications_admins_enabled.sqlserver_va_emails_notifications_admins_enabled",
             ispkg=False,
         ),
     ]
@@ -696,6 +724,10 @@ class Test_Check:
             (
                 "sqlserver_va_scan_reports_configured",
                 "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured",
+            ),
+            (
+                "sqlserver_va_emails_notifications_admins_enabled",
+                "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_va_emails_notifications_admins_enabled",
             ),
         ]
         returned_checks = recover_checks_from_provider(provider, service)

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -133,14 +133,14 @@ expected_packages = [
         module_finder=FileFinder(
             "/root_dir/prowler/providers/azure/services/sqlserver"
         ),
-        name="prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled",
+        name="prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled",
         ispkg=True,
     ),
     ModuleInfo(
         module_finder=FileFinder(
-            "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_periodic_recurring_scans_enabled"
+            "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled"
         ),
-        name="prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled",
+        name="prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_va_periodic_recurring_scans_enabled",
         ispkg=False,
     ),
 ]
@@ -254,14 +254,14 @@ def mock_list_modules(*_):
             module_finder=FileFinder(
                 "/root_dir/prowler/providers/azure/services/sqlserver"
             ),
-            name="prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled",
+            name="prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled",
             ispkg=True,
         ),
         ModuleInfo(
             module_finder=FileFinder(
-                "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_periodic_recurring_scans_enabled"
+                "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled"
             ),
-            name="prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled",
+            name="prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_va_periodic_recurring_scans_enabled",
             ispkg=False,
         ),
     ]
@@ -662,8 +662,8 @@ class Test_Check:
                 "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_vulnerability_assessment_enabled",
             ),
             (
-                "sqlserver_periodic_recurring_scans_enabled",
-                "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_periodic_recurring_scans_enabled",
+                "sqlserver_va_periodic_recurring_scans_enabled",
+                "/root_dir/prowler/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled",
             ),
         ]
         returned_checks = recover_checks_from_provider(provider, service)

--- a/tests/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled_test.py
@@ -1,0 +1,135 @@
+from unittest import mock
+from uuid import uuid4
+
+from azure.mgmt.sql.models import ServerSecurityAlertPolicy
+
+from prowler.providers.azure.services.sqlserver.sqlserver_service import Server
+
+AZURE_SUBSCRIPTION = str(uuid4())
+
+
+class Test_sqlserver_microsoft_defender_enabled:
+    def test_no_sql_servers(self):
+        sqlserver_client = mock.MagicMock
+        sqlserver_client.sql_servers = {}
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_microsoft_defender_enabled.sqlserver_microsoft_defender_enabled.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_microsoft_defender_enabled.sqlserver_microsoft_defender_enabled import (
+                sqlserver_microsoft_defender_enabled,
+            )
+
+            check = sqlserver_microsoft_defender_enabled()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_sql_servers_no_security_alert_policies(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=[],
+                    firewall_rules=None,
+                    security_alert_policies=None,
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_microsoft_defender_enabled.sqlserver_microsoft_defender_enabled.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_microsoft_defender_enabled.sqlserver_microsoft_defender_enabled import (
+                sqlserver_microsoft_defender_enabled,
+            )
+
+            check = sqlserver_microsoft_defender_enabled()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_sql_servers_microsoft_defender_disabled(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=[],
+                    firewall_rules=None,
+                    security_alert_policies=ServerSecurityAlertPolicy(state="Disabled"),
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_microsoft_defender_enabled.sqlserver_microsoft_defender_enabled.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_microsoft_defender_enabled.sqlserver_microsoft_defender_enabled import (
+                sqlserver_microsoft_defender_enabled,
+            )
+
+            check = sqlserver_microsoft_defender_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has microsoft defender disabled."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+
+    def test_sql_servers_microsoft_defender_enabled(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=[],
+                    firewall_rules=None,
+                    security_alert_policies=ServerSecurityAlertPolicy(state="Enabled"),
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_microsoft_defender_enabled.sqlserver_microsoft_defender_enabled.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_microsoft_defender_enabled.sqlserver_microsoft_defender_enabled import (
+                sqlserver_microsoft_defender_enabled,
+            )
+
+            check = sqlserver_microsoft_defender_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has microsoft defender enabled."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id

--- a/tests/providers/azure/services/sqlserver/sqlserver_periodic_recurring_scans_enabled/sqlserver_periodic_recurring_scans_enabled_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_periodic_recurring_scans_enabled/sqlserver_periodic_recurring_scans_enabled_test.py
@@ -1,0 +1,205 @@
+from unittest import mock
+from uuid import uuid4
+
+from azure.mgmt.sql.models import (
+    ServerVulnerabilityAssessment,
+    VulnerabilityAssessmentRecurringScansProperties,
+)
+
+from prowler.providers.azure.services.sqlserver.sqlserver_service import Server
+
+AZURE_SUBSCRIPTION = str(uuid4())
+
+
+class Test_sqlserver_periodic_recurring_scans_enabled:
+    def test_no_sql_servers(self):
+        sqlserver_client = mock.MagicMock
+        sqlserver_client.sql_servers = {}
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled import (
+                sqlserver_periodic_recurring_scans_enabled,
+            )
+
+            check = sqlserver_periodic_recurring_scans_enabled()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_sql_servers_no_vulnerability_assessment(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                    vulnerability_assessment=None,
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled import (
+                sqlserver_periodic_recurring_scans_enabled,
+            )
+
+            check = sqlserver_periodic_recurring_scans_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has vulnerability assessment disabled."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+
+    def test_sql_servers_no_vulnerability_assessment_storage_container_path(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                    vulnerability_assessment=ServerVulnerabilityAssessment(
+                        storage_container_path=None
+                    ),
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled import (
+                sqlserver_periodic_recurring_scans_enabled,
+            )
+
+            check = sqlserver_periodic_recurring_scans_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has vulnerability assessment disabled."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+
+    def test_sql_servers_vulnerability_assessment_recuring_scans_disabled(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                    vulnerability_assessment=ServerVulnerabilityAssessment(
+                        storage_container_path="/subcription_id/resource_group/sql_server",
+                        recurring_scans=VulnerabilityAssessmentRecurringScansProperties(
+                            is_enabled=False
+                        ),
+                    ),
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled import (
+                sqlserver_periodic_recurring_scans_enabled,
+            )
+
+            check = sqlserver_periodic_recurring_scans_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has vulnerability assessment enabled but no recurring scans."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+
+    def test_sql_servers_vulnerability_assessment_recuring_scans_enabled(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                    vulnerability_assessment=ServerVulnerabilityAssessment(
+                        storage_container_path="/subcription_id/resource_group/sql_server",
+                        recurring_scans=VulnerabilityAssessmentRecurringScansProperties(
+                            is_enabled=True
+                        ),
+                    ),
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled import (
+                sqlserver_periodic_recurring_scans_enabled,
+            )
+
+            check = sqlserver_periodic_recurring_scans_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has periodic recurring scans enabled."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id

--- a/tests/providers/azure/services/sqlserver/sqlserver_service_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_service_test.py
@@ -2,6 +2,9 @@ from unittest.mock import patch
 
 from azure.mgmt.sql.models import (
     EncryptionProtector,
+    FirewallRule,
+    ServerBlobAuditingPolicy,
+    ServerSecurityAlertPolicy,
     ServerVulnerabilityAssessment,
     TransparentDataEncryption,
 )
@@ -34,8 +37,8 @@ def mock_sqlserver_get_sql_servers(_):
                 public_network_access="public_network_access",
                 minimal_tls_version="minimal_tls_version",
                 administrators=None,
-                auditing_policies=None,
-                firewall_rules=None,
+                auditing_policies=ServerBlobAuditingPolicy(state="Disabled"),
+                firewall_rules=FirewallRule(name="name"),
                 encryption_protector=EncryptionProtector(
                     server_key_type="AzureKeyVault"
                 ),
@@ -43,6 +46,7 @@ def mock_sqlserver_get_sql_servers(_):
                 vulnerability_assessment=ServerVulnerabilityAssessment(
                     storage_container_path="/subcription_id/resource_group/sql_server"
                 ),
+                security_alert_policies=ServerSecurityAlertPolicy(state="Disabled"),
             )
         ]
     }
@@ -84,8 +88,18 @@ class Test_SqlServer_Service:
             == "minimal_tls_version"
         )
         assert sql_server.sql_servers[AZURE_SUBSCRIPTION][0].administrators is None
-        assert sql_server.sql_servers[AZURE_SUBSCRIPTION][0].auditing_policies is None
-        assert sql_server.sql_servers[AZURE_SUBSCRIPTION][0].firewall_rules is None
+        assert (
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][
+                0
+            ].auditing_policies.__class__.__name__
+            == "ServerBlobAuditingPolicy"
+        )
+        assert (
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][
+                0
+            ].firewall_rules.__class__.__name__
+            == "FirewallRule"
+        )
         assert (
             sql_server.sql_servers[AZURE_SUBSCRIPTION][
                 0
@@ -175,4 +189,50 @@ class Test_SqlServer_Service:
                 0
             ].vulnerability_assessment.storage_container_path
             == storage_container_path
+        )
+
+    def test__get_server_blob_auditing_policies__(self):
+        sql_server = SQLServer(set_mocked_azure_audit_info())
+        auditing_policies = ServerBlobAuditingPolicy(state="Disabled")
+        assert (
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][
+                0
+            ].auditing_policies.__class__.__name__
+            == "ServerBlobAuditingPolicy"
+        )
+        assert (
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][0].auditing_policies
+            == auditing_policies
+        )
+
+    def test__get_firewall_rules__(self):
+        sql_server = SQLServer(set_mocked_azure_audit_info())
+        firewall_rules = FirewallRule(name="name")
+        assert (
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][
+                0
+            ].firewall_rules.__class__.__name__
+            == "FirewallRule"
+        )
+        assert (
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][0].firewall_rules
+            == firewall_rules
+        )
+
+    def test__get_server_security_alert_policies__(self):
+        sql_server = SQLServer(set_mocked_azure_audit_info())
+        security_alert_policies = ServerSecurityAlertPolicy(state="Disabled")
+        assert (
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][
+                0
+            ].security_alert_policies.__class__.__name__
+            == "ServerSecurityAlertPolicy"
+        )
+        assert (
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][0].security_alert_policies
+            == security_alert_policies
+        )
+        assert (
+            sql_server.sql_servers[AZURE_SUBSCRIPTION][0].security_alert_policies.state
+            == "Disabled"
         )

--- a/tests/providers/azure/services/sqlserver/sqlserver_va_emails_notifications_admins_enabled/sqlserver_va_emails_notifications_admins_enabled_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_va_emails_notifications_admins_enabled/sqlserver_va_emails_notifications_admins_enabled_test.py
@@ -1,0 +1,208 @@
+from unittest import mock
+from uuid import uuid4
+
+from azure.mgmt.sql.models import (
+    ServerVulnerabilityAssessment,
+    VulnerabilityAssessmentRecurringScansProperties,
+)
+
+from prowler.providers.azure.services.sqlserver.sqlserver_service import Server
+
+AZURE_SUBSCRIPTION = str(uuid4())
+
+
+class Test_sqlserver_va_emails_notifications_admins_enabled:
+    def test_no_sql_servers(self):
+        sqlserver_client = mock.MagicMock
+        sqlserver_client.sql_servers = {}
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_emails_notifications_admins_enabled.sqlserver_va_emails_notifications_admins_enabled.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_emails_notifications_admins_enabled.sqlserver_va_emails_notifications_admins_enabled import (
+                sqlserver_va_emails_notifications_admins_enabled,
+            )
+
+            check = sqlserver_va_emails_notifications_admins_enabled()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_sql_servers_no_vulnerability_assessment(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                    vulnerability_assessment=None,
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_emails_notifications_admins_enabled.sqlserver_va_emails_notifications_admins_enabled.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_emails_notifications_admins_enabled.sqlserver_va_emails_notifications_admins_enabled import (
+                sqlserver_va_emails_notifications_admins_enabled,
+            )
+
+            check = sqlserver_va_emails_notifications_admins_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has vulnerability assessment disabled."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+
+    def test_sql_servers_no_vulnerability_assessment_no_admin_emails(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                    vulnerability_assessment=ServerVulnerabilityAssessment(
+                        storage_container_path="/subcription_id/resource_group/sql_server",
+                        recurring_scans=VulnerabilityAssessmentRecurringScansProperties(
+                            email_subscription_admins=None
+                        ),
+                    ),
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_emails_notifications_admins_enabled.sqlserver_va_emails_notifications_admins_enabled.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_emails_notifications_admins_enabled.sqlserver_va_emails_notifications_admins_enabled import (
+                sqlserver_va_emails_notifications_admins_enabled,
+            )
+
+            check = sqlserver_va_emails_notifications_admins_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has vulnerability assessment enabled but no scan reports configured for subscription admins."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+
+    def test_sql_servers_vulnerability_assessment_admin_emails_false(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                    vulnerability_assessment=ServerVulnerabilityAssessment(
+                        storage_container_path="/subcription_id/resource_group/sql_server",
+                        recurring_scans=VulnerabilityAssessmentRecurringScansProperties(
+                            email_subscription_admins=False
+                        ),
+                    ),
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_emails_notifications_admins_enabled.sqlserver_va_emails_notifications_admins_enabled.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_emails_notifications_admins_enabled.sqlserver_va_emails_notifications_admins_enabled import (
+                sqlserver_va_emails_notifications_admins_enabled,
+            )
+
+            check = sqlserver_va_emails_notifications_admins_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has vulnerability assessment enabled but no scan reports configured for subscription admins."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+
+    def test_sql_servers_vulnerability_assessment_no_email_subscription_admins(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                    vulnerability_assessment=ServerVulnerabilityAssessment(
+                        storage_container_path="/subcription_id/resource_group/sql_server",
+                        recurring_scans=VulnerabilityAssessmentRecurringScansProperties(
+                            email_subscription_admins=True
+                        ),
+                    ),
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_emails_notifications_admins_enabled.sqlserver_va_emails_notifications_admins_enabled.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_emails_notifications_admins_enabled.sqlserver_va_emails_notifications_admins_enabled import (
+                sqlserver_va_emails_notifications_admins_enabled,
+            )
+
+            check = sqlserver_va_emails_notifications_admins_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has vulnerability assessment enabled and scan reports configured for subscription admins."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id

--- a/tests/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled/sqlserver_va_periodic_recurring_scans_enabled_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled/sqlserver_va_periodic_recurring_scans_enabled_test.py
@@ -11,20 +11,20 @@ from prowler.providers.azure.services.sqlserver.sqlserver_service import Server
 AZURE_SUBSCRIPTION = str(uuid4())
 
 
-class Test_sqlserver_periodic_recurring_scans_enabled:
+class Test_sqlserver_va_periodic_recurring_scans_enabled:
     def test_no_sql_servers(self):
         sqlserver_client = mock.MagicMock
         sqlserver_client.sql_servers = {}
 
         with mock.patch(
-            "prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled.sqlserver_client",
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_client",
             new=sqlserver_client,
         ):
-            from prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled import (
-                sqlserver_periodic_recurring_scans_enabled,
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_va_periodic_recurring_scans_enabled import (
+                sqlserver_va_periodic_recurring_scans_enabled,
             )
 
-            check = sqlserver_periodic_recurring_scans_enabled()
+            check = sqlserver_va_periodic_recurring_scans_enabled()
             result = check.execute()
             assert len(result) == 0
 
@@ -50,14 +50,14 @@ class Test_sqlserver_periodic_recurring_scans_enabled:
         }
 
         with mock.patch(
-            "prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled.sqlserver_client",
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_client",
             new=sqlserver_client,
         ):
-            from prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled import (
-                sqlserver_periodic_recurring_scans_enabled,
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_va_periodic_recurring_scans_enabled import (
+                sqlserver_va_periodic_recurring_scans_enabled,
             )
 
-            check = sqlserver_periodic_recurring_scans_enabled()
+            check = sqlserver_va_periodic_recurring_scans_enabled()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
@@ -93,14 +93,14 @@ class Test_sqlserver_periodic_recurring_scans_enabled:
         }
 
         with mock.patch(
-            "prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled.sqlserver_client",
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_client",
             new=sqlserver_client,
         ):
-            from prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled import (
-                sqlserver_periodic_recurring_scans_enabled,
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_va_periodic_recurring_scans_enabled import (
+                sqlserver_va_periodic_recurring_scans_enabled,
             )
 
-            check = sqlserver_periodic_recurring_scans_enabled()
+            check = sqlserver_va_periodic_recurring_scans_enabled()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
@@ -139,14 +139,14 @@ class Test_sqlserver_periodic_recurring_scans_enabled:
         }
 
         with mock.patch(
-            "prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled.sqlserver_client",
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_client",
             new=sqlserver_client,
         ):
-            from prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled import (
-                sqlserver_periodic_recurring_scans_enabled,
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_va_periodic_recurring_scans_enabled import (
+                sqlserver_va_periodic_recurring_scans_enabled,
             )
 
-            check = sqlserver_periodic_recurring_scans_enabled()
+            check = sqlserver_va_periodic_recurring_scans_enabled()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
@@ -185,14 +185,14 @@ class Test_sqlserver_periodic_recurring_scans_enabled:
         }
 
         with mock.patch(
-            "prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled.sqlserver_client",
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_client",
             new=sqlserver_client,
         ):
-            from prowler.providers.azure.services.sqlserver.sqlserver_periodic_recurring_scans_enabled.sqlserver_periodic_recurring_scans_enabled import (
-                sqlserver_periodic_recurring_scans_enabled,
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_periodic_recurring_scans_enabled.sqlserver_va_periodic_recurring_scans_enabled import (
+                sqlserver_va_periodic_recurring_scans_enabled,
             )
 
-            check = sqlserver_periodic_recurring_scans_enabled()
+            check = sqlserver_va_periodic_recurring_scans_enabled()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "PASS"

--- a/tests/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured/sqlserver_va_scan_reports_configured_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured/sqlserver_va_scan_reports_configured_test.py
@@ -1,0 +1,254 @@
+from unittest import mock
+from uuid import uuid4
+
+from azure.mgmt.sql.models import (
+    ServerVulnerabilityAssessment,
+    VulnerabilityAssessmentRecurringScansProperties,
+)
+
+from prowler.providers.azure.services.sqlserver.sqlserver_service import Server
+
+AZURE_SUBSCRIPTION = str(uuid4())
+
+
+class Test_sqlserver_va_scan_reports_configured:
+    def test_no_sql_servers(self):
+        sqlserver_client = mock.MagicMock
+        sqlserver_client.sql_servers = {}
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured import (
+                sqlserver_va_scan_reports_configured,
+            )
+
+            check = sqlserver_va_scan_reports_configured()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_sql_servers_no_vulnerability_assessment(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                    vulnerability_assessment=None,
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured import (
+                sqlserver_va_scan_reports_configured,
+            )
+
+            check = sqlserver_va_scan_reports_configured()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has vulnerability assessment disabled."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+
+    def test_sql_servers_no_vulnerability_assessment_emails(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                    vulnerability_assessment=ServerVulnerabilityAssessment(
+                        storage_container_path="/subcription_id/resource_group/sql_server",
+                        recurring_scans=VulnerabilityAssessmentRecurringScansProperties(
+                            emails=None, email_subscription_admins=False
+                        ),
+                    ),
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured import (
+                sqlserver_va_scan_reports_configured,
+            )
+
+            check = sqlserver_va_scan_reports_configured()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has vulnerability assessment enabled but no scan reports configured."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+
+    def test_sql_servers_vulnerability_assessment_emails_none(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                    vulnerability_assessment=ServerVulnerabilityAssessment(
+                        storage_container_path="/subcription_id/resource_group/sql_server",
+                        recurring_scans=VulnerabilityAssessmentRecurringScansProperties(
+                            emails=None, email_subscription_admins=True
+                        ),
+                    ),
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured import (
+                sqlserver_va_scan_reports_configured,
+            )
+
+            check = sqlserver_va_scan_reports_configured()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has vulnerability assessment enabled and scan reports configured."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+
+    def test_sql_servers_vulnerability_assessment_no_email_subscription_admins(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                    vulnerability_assessment=ServerVulnerabilityAssessment(
+                        storage_container_path="/subcription_id/resource_group/sql_server",
+                        recurring_scans=VulnerabilityAssessmentRecurringScansProperties(
+                            emails=["email@email.com"], email_subscription_admins=False
+                        ),
+                    ),
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured import (
+                sqlserver_va_scan_reports_configured,
+            )
+
+            check = sqlserver_va_scan_reports_configured()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has vulnerability assessment enabled and scan reports configured."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+
+    def test_sql_servers_vulnerability_assessment_both_emails(self):
+        sqlserver_client = mock.MagicMock
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=None,
+                    encryption_protector=None,
+                    vulnerability_assessment=ServerVulnerabilityAssessment(
+                        storage_container_path="/subcription_id/resource_group/sql_server",
+                        recurring_scans=VulnerabilityAssessmentRecurringScansProperties(
+                            emails=["email@email.com"], email_subscription_admins=True
+                        ),
+                    ),
+                )
+            ]
+        }
+
+        with mock.patch(
+            "prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured.sqlserver_client",
+            new=sqlserver_client,
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_va_scan_reports_configured.sqlserver_va_scan_reports_configured import (
+                sqlserver_va_scan_reports_configured,
+            )
+
+            check = sqlserver_va_scan_reports_configured()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION} has vulnerability assessment enabled and scan reports configured."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id


### PR DESCRIPTION
### Context

Add new checks and related tests:

- [x] `sqlserver_microsoft_defender_enabled`
- [x] `sqlserver_va_periodic_recurring_scans_enabled`
- [x] `sqlserver_va_scan_reports_configured`
- [x] `sqlserver_va_emails_notifications_admins_enabled`

### Description

The task that are made for each check:

- Ensure that Microsoft Defender for SQL is set to 'On' for critical SQL Servers
- Ensure that Vulnerability Assessment (VA) setting 'Periodic recurring scans' is set to 'on' for each SQL server
- Ensure that Vulnerability Assessment (VA) setting 'Send scan reports to' is configured for a SQL server
- Ensure that Vulnerability Assessment (VA) setting 'Also send email notifications to admins and subscription owners' is set for each SQL Server


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
