### PR TITLE
fix(storage): update metadata with CIS 2.0 in `storage_default_network_access_rule_is_denied`

### DIFF
--- a/prowler/providers/azure/services/storage/storage_default_network_access_rule_is_denied/storage_default_network_access_rule_is_denied.metadata.json
+++ b/prowler/providers/azure/services/storage/storage_default_network_access_rule_is_denied/storage_default_network_access_rule_is_denied.metadata.json
@@ -8,8 +8,8 @@
   "ResourceIdTemplate": "",
   "Severity": "medium",
   "ResourceType": "AzureStorageAccount",
-  "Description": "Ensure Default Network Access Rule for Storage Accounts is Set to Deny",
-  "Risk": "By restricting access to your storage account default network, you add a new layer of security, since the default action is to accept connections from clients on any network.",
+  "Description": "Restricting default network access helps to provide a new layer of security, since storage accounts accept connections from clients on any network. To limit access toselected networks, the default action must be changed.",
+  "Risk": "Storage accounts should be configured to deny access to traffic from all networks (including internet traffic). Access can be granted to traffic from specific Azure Virtualnetworks, allowing a secure network boundary for specific applications to be built.Access can also be granted to public internet IP address ranges to enable connectionsfrom specific internet or on-premises clients. When network rules are configured, onlyapplications from allowed networks can access a storage account. When calling from anallowed network, applications continue to require proper authorization (a valid accesskey or SAS token) to access the storage account.",
   "RelatedUrl": "",
   "Remediation": {
     "Code": {
@@ -19,12 +19,12 @@
       "Terraform": "https://docs.bridgecrew.io/docs/set-default-network-access-rule-for-storage-accounts-to-deny#terraform"
     },
     "Recommendation": {
-      "Text": "To limit access to selected networks or IP addresses, you must first change the default action from 'Allow' to 'Deny'",
+      "Text": "1. Go to Storage Accounts 2. For each storage account, Click on the Networking blade 3. Click the Firewalls and virtual networks heading. 4. Ensure that you have elected to allow access from Selected networks 5. Add rules to allow traffic from specific network. 6. Click Save to apply your changes.",
       "Url": ""
     }
   },
   "Categories": [],
   "DependsOn": [],
   "RelatedTo": [],
-  "Notes": ""
+  "Notes": "All allowed networks will need to be whitelisted on each specific network, creating administrative overhead. This may result in loss of network connectivity, so do not turn on for critical resources during business hours."
 }


### PR DESCRIPTION
### Context

Update metadata with CIS 2.0 in `storage_default_network_access_rule_is_denied`.


### Description

Update of check Ensure Default Network Access Rule for Storage Accounts is Set to Deny metadata to CIS 2.0 


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
