### PR TITLE
chore(allowlist): add AFT IAM roles to allowlist

### DIFF
--- a/prowler/config/aws_allowlist.yaml
+++ b/prowler/config/aws_allowlist.yaml
@@ -38,6 +38,9 @@ Allowlist:
             - "aws-controltower-ReadOnlyExecutionRole"
             - "AWSControlTower_VPCFlowLogsRole"
             - "AWSControlTowerExecution"
+            - "AWSAFTAdmin"
+            - "AWSAFTExecution"
+            - "AWSAFTService"
         "iam_policy_*":
           Regions:
             - "*"


### PR DESCRIPTION
### Description

Include to the allowlist the AWS Control Tower Account Factory for Terraform (AFT) IAM Roles that are created on every AFT managed accounts.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
