### PR TITLE
chore(action): Prepare containers release for v4

### DIFF
--- a/.github/workflows/build-lint-push-containers.yml
+++ b/.github/workflows/build-lint-push-containers.yml
@@ -49,53 +49,39 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python (release)
-        if: github.event_name == 'release'
+      - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install dependencies (release)
-        if: github.event_name == 'release'
+      - name: Install Poetry
         run: |
           pipx install poetry
           pipx inject poetry poetry-bumpversion
 
-      - name: Get Prowler version (latest)
-        if: github.event_name == 'push'
+      - name: Get Prowler version
         run: |
           PROWLER_VERSION="$(poetry version -s 2>/dev/null)"
 
-          case ${PROWLER_VERSION%%.*} in
-          3)
-              echo "LATEST="v3-latest" >> "${GITHUB_ENV}"
-              ;;
-          4)
-              # Nothing to be done here, latest tag for v4 is "latest"
-              echo "LATEST="latest" >> "${GITHUB_ENV}"
-              ;;
-          *)
-              # Fallback if any other version is present
-              echo "Releasing another Prowler major version, aborting..."
-              exit 1
-              ;;
-          esac
-
-      - name: Get Prowler version (release)
-        if: github.event_name == 'release'
-        run: |
-          PROWLER_VERSION="${{ github.event.release.tag_name }}"
           # Store prowler version major just for the release
           PROWLER_VERSION_MAJOR="${PROWLER_VERSION%%.*}"
+          echo "PROWLER_VERSION_MAJOR=${PROWLER_VERSION_MAJOR}" >> "${GITHUB_ENV}"
 
           case ${PROWLER_VERSION_MAJOR} in
           3)
-              echo "STABLE_TAG="v3-stable" >> "${GITHUB_ENV}"
+              # TODO: update it for v3 and v4
+              # echo "LATEST=v3-latest" >> "${GITHUB_ENV}"
+              # echo "STABLE_TAG=v3-stable" >> "${GITHUB_ENV}"
+              echo "LATEST=latest" >> "${GITHUB_ENV}"
+              echo "STABLE_TAG=stable" >> "${GITHUB_ENV}"
               ;;
-          4)
-              # Nothing to be done here, latest tag for v4 is "latest"
-              echo "STABLE_TAG="stable" >> "${GITHUB_ENV}"
-              ;;
+
+          # TODO: uncomment for v3 and v4
+          # 4)
+          #     echo "LATEST=v4-latest" >> "${GITHUB_ENV}"
+          #     echo "STABLE_TAG=stable" >> "${GITHUB_ENV}"
+          #     ;;
+          
           *)
               # Fallback if any other version is present
               echo "Releasing another Prowler major version, aborting..."
@@ -106,7 +92,9 @@ jobs:
       - name: Update Prowler version (release)
         if: github.event_name == 'release'
         run: |
-          poetry version "${{ env.PROWLER_VERSION }}"
+          PROWLER_VERSION="${{ github.event.release.tag_name }}"
+          poetry version "${PROWLER_VERSION}"
+          echo "PROWLER_VERSION="${PROWLER_VERSION}" >> "${GITHUB_ENV}"
 
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/build-lint-push-containers.yml
+++ b/.github/workflows/build-lint-push-containers.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       # TODO: update it for v3 and v4
-      # - "v3-dev"
+      # - "v3"
       - "master"
     paths-ignore:
       - ".github/**"
@@ -169,4 +169,4 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.ACCESS_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            --data '{"event_type":"dispatch","client_payload":{"version":"release", "tag":"${{ github.event.release.tag_name }}"}}'
+            --data '{"event_type":"dispatch","client_payload":{"version":"release", "tag":"${{ env.PROWLER_VERSION }}"}}'

--- a/.github/workflows/build-lint-push-containers.yml
+++ b/.github/workflows/build-lint-push-containers.yml
@@ -3,6 +3,8 @@ name: build-lint-push-containers
 on:
   push:
     branches:
+      # TODO: update it for v3 and v4
+      # - "v3-dev"
       - "master"
     paths-ignore:
       - ".github/**"
@@ -13,15 +15,27 @@ on:
     types: [published]
 
 env:
+  # AWS Configuration
   AWS_REGION_STG: eu-west-1
   AWS_REGION_PLATFORM: eu-west-1
   AWS_REGION: us-east-1
+
+  # Container's configuration
   IMAGE_NAME: prowler
+  DOCKERFILE_PATH: ./Dockerfile
+
+  # Tags
   LATEST_TAG: latest
   STABLE_TAG: stable
-  TEMPORARY_TAG: temporary
-  DOCKERFILE_PATH: ./Dockerfile
-  PYTHON_VERSION: 3.9
+  # The RELEASE_TAG is set during runtime in releases
+  RELEASE_TAG: ""
+  # The PROWLER_VERSION and PROWLER_VERSION_MAJOR are set during runtime in releases
+  PROWLER_VERSION: ""
+  PROWLER_VERSION_MAJOR: ""
+  # TEMPORARY_TAG: temporary
+
+  # Python configuration
+  PYTHON_VERSION: 3.11
 
 jobs:
   # Build Prowler OSS container
@@ -30,11 +44,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       POETRY_VIRTUALENVS_CREATE: "false"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup python (release)
+      - name: Setup Python (release)
         if: github.event_name == 'release'
         uses: actions/setup-python@v5
         with:
@@ -46,10 +61,52 @@ jobs:
           pipx install poetry
           pipx inject poetry poetry-bumpversion
 
+      - name: Get Prowler version (latest)
+        if: github.event_name == 'push'
+        run: |
+          PROWLER_VERSION="$(poetry version -s 2>/dev/null)"
+
+          case ${PROWLER_VERSION%%.*} in
+          3)
+              echo "LATEST="v3-latest" >> "${GITHUB_ENV}"
+              ;;
+          4)
+              # Nothing to be done here, latest tag for v4 is "latest"
+              echo "LATEST="latest" >> "${GITHUB_ENV}"
+              ;;
+          *)
+              # Fallback if any other version is present
+              echo "Releasing another Prowler major version, aborting..."
+              exit 1
+              ;;
+          esac
+
+      - name: Get Prowler version (release)
+        if: github.event_name == 'release'
+        run: |
+          PROWLER_VERSION="${{ github.event.release.tag_name }}"
+          # Store prowler version major just for the release
+          PROWLER_VERSION_MAJOR="${PROWLER_VERSION%%.*}"
+
+          case ${PROWLER_VERSION_MAJOR} in
+          3)
+              echo "STABLE_TAG="v3-stable" >> "${GITHUB_ENV}"
+              ;;
+          4)
+              # Nothing to be done here, latest tag for v4 is "latest"
+              echo "STABLE_TAG="stable" >> "${GITHUB_ENV}"
+              ;;
+          *)
+              # Fallback if any other version is present
+              echo "Releasing another Prowler major version, aborting..."
+              exit 1
+              ;;
+          esac
+
       - name: Update Prowler version (release)
         if: github.event_name == 'release'
         run: |
-          poetry version ${{ github.event.release.tag_name }}
+          poetry version "${{ env.PROWLER_VERSION }}"
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -90,9 +147,9 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+            ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.PROWLER_VERSION }}
             ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.STABLE_TAG }}
-            ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+            ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.PROWLER_VERSION }}
             ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.STABLE_TAG }}
           file: ${{ env.DOCKERFILE_PATH }}
           cache-from: type=gha
@@ -107,11 +164,21 @@ jobs:
         run: |
           LATEST_COMMIT_HASH=$(echo ${{ github.event.after }} | cut -b -7)
           echo "LATEST_COMMIT_HASH=${LATEST_COMMIT_HASH}" >> $GITHUB_ENV
-      - name: Dispatch event for latest
-        if: github.event_name == 'push'
+
+      - name: Dispatch event (latest)
+        if: github.event_name == 'push' && ${{ env. PROWLER_VERSION_MAJOR }} == '3'
         run: |
-          curl https://api.github.com/repos/${{ secrets.DISPATCH_OWNER }}/${{ secrets.DISPATCH_REPO }}/dispatches -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.ACCESS_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" --data '{"event_type":"dispatch","client_payload":{"version":"latest", "tag": "${{ env.LATEST_COMMIT_HASH }}"}}'
-      - name: Dispatch event for release
-        if: github.event_name == 'release'
+          curl https://api.github.com/repos/${{ secrets.DISPATCH_OWNER }}/${{ secrets.DISPATCH_REPO }}/dispatches \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.ACCESS_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --data '{"event_type":"dispatch","client_payload":{"version":"latest", "tag": "${{ env.LATEST_COMMIT_HASH }}"}}'
+
+      - name: Dispatch event (release)
+        if: github.event_name == 'push' && ${{ env. PROWLER_VERSION_MAJOR }} == '3'
         run: |
-          curl https://api.github.com/repos/${{ secrets.DISPATCH_OWNER }}/${{ secrets.DISPATCH_REPO }}/dispatches -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.ACCESS_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" --data '{"event_type":"dispatch","client_payload":{"version":"release", "tag":"${{ github.event.release.tag_name }}"}}'
+          curl https://api.github.com/repos/${{ secrets.DISPATCH_OWNER }}/${{ secrets.DISPATCH_REPO }}/dispatches \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.ACCESS_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --data '{"event_type":"dispatch","client_payload":{"version":"release", "tag":"${{ github.event.release.tag_name }}"}}'

--- a/.github/workflows/build-lint-push-containers.yml
+++ b/.github/workflows/build-lint-push-containers.yml
@@ -81,7 +81,7 @@ jobs:
           #     echo "LATEST=v4-latest" >> "${GITHUB_ENV}"
           #     echo "STABLE_TAG=stable" >> "${GITHUB_ENV}"
           #     ;;
-          
+
           *)
               # Fallback if any other version is present
               echo "Releasing another Prowler major version, aborting..."

--- a/.github/workflows/build-lint-push-containers.yml
+++ b/.github/workflows/build-lint-push-containers.yml
@@ -78,7 +78,7 @@ jobs:
 
           # TODO: uncomment for v3 and v4
           # 4)
-          #     echo "LATEST=v4-latest" >> "${GITHUB_ENV}"
+          #     echo "LATEST=latest" >> "${GITHUB_ENV}"
           #     echo "STABLE_TAG=stable" >> "${GITHUB_ENV}"
           #     ;;
 
@@ -147,7 +147,7 @@ jobs:
     needs: container-build-push
     runs-on: ubuntu-latest
     steps:
-      - name: Get latest commit info
+      - name: Get latest commit info (latest)
         if: github.event_name == 'push'
         run: |
           LATEST_COMMIT_HASH=$(echo ${{ github.event.after }} | cut -b -7)
@@ -163,7 +163,7 @@ jobs:
             --data '{"event_type":"dispatch","client_payload":{"version":"latest", "tag": "${{ env.LATEST_COMMIT_HASH }}"}}'
 
       - name: Dispatch event (release)
-        if: github.event_name == 'push' && ${{ env. PROWLER_VERSION_MAJOR }} == '3'
+        if: github.event_name == 'release' && ${{ env. PROWLER_VERSION_MAJOR }} == '3'
         run: |
           curl https://api.github.com/repos/${{ secrets.DISPATCH_OWNER }}/${{ secrets.DISPATCH_REPO }}/dispatches \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -8,10 +8,7 @@ env:
   RELEASE_TAG: ${{ github.event.release.tag_name }}
   PYTHON_VERSION: 3.11
   CACHE: "poetry"
-  # This base branch is used to create a PR with the updated version
-  # We'd need to handle the base branch for v4 and v3, since they will be
-  # `master` and `3.0-dev`, respectively
-  GITHUB_BASE_BRANCH: "master"
+  # TODO: create a bot user for this kind of tasks, like prowler-bot
   GIT_COMMITTER_EMAIL: "sergio@prowler.com"
 
 jobs:
@@ -24,21 +21,13 @@ jobs:
       - name: Get base branch regarding Prowler version
         run: |
           PROWLER_VERSION="${{ env.RELEASE_TAG }}"
-          BASE_BRANCH=""
 
           case ${PROWLER_VERSION%%.*} in
           3)
               echo "Releasing Prowler v3 with tag ${PROWLER_VERSION}"
-              # TODO: modify it once v4 is ready
-              # echo "BASE_BRANCH=3.0-dev" >> "${GITHUB_ENV}"
-              echo "BASE_BRANCH=master" >> "${GITHUB_ENV}"
               ;;
           4)
               echo "Releasing Prowler v4 with tag ${PROWLER_VERSION}"
-              # TODO: modify it once v4 is ready
-              # echo "BASE_BRANCH=master" >> "${GITHUB_ENV}"
-              echo "Not available, aborting..."
-              exit 1
               ;;
           *)
               echo "Releasing another Prowler major version, aborting..."
@@ -100,23 +89,6 @@ jobs:
         run: |
           poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
           poetry publish
-
-      - name: Create PR to update version in the branch
-        run: |
-          echo "### Description
-
-          This PR updates Prowler Version to ${{ env.RELEASE_TAG }}.
-
-          ### License
-
-          By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license." |\
-          gh pr create \
-            --base ${{ env.BASE_BRANCH }} \
-            --head release-${{ env.RELEASE_TAG }} \
-            --title "chore(release): update Prowler Version to ${{ env.RELEASE_TAG }}." \
-            --body-file -
-        env:
-          GH_TOKEN: ${{ secrets.PROWLER_ACCESS_TOKEN }}
 
       - name: Replicate PyPI package
         run: |

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -18,7 +18,7 @@ jobs:
       POETRY_VIRTUALENVS_CREATE: "false"
     name: Release Prowler to PyPI
     steps:
-      - name: Get base branch regarding Prowler version
+      - name: Get Prowler version
         run: |
           PROWLER_VERSION="${{ env.RELEASE_TAG }}"
 
@@ -75,11 +75,6 @@ jobs:
 
           # Push the tag
           git push -f origin ${{ env.RELEASE_TAG }}
-
-      - name: Create new branch for the version update
-        run: |
-          git switch -c release-${{ env.RELEASE_TAG }}
-          git push --set-upstream origin release-${{ env.RELEASE_TAG }}
 
       - name: Build Prowler package
         run: |


### PR DESCRIPTION
### Context

For the upcoming Prowler v4 we need to be able to handle different paths for both v3 and v4 while releasing packages or pushing latest changes.


### Description

- Remove PR automation to update version in the configuration file since it is no longer needed.
- Handle v3 and v4 version while pushing containers.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
