### PR TITLE
fix(download): remove dataframe index from download in dashboard

### DIFF
--- a/dashboard/pages/overview.py
+++ b/dashboard/pages/overview.py
@@ -1008,8 +1008,9 @@ def filter_data(
         )
     ]
     if ctx.triggered_id == "download_link":
+
         csv_data = dcc.send_data_frame(
-            table_data.to_csv, "prowler-dashboard-export.csv"
+            table_data.to_csv, "prowler-dashboard-export.csv", index=False
         )
         return (
             status_graph,


### PR DESCRIPTION
### Context

When downloading the overview table from the dashboard the first column was the index. This pr removes this column.

Shout out @jfagoagas 

### Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
