### PR TITLE
fix(securityhub): Add validation and handle errors

### DIFF
--- a/prowler/lib/outputs/json_asff/models.py
+++ b/prowler/lib/outputs/json_asff/models.py
@@ -1,11 +1,13 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
+
+from prowler.config.config import prowler_version
 
 
 class ProductFields(BaseModel):
     ProviderName: str = "Prowler"
-    ProviderVersion: str
+    ProviderVersion: str = prowler_version
     ProwlerResourceName: str
 
 
@@ -27,25 +29,55 @@ class Compliance(BaseModel):
     AssociatedStandards: list[dict]
 
 
+class Recommendation(BaseModel):
+    Text: str = ""
+    Url: str = ""
+
+    @validator("Text", pre=True, always=True)
+    def text_must_not_exceed_512_chars(text):
+        text_validated = text
+        if len(text) > 512:
+            text_validated = text[:509] + "..."
+        return text_validated
+
+    @validator("Url", pre=True, always=True)
+    def set_default_url_if_empty(url):
+        default_url = "https://docs.aws.amazon.com/securityhub/latest/userguide/what-is-securityhub.html"
+        if url:
+            default_url = url
+        return default_url
+
+
+class Remediation(BaseModel):
+    Recommendation: Recommendation
+
+
 class Check_Output_JSON_ASFF(BaseModel):
     """
     Check_Output_JSON_ASFF generates a finding's output in JSON ASFF format: https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-findings-format-syntax.html
     """
 
     SchemaVersion: str = "2018-10-08"
-    Id: str = ""
-    ProductArn: str = ""
+    Id: str
+    ProductArn: str
     RecordState: str = "ACTIVE"
     ProductFields: ProductFields
-    GeneratorId: str = ""
-    AwsAccountId: str = ""
+    GeneratorId: str
+    AwsAccountId: str
     Types: list[str] = None
-    FirstObservedAt: str = ""
-    UpdatedAt: str = ""
-    CreatedAt: str = ""
+    FirstObservedAt: str
+    UpdatedAt: str
+    CreatedAt: str
     Severity: Severity
-    Title: str = ""
-    Description: str = ""
+    Title: str
+    Description: str
     Resources: list[Resource] = None
     Compliance: Compliance
-    Remediation: dict = None
+    Remediation: Remediation
+
+    @validator("Description", pre=True, always=True)
+    def description_must_not_exceed_1024_chars(description):
+        description_validated = description
+        if len(description) > 1024:
+            description_validated = description[:1021] + "..."
+        return description_validated

--- a/prowler/providers/aws/lib/security_hub/security_hub.py
+++ b/prowler/providers/aws/lib/security_hub/security_hub.py
@@ -82,7 +82,7 @@ def verify_security_hub_integration_enabled_per_region(
         error_message = client_error.response["Error"]["Message"]
         if (
             error_code == "InvalidAccessException"
-            and f"Account {aws_account_number} is not subscribed to AWS Security Hub in region {region}"
+            and f"Account {aws_account_number} is not subscribed to AWS Security Hub"
             in error_message
         ):
             logger.warning(


### PR DESCRIPTION
### Description

- Add validation for the `Description` and `Remediation.Recommendation.Text`
- Create the models for `Remediation` and `Recommendation`
- Handle errors when calling the Security Hub API
- Improve tests

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
