### PR TITLE
fix(backup): handle if `last_attempted_execution_date` is None

### DIFF
--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -152,5 +152,5 @@ class BackupReportPlan(BaseModel):
     arn: str
     region: str
     name: str
-    last_attempted_execution_date: datetime
+    last_attempted_execution_date: Optional[datetime]
     last_successful_execution_date: Optional[datetime]


### PR DESCRIPTION
### Description

Make `last_attempted_execution_date` attribute as Optional in Backup Report Plan to handle if `last_attempted_execution_date` is None.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
