### PR TITLE
fix(inspector2): Report must have status field

### DIFF
--- a/prowler/providers/aws/services/inspector2/inspector2_active_findings_exist/inspector2_active_findings_exist.py
+++ b/prowler/providers/aws/services/inspector2/inspector2_active_findings_exist/inspector2_active_findings_exist.py
@@ -8,11 +8,11 @@ class inspector2_active_findings_exist(Check):
     def execute(self):
         findings = []
         for inspector in inspector2_client.inspectors:
-            report = Check_Report_AWS(self.metadata())
-            report.resource_id = inspector.id
-            report.resource_arn = inspector.arn
-            report.region = inspector.region
             if inspector.status == "ENABLED":
+                report = Check_Report_AWS(self.metadata())
+                report.resource_id = inspector.id
+                report.resource_arn = inspector.arn
+                report.region = inspector.region
                 active_findings = 0
                 report.status = "PASS"
                 report.status_extended = "Inspector2 is enabled with no findings."
@@ -26,7 +26,7 @@ class inspector2_active_findings_exist(Check):
                     if active_findings > 0:
                         report.status = "FAIL"
                         report.status_extended = (
-                            f"There are {active_findings} ACTIVE Inspector2 findings."
+                            f"There are {active_findings} active Inspector2 findings."
                         )
                 findings.append(report)
 

--- a/prowler/providers/aws/services/inspector2/inspector2_is_enabled/inspector2_is_enabled.py
+++ b/prowler/providers/aws/services/inspector2/inspector2_is_enabled/inspector2_is_enabled.py
@@ -18,6 +18,7 @@ class inspector2_is_enabled(Check):
             if inspector.status == "ENABLED":
                 report.status = "PASS"
                 report.status_extended = "Inspector2 is enabled."
+                findings.append(report)
             else:
                 if inspector2_client.audit_info.ignore_unused_services:
                     funtions_in_region = False
@@ -35,6 +36,6 @@ class inspector2_is_enabled(Check):
                 ):
                     report.status = "FAIL"
                     report.status_extended = "Inspector2 is not enabled."
-            findings.append(report)
+                    findings.append(report)
 
         return findings

--- a/tests/providers/aws/services/inspector2/inspector2_active_findings_exist/inspector2_active_findings_exist_test.py
+++ b/tests/providers/aws/services/inspector2/inspector2_active_findings_exist/inspector2_active_findings_exist_test.py
@@ -176,7 +176,7 @@ class Test_inspector2_active_findings_exist:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "There are 1 ACTIVE Inspector2 findings."
+                    == "There are 1 active Inspector2 findings."
                 )
                 assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                 assert (
@@ -242,7 +242,7 @@ class Test_inspector2_active_findings_exist:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "There are 1 ACTIVE Inspector2 findings."
+                    == "There are 1 active Inspector2 findings."
                 )
                 assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                 assert (


### PR DESCRIPTION
### Description

Fix `report` without `status` field in the Inspector 2 checks.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
