### PR TITLE
fix(gcp): remove Default Project ID requirement

### DIFF
--- a/prowler/providers/common/audit_info.py
+++ b/prowler/providers/common/audit_info.py
@@ -46,10 +46,8 @@ class Audit_Info:
         # Beautify audited profile, set "default" if there is no profile set
         try:
             getattr(audit_info.credentials, "_service_account_email")
-            profile = (
-                audit_info.credentials._service_account_email
-                if audit_info.credentials._service_account_email is not None
-                else "default"
+            profile = getattr(
+                audit_info.credentials, "_service_account_email", "default"
             )
         except AttributeError:
             profile = "default"

--- a/prowler/providers/common/audit_info.py
+++ b/prowler/providers/common/audit_info.py
@@ -44,13 +44,7 @@ class Audit_Info:
 
     def print_gcp_credentials(self, audit_info: GCP_Audit_Info):
         # Beautify audited profile, set "default" if there is no profile set
-        try:
-            getattr(audit_info.credentials, "_service_account_email")
-            profile = getattr(
-                audit_info.credentials, "_service_account_email", "default"
-            )
-        except AttributeError:
-            profile = "default"
+        profile = getattr(audit_info.credentials, "_service_account_email", "default")
 
         report = f"""
 This report is being generated using credentials below:

--- a/prowler/providers/common/outputs.py
+++ b/prowler/providers/common/outputs.py
@@ -110,7 +110,7 @@ class Gcp_Output_Options(Provider_Output_Options):
             not hasattr(arguments, "output_filename")
             or arguments.output_filename is None
         ):
-            self.output_filename = f"prowler-output-{audit_info.default_project_id}-{output_file_timestamp}"
+            self.output_filename = f"prowler-output-{getattr(audit_info.credentials, '_service_account_email', 'default')}-{output_file_timestamp}"
         else:
             self.output_filename = arguments.output_filename
 

--- a/prowler/providers/common/outputs.py
+++ b/prowler/providers/common/outputs.py
@@ -110,7 +110,7 @@ class Gcp_Output_Options(Provider_Output_Options):
             not hasattr(arguments, "output_filename")
             or arguments.output_filename is None
         ):
-            self.output_filename = f"prowler-output-{getattr(audit_info.credentials, '_service_account_email', 'default')}-{output_file_timestamp}"
+            self.output_filename = f"prowler-output-{audit_info.default_project_id}-{output_file_timestamp}"
         else:
             self.output_filename = arguments.output_filename
 

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -18,9 +18,6 @@ class GCP_Provider:
         self.credentials, self.default_project_id = self.__set_credentials__(
             credentials_file
         )
-        if not self.default_project_id:
-            logger.critical("No Project ID associated to Google Credentials.")
-            sys.exit(1)
 
         self.project_ids = []
         accessible_projects = self.get_project_ids()
@@ -40,6 +37,10 @@ class GCP_Provider:
         else:
             # If not projects were input, all accessible projects are scanned by default
             self.project_ids = accessible_projects
+
+        # Set Default Project ID if not set in credentials
+        if not self.default_project_id:
+            self.default_project_id = self.project_ids[0]
 
     def __set_credentials__(self, credentials_file):
         try:


### PR DESCRIPTION
### Description

Since Prowler scans all accesible projects by default, there is no need now to have set a Default Project ID in your GCP credentials.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
