### PR TITLE
fix(compliance): set Generic Compliance as last model

### DIFF
--- a/prowler/lib/check/compliance_models.py
+++ b/prowler/lib/check/compliance_models.py
@@ -151,9 +151,9 @@ class Compliance_Requirement(BaseModel):
         Union[
             CIS_Requirement_Attribute,
             ENS_Requirement_Attribute,
-            Generic_Compliance_Requirement_Attribute,
             ISO27001_2013_Requirement_Attribute,
             AWS_Well_Architected_Requirement_Attribute,
+            Generic_Compliance_Requirement_Attribute,
         ]
     ]
     Checks: list[str]


### PR DESCRIPTION
### Description

Since all attributes in the Generic Compliance Requirement are Optional, we have to set it as the last model in the Compliance_Requirement Union.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
