### PR TITLE
fix(securityhub): Remove region from exception match

### DIFF
--- a/prowler/providers/aws/lib/security_hub/security_hub.py
+++ b/prowler/providers/aws/lib/security_hub/security_hub.py
@@ -86,7 +86,7 @@ def verify_security_hub_integration_enabled_per_region(
         error_message = client_error.response["Error"]["Message"]
         if (
             error_code == "InvalidAccessException"
-            and f"Account {aws_account_number} is not subscribed to AWS Security Hub in region {region}"
+            and f"Account {aws_account_number} is not subscribed to AWS Security Hub"
             in error_message
         ):
             logger.warning(


### PR DESCRIPTION
### Description

Remove `in region {region}` since that part may not be present in the API error.

This PR doesn't need backport since it's covered here https://github.com/prowler-cloud/prowler/pull/3590

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
