### PR TITLE
chore(providers): Store output options and mutelist

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -174,7 +174,10 @@ def prowler():
     checks_to_execute = sorted(checks_to_execute)
 
     # Setup Mute List
-    global_provider.mutelist = args.mutelist_file
+    # TODO: this should be available for all the providers
+    # Move the argument to the Prowler level to be available for all
+    if hasattr(args, "mutelist_file"):
+        global_provider.mutelist = args.mutelist_file
 
     # Setup Output Options
     global_provider.output_options = (args, bulk_checks_metadata)

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -564,7 +564,7 @@ def execute(
     )
 
     # Mute List findings
-    if hasattr(global_provider, "mutelist"):
+    if hasattr(global_provider, "mutelist") and global_provider.mutelist:
         check_findings = mutelist_findings(
             global_provider.mutelist,
             global_provider.identity.account,

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -398,6 +398,7 @@ def import_check(check_path: str) -> ModuleType:
     return lib
 
 
+# TODO: change ref to Provider_Output_Options
 def run_check(check: Check, output_options: Provider_Output_Options) -> list:
     findings = []
     if output_options.verbose:
@@ -422,7 +423,6 @@ def run_check(check: Check, output_options: Provider_Output_Options) -> list:
 def execute_checks(
     checks_to_execute: list,
     global_provider: Any,
-    audit_output_options: Provider_Output_Options,
     custom_checks_metadata: Any,
 ) -> list:
     # List to store all the check's findings
@@ -460,7 +460,7 @@ def execute_checks(
             )
 
     # Execution with the --only-logs flag
-    if audit_output_options.only_logs:
+    if global_provider.output_options.only_logs:
         for check_name in checks_to_execute:
             # Recover service from check name
             service = check_name.split("_")[0]
@@ -469,7 +469,6 @@ def execute_checks(
                     service,
                     check_name,
                     global_provider.type,
-                    audit_output_options,
                     global_provider.identity,
                     services_executed,
                     checks_executed,
@@ -514,7 +513,6 @@ def execute_checks(
                     check_findings = execute(
                         service,
                         check_name,
-                        audit_output_options,
                         global_provider,
                         services_executed,
                         checks_executed,
@@ -541,7 +539,6 @@ def execute_checks(
 def execute(
     service: str,
     check_name: str,
-    audit_output_options: Provider_Output_Options,
     global_provider: Any,
     services_executed: set,
     checks_executed: set,
@@ -559,7 +556,7 @@ def execute(
         c = update_check_metadata(c, custom_checks_metadata["Checks"][c.CheckID])
 
     # Run check
-    check_findings = run_check(c, audit_output_options)
+    check_findings = run_check(c, global_provider.output_options)
 
     # Update Audit Status
     services_executed.add(service)
@@ -569,15 +566,15 @@ def execute(
     )
 
     # Mute List findings
-    if audit_output_options.mutelist_file:
+    if global_provider.mutelist:
         check_findings = mutelist_findings(
-            audit_output_options.mutelist_file,
-            global_provider.audited_account,
+            global_provider.mutelist,
+            global_provider.identity.account,
             check_findings,
         )
 
     # Report the check's findings
-    report(check_findings, audit_output_options, global_provider)
+    report(check_findings, global_provider)
 
     if os.environ.get("PROWLER_REPORT_LIB_PATH"):
         try:
@@ -586,8 +583,9 @@ def execute(
             outputs_module = importlib.import_module(lib)
             custom_report_interface = getattr(outputs_module, "report")
 
+            # TODO: review this call and see if we can remove the global_provider.output_options since it is contained in the global_provider
             custom_report_interface(
-                check_findings, audit_output_options, global_provider
+                check_findings, global_provider.output_options, global_provider
             )
         except Exception:
             sys.exit(1)

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -24,7 +24,6 @@ from prowler.lib.utils.utils import open_file, parse_json_file
 from prowler.providers.aws.lib.mutelist.mutelist import mutelist_findings
 from prowler.providers.common.common import get_global_provider
 from prowler.providers.common.models import Audit_Metadata
-from prowler.providers.common.outputs import Provider_Output_Options
 
 
 # Load all checks metadata
@@ -398,8 +397,7 @@ def import_check(check_path: str) -> ModuleType:
     return lib
 
 
-# TODO: change ref to Provider_Output_Options
-def run_check(check: Check, output_options: Provider_Output_Options) -> list:
+def run_check(check: Check, output_options) -> list:
     findings = []
     if output_options.verbose:
         print(

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -566,7 +566,7 @@ def execute(
     )
 
     # Mute List findings
-    if global_provider.mutelist:
+    if hasattr(global_provider, "mutelist"):
         check_findings = mutelist_findings(
             global_provider.mutelist,
             global_provider.identity.account,

--- a/prowler/lib/outputs/models.py
+++ b/prowler/lib/outputs/models.py
@@ -48,7 +48,7 @@ def get_check_compliance(finding, provider_type, output_options) -> dict:
 
 def generate_provider_output_csv(provider, finding, mode: str, fd, output_options):
     """
-    set_provider_output_options configures automatically the outputs based on the selected provider and returns the Provider_Output_Options object.
+    generate_provider_output_csv creates the provider's CSV output
     """
     try:
         # Dynamically load the Provider_Output_Options class

--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -34,8 +34,9 @@ def stdout_report(finding, color, verbose, status):
         )
 
 
-def report(check_findings, output_options, provider):
+def report(check_findings, provider):
     try:
+        output_options = provider.output_options
         file_descriptors = {}
         if check_findings:
             # TO-DO Generic Function

--- a/prowler/lib/outputs/summary_table.py
+++ b/prowler/lib/outputs/summary_table.py
@@ -11,13 +11,12 @@ from prowler.config.config import (
     json_ocsf_file_suffix,
 )
 from prowler.lib.logger import logger
-from prowler.providers.common.outputs import Provider_Output_Options
 
 
 def display_summary_table(
     findings: list,
     provider,
-    output_options: Provider_Output_Options,
+    output_options,
 ):
     output_directory = output_options.output_directory
     output_filename = output_options.output_filename

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -33,6 +33,7 @@ from prowler.providers.aws.models import (
     AWSIdentityInfo,
     AWSMFAInfo,
     AWSOrganizationsInfo,
+    AWSOutputOptions,
     AWSSession,
 )
 from prowler.providers.common.models import Audit_Metadata
@@ -48,6 +49,9 @@ class AwsProvider(Provider):
     _audit_config: dict = {}
     _ignore_unused_services: bool = False
     _enabled_regions: set = set()
+    # TODO: enforce the mutelist for the Provider class
+    _mutelist: dict = {}
+    _output_options: AWSOutputOptions
     # TODO: this is not optional, enforce for all providers
     audit_metadata: Audit_Metadata
 
@@ -253,6 +257,31 @@ class AwsProvider(Provider):
     @property
     def audit_config(self):
         return self._audit_config
+
+    @property
+    def output_options(self):
+        return self._output_options
+
+    @output_options.setter
+    def output_options(self, options: tuple):
+        arguments, bulk_checks_metadata = options
+        self._output_options = AWSOutputOptions(
+            arguments, bulk_checks_metadata, self._identity
+        )
+
+    @property
+    def mutelist(self):
+        return self._mutelist
+
+    @mutelist.setter
+    def mutelist(self, mutelist_path):
+        if mutelist_path:
+            mutelist = parse_mutelist_file(
+                self._session.current_session, self._identity.account, mutelist_path
+            )
+        else:
+            mutelist = {}
+        self._mutelist = mutelist
 
     # TODO: This can be moved to another class since it doesn't need self
     def get_organizations_info(
@@ -773,17 +802,6 @@ Caller Identity ARN: {Fore.YELLOW}[{self._identity.identity_arn}]{Style.RESET_AL
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             sys.exit(1)
-
-    # TODO: maybe create a function in the provider with a default empty string
-    def get_mutelist(self, mutelist_file):
-        # Parse content from Mute List file and get it, if necessary, from S3
-        if mutelist_file:
-            mutelist_file = parse_mutelist_file(
-                self.session.session, self._identity.account, mutelist_file
-            )
-        else:
-            mutelist_file = None
-        return mutelist_file
 
 
 def read_aws_regions_file() -> dict:

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -11,7 +11,11 @@ from msgraph import GraphServiceClient
 
 from prowler.lib.logger import logger
 from prowler.providers.azure.lib.regions.regions import get_regions_config
-from prowler.providers.azure.models import AzureIdentityInfo, AzureRegionConfig
+from prowler.providers.azure.models import (
+    AzureIdentityInfo,
+    AzureOutputOptions,
+    AzureRegionConfig,
+)
 from prowler.providers.common.models import Audit_Metadata
 from prowler.providers.common.provider import Provider
 
@@ -23,6 +27,9 @@ class AzureProvider(Provider):
     _audit_config: Optional[dict]
     _region_config: AzureRegionConfig
     _locations: dict
+    _output_options: AzureOutputOptions
+    # TODO: enforce the mutelist for the Provider class
+    # _mutelist: dict = {}
     # TODO: this is not optional, enforce for all providers
     audit_metadata: Audit_Metadata
 
@@ -82,6 +89,32 @@ class AzureProvider(Provider):
     @property
     def audit_config(self):
         return self._audit_config
+
+    @property
+    def output_options(self):
+        return self._output_options
+
+    @output_options.setter
+    def output_options(self, options: tuple):
+        arguments, bulk_checks_metadata = options
+        self._output_options = AzureOutputOptions(
+            arguments, bulk_checks_metadata, self._identity
+        )
+
+    # TODO: pending to implement
+    # @property
+    # def mutelist(self):
+    #     return self._mutelist
+
+    # @mutelist.setter
+    # def mutelist(self, mutelist_path):
+    #     if mutelist_path:
+    #         mutelist = parse_mutelist_file(
+    #             self._session.current_session, self._identity.account, mutelist_path
+    #         )
+    #     else:
+    #         mutelist = {}
+    #     self._mutelist = mutelist
 
     # TODO: this should be moved to the argparse, if not we need to enforce it from the Provider
     def validate_arguments(

--- a/prowler/providers/azure/models.py
+++ b/prowler/providers/azure/models.py
@@ -1,5 +1,8 @@
 from pydantic import BaseModel
 
+from prowler.config.config import output_file_timestamp
+from prowler.providers.common.models import ProviderOutputOptions
+
 
 class AzureIdentityInfo(BaseModel):
     identity_id: str = ""
@@ -15,3 +18,30 @@ class AzureRegionConfig(BaseModel):
     authority: str = None
     base_url: str = ""
     credential_scopes: list = []
+
+
+class AzureOutputOptions(ProviderOutputOptions):
+    def __init__(self, arguments, bulk_checks_metadata, identity):
+        # First call Provider_Output_Options init
+        super().__init__(arguments, bulk_checks_metadata)
+
+        # Confire Shodan API
+        # TODO: review shodan for the new AWS provider
+        # if arguments.shodan:
+        #     audit_info = change_config_var(
+        #         "shodan_api_key", arguments.shodan, audit_info
+        #     )
+
+        # Check if custom output filename was input, if not, set the default
+        if (
+            not hasattr(arguments, "output_filename")
+            or arguments.output_filename is None
+        ):
+            if identity.domain != "Unknown tenant domain (missing AAD permissions)":
+                self.output_filename = (
+                    f"prowler-output-{identity.domain}-{output_file_timestamp}"
+                )
+            else:
+                self.output_filename = f"prowler-output-{'-'.join(identity.tenant_ids)}-{output_file_timestamp}"
+        else:
+            self.output_filename = arguments.output_filename

--- a/prowler/providers/common/models.py
+++ b/prowler/providers/common/models.py
@@ -1,3 +1,6 @@
+from os import makedirs
+from os.path import isdir
+
 from pydantic import BaseModel
 
 
@@ -9,3 +12,31 @@ class Audit_Metadata(BaseModel):
     expected_checks: list
     completed_checks: int
     audit_progress: int
+
+
+class ProviderOutputOptions:
+    status: bool
+    output_modes: list
+    output_directory: str
+    bulk_checks_metadata: dict
+    verbose: str
+    output_filename: str
+    only_logs: bool
+    unix_timestamp: bool
+
+    def __init__(self, arguments, bulk_checks_metadata):
+        self.status = arguments.status
+        self.output_modes = arguments.output_modes
+        self.output_directory = arguments.output_directory
+        self.verbose = arguments.verbose
+        self.bulk_checks_metadata = bulk_checks_metadata
+        self.only_logs = arguments.only_logs
+        self.unix_timestamp = arguments.unix_timestamp
+        # Check output directory, if it is not created -> create it
+        if arguments.output_directory:
+            if not isdir(arguments.output_directory):
+                if arguments.output_modes:
+                    makedirs(arguments.output_directory, exist_ok=True)
+            if not isdir(arguments.output_directory + "/compliance"):
+                if arguments.output_modes:
+                    makedirs(arguments.output_directory + "/compliance", exist_ok=True)

--- a/prowler/providers/common/outputs.py
+++ b/prowler/providers/common/outputs.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from os import makedirs
 from os.path import isdir
 
-from prowler.config.config import output_file_timestamp
 from prowler.lib.logger import logger
 
 
@@ -72,20 +71,3 @@ class Provider_Output_Options:
             if not isdir(arguments.output_directory + "/compliance"):
                 if arguments.output_modes:
                     makedirs(arguments.output_directory + "/compliance", exist_ok=True)
-
-
-class Kubernetes_Output_Options(Provider_Output_Options):
-    def __init__(self, arguments, identity, mutelist_file, bulk_checks_metadata):
-        # First call Provider_Output_Options init
-        super().__init__(arguments, mutelist_file, bulk_checks_metadata)
-        # TODO move the below if to Provider_Output_Options
-        # Check if custom output filename was input, if not, set the default
-        if (
-            not hasattr(arguments, "output_filename")
-            or arguments.output_filename is None
-        ):
-            self.output_filename = (
-                f"prowler-output-{identity.context}-{output_file_timestamp}"
-            )
-        else:
-            self.output_filename = arguments.output_filename

--- a/prowler/providers/common/outputs.py
+++ b/prowler/providers/common/outputs.py
@@ -133,38 +133,3 @@ class Kubernetes_Output_Options(Provider_Output_Options):
             )
         else:
             self.output_filename = arguments.output_filename
-
-
-class Aws_Output_Options(Provider_Output_Options):
-    security_hub_enabled: bool
-
-    def __init__(self, arguments, identity, mutelist_file, bulk_checks_metadata):
-        # First call Provider_Output_Options init
-        super().__init__(arguments, mutelist_file, bulk_checks_metadata)
-
-        # Confire Shodan API
-        # TODO: review shodan for the new AWS provider
-        # if arguments.shodan:
-        #     audit_info = change_config_var(
-        #         "shodan_api_key", arguments.shodan, audit_info
-        #     )
-
-        # Check if custom output filename was input, if not, set the default
-        if (
-            not hasattr(arguments, "output_filename")
-            or arguments.output_filename is None
-        ):
-            self.output_filename = (
-                f"prowler-output-{identity.account}-{output_file_timestamp}"
-            )
-        else:
-            self.output_filename = arguments.output_filename
-
-        # Security Hub Outputs
-        self.security_hub_enabled = arguments.security_hub
-        self.send_sh_only_fails = arguments.send_sh_only_fails
-        if arguments.security_hub:
-            if not self.output_modes:
-                self.output_modes = ["json-asff"]
-            else:
-                self.output_modes.append("json-asff")

--- a/prowler/providers/common/outputs.py
+++ b/prowler/providers/common/outputs.py
@@ -74,23 +74,6 @@ class Provider_Output_Options:
                     makedirs(arguments.output_directory + "/compliance", exist_ok=True)
 
 
-class Gcp_Output_Options(Provider_Output_Options):
-    def __init__(self, arguments, identity, mutelist_file, bulk_checks_metadata):
-        # First call Provider_Output_Options init
-        super().__init__(arguments, mutelist_file, bulk_checks_metadata)
-
-        # Check if custom output filename was input, if not, set the default
-        if (
-            not hasattr(arguments, "output_filename")
-            or arguments.output_filename is None
-        ):
-            self.output_filename = (
-                f"prowler-output-{identity.profile}-{output_file_timestamp}"
-            )
-        else:
-            self.output_filename = arguments.output_filename
-
-
 class Kubernetes_Output_Options(Provider_Output_Options):
     def __init__(self, arguments, identity, mutelist_file, bulk_checks_metadata):
         # First call Provider_Output_Options init

--- a/prowler/providers/common/outputs.py
+++ b/prowler/providers/common/outputs.py
@@ -1,33 +1,37 @@
 import importlib
-import sys
-from dataclasses import dataclass
-from os import makedirs
-from os.path import isdir
 
-from prowler.lib.logger import logger
+# TODO: remove after fixing tests
+# import sys
+# from dataclasses import dataclass
+# from os import makedirs
+# from os.path import isdir
 
-
-def set_provider_output_options(
-    provider: str, arguments, identity, mutelist_file, bulk_checks_metadata
-):
-    """
-    set_provider_output_options configures automatically the outputs based on the selected provider and returns the Provider_Output_Options object.
-    """
-    try:
-        # Dynamically load the Provider_Output_Options class
-        provider_output_class = f"{provider.capitalize()}_Output_Options"
-        provider_output_options = getattr(
-            importlib.import_module(__name__), provider_output_class
-        )(arguments, identity, mutelist_file, bulk_checks_metadata)
-    except Exception as error:
-        logger.critical(
-            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-        )
-        sys.exit(1)
-    else:
-        return provider_output_options
+# from prowler.lib.logger import logger
 
 
+# TODO: remove after fixing tests
+# def set_provider_output_options(
+#     provider: str, arguments, identity, mutelist_file, bulk_checks_metadata
+# ):
+#     """
+#     set_provider_output_options configures automatically the outputs based on the selected provider and returns the Provider_Output_Options object.
+#     """
+#     try:
+#         # Dynamically load the Provider_Output_Options class
+#         provider_output_class = f"{provider.capitalize()}_Output_Options"
+#         provider_output_options = getattr(
+#             importlib.import_module(__name__), provider_output_class
+#         )(arguments, identity, mutelist_file, bulk_checks_metadata)
+#     except Exception as error:
+#         logger.critical(
+#             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+#         )
+#         sys.exit(1)
+#     else:
+#         return provider_output_options
+
+
+# TODO: review this function, probably is not needed anymore
 def get_provider_output_model(provider_type):
     """
     get_provider_output_model returns the model <provider>_Check_Output_CSV for each provider
@@ -42,32 +46,33 @@ def get_provider_output_model(provider_type):
     return output_provider_model
 
 
-@dataclass
-class Provider_Output_Options:
-    status: bool
-    output_modes: list
-    output_directory: str
-    mutelist_file: str
-    bulk_checks_metadata: dict
-    verbose: str
-    output_filename: str
-    only_logs: bool
-    unix_timestamp: bool
+# TODO: remove after fixing tests
+# @dataclass
+# class Provider_Output_Options:
+#     status: bool
+#     output_modes: list
+#     output_directory: str
+#     mutelist_file: str
+#     bulk_checks_metadata: dict
+#     verbose: str
+#     output_filename: str
+#     only_logs: bool
+#     unix_timestamp: bool
 
-    def __init__(self, arguments, mutelist_file, bulk_checks_metadata):
-        self.status = arguments.status
-        self.output_modes = arguments.output_modes
-        self.output_directory = arguments.output_directory
-        self.verbose = arguments.verbose
-        self.bulk_checks_metadata = bulk_checks_metadata
-        self.mutelist_file = mutelist_file
-        self.only_logs = arguments.only_logs
-        self.unix_timestamp = arguments.unix_timestamp
-        # Check output directory, if it is not created -> create it
-        if arguments.output_directory:
-            if not isdir(arguments.output_directory):
-                if arguments.output_modes:
-                    makedirs(arguments.output_directory, exist_ok=True)
-            if not isdir(arguments.output_directory + "/compliance"):
-                if arguments.output_modes:
-                    makedirs(arguments.output_directory + "/compliance", exist_ok=True)
+#     def __init__(self, arguments, mutelist_file, bulk_checks_metadata):
+#         self.status = arguments.status
+#         self.output_modes = arguments.output_modes
+#         self.output_directory = arguments.output_directory
+#         self.verbose = arguments.verbose
+#         self.bulk_checks_metadata = bulk_checks_metadata
+#         self.mutelist_file = mutelist_file
+#         self.only_logs = arguments.only_logs
+#         self.unix_timestamp = arguments.unix_timestamp
+#         # Check output directory, if it is not created -> create it
+#         if arguments.output_directory:
+#             if not isdir(arguments.output_directory):
+#                 if arguments.output_modes:
+#                     makedirs(arguments.output_directory, exist_ok=True)
+#             if not isdir(arguments.output_directory + "/compliance"):
+#                 if arguments.output_modes:
+#                     makedirs(arguments.output_directory + "/compliance", exist_ok=True)

--- a/prowler/providers/common/outputs.py
+++ b/prowler/providers/common/outputs.py
@@ -74,33 +74,6 @@ class Provider_Output_Options:
                     makedirs(arguments.output_directory + "/compliance", exist_ok=True)
 
 
-class Azure_Output_Options(Provider_Output_Options):
-    def __init__(self, arguments, identity, mutelist_file, bulk_checks_metadata):
-        # First call Provider_Output_Options init
-        super().__init__(arguments, mutelist_file, bulk_checks_metadata)
-
-        # Confire Shodan API
-        # TODO: review shodan for the new AWS provider
-        # if arguments.shodan:
-        #     audit_info = change_config_var(
-        #         "shodan_api_key", arguments.shodan, audit_info
-        #     )
-
-        # Check if custom output filename was input, if not, set the default
-        if (
-            not hasattr(arguments, "output_filename")
-            or arguments.output_filename is None
-        ):
-            if identity.domain != "Unknown tenant domain (missing AAD permissions)":
-                self.output_filename = (
-                    f"prowler-output-{identity.domain}-{output_file_timestamp}"
-                )
-            else:
-                self.output_filename = f"prowler-output-{'-'.join(identity.tenant_ids)}-{output_file_timestamp}"
-        else:
-            self.output_filename = arguments.output_filename
-
-
 class Gcp_Output_Options(Provider_Output_Options):
     def __init__(self, arguments, identity, mutelist_file, bulk_checks_metadata):
         # First call Provider_Output_Options init

--- a/prowler/providers/common/provider.py
+++ b/prowler/providers/common/provider.py
@@ -62,6 +62,24 @@ class Provider(ABC):
     def setup_session(self):
         pass
 
+    @property
+    @abstractmethod
+    def output_options(self):
+        """
+        output_options method returns the provider's audit output configuration.
+
+        This method needs to be created in each provider.
+        """
+
+    @output_options.setter
+    @abstractmethod
+    def output_options(self):
+        """
+        output_options.setter sets the provider's audit output configuration.
+
+        This method needs to be created in each provider.
+        """
+
     # TODO: probably this won't be here since we want to do the arguments validation during the parse()
     def validate_arguments(self):
         pass

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from dataclasses import dataclass
 from typing import Optional
 
 from colorama import Fore, Style
@@ -11,12 +10,7 @@ from googleapiclient import discovery
 from prowler.lib.logger import logger
 from prowler.providers.common.models import Audit_Metadata
 from prowler.providers.common.provider import Provider
-
-
-@dataclass
-class GCPIdentityInfo:
-    profile: str
-    default_project_id: str
+from prowler.providers.gcp.models import GCPIdentityInfo, GCPOutputOptions
 
 
 class GcpProvider(Provider):
@@ -25,6 +19,9 @@ class GcpProvider(Provider):
     _project_ids: list
     _identity: GCPIdentityInfo
     _audit_config: Optional[dict]
+    _output_options: GCPOutputOptions
+    # TODO: enforce the mutelist for the Provider class
+    # _mutelist: dict = {}
     # TODO: this is not optional, enforce for all providers
     audit_metadata: Audit_Metadata
 
@@ -78,6 +75,32 @@ class GcpProvider(Provider):
     @property
     def audit_config(self):
         return self._audit_config
+
+    @property
+    def output_options(self):
+        return self._output_options
+
+    @output_options.setter
+    def output_options(self, options: tuple):
+        arguments, bulk_checks_metadata = options
+        self._output_options = GCPOutputOptions(
+            arguments, bulk_checks_metadata, self._identity
+        )
+
+    # TODO: pending to implement
+    # @property
+    # def mutelist(self):
+    #     return self._mutelist
+
+    # @mutelist.setter
+    # def mutelist(self, mutelist_path):
+    #     if mutelist_path:
+    #         mutelist = parse_mutelist_file(
+    #             self._session.current_session, self._identity.account, mutelist_path
+    #         )
+    #     else:
+    #         mutelist = {}
+    #     self._mutelist = mutelist
 
     def setup_session(self, credentials_file):
         try:

--- a/prowler/providers/gcp/models.py
+++ b/prowler/providers/gcp/models.py
@@ -12,7 +12,7 @@ class GCPIdentityInfo:
 
 class GCPOutputOptions(ProviderOutputOptions):
     def __init__(self, arguments, bulk_checks_metadata, identity):
-        # First call Provider_Output_Options init
+        # First call ProviderOutputOptions init
         super().__init__(arguments, bulk_checks_metadata)
 
         # Check if custom output filename was input, if not, set the default

--- a/prowler/providers/gcp/models.py
+++ b/prowler/providers/gcp/models.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+
+from prowler.config.config import output_file_timestamp
+from prowler.providers.common.models import ProviderOutputOptions
+
+
+@dataclass
+class GCPIdentityInfo:
+    profile: str
+    default_project_id: str
+
+
+class GCPOutputOptions(ProviderOutputOptions):
+    def __init__(self, arguments, bulk_checks_metadata, identity):
+        # First call Provider_Output_Options init
+        super().__init__(arguments, bulk_checks_metadata)
+
+        # Check if custom output filename was input, if not, set the default
+        if (
+            not hasattr(arguments, "output_filename")
+            or arguments.output_filename is None
+        ):
+            self.output_filename = (
+                f"prowler-output-{identity.profile}-{output_file_timestamp}"
+            )
+        else:
+            self.output_filename = arguments.output_filename

--- a/prowler/providers/kubernetes/kubernetes_provider.py
+++ b/prowler/providers/kubernetes/kubernetes_provider.py
@@ -1,7 +1,6 @@
 import os
 import sys
 from argparse import Namespace
-from dataclasses import dataclass
 from typing import Optional
 
 from colorama import Fore, Style
@@ -10,24 +9,11 @@ from kubernetes import client, config
 from prowler.lib.logger import logger
 from prowler.providers.common.models import Audit_Metadata
 from prowler.providers.common.provider import Provider
-
-
-@dataclass
-class KubernetesIdentityInfo:
-    context: str
-    cluster: str
-    user: str
-
-
-@dataclass
-class KubernetesSession:
-    """
-    KubernetesSession stores the Kubernetes session's configuration.
-
-    """
-
-    api_client: client.ApiClient
-    context: dict
+from prowler.providers.kubernetes.models import (
+    KubernetesIdentityInfo,
+    KubernetesOutputOptions,
+    KubernetesSession,
+)
 
 
 class KubernetesProvider(Provider):
@@ -36,6 +22,9 @@ class KubernetesProvider(Provider):
     _namespaces: list
     _audit_config: Optional[dict]
     _identity: KubernetesIdentityInfo
+    _output_options: KubernetesOutputOptions
+    # TODO: enforce the mutelist for the Provider class
+    # _mutelist: dict = {}
     # TODO: this is not optional, enforce for all providers
     audit_metadata: Audit_Metadata
 
@@ -82,6 +71,32 @@ class KubernetesProvider(Provider):
     @property
     def audit_config(self):
         return self._audit_config
+
+    @property
+    def output_options(self):
+        return self._output_options
+
+    @output_options.setter
+    def output_options(self, options: tuple):
+        arguments, bulk_checks_metadata = options
+        self._output_options = KubernetesOutputOptions(
+            arguments, bulk_checks_metadata, self._identity
+        )
+
+    # TODO: pending to implement
+    # @property
+    # def mutelist(self):
+    #     return self._mutelist
+
+    # @mutelist.setter
+    # def mutelist(self, mutelist_path):
+    #     if mutelist_path:
+    #         mutelist = parse_mutelist_file(
+    #             self._session.current_session, self._identity.account, mutelist_path
+    #         )
+    #     else:
+    #         mutelist = {}
+    #     self._mutelist = mutelist
 
     def setup_session(self, kubeconfig_file, input_context) -> KubernetesSession:
         """

--- a/prowler/providers/kubernetes/models.py
+++ b/prowler/providers/kubernetes/models.py
@@ -26,9 +26,9 @@ class KubernetesSession:
 
 class KubernetesOutputOptions(ProviderOutputOptions):
     def __init__(self, arguments, bulk_checks_metadata, identity):
-        # First call Provider_Output_Options init
+        # First call ProviderOutputOptions init
         super().__init__(arguments, bulk_checks_metadata)
-        # TODO move the below if to Provider_Output_Options
+        # TODO move the below if to ProviderOutputOptions
         # Check if custom output filename was input, if not, set the default
         if (
             not hasattr(arguments, "output_filename")

--- a/prowler/providers/kubernetes/models.py
+++ b/prowler/providers/kubernetes/models.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+
+from kubernetes import client
+
+from prowler.config.config import output_file_timestamp
+from prowler.providers.common.models import ProviderOutputOptions
+
+
+@dataclass
+class KubernetesIdentityInfo:
+    context: str
+    cluster: str
+    user: str
+
+
+@dataclass
+class KubernetesSession:
+    """
+    KubernetesSession stores the Kubernetes session's configuration.
+
+    """
+
+    api_client: client.ApiClient
+    context: dict
+
+
+class KubernetesOutputOptions(ProviderOutputOptions):
+    def __init__(self, arguments, bulk_checks_metadata, identity):
+        # First call Provider_Output_Options init
+        super().__init__(arguments, bulk_checks_metadata)
+        # TODO move the below if to Provider_Output_Options
+        # Check if custom output filename was input, if not, set the default
+        if (
+            not hasattr(arguments, "output_filename")
+            or arguments.output_filename is None
+        ):
+            self.output_filename = (
+                f"prowler-output-{identity.context}-{output_file_timestamp}"
+            )
+        else:
+            self.output_filename = arguments.output_filename


### PR DESCRIPTION
### Description

- Store output options within each provider
- `mutelist` is an attribute in each provider (only supported for AWS)
- commented out common code to be deleted after fixing tests

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
