### PR TITLE
docs(dashboard): improve dashboard documentation

### DIFF
--- a/docs/tutorials/dashboard.md
+++ b/docs/tutorials/dashboard.md
@@ -5,6 +5,12 @@ Prowler allows you to run your own local dashboards using the csv outputs provid
 prowler dashboard
 ```
 
+To run Prowler local dashboard with docker, use: 
+
+```sh
+docker run -e dashboard=dashboard <prowler-image>
+```
+
 The banner and additional info about the dashboard will be shown on your console:
 <img src="./img/dashboard/dashboard-banner.png">
 

--- a/docs/tutorials/dashboard.md
+++ b/docs/tutorials/dashboard.md
@@ -8,7 +8,7 @@ prowler dashboard
 To run Prowler local dashboard with docker, use: 
 
 ```sh
-docker run -e dashboard=dashboard <prowler-image>
+docker run <prowler-image> dashboard
 ```
 
 The banner and additional info about the dashboard will be shown on your console:

--- a/docs/tutorials/dashboard.md
+++ b/docs/tutorials/dashboard.md
@@ -32,6 +32,8 @@ This page shows all the info related to the compliance selected, you can apply m
 
 <img src="./img/dashboard/dashboard-compliance.png">
 
+To add your own compliance to compliance page, add a file with the compliance name (using `_` instead of `.`) to the path `/dashboard/compliance`
+
 ## S3 Integration
 
 If you are a Prowler Saas customer and you want to use your data from your S3 bucket, you can run:

--- a/docs/tutorials/dashboard.md
+++ b/docs/tutorials/dashboard.md
@@ -5,10 +5,10 @@ Prowler allows you to run your own local dashboards using the csv outputs provid
 prowler dashboard
 ```
 
-To run Prowler local dashboard with docker, use: 
+To run Prowler local dashboard with docker, use:
 
 ```sh
-docker run <prowler-image> dashboard
+docker run toniblyx/prowler:latest dashboard
 ```
 
 The banner and additional info about the dashboard will be shown on your console:
@@ -32,7 +32,36 @@ This page shows all the info related to the compliance selected, you can apply m
 
 <img src="./img/dashboard/dashboard-compliance.png">
 
-To add your own compliance to compliance page, add a file with the compliance name (using `_` instead of `.`) to the path `/dashboard/compliance`
+To add your own compliance to compliance page, add a file with the compliance name (using `_` instead of `.`) to the path `/dashboard/compliance`.
+
+In this file use the format present in the others compliance files to create the table. Example for CIS 2.0:
+```python
+import warnings
+
+from dashboard.common_methods import get_section_containers_cis
+
+warnings.filterwarnings("ignore")
+
+
+def get_table(data):
+    aux = data[
+        [
+            "REQUIREMENTS_ID",
+            "REQUIREMENTS_DESCRIPTION",
+            "REQUIREMENTS_ATTRIBUTES_SECTION",
+            "CHECKID",
+            "STATUS",
+            "REGION",
+            "ACCOUNTID",
+            "RESOURCEID",
+        ]
+    ].copy()
+
+    return get_section_containers_cis(
+        aux, "REQUIREMENTS_ID", "REQUIREMENTS_ATTRIBUTES_SECTION"
+    )
+
+```
 
 ## S3 Integration
 


### PR DESCRIPTION
### Context

This pr improves dashboard documentation


### Description

* Use docker to run prowler dashboard
* Add info about adding an own compliance to compliance page


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
