### PR TITLE
chore(gcp): set GCP account in output file name

### DIFF
--- a/prowler/providers/common/outputs.py
+++ b/prowler/providers/common/outputs.py
@@ -110,7 +110,7 @@ class Gcp_Output_Options(Provider_Output_Options):
             not hasattr(arguments, "output_filename")
             or arguments.output_filename is None
         ):
-            self.output_filename = f"prowler-output-{audit_info.default_project_id}-{output_file_timestamp}"
+            self.output_filename = f"prowler-output-{getattr(audit_info.credentials, '_service_account_email', 'default')}-{output_file_timestamp}"
         else:
             self.output_filename = arguments.output_filename
 

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -38,10 +38,6 @@ class GCP_Provider:
             # If not projects were input, all accessible projects are scanned by default
             self.project_ids = accessible_projects
 
-        # Set Default Project ID if not set in credentials
-        if not self.default_project_id:
-            self.default_project_id = self.project_ids[0]
-
     def __set_credentials__(self, credentials_file):
         try:
             if credentials_file:


### PR DESCRIPTION
### Description

Since Prowler is multi-project in GCP, it makes no sense setting the first or the default project in the output file name. Therefore, the GCP Account is set in the output file name.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
