### PR TITLE
chore(Azure): Optimize Entra service to use async funcs

### DIFF
--- a/prowler/providers/azure/services/entra/entra_service.py
+++ b/prowler/providers/azure/services/entra/entra_service.py
@@ -22,6 +22,7 @@ class Entra(AzureService):
 
         loop = get_event_loop()
 
+        # Get users first alone because it is a dependency for other attributes
         self.users = loop.run_until_complete(self.__get_users__())
 
         attributes = loop.run_until_complete(

--- a/prowler/providers/azure/services/entra/entra_service.py
+++ b/prowler/providers/azure/services/entra/entra_service.py
@@ -143,7 +143,9 @@ class Entra(AzureService):
         try:
             security_defaults = {}
             for tenant, client in self.clients.items():
-                security_default = await client.policies.identity_security_defaults_enforcement_policy.get()
+                security_default = (
+                    await client.policies.identity_security_defaults_enforcement_policy.get()
+                )
                 security_defaults.update(
                     {
                         tenant: SecurityDefault(


### PR DESCRIPTION
### Context

The implementation of Entra use `await` sentencies but execute all functions in order, this PR change to execute it concurrently.

### Description

Change the Entra service to use the `gather` function to run all functions concurrently.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
