### PR TITLE
docs(azure): audit_info updated to provider

### DIFF
--- a/docs/developer-guide/audit-info.md
+++ b/docs/developer-guide/audit-info.md
@@ -1,9 +1,0 @@
-# Audit Info
-
-In each Prowler provider we have a Python object called `audit_info` which is in charge of keeping the credentials, the configuration and the state of each audit, and it's passed to each service during the `__init__`.
-
-- AWS: https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/aws/lib/audit_info/models.py#L34-L54
-- GCP: https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/aws/lib/audit_info/models.py#L7-L30
-- Azure: https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/azure/lib/audit_info/models.py#L17-L31
-
-This `audit_info` object is shared during the Prowler execution and for that reason is important to mock it in each test to isolate them. See the [testing guide](./unit-testing.md) for more information.

--- a/docs/developer-guide/provider.md
+++ b/docs/developer-guide/provider.md
@@ -1,0 +1,9 @@
+# Providers
+
+In each Prowler provider we have a Python object called `<provider_name>_provider` which is in charge of keeping the credentials, the configuration and the state of each audit, and it's passed to each service during the `__init__`. 
+
+- AWS: https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/aws/aws_provider.py
+- GCP: https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/gcp/gcp_provider.py
+- Azure: https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/azure/azure_provider.py
+
+This `<provider_name>_provider` object is shared during the Prowler execution for each provider and for that reason is important to mock it in each test to isolate them. See the [testing guide](./unit-testing.md) for more information.

--- a/docs/developer-guide/provider.md
+++ b/docs/developer-guide/provider.md
@@ -1,4 +1,4 @@
-# Providers
+# Provider
 
 In each Prowler provider we have a Python object called `<provider_name>_provider` which is in charge of keeping the credentials, the configuration and the state of each audit, and it's passed to each service during the `__init__`. 
 

--- a/docs/developer-guide/unit-testing.md
+++ b/docs/developer-guide/unit-testing.md
@@ -62,50 +62,10 @@ For the AWS provider we have ways to test a Prowler check based on the following
 
 In the following section we are going to explain all of the above scenarios with examples. The main difference between those scenarios comes from if the [Moto](https://github.com/getmoto/moto) library covers the AWS API calls made by the service. You can check the covered API calls [here](https://github.com/getmoto/moto/blob/master/IMPLEMENTATION_COVERAGE.md).
 
-An important point for the AWS testing is that in each check we MUST have a unique `audit_info` which is the key object during the AWS execution to isolate the test execution.
+An important point for the AWS testing is that in each check we MUST have a mocked object, which the one that we test once we have it done. We can do this because of the provider which keeps credentials and configuration.
 
 Check the [Provider](./provider.md) section to get more details.
 
-```python
-# We need to import the AWS_Audit_Info and the Audit_Metadata
-# to set the audit_info to call AWS APIs
-from prowler.providers.aws.lib.audit_info.models import AWS_Audit_Info
-from prowler.providers.common.models import Audit_Metadata
-
-AWS_ACCOUNT_NUMBER = "123456789012"
-
-def set_mocked_audit_info(self):
-  audit_info = AWS_Audit_Info(
-      session_config=None,
-      original_session=None,
-      audit_session=session.Session(
-          profile_name=None,
-          botocore_session=None,
-      ),
-      audit_config=None,
-      audited_account=AWS_ACCOUNT_NUMBER,
-      audited_account_arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root",
-      audited_user_id=None,
-      audited_partition="aws",
-      audited_identity_arn=None,
-      profile=None,
-      profile_region=None,
-      credentials=None,
-      assumed_role_info=None,
-      audited_regions=["us-east-1", "eu-west-1"],
-      organizations_metadata=None,
-      audit_resources=None,
-      mfa_enabled=False,
-      audit_metadata=Audit_Metadata(
-          services_scanned=0,
-          expected_checks=[],
-          completed_checks=0,
-          audit_progress=0,
-      ),
-  )
-
-  return audit_info
-```
 ### Checks
 
 For the AWS tests examples we are going to use the tests for the `iam_password_policy_uppercase` check.
@@ -239,7 +199,9 @@ class Test_iam_password_policy_uppercase:
     # between checks
     current_audit_info = self.set_mocked_audit_info()
 
-    # In this scenario we have to mock also the IAM service and the iam_client from the check to enforce    # that the iam_client used is the one created within this check because patch != import, and if you     # execute tests in parallel some objects can be already initialised hence the check won't be isolated.
+    # In this scenario we have to mock also the IAM service and the iam_client from the check to enforce    
+    # that the iam_client used is the one created within this check because patch != import, and if you     
+    # execute tests in parallel some objects can be already initialised hence the check won't be isolated.
     # In this case we don't use the Moto decorator, we use the mocked IAM client for both objects
     with mock.patch(
         "prowler.providers.aws.services.iam.iam_service.IAM",

--- a/docs/developer-guide/unit-testing.md
+++ b/docs/developer-guide/unit-testing.md
@@ -64,7 +64,7 @@ In the following section we are going to explain all of the above scenarios with
 
 An important point for the AWS testing is that in each check we MUST have a unique `audit_info` which is the key object during the AWS execution to isolate the test execution.
 
-Check the [Audit Info](./audit-info.md) section to get more details.
+Check the [Provider](./provider.md) section to get more details.
 
 ```python
 # We need to import the AWS_Audit_Info and the Audit_Metadata

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,7 @@ nav:
           - Authentication: tutorials/gcp/authentication.md
   - Developer Guide:
       - Introduction: developer-guide/introduction.md
-      - Audit Info: developer-guide/audit-info.md
+      - Provider: developer-guide/provider.md
       - Services: developer-guide/services.md
       - Checks: developer-guide/checks.md
       - Documentation: developer-guide/documentation.md


### PR DESCRIPTION
### Context

audit_info doc updated to provider


### Description

Documentation in developer guide about audit_info updated to provider, which is what we right now have in Prowler V4.
We don't use audit_info anymore, we now have the provider file for each provider which works better, that's what im updating in the documentation here.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
