### PR TITLE
fix(compliance): fix Mitre Attack csv output format for aws

### DIFF
--- a/prowler/lib/outputs/compliance.py
+++ b/prowler/lib/outputs/compliance.py
@@ -270,10 +270,10 @@ def fill_compliance(output_options, finding, audit_info, file_descriptors):
                         attributes_values = ""
                         attributes_comments = ""
                         for attribute in requirement.Attributes:
-                            attributes_aws_services += attribute.AWSService + "\n"
-                            attributes_categories += attribute.Category + "\n"
-                            attributes_values += attribute.Value + "\n"
-                            attributes_comments += attribute.Comment + "\n"
+                            attributes_aws_services += attribute.AWSService
+                            attributes_categories += attribute.Category
+                            attributes_values += attribute.Value
+                            attributes_comments += attribute.Comment
                         compliance_row = Check_Output_MITRE_ATTACK(
                             Provider=finding.check_metadata.Provider,
                             Description=compliance.Description,


### PR DESCRIPTION
### Context

The output format of the csv for mitre_attack framework had some line breaks that were breaking the output:
![Screenshot 2024-03-20 at 11 01 23](https://github.com/prowler-cloud/prowler/assets/56402503/18176688-136a-423b-8f50-25f44e4faa8a)


### Description




### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
