### PR TITLE
fix(compliance): Add new fields to csv output for ENS compliance

### DIFF
--- a/prowler/compliance/aws/ens_rd2022_aws.json
+++ b/prowler/compliance/aws/ens_rd2022_aws.json
@@ -1365,7 +1365,7 @@
       "Checks": [
         "iam_policy_allows_privilege_escalation",
         "iam_customer_attached_policy_no_administrative_privileges",
-        "iam_customer_unattached_policy_no_administrative_privilege",
+        "iam_customer_unattached_policy_no_administrative_privileges",
         "iam_no_custom_policy_permissive_role_assumption",
         "iam_policy_attached_only_to_group_or_roles",
         "iam_role_cross_service_confused_deputy_prevention",

--- a/prowler/lib/check/compliance_models.py
+++ b/prowler/lib/check/compliance_models.py
@@ -46,6 +46,8 @@ class ENS_Requirement_Attribute(BaseModel):
     Tipo: ENS_Requirement_Attribute_Tipos
     Nivel: ENS_Requirement_Attribute_Nivel
     Dimensiones: list[ENS_Requirement_Attribute_Dimensiones]
+    ModoEjecucion: str
+    Dependencias: list[str]
 
 
 # Generic Compliance Requirement Attribute

--- a/prowler/lib/outputs/compliance.py
+++ b/prowler/lib/outputs/compliance.py
@@ -84,6 +84,10 @@ def fill_compliance(output_options, finding, audit_info, file_descriptors):
                             Requirements_Attributes_Dimensiones=",".join(
                                 attribute.Dimensiones
                             ),
+                            Requirements_Attributes_ModoEjecucion=attribute.ModoEjecucion,
+                            Requirements_Attributes_Dependencias=",".join(
+                                attribute.Dependencias
+                            ),
                             Status=finding.status,
                             StatusExtended=finding.status_extended,
                             ResourceId=finding.resource_id,

--- a/prowler/lib/outputs/models.py
+++ b/prowler/lib/outputs/models.py
@@ -536,6 +536,8 @@ class Check_Output_CSV_ENS_RD2022(BaseModel):
     Requirements_Attributes_Nivel: str
     Requirements_Attributes_Tipo: str
     Requirements_Attributes_Dimensiones: str
+    Requirements_Attributes_ModoEjecucion: str
+    Requirements_Attributes_Dependencias: Optional[str]
     Status: str
     StatusExtended: str
     ResourceId: str


### PR DESCRIPTION
### Context

This pr adds two new fields to csv output for ENS compliance:
* ModoEjecucion
* Dependencias


### Description

Changes in models and csv generation to admit new fields


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
