### PR TITLE
chore(compliance): rename AWS FTR compliance

### DIFF
--- a/docs/tutorials/compliance.md
+++ b/docs/tutorials/compliance.md
@@ -23,7 +23,7 @@ Currently, the available frameworks are:
 - `fedramp_low_revision_4_aws`
 - `fedramp_moderate_revision_4_aws`
 - `ffiec_aws`
-- `foundational_technical_review_aws`
+- `aws_foundational_technical_review_aws`
 - `gdpr_aws`
 - `gxp_21_cfr_part_11_aws`
 - `gxp_eu_annex_11_aws`

--- a/prowler/compliance/aws/aws_foundational_technical_review_aws.json
+++ b/prowler/compliance/aws/aws_foundational_technical_review_aws.json
@@ -1,8 +1,8 @@
 {
-  "Framework": "Foundational-Technical-Review",
+  "Framework": "AWS-Foundational-Technical-Review",
   "Version": "",
   "Provider": "AWS",
-  "Description": "The Foundational Technical Review (FTR) assesses an AWS Partner's solution against a specific set of Amazon Web Services (AWS) best practices around security, performance, and operational processes that are most critical for customer success. Passing the FTR is required to qualify AWS Software Partners for AWS Partner Network (APN) programs such as AWS Competency and AWS Service Ready but any AWS Partner who offers a technology solution may request a FTR review through AWS Partner Central.",
+  "Description": "The AWS Foundational Technical Review (FTR) assesses an AWS Partner's solution against a specific set of Amazon Web Services (AWS) best practices around security, performance, and operational processes that are most critical for customer success. Passing the FTR is required to qualify AWS Software Partners for AWS Partner Network (APN) programs such as AWS Competency and AWS Service Ready but any AWS Partner who offers a technology solution may request a FTR review through AWS Partner Central.",
   "Requirements": [
     {
       "Id": "HOST-001",


### PR DESCRIPTION
### Description

Rename AWS FTR compliance so it follows the pattern of Prowler.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
