### PR TITLE
fix(allowlist): Handle tags and resources

### DIFF
--- a/prowler/providers/aws/lib/allowlist/allowlist.py
+++ b/prowler/providers/aws/lib/allowlist/allowlist.py
@@ -199,7 +199,11 @@ def is_allowlisted_in_check(
 
             allowlisted_regions = allowlisted_check_info.get("Regions")
             allowlisted_resources = allowlisted_check_info.get("Resources")
-            allowlisted_tags = allowlisted_check_info.get("Tags")
+            allowlisted_tags = allowlisted_check_info.get("Tags", "*")
+            # We need to set the allowlisted_tags if None, "" or [], so the falsy helps
+            if not allowlisted_tags:
+                allowlisted_tags = "*"
+
             # If there is a *, it affects to all checks
             if (
                 "*" == allowlisted_check
@@ -220,13 +224,15 @@ def is_allowlisted_in_check(
                 # For a finding to be allowlisted requires the following set to True:
                 # - allowlisted_in_check -> True
                 # - allowlisted_in_region -> True
-                # - allowlisted_in_tags -> True or allowlisted_in_resource -> True
+                # - allowlisted_in_tags -> True
+                # - allowlisted_in_resource -> True
                 # - excepted -> False
 
                 if (
                     allowlisted_in_check
                     and allowlisted_in_region
-                    and (allowlisted_in_tags or allowlisted_in_resource)
+                    and allowlisted_in_tags
+                    and allowlisted_in_resource
                 ):
                     is_check_allowlisted = True
 

--- a/tests/providers/aws/lib/allowlist/allowlist_test.py
+++ b/tests/providers/aws/lib/allowlist/allowlist_test.py
@@ -261,6 +261,39 @@ class Test_Allowlist:
             "",
         )
 
+    def test_is_allowlisted_with_default_allowlist_with_tags(self):
+        allowlist = {
+            "Accounts": {
+                "*": {
+                    "Checks": {
+                        "*": {
+                            "Regions": ["*"],
+                            "Resources": ["*"],
+                            "Tags": ["Compliance=allow"],
+                        }
+                    }
+                }
+            }
+        }
+
+        assert is_allowlisted(
+            allowlist,
+            AWS_ACCOUNT_NUMBER,
+            "athena_1",
+            AWS_REGION_US_EAST_1,
+            "prowler",
+            "Compliance=allow",
+        )
+
+        assert not is_allowlisted(
+            allowlist,
+            AWS_ACCOUNT_NUMBER,
+            "athena_1",
+            AWS_REGION_US_EAST_1,
+            "prowler",
+            "Compliance=deny",
+        )
+
     def test_is_allowlisted(self):
         # Allowlist example
         allowlist = {


### PR DESCRIPTION
### Context

Fix #3368 

### Description

Handle allowlists with everything with a wildcard but the tags, like:
```yaml
Allowlist:
  Accounts:
    "*":
      Checks:
        "*":
          Regions:
            - "*"
          Resources:
            - "*"
          Tags:
            - "Compliance=allow" 
```

So as the `Tags` is an optional value, we need to set it as `*` if nothing is set.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
