### PR TITLE
fix(alias): allow multiple check aliases

### DIFF
--- a/prowler/providers/aws/services/inspector2/inspector2_active_findings_exist/inspector2_active_findings_exist.metadata.json
+++ b/prowler/providers/aws/services/inspector2/inspector2_active_findings_exist/inspector2_active_findings_exist.metadata.json
@@ -2,6 +2,9 @@
   "Provider": "aws",
   "CheckID": "inspector2_active_findings_exist",
   "CheckTitle": "Check if Inspector2 findings exist",
+  "CheckAliases": [
+    "inspector2_findings_exist"
+  ],
   "CheckType": [],
   "ServiceName": "inspector2",
   "SubServiceName": "",

--- a/prowler/providers/aws/services/inspector2/inspector2_is_enabled/inspector2_is_enabled.metadata.json
+++ b/prowler/providers/aws/services/inspector2/inspector2_is_enabled/inspector2_is_enabled.metadata.json
@@ -2,6 +2,9 @@
   "Provider": "aws",
   "CheckID": "inspector2_is_enabled",
   "CheckTitle": "Check if Inspector2 is enabled",
+  "CheckAliases": [
+    "inspector2_findings_exist"
+  ],
   "CheckType": [],
   "ServiceName": "inspector2",
   "SubServiceName": "",

--- a/tests/lib/check/check_loader_test.py
+++ b/tests/lib/check/check_loader_test.py
@@ -313,7 +313,14 @@ class TestCheckLoader:
 
     def test_update_checks_to_execute_with_aliases(self):
         checks_to_execute = {"renamed_check"}
-        check_aliases = {"renamed_check": "check_name"}
+        check_aliases = {"renamed_check": ["check_name"]}
         assert {"check_name"} == update_checks_to_execute_with_aliases(
+            checks_to_execute, check_aliases
+        )
+
+    def test_update_checks_to_execute_with_multiple_aliases(self):
+        checks_to_execute = {"renamed_check"}
+        check_aliases = {"renamed_check": ["check1_name", "check2_name"]}
+        assert {"check1_name", "check2_name"} == update_checks_to_execute_with_aliases(
             checks_to_execute, check_aliases
         )


### PR DESCRIPTION
### Context

When a Check Alias applies to multiple checks, Prowler only executes the first one.

### Description

Execute all the applicable check to the specific alias.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
