### PR TITLE
chore(azure): Fix AKS and App tests to new format

### DIFF
--- a/tests/providers/azure/services/aks/aks_cluster_rbac_enabled/aks_cluster_rbac_enabled_test.py
+++ b/tests/providers/azure/services/aks/aks_cluster_rbac_enabled/aks_cluster_rbac_enabled_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.aks.aks_service import Cluster
 from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_aks_cluster_rbac_enabled:
     def test_aks_no_subscriptions(self):
         aks_client = mock.MagicMock
-        aks_client.clusters = {}
 
         with mock.patch(
             "prowler.providers.azure.services.aks.aks_cluster_rbac_enabled.aks_cluster_rbac_enabled.aks_client",
@@ -17,6 +15,8 @@ class Test_aks_cluster_rbac_enabled:
             from prowler.providers.azure.services.aks.aks_cluster_rbac_enabled.aks_cluster_rbac_enabled import (
                 aks_cluster_rbac_enabled,
             )
+
+            aks_client.clusters = {}
 
             check = aks_cluster_rbac_enabled()
             result = check.execute()
@@ -41,18 +41,6 @@ class Test_aks_cluster_rbac_enabled:
     def test_aks_cluster_rbac_enabled(self):
         aks_client = mock.MagicMock
         cluster_id = str(uuid4())
-        aks_client.clusters = {
-            AZURE_SUBSCRIPTION: {
-                cluster_id: Cluster(
-                    name="cluster_name",
-                    public_fqdn="public_fqdn",
-                    private_fqdn=None,
-                    network_policy="network_policy",
-                    agent_pool_profiles=[mock.MagicMock(enable_node_public_ip=False)],
-                    rbac_enabled=True,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.aks.aks_cluster_rbac_enabled.aks_cluster_rbac_enabled.aks_client",
@@ -61,6 +49,22 @@ class Test_aks_cluster_rbac_enabled:
             from prowler.providers.azure.services.aks.aks_cluster_rbac_enabled.aks_cluster_rbac_enabled import (
                 aks_cluster_rbac_enabled,
             )
+            from prowler.providers.azure.services.aks.aks_service import Cluster
+
+            aks_client.clusters = {
+                AZURE_SUBSCRIPTION: {
+                    cluster_id: Cluster(
+                        name="cluster_name",
+                        public_fqdn="public_fqdn",
+                        private_fqdn=None,
+                        network_policy="network_policy",
+                        agent_pool_profiles=[
+                            mock.MagicMock(enable_node_public_ip=False)
+                        ],
+                        rbac_enabled=True,
+                    )
+                }
+            }
 
             check = aks_cluster_rbac_enabled()
             result = check.execute()
@@ -77,18 +81,6 @@ class Test_aks_cluster_rbac_enabled:
     def test_aks_rbac_not_enabled(self):
         aks_client = mock.MagicMock
         cluster_id = str(uuid4())
-        aks_client.clusters = {
-            AZURE_SUBSCRIPTION: {
-                cluster_id: Cluster(
-                    name="cluster_name",
-                    public_fqdn="public_fqdn",
-                    private_fqdn=None,
-                    network_policy="network_policy",
-                    agent_pool_profiles=[mock.MagicMock(enable_node_public_ip=False)],
-                    rbac_enabled=False,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.aks.aks_cluster_rbac_enabled.aks_cluster_rbac_enabled.aks_client",
@@ -97,6 +89,22 @@ class Test_aks_cluster_rbac_enabled:
             from prowler.providers.azure.services.aks.aks_cluster_rbac_enabled.aks_cluster_rbac_enabled import (
                 aks_cluster_rbac_enabled,
             )
+            from prowler.providers.azure.services.aks.aks_service import Cluster
+
+            aks_client.clusters = {
+                AZURE_SUBSCRIPTION: {
+                    cluster_id: Cluster(
+                        name="cluster_name",
+                        public_fqdn="public_fqdn",
+                        private_fqdn=None,
+                        network_policy="network_policy",
+                        agent_pool_profiles=[
+                            mock.MagicMock(enable_node_public_ip=False)
+                        ],
+                        rbac_enabled=False,
+                    )
+                }
+            }
 
             check = aks_cluster_rbac_enabled()
             result = check.execute()

--- a/tests/providers/azure/services/aks/aks_clusters_created_with_private_nodes/aks_clusters_created_with_private_nodes_test.py
+++ b/tests/providers/azure/services/aks/aks_clusters_created_with_private_nodes/aks_clusters_created_with_private_nodes_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.aks.aks_service import Cluster
 from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_aks_clusters_created_with_private_nodes:
     def test_aks_no_subscriptions(self):
         aks_client = mock.MagicMock
-        aks_client.clusters = {}
 
         with mock.patch(
             "prowler.providers.azure.services.aks.aks_clusters_created_with_private_nodes.aks_clusters_created_with_private_nodes.aks_client",
@@ -17,6 +15,8 @@ class Test_aks_clusters_created_with_private_nodes:
             from prowler.providers.azure.services.aks.aks_clusters_created_with_private_nodes.aks_clusters_created_with_private_nodes import (
                 aks_clusters_created_with_private_nodes,
             )
+
+            aks_client.clusters = {}
 
             check = aks_clusters_created_with_private_nodes()
             result = check.execute()
@@ -24,7 +24,6 @@ class Test_aks_clusters_created_with_private_nodes:
 
     def test_aks_subscription_empty(self):
         aks_client = mock.MagicMock
-        aks_client.clusters = {AZURE_SUBSCRIPTION: {}}
 
         with mock.patch(
             "prowler.providers.azure.services.aks.aks_clusters_created_with_private_nodes.aks_clusters_created_with_private_nodes.aks_client",
@@ -33,6 +32,8 @@ class Test_aks_clusters_created_with_private_nodes:
             from prowler.providers.azure.services.aks.aks_clusters_created_with_private_nodes.aks_clusters_created_with_private_nodes import (
                 aks_clusters_created_with_private_nodes,
             )
+
+            aks_client.clusters = {AZURE_SUBSCRIPTION: {}}
 
             check = aks_clusters_created_with_private_nodes()
             result = check.execute()
@@ -41,18 +42,6 @@ class Test_aks_clusters_created_with_private_nodes:
     def test_aks_cluster_no_private_nodes(self):
         aks_client = mock.MagicMock
         cluster_id = str(uuid4())
-        aks_client.clusters = {
-            AZURE_SUBSCRIPTION: {
-                cluster_id: Cluster(
-                    name="cluster_name",
-                    public_fqdn="public_fqdn",
-                    private_fqdn="",
-                    network_policy="network_policy",
-                    agent_pool_profiles=[mock.MagicMock(enable_node_public_ip=True)],
-                    rbac_enabled=True,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.aks.aks_clusters_created_with_private_nodes.aks_clusters_created_with_private_nodes.aks_client",
@@ -61,6 +50,22 @@ class Test_aks_clusters_created_with_private_nodes:
             from prowler.providers.azure.services.aks.aks_clusters_created_with_private_nodes.aks_clusters_created_with_private_nodes import (
                 aks_clusters_created_with_private_nodes,
             )
+            from prowler.providers.azure.services.aks.aks_service import Cluster
+
+            aks_client.clusters = {
+                AZURE_SUBSCRIPTION: {
+                    cluster_id: Cluster(
+                        name="cluster_name",
+                        public_fqdn="public_fqdn",
+                        private_fqdn="",
+                        network_policy="network_policy",
+                        agent_pool_profiles=[
+                            mock.MagicMock(enable_node_public_ip=True)
+                        ],
+                        rbac_enabled=True,
+                    )
+                }
+            }
 
             check = aks_clusters_created_with_private_nodes()
             result = check.execute()
@@ -77,18 +82,6 @@ class Test_aks_clusters_created_with_private_nodes:
     def test_aks_cluster_private_nodes(self):
         aks_client = mock.MagicMock
         cluster_id = str(uuid4())
-        aks_client.clusters = {
-            AZURE_SUBSCRIPTION: {
-                cluster_id: Cluster(
-                    name="cluster_name",
-                    public_fqdn="public_fqdn",
-                    private_fqdn="private_fqdn",
-                    network_policy="network_policy",
-                    agent_pool_profiles=[mock.MagicMock(enable_node_public_ip=False)],
-                    rbac_enabled=True,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.aks.aks_clusters_created_with_private_nodes.aks_clusters_created_with_private_nodes.aks_client",
@@ -97,6 +90,22 @@ class Test_aks_clusters_created_with_private_nodes:
             from prowler.providers.azure.services.aks.aks_clusters_created_with_private_nodes.aks_clusters_created_with_private_nodes import (
                 aks_clusters_created_with_private_nodes,
             )
+            from prowler.providers.azure.services.aks.aks_service import Cluster
+
+            aks_client.clusters = {
+                AZURE_SUBSCRIPTION: {
+                    cluster_id: Cluster(
+                        name="cluster_name",
+                        public_fqdn="public_fqdn",
+                        private_fqdn="private_fqdn",
+                        network_policy="network_policy",
+                        agent_pool_profiles=[
+                            mock.MagicMock(enable_node_public_ip=False)
+                        ],
+                        rbac_enabled=True,
+                    )
+                }
+            }
 
             check = aks_clusters_created_with_private_nodes()
             result = check.execute()
@@ -113,22 +122,6 @@ class Test_aks_clusters_created_with_private_nodes:
     def test_aks_cluster_public_and_private_nodes(self):
         aks_client = mock.MagicMock
         cluster_id = str(uuid4())
-        aks_client.clusters = {
-            AZURE_SUBSCRIPTION: {
-                cluster_id: Cluster(
-                    name="cluster_name",
-                    public_fqdn="public_fqdn",
-                    private_fqdn="private_fqdn",
-                    network_policy="network_policy",
-                    agent_pool_profiles=[
-                        mock.MagicMock(enable_node_public_ip=False),
-                        mock.MagicMock(enable_node_public_ip=True),
-                        mock.MagicMock(enable_node_public_ip=False),
-                    ],
-                    rbac_enabled=True,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.aks.aks_clusters_created_with_private_nodes.aks_clusters_created_with_private_nodes.aks_client",
@@ -137,6 +130,24 @@ class Test_aks_clusters_created_with_private_nodes:
             from prowler.providers.azure.services.aks.aks_clusters_created_with_private_nodes.aks_clusters_created_with_private_nodes import (
                 aks_clusters_created_with_private_nodes,
             )
+            from prowler.providers.azure.services.aks.aks_service import Cluster
+
+            aks_client.clusters = {
+                AZURE_SUBSCRIPTION: {
+                    cluster_id: Cluster(
+                        name="cluster_name",
+                        public_fqdn="public_fqdn",
+                        private_fqdn="private_fqdn",
+                        network_policy="network_policy",
+                        agent_pool_profiles=[
+                            mock.MagicMock(enable_node_public_ip=False),
+                            mock.MagicMock(enable_node_public_ip=True),
+                            mock.MagicMock(enable_node_public_ip=False),
+                        ],
+                        rbac_enabled=True,
+                    )
+                }
+            }
 
             check = aks_clusters_created_with_private_nodes()
             result = check.execute()

--- a/tests/providers/azure/services/aks/aks_clusters_public_access_disabled/aks_clusters_public_access_disabled_test.py
+++ b/tests/providers/azure/services/aks/aks_clusters_public_access_disabled/aks_clusters_public_access_disabled_test.py
@@ -1,7 +1,6 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.aks.aks_service import Cluster
 from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
@@ -41,18 +40,6 @@ class Test_aks_clusters_public_access_disabled:
     def test_aks_cluster_public_fqdn(self):
         aks_client = mock.MagicMock
         cluster_id = str(uuid4())
-        aks_client.clusters = {
-            AZURE_SUBSCRIPTION: {
-                cluster_id: Cluster(
-                    name="cluster_name",
-                    public_fqdn="public_fqdn",
-                    private_fqdn=None,
-                    network_policy="network_policy",
-                    agent_pool_profiles=[mock.MagicMock(enable_node_public_ip=False)],
-                    rbac_enabled=True,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.aks.aks_clusters_public_access_disabled.aks_clusters_public_access_disabled.aks_client",
@@ -61,6 +48,22 @@ class Test_aks_clusters_public_access_disabled:
             from prowler.providers.azure.services.aks.aks_clusters_public_access_disabled.aks_clusters_public_access_disabled import (
                 aks_clusters_public_access_disabled,
             )
+            from prowler.providers.azure.services.aks.aks_service import Cluster
+
+            aks_client.clusters = {
+                AZURE_SUBSCRIPTION: {
+                    cluster_id: Cluster(
+                        name="cluster_name",
+                        public_fqdn="public_fqdn",
+                        private_fqdn=None,
+                        network_policy="network_policy",
+                        agent_pool_profiles=[
+                            mock.MagicMock(enable_node_public_ip=False)
+                        ],
+                        rbac_enabled=True,
+                    )
+                }
+            }
 
             check = aks_clusters_public_access_disabled()
             result = check.execute()
@@ -77,18 +80,6 @@ class Test_aks_clusters_public_access_disabled:
     def test_aks_cluster_private_fqdn(self):
         aks_client = mock.MagicMock
         cluster_id = str(uuid4())
-        aks_client.clusters = {
-            AZURE_SUBSCRIPTION: {
-                cluster_id: Cluster(
-                    name="cluster_name",
-                    public_fqdn="public_fqdn",
-                    private_fqdn="private_fqdn",
-                    network_policy="network_policy",
-                    agent_pool_profiles=[mock.MagicMock(enable_node_public_ip=False)],
-                    rbac_enabled=True,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.aks.aks_clusters_public_access_disabled.aks_clusters_public_access_disabled.aks_client",
@@ -97,6 +88,22 @@ class Test_aks_clusters_public_access_disabled:
             from prowler.providers.azure.services.aks.aks_clusters_public_access_disabled.aks_clusters_public_access_disabled import (
                 aks_clusters_public_access_disabled,
             )
+            from prowler.providers.azure.services.aks.aks_service import Cluster
+
+            aks_client.clusters = {
+                AZURE_SUBSCRIPTION: {
+                    cluster_id: Cluster(
+                        name="cluster_name",
+                        public_fqdn="public_fqdn",
+                        private_fqdn="private_fqdn",
+                        network_policy="network_policy",
+                        agent_pool_profiles=[
+                            mock.MagicMock(enable_node_public_ip=False)
+                        ],
+                        rbac_enabled=True,
+                    )
+                }
+            }
 
             check = aks_clusters_public_access_disabled()
             result = check.execute()
@@ -113,18 +120,6 @@ class Test_aks_clusters_public_access_disabled:
     def test_aks_cluster_private_fqdn_with_public_ip(self):
         aks_client = mock.MagicMock
         cluster_id = str(uuid4())
-        aks_client.clusters = {
-            AZURE_SUBSCRIPTION: {
-                cluster_id: Cluster(
-                    name="cluster_name",
-                    public_fqdn="public_fqdn",
-                    private_fqdn="private_fqdn",
-                    network_policy="network_policy",
-                    agent_pool_profiles=[mock.MagicMock(enable_node_public_ip=True)],
-                    rbac_enabled=True,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.aks.aks_clusters_public_access_disabled.aks_clusters_public_access_disabled.aks_client",
@@ -133,6 +128,22 @@ class Test_aks_clusters_public_access_disabled:
             from prowler.providers.azure.services.aks.aks_clusters_public_access_disabled.aks_clusters_public_access_disabled import (
                 aks_clusters_public_access_disabled,
             )
+            from prowler.providers.azure.services.aks.aks_service import Cluster
+
+            aks_client.clusters = {
+                AZURE_SUBSCRIPTION: {
+                    cluster_id: Cluster(
+                        name="cluster_name",
+                        public_fqdn="public_fqdn",
+                        private_fqdn="private_fqdn",
+                        network_policy="network_policy",
+                        agent_pool_profiles=[
+                            mock.MagicMock(enable_node_public_ip=True)
+                        ],
+                        rbac_enabled=True,
+                    )
+                }
+            }
 
             check = aks_clusters_public_access_disabled()
             result = check.execute()

--- a/tests/providers/azure/services/aks/aks_network_policy_enabled/aks_network_policy_enabled_test.py
+++ b/tests/providers/azure/services/aks/aks_network_policy_enabled/aks_network_policy_enabled_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.aks.aks_service import Cluster
 from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_aks_network_policy_enabled:
     def test_aks_no_subscriptions(self):
         aks_client = mock.MagicMock
-        aks_client.clusters = {}
 
         with mock.patch(
             "prowler.providers.azure.services.aks.aks_network_policy_enabled.aks_network_policy_enabled.aks_client",
@@ -17,6 +15,8 @@ class Test_aks_network_policy_enabled:
             from prowler.providers.azure.services.aks.aks_network_policy_enabled.aks_network_policy_enabled import (
                 aks_network_policy_enabled,
             )
+
+            aks_client.clusters = {}
 
             check = aks_network_policy_enabled()
             result = check.execute()
@@ -24,7 +24,6 @@ class Test_aks_network_policy_enabled:
 
     def test_aks_subscription_empty(self):
         aks_client = mock.MagicMock
-        aks_client.clusters = {AZURE_SUBSCRIPTION: {}}
 
         with mock.patch(
             "prowler.providers.azure.services.aks.aks_network_policy_enabled.aks_network_policy_enabled.aks_client",
@@ -33,6 +32,8 @@ class Test_aks_network_policy_enabled:
             from prowler.providers.azure.services.aks.aks_network_policy_enabled.aks_network_policy_enabled import (
                 aks_network_policy_enabled,
             )
+
+            aks_client.clusters = {AZURE_SUBSCRIPTION: {}}
 
             check = aks_network_policy_enabled()
             result = check.execute()
@@ -41,18 +42,6 @@ class Test_aks_network_policy_enabled:
     def test_aks_network_policy_enabled(self):
         aks_client = mock.MagicMock
         cluster_id = str(uuid4())
-        aks_client.clusters = {
-            AZURE_SUBSCRIPTION: {
-                cluster_id: Cluster(
-                    name="cluster_name",
-                    public_fqdn="public_fqdn",
-                    private_fqdn=None,
-                    network_policy="network_policy",
-                    agent_pool_profiles=[mock.MagicMock(enable_node_public_ip=False)],
-                    rbac_enabled=True,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.aks.aks_network_policy_enabled.aks_network_policy_enabled.aks_client",
@@ -61,6 +50,22 @@ class Test_aks_network_policy_enabled:
             from prowler.providers.azure.services.aks.aks_network_policy_enabled.aks_network_policy_enabled import (
                 aks_network_policy_enabled,
             )
+            from prowler.providers.azure.services.aks.aks_service import Cluster
+
+            aks_client.clusters = {
+                AZURE_SUBSCRIPTION: {
+                    cluster_id: Cluster(
+                        name="cluster_name",
+                        public_fqdn="public_fqdn",
+                        private_fqdn=None,
+                        network_policy="network_policy",
+                        agent_pool_profiles=[
+                            mock.MagicMock(enable_node_public_ip=False)
+                        ],
+                        rbac_enabled=True,
+                    )
+                }
+            }
 
             check = aks_network_policy_enabled()
             result = check.execute()
@@ -77,18 +82,6 @@ class Test_aks_network_policy_enabled:
     def test_aks_network_policy_disabled(self):
         aks_client = mock.MagicMock
         cluster_id = str(uuid4())
-        aks_client.clusters = {
-            AZURE_SUBSCRIPTION: {
-                cluster_id: Cluster(
-                    name="cluster_name",
-                    public_fqdn="public_fqdn",
-                    private_fqdn=None,
-                    network_policy=None,
-                    agent_pool_profiles=[mock.MagicMock(enable_node_public_ip=False)],
-                    rbac_enabled=True,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.aks.aks_network_policy_enabled.aks_network_policy_enabled.aks_client",
@@ -97,6 +90,22 @@ class Test_aks_network_policy_enabled:
             from prowler.providers.azure.services.aks.aks_network_policy_enabled.aks_network_policy_enabled import (
                 aks_network_policy_enabled,
             )
+            from prowler.providers.azure.services.aks.aks_service import Cluster
+
+            aks_client.clusters = {
+                AZURE_SUBSCRIPTION: {
+                    cluster_id: Cluster(
+                        name="cluster_name",
+                        public_fqdn="public_fqdn",
+                        private_fqdn=None,
+                        network_policy=None,
+                        agent_pool_profiles=[
+                            mock.MagicMock(enable_node_public_ip=False)
+                        ],
+                        rbac_enabled=True,
+                    )
+                }
+            }
 
             check = aks_network_policy_enabled()
             result = check.execute()

--- a/tests/providers/azure/services/app/app_client_certificates_on/app_client_certificates_on_test.py
+++ b/tests/providers/azure/services/app/app_client_certificates_on/app_client_certificates_on_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.app.app_service import WebApp
 from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_app_client_certificates_on:
     def test_app_no_subscriptions(self):
         app_client = mock.MagicMock
-        app_client.apps = {}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_client_certificates_on.app_client_certificates_on.app_client",
@@ -17,6 +15,8 @@ class Test_app_client_certificates_on:
             from prowler.providers.azure.services.app.app_client_certificates_on.app_client_certificates_on import (
                 app_client_certificates_on,
             )
+
+            app_client.apps = {}
 
             check = app_client_certificates_on()
             result = check.execute()
@@ -24,7 +24,6 @@ class Test_app_client_certificates_on:
 
     def test_app_subscription_empty(self):
         app_client = mock.MagicMock
-        app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_client_certificates_on.app_client_certificates_on.app_client",
@@ -33,6 +32,8 @@ class Test_app_client_certificates_on:
             from prowler.providers.azure.services.app.app_client_certificates_on.app_client_certificates_on import (
                 app_client_certificates_on,
             )
+
+            app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
             check = app_client_certificates_on()
             result = check.execute()
@@ -41,18 +42,6 @@ class Test_app_client_certificates_on:
     def test_app_client_certificates_on(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=None,
-                    client_cert_mode="Required",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_client_certificates_on.app_client_certificates_on.app_client",
@@ -61,6 +50,20 @@ class Test_app_client_certificates_on:
             from prowler.providers.azure.services.app.app_client_certificates_on.app_client_certificates_on import (
                 app_client_certificates_on,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=None,
+                        client_cert_mode="Required",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_client_certificates_on()
             result = check.execute()
@@ -77,18 +80,6 @@ class Test_app_client_certificates_on:
     def test_app_client_certificates_off(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=None,
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_client_certificates_on.app_client_certificates_on.app_client",
@@ -97,6 +88,20 @@ class Test_app_client_certificates_on:
             from prowler.providers.azure.services.app.app_client_certificates_on.app_client_certificates_on import (
                 app_client_certificates_on,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=None,
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_client_certificates_on()
             result = check.execute()

--- a/tests/providers/azure/services/app/app_ensure_auth_is_set_up/app_ensure_auth_is_set_up_test.py
+++ b/tests/providers/azure/services/app/app_ensure_auth_is_set_up/app_ensure_auth_is_set_up_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.app.app_service import WebApp
 from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_app_ensure_auth_is_set_up:
     def test_app_no_subscriptions(self):
         app_client = mock.MagicMock
-        app_client.apps = {}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_auth_is_set_up.app_ensure_auth_is_set_up.app_client",
@@ -17,6 +15,8 @@ class Test_app_ensure_auth_is_set_up:
             from prowler.providers.azure.services.app.app_ensure_auth_is_set_up.app_ensure_auth_is_set_up import (
                 app_ensure_auth_is_set_up,
             )
+
+            app_client.apps = {}
 
             check = app_ensure_auth_is_set_up()
             result = check.execute()
@@ -24,7 +24,6 @@ class Test_app_ensure_auth_is_set_up:
 
     def test_app_subscription_empty(self):
         app_client = mock.MagicMock
-        app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_auth_is_set_up.app_ensure_auth_is_set_up.app_client",
@@ -33,6 +32,8 @@ class Test_app_ensure_auth_is_set_up:
             from prowler.providers.azure.services.app.app_ensure_auth_is_set_up.app_ensure_auth_is_set_up import (
                 app_ensure_auth_is_set_up,
             )
+
+            app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
             check = app_ensure_auth_is_set_up()
             result = check.execute()
@@ -41,18 +42,6 @@ class Test_app_ensure_auth_is_set_up:
     def test_app_auth_enabled(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_auth_is_set_up.app_ensure_auth_is_set_up.app_client",
@@ -61,6 +50,20 @@ class Test_app_ensure_auth_is_set_up:
             from prowler.providers.azure.services.app.app_ensure_auth_is_set_up.app_ensure_auth_is_set_up import (
                 app_ensure_auth_is_set_up,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_ensure_auth_is_set_up()
             result = check.execute()
@@ -77,18 +80,6 @@ class Test_app_ensure_auth_is_set_up:
     def test_app_auth_disabled(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=False,
-                    configurations=mock.MagicMock(),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_auth_is_set_up.app_ensure_auth_is_set_up.app_client",
@@ -97,6 +88,20 @@ class Test_app_ensure_auth_is_set_up:
             from prowler.providers.azure.services.app.app_ensure_auth_is_set_up.app_ensure_auth_is_set_up import (
                 app_ensure_auth_is_set_up,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=False,
+                        configurations=mock.MagicMock(),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_ensure_auth_is_set_up()
             result = check.execute()

--- a/tests/providers/azure/services/app/app_ensure_http_is_redirected_to_https/app_ensure_http_is_redirected_to_https_test.py
+++ b/tests/providers/azure/services/app/app_ensure_http_is_redirected_to_https/app_ensure_http_is_redirected_to_https_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.app.app_service import WebApp
 from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_app_ensure_http_is_redirected_to_https:
     def test_app_no_subscriptions(self):
         app_client = mock.MagicMock
-        app_client.apps = {}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_http_is_redirected_to_https.app_ensure_http_is_redirected_to_https.app_client",
@@ -17,6 +15,8 @@ class Test_app_ensure_http_is_redirected_to_https:
             from prowler.providers.azure.services.app.app_ensure_http_is_redirected_to_https.app_ensure_http_is_redirected_to_https import (
                 app_ensure_http_is_redirected_to_https,
             )
+
+            app_client.apps = {}
 
             check = app_ensure_http_is_redirected_to_https()
             result = check.execute()
@@ -24,7 +24,6 @@ class Test_app_ensure_http_is_redirected_to_https:
 
     def test_app_subscriptions_empty_empty(self):
         app_client = mock.MagicMock
-        app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_http_is_redirected_to_https.app_ensure_http_is_redirected_to_https.app_client",
@@ -33,6 +32,8 @@ class Test_app_ensure_http_is_redirected_to_https:
             from prowler.providers.azure.services.app.app_ensure_http_is_redirected_to_https.app_ensure_http_is_redirected_to_https import (
                 app_ensure_http_is_redirected_to_https,
             )
+
+            app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
             check = app_ensure_http_is_redirected_to_https()
             result = check.execute()
@@ -41,18 +42,6 @@ class Test_app_ensure_http_is_redirected_to_https:
     def test_app_http_to_https(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_http_is_redirected_to_https.app_ensure_http_is_redirected_to_https.app_client",
@@ -61,6 +50,20 @@ class Test_app_ensure_http_is_redirected_to_https:
             from prowler.providers.azure.services.app.app_ensure_http_is_redirected_to_https.app_ensure_http_is_redirected_to_https import (
                 app_ensure_http_is_redirected_to_https,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_ensure_http_is_redirected_to_https()
             result = check.execute()
@@ -77,18 +80,6 @@ class Test_app_ensure_http_is_redirected_to_https:
     def test_app_http_to_https_enabled(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(),
-                    client_cert_mode="Ignore",
-                    https_only=True,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_http_is_redirected_to_https.app_ensure_http_is_redirected_to_https.app_client",
@@ -97,6 +88,20 @@ class Test_app_ensure_http_is_redirected_to_https:
             from prowler.providers.azure.services.app.app_ensure_http_is_redirected_to_https.app_ensure_http_is_redirected_to_https import (
                 app_ensure_http_is_redirected_to_https,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(),
+                        client_cert_mode="Ignore",
+                        https_only=True,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_ensure_http_is_redirected_to_https()
             result = check.execute()

--- a/tests/providers/azure/services/app/app_ensure_java_version_is_latest/app_ensure_java_version_is_latest_test.py
+++ b/tests/providers/azure/services/app/app_ensure_java_version_is_latest/app_ensure_java_version_is_latest_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.app.app_service import WebApp
 from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_app_ensure_java_version_is_latest:
     def test_app_no_subscriptions(self):
         app_client = mock.MagicMock
-        app_client.apps = {}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest.app_client",
@@ -17,6 +15,8 @@ class Test_app_ensure_java_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest import (
                 app_ensure_java_version_is_latest,
             )
+
+            app_client.apps = {}
 
             check = app_ensure_java_version_is_latest()
             result = check.execute()
@@ -24,7 +24,6 @@ class Test_app_ensure_java_version_is_latest:
 
     def test_app_subscriptions_empty(self):
         app_client = mock.MagicMock
-        app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest.app_client",
@@ -33,6 +32,8 @@ class Test_app_ensure_java_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest import (
                 app_ensure_java_version_is_latest,
             )
+
+            app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
             check = app_ensure_java_version_is_latest()
             result = check.execute()
@@ -41,18 +42,6 @@ class Test_app_ensure_java_version_is_latest:
     def test_app_configurations_none(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=None,
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest.app_client",
@@ -61,6 +50,20 @@ class Test_app_ensure_java_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest import (
                 app_ensure_java_version_is_latest,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=None,
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_ensure_java_version_is_latest()
             result = check.execute()
@@ -69,22 +72,6 @@ class Test_app_ensure_java_version_is_latest:
     def test_app_linux_java_version_latest(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(
-                        linux_fx_version="Tomcat|9.0-java17", java_version=None
-                    ),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
-
-        app_client.audit_config = {"java_latest_version": "17"}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest.app_client",
@@ -93,6 +80,24 @@ class Test_app_ensure_java_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest import (
                 app_ensure_java_version_is_latest,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(
+                            linux_fx_version="Tomcat|9.0-java17", java_version=None
+                        ),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
+
+            app_client.audit_config = {"java_latest_version": "17"}
 
             check = app_ensure_java_version_is_latest()
             result = check.execute()
@@ -109,22 +114,6 @@ class Test_app_ensure_java_version_is_latest:
     def test_app_linux_java_version_not_latest(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(
-                        linux_fx_version="Tomcat|9.0-java11", java_version=None
-                    ),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
-
-        app_client.audit_config = {"java_latest_version": "17"}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest.app_client",
@@ -133,6 +122,24 @@ class Test_app_ensure_java_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest import (
                 app_ensure_java_version_is_latest,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(
+                            linux_fx_version="Tomcat|9.0-java11", java_version=None
+                        ),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
+
+            app_client.audit_config = {"java_latest_version": "17"}
 
             check = app_ensure_java_version_is_latest()
             result = check.execute()
@@ -149,22 +156,6 @@ class Test_app_ensure_java_version_is_latest:
     def test_app_windows_java_version_latest(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(
-                        linux_fx_version="", java_version="17"
-                    ),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
-
-        app_client.audit_config = {"java_latest_version": "17"}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest.app_client",
@@ -173,6 +164,24 @@ class Test_app_ensure_java_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest import (
                 app_ensure_java_version_is_latest,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(
+                            linux_fx_version="", java_version="17"
+                        ),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
+
+            app_client.audit_config = {"java_latest_version": "17"}
 
             check = app_ensure_java_version_is_latest()
             result = check.execute()
@@ -189,22 +198,6 @@ class Test_app_ensure_java_version_is_latest:
     def test_app_windows_java_version_not_latest(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(
-                        linux_fx_version="", java_version="11"
-                    ),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
-
-        app_client.audit_config = {"java_latest_version": "17"}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest.app_client",
@@ -213,6 +206,24 @@ class Test_app_ensure_java_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest import (
                 app_ensure_java_version_is_latest,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(
+                            linux_fx_version="", java_version="11"
+                        ),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
+
+            app_client.audit_config = {"java_latest_version": "17"}
 
             check = app_ensure_java_version_is_latest()
             result = check.execute()
@@ -229,22 +240,6 @@ class Test_app_ensure_java_version_is_latest:
     def test_app_linux_php_version_latest(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(
-                        linux_fx_version="php|8.0", java_version=None
-                    ),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
-
-        app_client.audit_config = {"java_latest_version": "17"}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest.app_client",
@@ -253,6 +248,24 @@ class Test_app_ensure_java_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_java_version_is_latest.app_ensure_java_version_is_latest import (
                 app_ensure_java_version_is_latest,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(
+                            linux_fx_version="php|8.0", java_version=None
+                        ),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
+
+            app_client.audit_config = {"java_latest_version": "17"}
 
             check = app_ensure_java_version_is_latest()
             result = check.execute()

--- a/tests/providers/azure/services/app/app_ensure_php_version_is_latest/app_ensure_php_version_is_latest_test.py
+++ b/tests/providers/azure/services/app/app_ensure_php_version_is_latest/app_ensure_php_version_is_latest_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.app.app_service import WebApp
 from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_app_ensure_php_version_is_latest:
     def test_app_no_subscriptions(self):
         app_client = mock.MagicMock
-        app_client.apps = {}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_php_version_is_latest.app_ensure_php_version_is_latest.app_client",
@@ -17,6 +15,8 @@ class Test_app_ensure_php_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_php_version_is_latest.app_ensure_php_version_is_latest import (
                 app_ensure_php_version_is_latest,
             )
+
+            app_client.apps = {}
 
             check = app_ensure_php_version_is_latest()
             result = check.execute()
@@ -24,7 +24,6 @@ class Test_app_ensure_php_version_is_latest:
 
     def test_app_subscription_empty(self):
         app_client = mock.MagicMock
-        app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_php_version_is_latest.app_ensure_php_version_is_latest.app_client",
@@ -33,6 +32,8 @@ class Test_app_ensure_php_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_php_version_is_latest.app_ensure_php_version_is_latest import (
                 app_ensure_php_version_is_latest,
             )
+
+            app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
             check = app_ensure_php_version_is_latest()
             result = check.execute()
@@ -41,18 +42,6 @@ class Test_app_ensure_php_version_is_latest:
     def test_app_configurations_none(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=None,
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_php_version_is_latest.app_ensure_php_version_is_latest.app_client",
@@ -61,6 +50,20 @@ class Test_app_ensure_php_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_php_version_is_latest.app_ensure_php_version_is_latest import (
                 app_ensure_php_version_is_latest,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=None,
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_ensure_php_version_is_latest()
             result = check.execute()
@@ -69,18 +72,6 @@ class Test_app_ensure_php_version_is_latest:
     def test_app_php_version_not_latest(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(linux_fx_version="php|8.0"),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         app_client.audit_config = {"php_latest_version": "8.2"}
 
@@ -91,6 +82,20 @@ class Test_app_ensure_php_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_php_version_is_latest.app_ensure_php_version_is_latest import (
                 app_ensure_php_version_is_latest,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(linux_fx_version="php|8.0"),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_ensure_php_version_is_latest()
             result = check.execute()
@@ -107,18 +112,6 @@ class Test_app_ensure_php_version_is_latest:
     def test_app_php_version_latest(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(linux_fx_version="php|8.2"),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         app_client.audit_config = {"php_latest_version": "8.2"}
 
@@ -129,6 +122,20 @@ class Test_app_ensure_php_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_php_version_is_latest.app_ensure_php_version_is_latest import (
                 app_ensure_php_version_is_latest,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(linux_fx_version="php|8.2"),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_ensure_php_version_is_latest()
             result = check.execute()

--- a/tests/providers/azure/services/app/app_ensure_python_version_is_latest/app_ensure_python_version_is_latest_test.py
+++ b/tests/providers/azure/services/app/app_ensure_python_version_is_latest/app_ensure_python_version_is_latest_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.app.app_service import WebApp
 from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_app_ensure_python_version_is_latest:
     def test_app_no_subscriptions(self):
         app_client = mock.MagicMock
-        app_client.apps = {}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_python_version_is_latest.app_ensure_python_version_is_latest.app_client",
@@ -17,6 +15,8 @@ class Test_app_ensure_python_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_python_version_is_latest.app_ensure_python_version_is_latest import (
                 app_ensure_python_version_is_latest,
             )
+
+            app_client.apps = {}
 
             check = app_ensure_python_version_is_latest()
             result = check.execute()
@@ -24,7 +24,6 @@ class Test_app_ensure_python_version_is_latest:
 
     def test_app_subscriptions_empty(self):
         app_client = mock.MagicMock
-        app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_python_version_is_latest.app_ensure_python_version_is_latest.app_client",
@@ -33,6 +32,8 @@ class Test_app_ensure_python_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_python_version_is_latest.app_ensure_python_version_is_latest import (
                 app_ensure_python_version_is_latest,
             )
+
+            app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
             check = app_ensure_python_version_is_latest()
             result = check.execute()
@@ -41,18 +42,6 @@ class Test_app_ensure_python_version_is_latest:
     def test_app_configurations_none(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=None,
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_python_version_is_latest.app_ensure_python_version_is_latest.app_client",
@@ -61,6 +50,20 @@ class Test_app_ensure_python_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_python_version_is_latest.app_ensure_python_version_is_latest import (
                 app_ensure_python_version_is_latest,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=None,
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_ensure_python_version_is_latest()
             result = check.execute()
@@ -69,20 +72,6 @@ class Test_app_ensure_python_version_is_latest:
     def test_app_python_version_latest(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(linux_fx_version="python|3.12"),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
-
-        app_client.audit_config = {"python_latest_version": "3.12"}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_python_version_is_latest.app_ensure_python_version_is_latest.app_client",
@@ -91,6 +80,21 @@ class Test_app_ensure_python_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_python_version_is_latest.app_ensure_python_version_is_latest import (
                 app_ensure_python_version_is_latest,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(linux_fx_version="python|3.12"),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
+            app_client.audit_config = {"python_latest_version": "3.12"}
 
             check = app_ensure_python_version_is_latest()
             result = check.execute()
@@ -107,20 +111,6 @@ class Test_app_ensure_python_version_is_latest:
     def test_app_python_version_not_latest(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(linux_fx_version="python|3.10"),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
-
-        app_client.audit_config = {"python_latest_version": "3.12"}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_python_version_is_latest.app_ensure_python_version_is_latest.app_client",
@@ -129,6 +119,22 @@ class Test_app_ensure_python_version_is_latest:
             from prowler.providers.azure.services.app.app_ensure_python_version_is_latest.app_ensure_python_version_is_latest import (
                 app_ensure_python_version_is_latest,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(linux_fx_version="python|3.10"),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
+
+            app_client.audit_config = {"python_latest_version": "3.12"}
 
             check = app_ensure_python_version_is_latest()
             result = check.execute()

--- a/tests/providers/azure/services/app/app_ensure_using_http20/app_ensure_using_http20_test.py
+++ b/tests/providers/azure/services/app/app_ensure_using_http20/app_ensure_using_http20_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.app.app_service import WebApp
 from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_app_ensure_using_http20:
     def test_app_no_subscriptions(self):
         app_client = mock.MagicMock
-        app_client.apps = {}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_using_http20.app_ensure_using_http20.app_client",
@@ -17,6 +15,8 @@ class Test_app_ensure_using_http20:
             from prowler.providers.azure.services.app.app_ensure_using_http20.app_ensure_using_http20 import (
                 app_ensure_using_http20,
             )
+
+            app_client.apps = {}
 
             check = app_ensure_using_http20()
             result = check.execute()
@@ -24,7 +24,6 @@ class Test_app_ensure_using_http20:
 
     def test_app_subscription_empty(self):
         app_client = mock.MagicMock
-        app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_using_http20.app_ensure_using_http20.app_client",
@@ -33,6 +32,8 @@ class Test_app_ensure_using_http20:
             from prowler.providers.azure.services.app.app_ensure_using_http20.app_ensure_using_http20 import (
                 app_ensure_using_http20,
             )
+
+            app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
             check = app_ensure_using_http20()
             result = check.execute()
@@ -41,18 +42,6 @@ class Test_app_ensure_using_http20:
     def test_app_configurations_none(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=None,
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_using_http20.app_ensure_using_http20.app_client",
@@ -61,6 +50,20 @@ class Test_app_ensure_using_http20:
             from prowler.providers.azure.services.app.app_ensure_using_http20.app_ensure_using_http20 import (
                 app_ensure_using_http20,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=None,
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_ensure_using_http20()
             result = check.execute()
@@ -77,18 +80,6 @@ class Test_app_ensure_using_http20:
     def test_app_http20_enabled(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(http20_enabled=True),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_using_http20.app_ensure_using_http20.app_client",
@@ -97,6 +88,20 @@ class Test_app_ensure_using_http20:
             from prowler.providers.azure.services.app.app_ensure_using_http20.app_ensure_using_http20 import (
                 app_ensure_using_http20,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(http20_enabled=True),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_ensure_using_http20()
             result = check.execute()
@@ -113,18 +118,6 @@ class Test_app_ensure_using_http20:
     def test_app_http20_not_enabled(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(http20_enabled=False),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ensure_using_http20.app_ensure_using_http20.app_client",
@@ -133,6 +126,20 @@ class Test_app_ensure_using_http20:
             from prowler.providers.azure.services.app.app_ensure_using_http20.app_ensure_using_http20 import (
                 app_ensure_using_http20,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(http20_enabled=False),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_ensure_using_http20()
             result = check.execute()

--- a/tests/providers/azure/services/app/app_ftp_deployment_disabled/app_ftp_deployment_disabled_test.py
+++ b/tests/providers/azure/services/app/app_ftp_deployment_disabled/app_ftp_deployment_disabled_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.app.app_service import WebApp
 from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_app_ftp_deployment_disabled:
     def test_app_no_subscriptions(self):
         app_client = mock.MagicMock
-        app_client.apps = {}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ftp_deployment_disabled.app_ftp_deployment_disabled.app_client",
@@ -17,6 +15,8 @@ class Test_app_ftp_deployment_disabled:
             from prowler.providers.azure.services.app.app_ftp_deployment_disabled.app_ftp_deployment_disabled import (
                 app_ftp_deployment_disabled,
             )
+
+            app_client.apps = {}
 
             check = app_ftp_deployment_disabled()
             result = check.execute()
@@ -24,7 +24,6 @@ class Test_app_ftp_deployment_disabled:
 
     def test_app_subscriptions_empty(self):
         app_client = mock.MagicMock
-        app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ftp_deployment_disabled.app_ftp_deployment_disabled.app_client",
@@ -33,6 +32,8 @@ class Test_app_ftp_deployment_disabled:
             from prowler.providers.azure.services.app.app_ftp_deployment_disabled.app_ftp_deployment_disabled import (
                 app_ftp_deployment_disabled,
             )
+
+            app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
             check = app_ftp_deployment_disabled()
             result = check.execute()
@@ -41,18 +42,6 @@ class Test_app_ftp_deployment_disabled:
     def test_app_configurations_none(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=None,
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ftp_deployment_disabled.app_ftp_deployment_disabled.app_client",
@@ -61,6 +50,20 @@ class Test_app_ftp_deployment_disabled:
             from prowler.providers.azure.services.app.app_ftp_deployment_disabled.app_ftp_deployment_disabled import (
                 app_ftp_deployment_disabled,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=None,
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_ftp_deployment_disabled()
             result = check.execute()
@@ -77,18 +80,6 @@ class Test_app_ftp_deployment_disabled:
     def test_app_ftp_deployment_disabled(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(ftps_state="AllAllowed"),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ftp_deployment_disabled.app_ftp_deployment_disabled.app_client",
@@ -97,6 +88,20 @@ class Test_app_ftp_deployment_disabled:
             from prowler.providers.azure.services.app.app_ftp_deployment_disabled.app_ftp_deployment_disabled import (
                 app_ftp_deployment_disabled,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(ftps_state="AllAllowed"),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_ftp_deployment_disabled()
             result = check.execute()
@@ -113,18 +118,6 @@ class Test_app_ftp_deployment_disabled:
     def test_app_ftp_deploy_enabled(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(ftps_state="Disabled"),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_ftp_deployment_disabled.app_ftp_deployment_disabled.app_client",
@@ -133,6 +126,20 @@ class Test_app_ftp_deployment_disabled:
             from prowler.providers.azure.services.app.app_ftp_deployment_disabled.app_ftp_deployment_disabled import (
                 app_ftp_deployment_disabled,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(ftps_state="Disabled"),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_ftp_deployment_disabled()
             result = check.execute()

--- a/tests/providers/azure/services/app/app_http_logs_enabled/app_http_logs_enabled_test.py
+++ b/tests/providers/azure/services/app/app_http_logs_enabled/app_http_logs_enabled_test.py
@@ -4,19 +4,18 @@ from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_app_http_logs_enabled:
-
     def test_app_http_logs_enabled_no_subscriptions(self):
         app_client = mock.MagicMock
-        app_client.apps = {}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_http_logs_enabled.app_http_logs_enabled.app_client",
             new=app_client,
         ):
-
             from prowler.providers.azure.services.app.app_http_logs_enabled.app_http_logs_enabled import (
                 app_http_logs_enabled,
             )
+
+            app_client.apps = {}
 
             check = app_http_logs_enabled()
             result = check.execute()
@@ -24,7 +23,6 @@ class Test_app_http_logs_enabled:
 
     def test_app_subscriptions_empty(self):
         app_client = mock.MagicMock
-        app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_register_with_identity.app_register_with_identity.app_client",
@@ -34,12 +32,14 @@ class Test_app_http_logs_enabled:
                 app_register_with_identity,
             )
 
+            app_client.apps = {AZURE_SUBSCRIPTION: {}}
+
             check = app_register_with_identity()
             result = check.execute()
             assert len(result) == 0
 
     def test_no_diagnostics_settings(self):
-        app_client = mock.MagicMock()
+        app_client = mock.MagicMock
         with mock.patch(
             "prowler.providers.azure.services.app.app_http_logs_enabled.app_http_logs_enabled.app_client",
             new=app_client,

--- a/tests/providers/azure/services/app/app_minimum_tls_version_12/app_minimum_tls_version_12_test.py
+++ b/tests/providers/azure/services/app/app_minimum_tls_version_12/app_minimum_tls_version_12_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.app.app_service import WebApp
 from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_app_minimum_tls_version_12:
     def test_app_no_subscriptions(self):
         app_client = mock.MagicMock
-        app_client.apps = {}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_minimum_tls_version_12.app_minimum_tls_version_12.app_client",
@@ -17,6 +15,8 @@ class Test_app_minimum_tls_version_12:
             from prowler.providers.azure.services.app.app_minimum_tls_version_12.app_minimum_tls_version_12 import (
                 app_minimum_tls_version_12,
             )
+
+            app_client.apps = {}
 
             check = app_minimum_tls_version_12()
             result = check.execute()
@@ -24,7 +24,6 @@ class Test_app_minimum_tls_version_12:
 
     def test_app_subscriptions_empty(self):
         app_client = mock.MagicMock
-        app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_minimum_tls_version_12.app_minimum_tls_version_12.app_client",
@@ -33,6 +32,8 @@ class Test_app_minimum_tls_version_12:
             from prowler.providers.azure.services.app.app_minimum_tls_version_12.app_minimum_tls_version_12 import (
                 app_minimum_tls_version_12,
             )
+
+            app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
             check = app_minimum_tls_version_12()
             result = check.execute()
@@ -41,18 +42,6 @@ class Test_app_minimum_tls_version_12:
     def test_app_none_configurations(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=None,
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_minimum_tls_version_12.app_minimum_tls_version_12.app_client",
@@ -61,6 +50,20 @@ class Test_app_minimum_tls_version_12:
             from prowler.providers.azure.services.app.app_minimum_tls_version_12.app_minimum_tls_version_12 import (
                 app_minimum_tls_version_12,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=None,
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_minimum_tls_version_12()
             result = check.execute()
@@ -77,18 +80,6 @@ class Test_app_minimum_tls_version_12:
     def test_app_min_tls_version_12(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=mock.MagicMock(min_tls_version="1.2"),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_minimum_tls_version_12.app_minimum_tls_version_12.app_client",
@@ -97,6 +88,20 @@ class Test_app_minimum_tls_version_12:
             from prowler.providers.azure.services.app.app_minimum_tls_version_12.app_minimum_tls_version_12 import (
                 app_minimum_tls_version_12,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=mock.MagicMock(min_tls_version="1.2"),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_minimum_tls_version_12()
             result = check.execute()
@@ -113,18 +118,6 @@ class Test_app_minimum_tls_version_12:
     def test_app_min_tls_version_10(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=False,
-                    configurations=mock.MagicMock(min_tls_version="1.0"),
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_minimum_tls_version_12.app_minimum_tls_version_12.app_client",
@@ -133,6 +126,20 @@ class Test_app_minimum_tls_version_12:
             from prowler.providers.azure.services.app.app_minimum_tls_version_12.app_minimum_tls_version_12 import (
                 app_minimum_tls_version_12,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=False,
+                        configurations=mock.MagicMock(min_tls_version="1.0"),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_minimum_tls_version_12()
             result = check.execute()

--- a/tests/providers/azure/services/app/app_register_with_identity/app_register_with_identity_test.py
+++ b/tests/providers/azure/services/app/app_register_with_identity/app_register_with_identity_test.py
@@ -1,14 +1,12 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.app.app_service import WebApp
 from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION
 
 
 class Test_app_register_with_identity:
     def test_app_no_subscriptions(self):
         app_client = mock.MagicMock
-        app_client.apps = {}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_register_with_identity.app_register_with_identity.app_client",
@@ -17,6 +15,8 @@ class Test_app_register_with_identity:
             from prowler.providers.azure.services.app.app_register_with_identity.app_register_with_identity import (
                 app_register_with_identity,
             )
+
+            app_client.apps = {}
 
             check = app_register_with_identity()
             result = check.execute()
@@ -24,7 +24,6 @@ class Test_app_register_with_identity:
 
     def test_app_subscriptions_empty(self):
         app_client = mock.MagicMock
-        app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_register_with_identity.app_register_with_identity.app_client",
@@ -33,6 +32,8 @@ class Test_app_register_with_identity:
             from prowler.providers.azure.services.app.app_register_with_identity.app_register_with_identity import (
                 app_register_with_identity,
             )
+
+            app_client.apps = {AZURE_SUBSCRIPTION: {}}
 
             check = app_register_with_identity()
             result = check.execute()
@@ -41,18 +42,6 @@ class Test_app_register_with_identity:
     def test_app_none_configurations(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=None,
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=None,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_register_with_identity.app_register_with_identity.app_client",
@@ -61,6 +50,20 @@ class Test_app_register_with_identity:
             from prowler.providers.azure.services.app.app_register_with_identity.app_register_with_identity import (
                 app_register_with_identity,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=None,
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                    )
+                }
+            }
 
             check = app_register_with_identity()
             result = check.execute()
@@ -77,18 +80,6 @@ class Test_app_register_with_identity:
     def test_app_identity(self):
         resource_id = f"/subscriptions/{uuid4()}"
         app_client = mock.MagicMock
-        app_client.apps = {
-            AZURE_SUBSCRIPTION: {
-                "app_id-1": WebApp(
-                    resource_id=resource_id,
-                    auth_enabled=True,
-                    configurations=None,
-                    client_cert_mode="Ignore",
-                    https_only=False,
-                    identity=mock.MagicMock,
-                )
-            }
-        }
 
         with mock.patch(
             "prowler.providers.azure.services.app.app_register_with_identity.app_register_with_identity.app_client",
@@ -97,6 +88,20 @@ class Test_app_register_with_identity:
             from prowler.providers.azure.services.app.app_register_with_identity.app_register_with_identity import (
                 app_register_with_identity,
             )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=True,
+                        configurations=None,
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=mock.MagicMock,
+                    )
+                }
+            }
 
             check = app_register_with_identity()
             result = check.execute()


### PR DESCRIPTION
### Context

The AKS and App tests was with the old format

### Description

Move all test imports inside the check

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
