### PR TITLE
feat(gcp): improve Google Projects scan customization

### DIFF
--- a/docs/tutorials/gcp/projects.md
+++ b/docs/tutorials/gcp/projects.md
@@ -1,0 +1,28 @@
+# GCP Projects
+
+By default, Prowler is multi-project, which means that is going to scan all the Google Cloud projects that the authenticated user has access to. If you want to scan a specific project(s), you can use the `--project-ids` argument.
+
+```console
+prowler gcp --project-ids project-id1 project-id2
+```
+
+???+ note
+    You can use asterisk `*` to scan projects that match a pattern. For example, `prowler gcp --project-ids "prowler*"` will scan all the projects that start with `prowler`.
+
+???+ note
+    If you want to know the projects that you have access to, you can use the following command:
+
+    ```console
+    prowler gcp --list-project-ids
+    ```
+
+### Exclude Projects
+
+If you want to exclude some projects from the scan, you can use the `--exclude-project-ids` argument.
+
+```console
+prowler gcp --exclude-project-ids project-id1 project-id2
+```
+
+???+ note
+    You can use asterisk `*` to exclude projects that match a pattern. For example, `prowler gcp --exclude-project-ids "sys*"` will exclude all the projects that start with `sys`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
           - Subscriptions: tutorials/azure/subscriptions.md
       - Google Cloud:
           - Authentication: tutorials/gcp/authentication.md
+          - Projects: tutorials/gcp/projects.md
   - Developer Guide:
       - Introduction: developer-guide/introduction.md
       - Audit Info: developer-guide/audit-info.md

--- a/prowler/providers/gcp/lib/arguments/arguments.py
+++ b/prowler/providers/gcp/lib/arguments/arguments.py
@@ -12,12 +12,25 @@ def init_parser(self):
         metavar="FILE_PATH",
         help="Authenticate using a Google Service Account Application Credentials JSON file",
     )
-    # Subscriptions
-    gcp_subscriptions_subparser = gcp_parser.add_argument_group("Projects")
-    gcp_subscriptions_subparser.add_argument(
+    # Projects
+    gcp_projects_subparser = gcp_parser.add_argument_group("Projects")
+    gcp_projects_subparser.add_argument(
         "--project-id",
         "--project-ids",
         nargs="+",
         default=[],
         help="GCP Project IDs to be scanned by Prowler",
+    )
+    gcp_projects_subparser.add_argument(
+        "--excluded-project-id",
+        "--excluded-project-ids",
+        nargs="+",
+        default=[],
+        help="Excluded GCP Project IDs to be scanned by Prowler",
+    )
+    gcp_projects_subparser.add_argument(
+        "--list-project-id",
+        "--list-project-ids",
+        action="store_true",
+        help="List available project IDs in Google Cloud which can be scanned by Prowler",
     )

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -1188,6 +1188,24 @@ class Test_Parser:
         assert parsed.project_id[0] == project_1
         assert parsed.project_id[1] == project_2
 
+    def test_parser_gcp_excluded_project_id(self):
+        argument = "--excluded-project-id"
+        project_1 = "test_project_1"
+        project_2 = "test_project_2"
+        command = [prowler_command, "gcp", argument, project_1, project_2]
+        parsed = self.parser.parse(command)
+        assert parsed.provider == "gcp"
+        assert len(parsed.excluded_project_id) == 2
+        assert parsed.excluded_project_id[0] == project_1
+        assert parsed.excluded_project_id[1] == project_2
+
+    def test_parser_gcp_list_project_id(self):
+        argument = "--list-project-id"
+        command = [prowler_command, "gcp", argument]
+        parsed = self.parser.parse(command)
+        assert parsed.provider == "gcp"
+        assert parsed.list_project_id
+
     def test_parser_kubernetes_auth_kubeconfig_file(self):
         argument = "--kubeconfig-file"
         file = "config"

--- a/tests/providers/gcp/gcp_provider_test.py
+++ b/tests/providers/gcp/gcp_provider_test.py
@@ -14,6 +14,8 @@ class TestGCPProvider:
     def test_gcp_provider(self):
         arguments = Namespace()
         arguments.project_id = []
+        arguments.excluded_project_id = []
+        arguments.list_project_id = False
         arguments.credentials_file = ""
         arguments.config_file = default_config_file_path
 
@@ -47,6 +49,8 @@ class TestGCPProvider:
     def test_gcp_provider_output_options(self):
         arguments = Namespace()
         arguments.project_id = []
+        arguments.excluded_project_id = []
+        arguments.list_project_id = False
         arguments.credentials_file = ""
         arguments.config_file = default_config_file_path
 
@@ -106,3 +110,58 @@ class TestGCPProvider:
             # TODO: move this to a fixtures file
             rmdir(f"{arguments.output_directory}/compliance")
             rmdir(arguments.output_directory)
+
+    @freeze_time(datetime.today())
+    def test_is_project_matching(self):
+        arguments = Namespace()
+        arguments.project_id = []
+        arguments.excluded_project_id = []
+        arguments.list_project_id = False
+        arguments.credentials_file = ""
+        arguments.config_file = default_config_file_path
+
+        # Output options
+        arguments.status = []
+        arguments.output_formats = ["csv"]
+        arguments.output_directory = "output_test_directory"
+        arguments.verbose = True
+        arguments.only_logs = False
+        arguments.unix_timestamp = False
+        arguments.shodan = "test-api-key"
+
+        projects = {
+            "test-project": GCPProject(
+                number="55555555",
+                id="project/55555555",
+                name="test-project",
+                labels="",
+                lifecycle_state="",
+            )
+        }
+        with patch(
+            "prowler.providers.gcp.gcp_provider.GcpProvider.setup_session",
+            return_value=None,
+        ), patch(
+            "prowler.providers.gcp.gcp_provider.GcpProvider.get_projects",
+            return_value=projects,
+        ), patch(
+            "prowler.providers.gcp.gcp_provider.GcpProvider.update_projects_with_organizations",
+            return_value=None,
+        ):
+            gcp_provider = GcpProvider(arguments)
+            gcp_provider.output_options = arguments, {}
+        input_project = "sys-*"
+        project_to_match = "sys-12345678"
+        assert gcp_provider.is_project_matching(input_project, project_to_match)
+        input_project = "*prowler"
+        project_to_match = "test-prowler"
+        assert gcp_provider.is_project_matching(input_project, project_to_match)
+        input_project = "test-project"
+        project_to_match = "test-project"
+        assert gcp_provider.is_project_matching(input_project, project_to_match)
+        input_project = "*test*"
+        project_to_match = "prowler-test-project"
+        assert gcp_provider.is_project_matching(input_project, project_to_match)
+        input_project = "prowler-test-project"
+        project_to_match = "prowler-test"
+        assert not gcp_provider.is_project_matching(input_project, project_to_match)


### PR DESCRIPTION
### Description

Improve Google Projects scan customization by:

- Allowing asterisk  `*` in `--project-ids` flag.
<img width="593" alt="image" src="https://github.com/prowler-cloud/prowler/assets/38561120/bfafbcca-22fe-4cc8-ac50-95c62d4f216e">


- Adding `--list-project-ids` flag to allow the user to copy and paste values and know the accessible projects to be scanned.
<img width="1223" alt="image" src="https://github.com/prowler-cloud/prowler/assets/38561120/a1ef5cfb-ae7e-4b9c-ad05-89b11c2ed4f0">

- Adding `--excluded-project-ids` flag to allow the user to exclude projects to be scanned (it also accepts asterisk `*`).
<img width="1152" alt="image" src="https://github.com/prowler-cloud/prowler/assets/38561120/133a39f9-513a-45e6-b956-ce65b0fade2b">



### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
