### PR TITLE
fix(compliance): fix csv output for framework Mitre Attack v3

### DIFF
--- a/prowler/lib/outputs/compliance.py
+++ b/prowler/lib/outputs/compliance.py
@@ -269,11 +269,18 @@ def fill_compliance(output_options, finding, audit_info, file_descriptors):
                         attributes_categories = ""
                         attributes_values = ""
                         attributes_comments = ""
-                        for attribute in requirement.Attributes:
-                            attributes_aws_services += attribute.AWSService + "\n"
-                            attributes_categories += attribute.Category + "\n"
-                            attributes_values += attribute.Value + "\n"
-                            attributes_comments += attribute.Comment + "\n"
+                        attributes_aws_services = ", ".join(
+                            attribute.AWSService for attribute in requirement.Attributes
+                        )
+                        attributes_categories = ", ".join(
+                            attribute.Category for attribute in requirement.Attributes
+                        )
+                        attributes_values = ", ".join(
+                            attribute.Value for attribute in requirement.Attributes
+                        )
+                        attributes_comments = ", ".join(
+                            attribute.Comment for attribute in requirement.Attributes
+                        )
                         compliance_row = Check_Output_MITRE_ATTACK(
                             Provider=finding.check_metadata.Provider,
                             Description=compliance.Description,

--- a/prowler/lib/outputs/compliance.py
+++ b/prowler/lib/outputs/compliance.py
@@ -281,6 +281,7 @@ def fill_compliance(output_options, finding, audit_info, file_descriptors):
                         attributes_comments = ", ".join(
                             attribute.Comment for attribute in requirement.Attributes
                         )
+
                         compliance_row = Check_Output_MITRE_ATTACK(
                             Provider=finding.check_metadata.Provider,
                             Description=compliance.Description,


### PR DESCRIPTION
### Context

The output format of the csv for Mitre Attack framework had some line breaks that were breaking the output

### Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
