### PR TITLE
fix(compliance): fix csv output for framework Mitre Attack

### DIFF
--- a/prowler/lib/outputs/compliance/mitre_attack_aws.py
+++ b/prowler/lib/outputs/compliance/mitre_attack_aws.py
@@ -36,10 +36,10 @@ def write_compliance_row_mitre_attack_aws(
             attributes_categories += attribute.Category + ", "
             attributes_values += attribute.Value + ", "
             attributes_comments += attribute.Comment + ", "
-        attributes_aws_services = attributes_aws_services[:-2]
-        attributes_categories = attributes_categories[:-2]
-        attributes_values = attributes_values[:-2]
-        attributes_comments = attributes_comments[:-2]
+        attributes_aws_services = attributes_aws_services.rstrip(", ")
+        attributes_categories = attributes_categories.rstrip(", ")
+        attributes_values = attributes_values.rstrip(", ")
+        attributes_comments = attributes_comments.rstrip(", ")
         compliance_row = Check_Output_MITRE_ATTACK(
             Provider=finding.check_metadata.Provider,
             Description=compliance.Description,

--- a/prowler/lib/outputs/compliance/mitre_attack_aws.py
+++ b/prowler/lib/outputs/compliance/mitre_attack_aws.py
@@ -27,19 +27,18 @@ def write_compliance_row_mitre_attack_aws(
         requirement_description = requirement.Description
         requirement_id = requirement.Id
         requirement_name = requirement.Name
-        attributes_aws_services = ""
-        attributes_categories = ""
-        attributes_values = ""
-        attributes_comments = ""
-        for attribute in requirement.Attributes:
-            attributes_aws_services += attribute.AWSService + ", "
-            attributes_categories += attribute.Category + ", "
-            attributes_values += attribute.Value + ", "
-            attributes_comments += attribute.Comment + ", "
-        attributes_aws_services = attributes_aws_services.rstrip(", ")
-        attributes_categories = attributes_categories.rstrip(", ")
-        attributes_values = attributes_values.rstrip(", ")
-        attributes_comments = attributes_comments.rstrip(", ")
+        attributes_aws_services = ", ".join(
+            attribute.AWSService for attribute in requirement.Attributes
+        )
+        attributes_categories = ", ".join(
+            attribute.Category for attribute in requirement.Attributes
+        )
+        attributes_values = ", ".join(
+            attribute.Value for attribute in requirement.Attributes
+        )
+        attributes_comments = ", ".join(
+            attribute.Comment for attribute in requirement.Attributes
+        )
         compliance_row = Check_Output_MITRE_ATTACK(
             Provider=finding.check_metadata.Provider,
             Description=compliance.Description,

--- a/prowler/lib/outputs/compliance/mitre_attack_aws.py
+++ b/prowler/lib/outputs/compliance/mitre_attack_aws.py
@@ -32,10 +32,14 @@ def write_compliance_row_mitre_attack_aws(
         attributes_values = ""
         attributes_comments = ""
         for attribute in requirement.Attributes:
-            attributes_aws_services += attribute.AWSService + "\n"
-            attributes_categories += attribute.Category + "\n"
-            attributes_values += attribute.Value + "\n"
-            attributes_comments += attribute.Comment + "\n"
+            attributes_aws_services += attribute.AWSService + ", "
+            attributes_categories += attribute.Category + ", "
+            attributes_values += attribute.Value + ", "
+            attributes_comments += attribute.Comment + ", "
+        attributes_aws_services = attributes_aws_services[:-2]
+        attributes_categories = attributes_categories[:-2]
+        attributes_values = attributes_values[:-2]
+        attributes_comments = attributes_comments[:-2]
         compliance_row = Check_Output_MITRE_ATTACK(
             Provider=finding.check_metadata.Provider,
             Description=compliance.Description,


### PR DESCRIPTION
### Description

The output format of the csv for Mitre Attack framework had some line breaks that were breaking the output


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
