### PR TITLE
fix(aws): break loop after FAIL in SQS and SNS checks

### DIFF
--- a/prowler/providers/aws/services/sns/sns_topics_not_publicly_accessible/sns_topics_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/sns/sns_topics_not_publicly_accessible/sns_topics_not_publicly_accessible.py
@@ -43,6 +43,7 @@ class sns_topics_not_publicly_accessible(Check):
                             else:
                                 report.status = "FAIL"
                                 report.status_extended = f"SNS topic {topic.name} is public because its policy allows public access."
+                                break
 
             findings.append(report)
 

--- a/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible.py
@@ -41,9 +41,11 @@ class sqs_queues_not_publicly_accessible(Check):
                                 else:
                                     report.status = "FAIL"
                                     report.status_extended = f"SQS queue {queue.id} is public because its policy allows public access, and the condition does not limit access to resources within the same account."
+                                    break
                             else:
                                 report.status = "FAIL"
                                 report.status_extended = f"SQS queue {queue.id} is public because its policy allows public access."
+                                break
             findings.append(report)
 
         return findings


### PR DESCRIPTION
### Context

Both checks `sns_topics_not_publicly_accessible` and `sqs_queues_not_publicly_accessible` may report "FAIL" even though their report message states that the resource is **not** public.
This happens because Prowler iterates over **all** statements in the policy and does not break the loop in case of "FAIL". Therefore, if Prowler encounters thereafter a policy statement without security findings, the report message changes to "is not public" although the status remains "FAIL".

### Description

The bugfix breaks the loop in case of "FAIL" so that succeeding statements will not change the report message anymore.
To summarize, one found "FAILed" statement within the policy is sufficient to "FAIL" the checked resource. 


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
