### PR TITLE
chore(gcp): remove unnecessary default project id

### DIFF
--- a/prowler/providers/common/audit_info.py
+++ b/prowler/providers/common/audit_info.py
@@ -385,7 +385,6 @@ Azure Identity Type: {Fore.YELLOW}[{audit_info.identity.identity_type}]{Style.RE
 
         (
             gcp_audit_info.credentials,
-            gcp_audit_info.default_project_id,
             gcp_audit_info.project_ids,
         ) = gcp_provider.get_credentials()
 

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -15,7 +15,7 @@ class GCP_Provider:
         input_project_ids: list,
     ):
         logger.info("Instantiating GCP Provider ...")
-        self.credentials, _ = self.__set_credentials__(credentials_file)
+        self.credentials = self.__set_credentials__(credentials_file)
 
         self.project_ids = []
         accessible_projects = self.get_project_ids()
@@ -41,9 +41,10 @@ class GCP_Provider:
             if credentials_file:
                 self.__set_gcp_creds_env_var__(credentials_file)
 
-            return auth.default(
+            credentials, _ = auth.default(
                 scopes=["https://www.googleapis.com/auth/cloud-platform"]
             )
+            return credentials
         except Exception as error:
             logger.critical(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -15,9 +15,7 @@ class GCP_Provider:
         input_project_ids: list,
     ):
         logger.info("Instantiating GCP Provider ...")
-        self.credentials, self.default_project_id = self.__set_credentials__(
-            credentials_file
-        )
+        self.credentials, _ = self.__set_credentials__(credentials_file)
 
         self.project_ids = []
         accessible_projects = self.get_project_ids()
@@ -60,7 +58,7 @@ class GCP_Provider:
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = client_secrets_path
 
     def get_credentials(self):
-        return self.credentials, self.default_project_id, self.project_ids
+        return self.credentials, self.project_ids
 
     def get_project_ids(self):
         try:

--- a/prowler/providers/gcp/lib/audit_info/audit_info.py
+++ b/prowler/providers/gcp/lib/audit_info/audit_info.py
@@ -2,7 +2,6 @@ from prowler.providers.gcp.lib.audit_info.models import GCP_Audit_Info
 
 gcp_audit_info = GCP_Audit_Info(
     credentials=None,
-    default_project_id=None,
     project_ids=[],
     audit_resources=None,
     audit_metadata=None,

--- a/prowler/providers/gcp/lib/audit_info/models.py
+++ b/prowler/providers/gcp/lib/audit_info/models.py
@@ -7,7 +7,6 @@ from google.oauth2.credentials import Credentials
 @dataclass
 class GCP_Audit_Info:
     credentials: Credentials
-    default_project_id: str
     project_ids: list
     audit_resources: Optional[Any]
     audit_metadata: Optional[Any]
@@ -16,14 +15,12 @@ class GCP_Audit_Info:
     def __init__(
         self,
         credentials,
-        default_project_id,
         project_ids,
         audit_metadata,
         audit_resources,
         audit_config,
     ):
         self.credentials = credentials
-        self.default_project_id = default_project_id
         self.project_ids = project_ids
         self.audit_metadata = audit_metadata
         self.audit_resources = audit_resources

--- a/prowler/providers/gcp/lib/service/service.py
+++ b/prowler/providers/gcp/lib/service/service.py
@@ -24,7 +24,6 @@ class GCPService:
         self.service = service.lower() if not service.islower() else service
         self.credentials = audit_info.credentials
         self.api_version = api_version
-        self.default_project_id = audit_info.default_project_id
         self.region = region
         self.client = self.__generate_client__(
             self.service, api_version, audit_info.credentials

--- a/tests/lib/outputs/slack_test.py
+++ b/tests/lib/outputs/slack_test.py
@@ -56,7 +56,6 @@ class Test_Slack_Integration:
         )
         gcp_audit_info = GCP_Audit_Info(
             credentials=None,
-            default_project_id="test-project1",
             project_ids=["test-project1", "test-project2"],
             audit_resources=None,
             audit_metadata=None,

--- a/tests/providers/common/common_outputs_test.py
+++ b/tests/providers/common/common_outputs_test.py
@@ -44,7 +44,6 @@ class Test_Common_Output_Options:
     def set_mocked_gcp_audit_info(self):
         audit_info = GCP_Audit_Info(
             credentials=None,
-            default_project_id="test-project1",
             project_ids=["test-project1", "test-project2"],
             audit_resources=None,
             audit_metadata=None,


### PR DESCRIPTION
### Description

Remove unnecessary GCP default project id.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
