### PR TITLE
fix(labeler): Work on forks too

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: "Pull Request Labeler"
 
 on:
-    pull_request:
+    pull_request_target:
       branches:
         - "master"
         - "prowler-4.0-dev"


### PR DESCRIPTION
### Description

Make `labeler` to work on PR from forks. Rationale: https://github.com/actions/labeler?tab=readme-ov-file#permissions

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
