### PR TITLE
fix(iam): ignore Root User in iam_user_mfa_enabled_console_access

### DIFF
--- a/prowler/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access.py
+++ b/prowler/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access.py
@@ -7,12 +7,12 @@ class iam_user_mfa_enabled_console_access(Check):
         findings = []
         response = iam_client.credential_report
         for user in response:
-            report = Check_Report_AWS(self.metadata())
-            report.resource_id = user["user"]
-            report.resource_arn = user["arn"]
-            report.region = iam_client.region
             # all the users but root (which by default does not support console password)
-            if user["password_enabled"] != "not_supported":
+            if user["user"] != "<root_account>":
+                report = Check_Report_AWS(self.metadata())
+                report.resource_id = user["user"]
+                report.resource_arn = user["arn"]
+                report.region = iam_client.region
                 # check if the user has password enabled
                 if user["password_enabled"] == "true":
                     if user["mfa_active"] == "false":
@@ -26,12 +26,6 @@ class iam_user_mfa_enabled_console_access(Check):
                     report.status_extended = (
                         f"User {user['user']} does not have Console Password enabled."
                     )
-            # root user
-            else:
-                report.status = "PASS"
-                report.status_extended = (
-                    f"User {user['user']} does not have Console Password enabled."
-                )
-            findings.append(report)
+                findings.append(report)
 
         return findings

--- a/tests/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access_test.py
+++ b/tests/providers/aws/services/iam/iam_user_mfa_enabled_console_access/iam_user_mfa_enabled_console_access_test.py
@@ -21,10 +21,6 @@ class Test_iam_user_mfa_enabled_console_access_test:
 
     @mock_aws
     def test_root_user_not_password_console_enabled(self):
-        iam_client = client("iam")
-        user = "test-user"
-        arn = iam_client.create_user(UserName=user)["User"]["Arn"]
-
         from prowler.providers.aws.services.iam.iam_service import IAM
 
         current_audit_info = set_mocked_aws_audit_info([AWS_REGION_US_EAST_1])
@@ -39,18 +35,37 @@ class Test_iam_user_mfa_enabled_console_access_test:
                 iam_user_mfa_enabled_console_access,
             )
 
-            service_client.credential_report[0]["password_enabled"] = "not_supported"
+            service_client.credential_report = [
+                {
+                    "user": "<root_account>",
+                    "arn": f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
+                    "user_creation_time": "2022-02-17T14:59:38+00:00",
+                    "password_enabled": "not_supported",
+                    "password_last_used": "2023-05-22T09:52:24+00:00",
+                    "password_last_changed": "not_supported",
+                    "password_next_rotation": "not_supported",
+                    "mfa_active": "true",
+                    "access_key_1_active": "false",
+                    "access_key_1_last_rotated": "N/A",
+                    "access_key_1_last_used_date": "N/A",
+                    "access_key_1_last_used_region": "N/A",
+                    "access_key_1_last_used_service": "N/A",
+                    "access_key_2_active": "false",
+                    "access_key_2_last_rotated": "N/A",
+                    "access_key_2_last_used_date": "N/A",
+                    "access_key_2_last_used_region": "N/A",
+                    "access_key_2_last_used_service": "N/A",
+                    "cert_1_active": "false",
+                    "cert_1_last_rotated": "N/A",
+                    "cert_2_active": "false",
+                    "cert_2_last_rotated": "N/A",
+                }
+            ]
 
             check = iam_user_mfa_enabled_console_access()
             result = check.execute()
 
-            assert result[0].status == "PASS"
-            assert (
-                result[0].status_extended
-                == f"User {user} does not have Console Password enabled."
-            )
-            assert result[0].resource_id == user
-            assert result[0].resource_arn == arn
+            assert len(result) == 0
 
     @mock_aws
     def test_user_not_password_console_enabled(self):


### PR DESCRIPTION
### Context

In the AWS Check iam_user_mfa_enabled_console_access, the results include a finding for the root user (since it is included in the credential report), the Status Extended field states: "User <root_account> does not have Console Password enabled." which is factually incorrect, as the root user can always login to the console.

### Description

Exclude the root user from this check. There is a specific check for root MFA.
Thanks @jchrisfarris for the catch!

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
