### PR TITLE
fix(docs): Fix typo and change info about mocking

### DIFF
--- a/docs/developer-guide/unit-testing.md
+++ b/docs/developer-guide/unit-testing.md
@@ -385,7 +385,7 @@ with mock.patch(
     "prowler.providers.<provider>.lib.audit_info.audit_info.audit_info",
     new=audit_info,
 ), mock.patch(
-    "prowler.providers.aws.services.<service>.<check>.<check>.<service>_client",
+    "prowler.providers.<provider>.services.<service>.<check>.<check>.<service>_client",
     new=<SERVICE>(audit_info),
 ):
 ```
@@ -407,10 +407,10 @@ with mock.patch(
     "prowler.providers.<provider>.lib.audit_info.audit_info.audit_info",
     new=audit_info,
 ), mock.patch(
-    "prowler.providers.aws.services.<service>.<SERVICE>",
+    "prowler.providers.<provider>.services.<service>.<SERVICE>",
     new=<SERVICE>(audit_info),
 ) as service_client, mock.patch(
-    "prowler.providers.aws.services.<service>.<service>_client.<service>_client",
+    "prowler.providers.<provider>.services.<service>.<service>_client.<service>_client",
     new=service_client,
 ):
 ```


### PR DESCRIPTION
### Context

This pr fix typo in unit-testing documentation changing aws to <provider> tag


### Description




### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
