### PR TITLE
docs(mutelist): remove MUTED and explain new fields

### DIFF
--- a/docs/tutorials/mutelist.md
+++ b/docs/tutorials/mutelist.md
@@ -1,14 +1,17 @@
 # Mutelisting
 Sometimes you may find resources that are intentionally configured in a certain way that may be a bad practice but it is all right with it, for example an AWS S3 Bucket open to the internet hosting a web site, or an AWS Security Group with an open port needed in your use case.
 
-Mutelist option works along with other options and adds a `MUTED` instead of `MANUAL`, `PASS` or `FAIL` to any output format.
+Mutelist option works along with other options and will modify the output in the following way:
+- JSON-OCSF: `status_id` is `Suppressed` if the finding is muted.
+- CSV: `muted` is `True`. The field `status` will keep the original status, `MANUAL`, `PASS` or `FAIL`, of the finding.
+
 
 You can use `-w`/`--mutelist-file` with the path of your mutelist yaml file:
 ```
 prowler <provider> -w mutelist.yaml
 ```
 
-## Mutelist Yaml File Syntax
+## Mutelist YAML File Syntax
 
 ???+ note
     For Azure provider, the Account ID is the Subscription Name and the Region is the Location.
@@ -94,7 +97,9 @@ The Mutelist file is a YAML file with the following syntax:
                 Tags:
                   - "environment=prod"   # Will ignore every resource except in account 123456789012 except the ones containing the string "test" and tag environment=prod
 ```
-## Mute specific AWS regions
+
+## AWS Mutelist
+### Mute specific AWS regions
 If you want to mute failed findings only in specific regions, create a file with the following syntax and run it with `prowler aws -w mutelist.yaml`:
 
     Mutelist:
@@ -108,15 +113,15 @@ If you want to mute failed findings only in specific regions, create a file with
             Resources:
               - "*"
 
-## Default AWS Mutelist
+### Default Mutelist
 For the AWS Provider, Prowler is executed with a Default AWS Mutelist with the AWS Resources that should be muted such as all resources created by AWS Control Tower when setting up a landing zone.
 You can see this Mutelist file in [`prowler/config/aws_mutelist.yaml`](https://github.com/prowler-cloud/prowler/blob/master/prowler/config/aws_allowlist.yaml).
 
-## Supported AWS Mutelist Locations
+### Supported Mutelist Locations
 
 The mutelisting flag supports the following AWS locations when using the AWS Provider:
 
-### AWS S3 URI
+#### AWS S3 URI
 You will need to pass the S3 URI where your Mutelist YAML file was uploaded to your bucket:
 ```
 prowler aws -w s3://<bucket>/<prefix>/mutelist.yaml
@@ -124,7 +129,7 @@ prowler aws -w s3://<bucket>/<prefix>/mutelist.yaml
 ???+ note
     Make sure that the used AWS credentials have `s3:GetObject` permissions in the S3 path where the mutelist file is located.
 
-### AWS DynamoDB Table ARN
+#### AWS DynamoDB Table ARN
 
 You will need to pass the DynamoDB Mutelist Table ARN:
 
@@ -150,7 +155,7 @@ The following example will mute all resources in all accounts for the EC2 checks
 ???+ note
     Make sure that the used AWS credentials have `dynamodb:PartiQLSelect` permissions in the table.
 
-### AWS Lambda ARN
+#### AWS Lambda ARN
 
 You will need to pass the AWS Lambda Function ARN:
 

--- a/docs/tutorials/mutelist.md
+++ b/docs/tutorials/mutelist.md
@@ -1,8 +1,8 @@
 # Mutelisting
 Sometimes you may find resources that are intentionally configured in a certain way that may be a bad practice but it is all right with it, for example an AWS S3 Bucket open to the internet hosting a web site, or an AWS Security Group with an open port needed in your use case.
 
-Mutelist option works along with other options and will modify the output in the following way:
-- JSON-OCSF: `status_id` is `Suppressed` if the finding is muted.
+Mutelist option works along with other options and will modify the output in the following way if the finding is muted:
+- JSON-OCSF: `status_id` is `Suppressed`.
 - CSV: `muted` is `True`. The field `status` will keep the original status, `MANUAL`, `PASS` or `FAIL`, of the finding.
 
 

--- a/docs/tutorials/mutelist.md
+++ b/docs/tutorials/mutelist.md
@@ -2,6 +2,7 @@
 Sometimes you may find resources that are intentionally configured in a certain way that may be a bad practice but it is all right with it, for example an AWS S3 Bucket open to the internet hosting a web site, or an AWS Security Group with an open port needed in your use case.
 
 Mutelist option works along with other options and will modify the output in the following way if the finding is muted:
+
 - JSON-OCSF: `status_id` is `Suppressed`.
 - CSV: `muted` is `True`. The field `status` will keep the original status, `MANUAL`, `PASS` or `FAIL`, of the finding.
 


### PR DESCRIPTION
### Context

Since Prowler v4, `WARNING` or `MUTED` are not valid statuses, the finding has a `muted` attribute to store if muted or not.

### Description

MUTED is not valid status anymore. Remove it from the documentation.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
