### PR TITLE
fix(compliance): add default severity to Manual Mocked Metadata

### DIFF
--- a/prowler/lib/check/compliance.py
+++ b/prowler/lib/check/compliance.py
@@ -60,7 +60,7 @@ def update_checks_metadata_with_compliance(
                 "ServiceName": "",
                 "SubServiceName": "",
                 "ResourceIdTemplate": "",
-                "Severity": "",
+                "Severity": "low",
                 "ResourceType": "",
                 "Description": "",
                 "Risk": "",


### PR DESCRIPTION
### Description

Since we add a Severity validator, we need to add a default severity to the Manual Mocked Metadata.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
