### PR TITLE
fix(azure): Typo in appinsights service

### DIFF
--- a/tests/providers/azure/services/appinsights/appinsights_service_test.py
+++ b/tests/providers/azure/services/appinsights/appinsights_service_test.py
@@ -37,7 +37,7 @@ class Test_AppInsights_Service:
         app_insights = AppInsights(set_mocked_azure_audit_info())
         assert app_insights.subscriptions.__class__.__name__ == "dict"
 
-    def test__get_componentes(self):
+    def test__get_components(self):
         appinsights = AppInsights(set_mocked_azure_audit_info())
         assert len(appinsights.components) == 1
         assert (

--- a/tests/providers/azure/services/appinsights/appinsights_service_test.py
+++ b/tests/providers/azure/services/appinsights/appinsights_service_test.py
@@ -37,7 +37,7 @@ class Test_AppInsights_Service:
         app_insights = AppInsights(set_mocked_azure_audit_info())
         assert app_insights.subscriptions.__class__.__name__ == "dict"
 
-    def test__get_components(self):
+    def test__get_components__(self):
         appinsights = AppInsights(set_mocked_azure_audit_info())
         assert len(appinsights.components) == 1
         assert (


### PR DESCRIPTION
### Context

Fix a typo in AppInsights Azure service


### Description

It changes one method test name from "componentes" to "components"


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
