### PR TITLE
fix(json-asff): Remediation.Recommendation.Text < 512 chars

### DIFF
--- a/prowler/lib/outputs/json.py
+++ b/prowler/lib/outputs/json.py
@@ -100,7 +100,17 @@ def fill_json_asff(finding_output, audit_info, finding, output_options):
         if not finding.check_metadata.Remediation.Recommendation.Url:
             finding.check_metadata.Remediation.Recommendation.Url = "https://docs.aws.amazon.com/securityhub/latest/userguide/what-is-securityhub.html"
         finding_output.Remediation = {
-            "Recommendation": finding.check_metadata.Remediation.Recommendation
+            "Recommendation": {
+                "Text": (
+                    (
+                        finding.check_metadata.Remediation.Recommendation.Text[:509]
+                        + "..."
+                    )
+                    if len(finding.check_metadata.Remediation.Recommendation.Text) > 512
+                    else finding.check_metadata.Remediation.Recommendation.Text
+                ),
+                "Url": finding.check_metadata.Remediation.Recommendation.Url,
+            }
         }
 
         return finding_output

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -577,7 +577,7 @@ class Test_Outputs:
             fill_json_asff(input, input_audit_info, finding, output_options) == expected
         )
 
-    def test_fill_json_asff_with_long_description(self):
+    def test_fill_json_asff_with_long_description_and_recommendation_text(self):
         input_audit_info = AWS_Audit_Info(
             session_config=None,
             original_session=None,
@@ -610,13 +610,16 @@ class Test_Outputs:
 
         # Empty the Remediation.Recomendation.URL
         finding.check_metadata.Remediation.Recommendation.Url = ""
+        # It has to be limited to 509+...
+        finding.check_metadata.Remediation.Recommendation.Text = "x" * 513
 
         finding.resource_details = "Test resource details"
         finding.resource_id = "test-resource"
         finding.resource_arn = "test-arn"
         finding.region = "eu-west-1"
         finding.status = "PASS"
-        finding.status_extended = "x" * 2000  # it has to be limited to 1000+...
+        # It has to be limited to 1000+...
+        finding.status_extended = "x" * 2000
 
         expected = Check_Output_JSON_ASFF()
         expected.Id = f"prowler-{finding.check_metadata.CheckID}-123456789012-eu-west-1-{hash_sha512('test-resource')}"
@@ -654,16 +657,13 @@ class Test_Outputs:
             # "Code": finding.check_metadata.Remediation.Code,
         }
 
-        expected.Remediation["Recommendation"].Text = (
-            finding.check_metadata.Remediation.Recommendation.Text
-        )
+        expected.Remediation["Recommendation"].Text = "x" * 512
         expected.Remediation["Recommendation"].Url = (
             "https://docs.aws.amazon.com/securityhub/latest/userguide/what-is-securityhub.html"
         )
 
         input = Check_Output_JSON_ASFF()
         output_options = mock.MagicMock()
-
         assert (
             fill_json_asff(input, input_audit_info, finding, output_options) == expected
         )


### PR DESCRIPTION
### Description

The JSON-ASFF format the `Remediation.Recommendation.Text` cannot exceed 512 characters.

Also handle errors when calling the Security Hub API.

This PR doesn't need the backport since is covered here https://github.com/prowler-cloud/prowler/pull/3590

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
