### PR TITLE
fix(cloudtrail): use dictionary instead of list

### DIFF
--- a/prowler/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled.py
@@ -20,7 +20,7 @@ class awslambda_function_invoke_api_operations_cloudtrail_logging_enabled(Check)
                 f"Lambda function {function.name} is not recorded by CloudTrail."
             )
             lambda_recorded_cloudtrail = False
-            for trail in cloudtrail_client.trails:
+            for trail in cloudtrail_client.trails.values():
                 for data_event in trail.data_events:
                     # classic event selectors
                     if not data_event.is_advanced:

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_bucket_requires_mfa_delete/cloudtrail_bucket_requires_mfa_delete.py
@@ -8,7 +8,7 @@ from prowler.providers.aws.services.s3.s3_client import s3_client
 class cloudtrail_bucket_requires_mfa_delete(Check):
     def execute(self):
         findings = []
-        for trail in cloudtrail_client.trails:
+        for trail in cloudtrail_client.trails.values():
             if trail.is_logging:
                 trail_bucket_is_in_account = False
                 trail_bucket = trail.s3_bucket

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_cloudwatch_logging_enabled/cloudtrail_cloudwatch_logging_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_cloudwatch_logging_enabled/cloudtrail_cloudwatch_logging_enabled.py
@@ -11,7 +11,7 @@ maximum_time_without_logging = 1
 class cloudtrail_cloudwatch_logging_enabled(Check):
     def execute(self):
         findings = []
-        for trail in cloudtrail_client.trails:
+        for trail in cloudtrail_client.trails.values():
             if trail.name:
                 report = Check_Report_AWS(self.metadata())
                 report.region = trail.region

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_insights_exist/cloudtrail_insights_exist.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_insights_exist/cloudtrail_insights_exist.py
@@ -7,7 +7,8 @@ from prowler.providers.aws.services.cloudtrail.cloudtrail_client import (
 class cloudtrail_insights_exist(Check):
     def execute(self):
         findings = []
-        for trail in cloudtrail_client.trails:
+        for trail in cloudtrail_client.trails.values():
+            print(trail.arn)
             if trail.is_logging:
                 report = Check_Report_AWS(self.metadata())
                 report.region = trail.region

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_insights_exist/cloudtrail_insights_exist.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_insights_exist/cloudtrail_insights_exist.py
@@ -8,7 +8,6 @@ class cloudtrail_insights_exist(Check):
     def execute(self):
         findings = []
         for trail in cloudtrail_client.trails.values():
-            print(trail.arn)
             if trail.is_logging:
                 report = Check_Report_AWS(self.metadata())
                 report.region = trail.region

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_kms_encryption_enabled/cloudtrail_kms_encryption_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_kms_encryption_enabled/cloudtrail_kms_encryption_enabled.py
@@ -7,7 +7,7 @@ from prowler.providers.aws.services.cloudtrail.cloudtrail_client import (
 class cloudtrail_kms_encryption_enabled(Check):
     def execute(self):
         findings = []
-        for trail in cloudtrail_client.trails:
+        for trail in cloudtrail_client.trails.values():
             if trail.name:
                 report = Check_Report_AWS(self.metadata())
                 report.region = trail.region

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_log_file_validation_enabled/cloudtrail_log_file_validation_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_log_file_validation_enabled/cloudtrail_log_file_validation_enabled.py
@@ -7,7 +7,7 @@ from prowler.providers.aws.services.cloudtrail.cloudtrail_client import (
 class cloudtrail_log_file_validation_enabled(Check):
     def execute(self):
         findings = []
-        for trail in cloudtrail_client.trails:
+        for trail in cloudtrail_client.trails.values():
             if trail.name:
                 report = Check_Report_AWS(self.metadata())
                 report.region = trail.region

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_access_logging_enabled/cloudtrail_logs_s3_bucket_access_logging_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_access_logging_enabled/cloudtrail_logs_s3_bucket_access_logging_enabled.py
@@ -8,7 +8,7 @@ from prowler.providers.aws.services.s3.s3_client import s3_client
 class cloudtrail_logs_s3_bucket_access_logging_enabled(Check):
     def execute(self):
         findings = []
-        for trail in cloudtrail_client.trails:
+        for trail in cloudtrail_client.trails.values():
             if trail.name:
                 trail_bucket_is_in_account = False
                 trail_bucket = trail.s3_bucket

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible.py
@@ -8,7 +8,7 @@ from prowler.providers.aws.services.s3.s3_client import s3_client
 class cloudtrail_logs_s3_bucket_is_not_publicly_accessible(Check):
     def execute(self):
         findings = []
-        for trail in cloudtrail_client.trails:
+        for trail in cloudtrail_client.trails.values():
             if trail.name:
                 trail_bucket_is_in_account = False
                 trail_bucket = trail.s3_bucket

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled.py
@@ -11,7 +11,7 @@ class cloudtrail_multi_region_enabled(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = region
             for trail in cloudtrail_client.trails.values():
-                if trail.region == region:
+                if trail.region == region or trail.is_multiregion:
                     if trail.is_logging:
                         report.status = "PASS"
                         report.resource_id = trail.name

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled.py
@@ -10,7 +10,7 @@ class cloudtrail_multi_region_enabled(Check):
         for region in cloudtrail_client.regional_clients.keys():
             report = Check_Report_AWS(self.metadata())
             report.region = region
-            for trail in cloudtrail_client.trails:
+            for trail in cloudtrail_client.trails.values():
                 if trail.region == region:
                     if trail.is_logging:
                         report.status = "PASS"

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled_logging_management_events/cloudtrail_multi_region_enabled_logging_management_events.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled_logging_management_events/cloudtrail_multi_region_enabled_logging_management_events.py
@@ -16,7 +16,7 @@ class cloudtrail_multi_region_enabled_logging_management_events(Check):
         report.resource_id = cloudtrail_client.audited_account
         report.resource_arn = cloudtrail_client.trail_arn_template
 
-        for trail in cloudtrail_client.trails:
+        for trail in cloudtrail_client.trails.values():
             if trail.is_logging:
                 if trail.is_multiregion:
                     for event in trail.data_events:

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_read_enabled/cloudtrail_s3_dataevents_read_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_read_enabled/cloudtrail_s3_dataevents_read_enabled.py
@@ -8,7 +8,7 @@ from prowler.providers.aws.services.s3.s3_client import s3_client
 class cloudtrail_s3_dataevents_read_enabled(Check):
     def execute(self):
         findings = []
-        for trail in cloudtrail_client.trails:
+        for trail in cloudtrail_client.trails.values():
             for data_event in trail.data_events:
                 # classic event selectors
                 if not data_event.is_advanced:

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_write_enabled/cloudtrail_s3_dataevents_write_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_write_enabled/cloudtrail_s3_dataevents_write_enabled.py
@@ -8,7 +8,7 @@ from prowler.providers.aws.services.s3.s3_client import s3_client
 class cloudtrail_s3_dataevents_write_enabled(Check):
     def execute(self):
         findings = []
-        for trail in cloudtrail_client.trails:
+        for trail in cloudtrail_client.trails.values():
             for data_event in trail.data_events:
                 # Classic event selectors
                 if not data_event.is_advanced:

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -15,7 +15,7 @@ class Cloudtrail(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, audit_info)
         self.trail_arn_template = f"arn:{self.audited_partition}:cloudtrail:{self.region}:{self.audited_account}:trail"
-        self.trails = []
+        self.trails = {}
         self.__threading_call__(self.__get_trails__)
         self.__get_trail_status__()
         self.__get_insight_selectors__()
@@ -45,27 +45,23 @@ class Cloudtrail(AWSService):
                         kms_key_id = trail["KmsKeyId"]
                     if "CloudWatchLogsLogGroupArn" in trail:
                         log_group_arn = trail["CloudWatchLogsLogGroupArn"]
-                    self.trails.append(
-                        Trail(
-                            name=trail["Name"],
-                            is_multiregion=trail["IsMultiRegionTrail"],
-                            home_region=trail["HomeRegion"],
-                            arn=trail["TrailARN"],
-                            region=regional_client.region,
-                            is_logging=False,
-                            log_file_validation_enabled=trail[
-                                "LogFileValidationEnabled"
-                            ],
-                            latest_cloudwatch_delivery_time=None,
-                            s3_bucket=trail["S3BucketName"],
-                            kms_key=kms_key_id,
-                            log_group_arn=log_group_arn,
-                            data_events=[],
-                            has_insight_selectors=trail.get("HasInsightSelectors"),
-                        )
+                    self.trails[trail["TrailARN"]] = Trail(
+                        name=trail["Name"],
+                        is_multiregion=trail["IsMultiRegionTrail"],
+                        home_region=trail["HomeRegion"],
+                        arn=trail["TrailARN"],
+                        region=regional_client.region,
+                        is_logging=False,
+                        log_file_validation_enabled=trail["LogFileValidationEnabled"],
+                        latest_cloudwatch_delivery_time=None,
+                        s3_bucket=trail["S3BucketName"],
+                        kms_key=kms_key_id,
+                        log_group_arn=log_group_arn,
+                        data_events=[],
+                        has_insight_selectors=trail.get("HasInsightSelectors"),
                     )
             if trails_count == 0:
-                self.trails.append(
+                self.trails[self.__get_trail_arn_template__(regional_client.region)] = (
                     Trail(
                         region=regional_client.region,
                     )
@@ -79,7 +75,7 @@ class Cloudtrail(AWSService):
     def __get_trail_status__(self):
         logger.info("Cloudtrail - Getting trail status")
         try:
-            for trail in self.trails:
+            for trail in self.trails.values():
                 for region, client in self.regional_clients.items():
                     if trail.region == region and trail.name:
                         status = client.get_trail_status(Name=trail.arn)
@@ -97,7 +93,7 @@ class Cloudtrail(AWSService):
     def __get_event_selectors__(self):
         logger.info("Cloudtrail - Getting event selector")
         try:
-            for trail in self.trails:
+            for trail in self.trails.values():
                 for region, client in self.regional_clients.items():
                     if trail.region == region and trail.name:
                         data_events = client.get_event_selectors(TrailName=trail.arn)
@@ -131,7 +127,7 @@ class Cloudtrail(AWSService):
         logger.info("Cloudtrail - Getting trail insight selectors...")
 
         try:
-            for trail in self.trails:
+            for trail in self.trails.values():
                 for region, client in self.regional_clients.items():
                     if trail.region == region and trail.name:
                         insight_selectors = None
@@ -180,7 +176,7 @@ class Cloudtrail(AWSService):
     def __list_tags_for_resource__(self):
         logger.info("CloudTrail - List Tags...")
         try:
-            for trail in self.trails:
+            for trail in self.trails.values():
                 # Check if trails are in this account and region
                 if (
                     trail.region == trail.home_region

--- a/prowler/providers/aws/services/cloudwatch/lib/metric_filters.py
+++ b/prowler/providers/aws/services/cloudwatch/lib/metric_filters.py
@@ -12,7 +12,7 @@ def check_cloudwatch_log_metric_filter(
 ):
     # 1. Iterate for CloudWatch Log Group in CloudTrail trails
     log_groups = []
-    for trail in trails:
+    for trail in trails.values():
         if trail.log_group_arn:
             log_groups.append(trail.log_group_arn.split(":")[6])
     # 2. Describe metric filters for previous log groups

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_cloudwatch_logging_enabled/cloudtrail_cloudwatch_logging_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_cloudwatch_logging_enabled/cloudtrail_cloudwatch_logging_enabled_test.py
@@ -87,7 +87,7 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
                     cloudtrail_cloudwatch_logging_enabled,
                 )
 
-                for trail in service_client.trails:
+                for trail in service_client.trails.values():
                     if trail.name == trail_name_us:
                         trail.latest_cloudwatch_delivery_time = datetime.now().replace(
                             tzinfo=timezone.utc
@@ -174,7 +174,7 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
                     cloudtrail_cloudwatch_logging_enabled,
                 )
 
-                for trail in service_client.trails:
+                for trail in service_client.trails.values():
                     if trail.name == trail_name_us:
                         trail.latest_cloudwatch_delivery_time = datetime.now().replace(
                             tzinfo=timezone.utc
@@ -190,8 +190,7 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
 
                 check = cloudtrail_cloudwatch_logging_enabled()
                 result = check.execute()
-                # len of result should be 3 -> (1 multiregion entry per region + 1 entry because of single region trail)
-                assert len(result) == 3
+                assert len(result) == 2
                 for report in result:
                     if report.resource_id == trail_name_us:
                         assert report.resource_id == trail_name_us
@@ -262,7 +261,7 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
                     cloudtrail_cloudwatch_logging_enabled,
                 )
 
-                for trail in service_client.trails:
+                for trail in service_client.trails.values():
                     if trail.name == trail_name_us:
                         trail.latest_cloudwatch_delivery_time = datetime.now().replace(
                             tzinfo=timezone.utc

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_cloudwatch_logging_enabled/cloudtrail_cloudwatch_logging_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_cloudwatch_logging_enabled/cloudtrail_cloudwatch_logging_enabled_test.py
@@ -190,6 +190,7 @@ class Test_cloudtrail_cloudwatch_logging_enabled:
 
                 check = cloudtrail_cloudwatch_logging_enabled()
                 result = check.execute()
+                # len of result should be 2 -> (1 per trail)
                 assert len(result) == 2
                 for report in result:
                     if report.resource_id == trail_name_us:

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_test.py
@@ -269,7 +269,7 @@ class Test_cloudtrail_multi_region_enabled:
 
                 check = cloudtrail_multi_region_enabled()
                 result = check.execute()
-                assert len(result) == len(current_audit_info.audited_regions)
+                assert len(result) == 1
                 for report in result:
                     if report.region == AWS_REGION_US_EAST_1:
                         assert report.status == "PASS"

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_test.py
@@ -163,7 +163,7 @@ class Test_cloudtrail_multi_region_enabled:
         trail_us = cloudtrail_client_us_east_1.create_trail(
             Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=False
         )
-        cloudtrail_client_eu_west_1.create_trail(
+        _ = cloudtrail_client_eu_west_1.create_trail(
             Name=trail_name_eu, S3BucketName=bucket_name_eu, IsMultiRegionTrail=False
         )
         _ = cloudtrail_client_us_east_1.start_logging(Name=trail_name_us)
@@ -194,7 +194,7 @@ class Test_cloudtrail_multi_region_enabled:
                 result = check.execute()
                 assert len(result) == len(current_audit_info.audited_regions)
                 for report in result:
-                    if report.resource_id == trail_name_us:
+                    if report.region == AWS_REGION_US_EAST_1:
                         assert report.status == "PASS"
                         assert search(
                             "is not multiregion and it is logging",
@@ -269,7 +269,7 @@ class Test_cloudtrail_multi_region_enabled:
 
                 check = cloudtrail_multi_region_enabled()
                 result = check.execute()
-                assert len(result) == 1
+                assert len(result) == len(current_audit_info.audited_regions)
                 for report in result:
                     if report.region == AWS_REGION_US_EAST_1:
                         assert report.status == "PASS"

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_test.py
@@ -163,7 +163,7 @@ class Test_cloudtrail_multi_region_enabled:
         trail_us = cloudtrail_client_us_east_1.create_trail(
             Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=False
         )
-        _ = cloudtrail_client_eu_west_1.create_trail(
+        cloudtrail_client_eu_west_1.create_trail(
             Name=trail_name_eu, S3BucketName=bucket_name_eu, IsMultiRegionTrail=False
         )
         _ = cloudtrail_client_us_east_1.start_logging(Name=trail_name_us)
@@ -194,7 +194,7 @@ class Test_cloudtrail_multi_region_enabled:
                 result = check.execute()
                 assert len(result) == len(current_audit_info.audited_regions)
                 for report in result:
-                    if report.region == AWS_REGION_US_EAST_1:
+                    if report.resource_id == trail_name_us:
                         assert report.status == "PASS"
                         assert search(
                             "is not multiregion and it is logging",

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_service_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_service_test.py
@@ -88,7 +88,7 @@ class Test_Cloudtrail_Service:
         )
         cloudtrail = Cloudtrail(audit_info)
         assert len(cloudtrail.trails) == 2
-        for trail in cloudtrail.trails:
+        for trail in cloudtrail.trails.values():
             if trail.name:
                 assert trail.name == trail_name_us or trail.name == trail_name_eu
                 assert not trail.is_multiregion
@@ -145,7 +145,7 @@ class Test_Cloudtrail_Service:
         )
         cloudtrail = Cloudtrail(audit_info)
         assert len(cloudtrail.trails) == len(audit_info.audited_regions)
-        for trail in cloudtrail.trails:
+        for trail in cloudtrail.trails.values():
             if trail.name:
                 if trail.name == trail_name_us:
                     assert not trail.is_multiregion
@@ -189,7 +189,7 @@ class Test_Cloudtrail_Service:
         )
         cloudtrail = Cloudtrail(audit_info)
         assert len(cloudtrail.trails) == len(audit_info.audited_regions)
-        for trail in cloudtrail.trails:
+        for trail in cloudtrail.trails.values():
             if trail.name:
                 if trail.name == trail_name_us:
                     assert not trail.is_multiregion
@@ -237,7 +237,7 @@ class Test_Cloudtrail_Service:
         )
         cloudtrail = Cloudtrail(audit_info)
         assert len(cloudtrail.trails) == len(audit_info.audited_regions)
-        for trail in cloudtrail.trails:
+        for trail in cloudtrail.trails.values():
             if trail.name:
                 if trail.name == trail_name_us:
                     assert not trail.is_multiregion


### PR DESCRIPTION
### Description

In order for not having duplicate Trails in memory, use a dictionary to store unique trails based on the ARN.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
