### PR TITLE
fix(k8s): sanitize context syntax only for output file names

### DIFF
--- a/prowler/providers/kubernetes/kubernetes_provider.py
+++ b/prowler/providers/kubernetes/kubernetes_provider.py
@@ -48,7 +48,7 @@ class KubernetesProvider(Provider):
             sys.exit(1)
 
         self._identity = KubernetesIdentityInfo(
-            context=self._session.context["name"].replace(":", "_").replace("/", "_"),
+            context=self._session.context["name"],
             user=self._session.context["context"]["user"],
             cluster=self._session.context["context"]["cluster"],
         )

--- a/prowler/providers/kubernetes/models.py
+++ b/prowler/providers/kubernetes/models.py
@@ -34,8 +34,6 @@ class KubernetesOutputOptions(ProviderOutputOptions):
             not hasattr(arguments, "output_filename")
             or arguments.output_filename is None
         ):
-            self.output_filename = (
-                f"prowler-output-{identity.context}-{output_file_timestamp}"
-            )
+            self.output_filename = f"prowler-output-{identity.context.replace(':', '_').replace('/', '_')}-{output_file_timestamp}"
         else:
             self.output_filename = arguments.output_filename


### PR DESCRIPTION
### Description

Sanitize context syntax only for output file names, since we want the full EKS ARN for the rest of the locations.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
