### PR TITLE
chore(kubernetes): add strong ciphers config vars

### DIFF
--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -66,8 +66,8 @@ aws:
     ]
 
   # AWS Organizations
-  # organizations_scp_check_deny_regions
-  # organizations_enabled_regions: [
+  # aws.organizations_scp_check_deny_regions
+  # aws.organizations_enabled_regions: [
   #   "eu-central-1",
   #   "eu-west-1",
   #   "us-east-1"
@@ -76,14 +76,14 @@ aws:
   organizations_trusted_delegated_administrators: []
 
   # AWS ECR
-  # ecr_repositories_scan_vulnerabilities_in_latest_image
+  # aws.ecr_repositories_scan_vulnerabilities_in_latest_image
   # CRITICAL
   # HIGH
   # MEDIUM
   ecr_repository_vulnerability_minimum_severity: "MEDIUM"
 
   # AWS Trusted Advisor
-  # trustedadvisor_premium_support_plan_subscribed
+  # aws.trustedadvisor_premium_support_plan_subscribed
   verify_premium_support_plans: True
 
 # Azure Configuration
@@ -106,9 +106,27 @@ gcp:
 # Kubernetes Configuration
 kubernetes:
   # Kubernetes API Server
-  # apiserver_audit_log_maxbackup_set
+  # kubernetes.apiserver_audit_log_maxbackup_set
   audit_log_maxbackup: 10
-  # apiserver_audit_log_maxsize_set
+  # kubernetes.apiserver_audit_log_maxsize_set
   audit_log_maxsize: 100
-  # apiserver_audit_log_maxage_set
+  # kubernetes.apiserver_audit_log_maxage_set
   audit_log_maxage: 30
+  # kubernetes.apiserver_strong_ciphers_only
+  apiserver_strong_ciphers: [
+      "TLS_AES_128_GCM_SHA256",
+      "TLS_AES_256_GCM_SHA384",
+      "TLS_CHACHA20_POLY1305_SHA256",
+  ]
+  # Kubelet
+  # kubernetes.kubelet_strong_ciphers_only
+  kubelet_strong_ciphers: [
+      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+      "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+      "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+      "TLS_RSA_WITH_AES_256_GCM_SHA384",
+      "TLS_RSA_WITH_AES_128_GCM_SHA256",
+  ]

--- a/prowler/providers/kubernetes/services/apiserver/apiserver_strong_ciphers_only/apiserver_strong_ciphers_only.py
+++ b/prowler/providers/kubernetes/services/apiserver/apiserver_strong_ciphers_only/apiserver_strong_ciphers_only.py
@@ -14,20 +14,22 @@ class apiserver_strong_ciphers_only(Check):
             report.resource_id = pod.uid
             report.status = "PASS"
             report.status_extended = f"API Server is configured with strong cryptographic ciphers in pod {pod.name}."
-            strong_ciphers_set = True
+            strong_ciphers_set = False
             for container in pod.containers.values():
-                strong_ciphers_set = True
+                strong_ciphers_set = False
                 # Check if strong ciphers are set in "--tls-cipher-suites"
                 for command in container.command:
                     if command.startswith("--tls-cipher-suites"):
-                        for cipher in command.split("=")[1].split(","):
-                            if cipher not in [
-                                "TLS_AES_128_GCM_SHA256",
-                                "TLS_AES_256_GCM_SHA384",
-                                "TLS_CHACHA20_POLY1305_SHA256",
-                            ]:
-                                strong_ciphers_set = False
-                                break
+                        if (
+                            command.split("=")[1]
+                            .split(",")
+                            .issubset(
+                                apiserver_client.audit_config.get(
+                                    "apiserver_strong_ciphers", []
+                                )
+                            )
+                        ):
+                            strong_ciphers_set = True
                 if not strong_ciphers_set:
                     break
 

--- a/prowler/providers/kubernetes/services/kubelet/kubelet_strong_ciphers_only/kubelet_strong_ciphers_only.py
+++ b/prowler/providers/kubernetes/services/kubelet/kubelet_strong_ciphers_only/kubelet_strong_ciphers_only.py
@@ -4,16 +4,6 @@ from prowler.providers.kubernetes.services.kubelet.kubelet_client import kubelet
 
 class kubelet_strong_ciphers_only(Check):
     def execute(self) -> Check_Report_Kubernetes:
-        strong_ciphers = [
-            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-            "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
-            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-            "TLS_RSA_WITH_AES_256_GCM_SHA384",
-            "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        ]
         findings = []
         for cm in kubelet_client.kubelet_config_maps:
             report = Check_Report_Kubernetes(self.metadata())
@@ -24,7 +14,9 @@ class kubelet_strong_ciphers_only(Check):
                 report.status = "MANUAL"
                 report.status_extended = f"Kubelet does not have the argument `tlsCipherSuites` in config file {cm.name}, verify it in the node's arguments."
             else:
-                if cm.kubelet_args["tlsCipherSuites"].issubset(strong_ciphers):
+                if cm.kubelet_args["tlsCipherSuites"].issubset(
+                    kubelet_client.audit_config.get("kubelet_strong_ciphers", [])
+                ):
                     report.status = "PASS"
                     report.status_extended = f"Kubelet is configured with strong cryptographic ciphers in config file {cm.name}."
                 else:


### PR DESCRIPTION
### Description

Add `apiserver_strong_ciphers_only` and `kubelet_strong_ciphers_only` ciphers in `config.yaml` as configurable variables.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
