### PR TITLE
chore(docs): Support toggle light/dark mode

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,8 +16,23 @@ theme:
     - navigation.sections
     - navigation.top
   palette:
-    primary: black
-    accent: green
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: black
+      accent: green
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      accent: green
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
 
 plugins:
   - search


### PR DESCRIPTION
### Context

Reading the documentation only in clear mode can be a bit tiring for the eyes.


### Description

This PR includes the necessary `mkdocks.yml` changes to support clear and dark mode. The first time is chosen according to system preferences.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
