### PR TITLE
fix(apigatewayv2): handle empty names

### DIFF
--- a/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
+++ b/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
@@ -32,7 +32,7 @@ class ApiGatewayV2(AWSService):
                                 arn=arn,
                                 id=apigw["ApiId"],
                                 region=regional_client.region,
-                                name=apigw["Name"],
+                                name=apigw.get("Name", ""),
                                 tags=[apigw.get("Tags")],
                             )
                         )


### PR DESCRIPTION
### Description

Handle empty Api Gateway v2 names.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
