### PR TITLE
chore(entra): Moving constants from checks and services to config file

### DIFF
--- a/prowler/providers/azure/config.py
+++ b/prowler/providers/azure/config.py
@@ -1,3 +1,12 @@
+from uuid import UUID
+
+# Service management API
+WINDOWS_AZURE_SERVICE_MANAGEMENT_API = "797f4846-ba00-4fd7-ba43-dac1f8f63013"
+
+# Authorization policy roles
+GUEST_USER_ACCESS_NO_RESTRICTICTED = UUID("a0b1b346-4d3e-4e8b-98f8-753987be4970")
+GUEST_USER_ACCESS_RESTRICTICTED = UUID("2af84b1e-32c8-42b7-82bc-daa82404023b")
+
 # General built-in roles
 CONTRIBUTOR_ROLE_ID = "b24988ac-6180-42a0-ab88-20f7382dd24c"
 OWNER_ROLE_ID = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"

--- a/prowler/providers/azure/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api.py
+++ b/prowler/providers/azure/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api.py
@@ -1,11 +1,11 @@
 from prowler.lib.check.models import Check, Check_Report_Azure
+from prowler.providers.azure.config import WINDOWS_AZURE_SERVICE_MANAGEMENT_API
 from prowler.providers.azure.services.entra.entra_client import entra_client
 
 
 class entra_conditional_access_policy_require_mfa_for_management_api(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
-        WINDOWS_AZURE_SERVICE_MANAGEMENT_API = "797f4846-ba00-4fd7-ba43-dac1f8f63013"
 
         for (
             tenant_name,

--- a/prowler/providers/azure/services/entra/entra_policy_guest_users_access_restrictions/entra_policy_guest_users_access_restrictions.py
+++ b/prowler/providers/azure/services/entra/entra_policy_guest_users_access_restrictions/entra_policy_guest_users_access_restrictions.py
@@ -1,12 +1,10 @@
-from uuid import UUID
-
 from prowler.lib.check.models import Check, Check_Report_Azure
+from prowler.providers.azure.config import GUEST_USER_ACCESS_RESTRICTICTED
 from prowler.providers.azure.services.entra.entra_client import entra_client
 
 
 class entra_policy_guest_users_access_restrictions(Check):
     def execute(self) -> Check_Report_Azure:
-        GUEST_USER_ACCESS_RESTRICTICTED = UUID("2af84b1e-32c8-42b7-82bc-daa82404023b")
         findings = []
 
         for tenant_domain, auth_policy in entra_client.authorization_policy.items():

--- a/prowler/providers/azure/services/entra/entra_service.py
+++ b/prowler/providers/azure/services/entra/entra_service.py
@@ -11,6 +11,7 @@ from msgraph.generated.models.setting_value import SettingValue
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
+from prowler.providers.azure.config import GUEST_USER_ACCESS_NO_RESTRICTICTED
 from prowler.providers.azure.lib.service.service import AzureService
 
 
@@ -75,9 +76,7 @@ class Entra(AzureService):
 
     async def __get_authorization_policy__(self):
         logger.info("Entra - Getting authorization policy...")
-        GUEST_USER_ACCESS_NO_RESTRICTICTED = UUID(
-            "a0b1b346-4d3e-4e8b-98f8-753987be4970"
-        )
+
         authorization_policy = {}
         try:
             for tenant, client in self.clients.items():


### PR DESCRIPTION
### Context

There was some Azure constants values distributed in some checks and services


### Description

This PR move all of this constants values to a single file, `config.py`.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
