### PR TITLE
fix(service_name): fix typo in ServiceName field for v3

### DIFF
--- a/prowler/providers/aws/services/eks/eks_cluster_private_nodes_enabled/eks_cluster_private_nodes_enabled.metadata.json
+++ b/prowler/providers/aws/services/eks/eks_cluster_private_nodes_enabled/eks_cluster_private_nodes_enabled.metadata.json
@@ -6,7 +6,7 @@
     "Security",
     "Configuration"
   ],
-  "ServiceName": "EKS",
+  "ServiceName": "eks",
   "SubServiceName": "",
   "ResourceIdTemplate": "",
   "Severity": "high",

--- a/prowler/providers/gcp/services/artifacts/artifacts_container_analysis_enabled/artifacts_container_analysis_enabled.metadata.json
+++ b/prowler/providers/gcp/services/artifacts/artifacts_container_analysis_enabled/artifacts_container_analysis_enabled.metadata.json
@@ -6,7 +6,7 @@
     "Security",
     "Configuration"
   ],
-  "ServiceName": "Artifact Registry",
+  "ServiceName": "artifactregistry",
   "SubServiceName": "Container Analysis",
   "ResourceIdTemplate": "",
   "Severity": "medium",

--- a/prowler/providers/gcp/services/artifacts/artifacts_container_analysis_enabled/artifacts_container_analysis_enabled.metadata.json
+++ b/prowler/providers/gcp/services/artifacts/artifacts_container_analysis_enabled/artifacts_container_analysis_enabled.metadata.json
@@ -6,7 +6,7 @@
     "Security",
     "Configuration"
   ],
-  "ServiceName": "artifactregistry",
+  "ServiceName": "artifacts",
   "SubServiceName": "Container Analysis",
   "ResourceIdTemplate": "",
   "Severity": "medium",

--- a/prowler/providers/gcp/services/gcr/gcr_container_scanning_enabled/gcr_container_scanning_enabled.metadata.json
+++ b/prowler/providers/gcp/services/gcr/gcr_container_scanning_enabled/gcr_container_scanning_enabled.metadata.json
@@ -6,7 +6,7 @@
     "Security",
     "Configuration"
   ],
-  "ServiceName": "Google Container Registry (GCR)",
+  "ServiceName": "gcr",
   "SubServiceName": "Container Scanning",
   "ResourceIdTemplate": "",
   "Severity": "medium",

--- a/prowler/providers/gcp/services/gke/gke_cluster_no_default_service_account/gke_cluster_no_default_service_account.metadata.json
+++ b/prowler/providers/gcp/services/gke/gke_cluster_no_default_service_account/gke_cluster_no_default_service_account.metadata.json
@@ -6,7 +6,7 @@
     "Security",
     "Configuration"
   ],
-  "ServiceName": "Google Kubernetes Engine (GKE)",
+  "ServiceName": "gke",
   "SubServiceName": "",
   "ResourceIdTemplate": "",
   "Severity": "medium",


### PR DESCRIPTION
### Context

This pr fix the typo in ServiceName field for eks_cluster_private_nodes_enabled


### Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
