### PR TITLE
fix(compliance): Add muted info to compliance outputs

### DIFF
--- a/prowler/config/aws_mutelist.yaml
+++ b/prowler/config/aws_mutelist.yaml
@@ -5,8 +5,62 @@ Mutelist:
       ### The following entries includes all resources created by AWS Control Tower when setting up a landing zone ###
       # https://docs.aws.amazon.com/controltower/latest/userguide/how-control-tower-works.html #
       Checks:
-        "*":
+        "cloudwatch_log_group_*":
+          Regions:
+            - "*"
+          Resources:
+            - "/aws/lambda/aws-controltower-NotificationForwarder"
+            - "StackSet-AWSControlTowerBP-*"
+        "awslambda_function_*":
+          Regions:
+            - "*"
+          Resources:
+            - "aws-controltower-NotificationForwarder"
+        "cloudformation_stacks_*":
+          Regions:
+            - "*"
+          Resources:
+            - "StackSet-AWSControlTowerGuardrailAWS-*"
+            - "StackSet-AWSControlTowerBP-*"
+        "cloudtrail_*":
+          Regions:
+            - "*"
+          Resources:
+            - "aws-controltower-BaselineCloudTrail"
+        "iam_role_*":
+          Regions:
+            - "*"
+          Resources:
+            - "aws-controltower-AdministratorExecutionRole"
+            - "aws-controltower-CloudWatchLogsRole"
+            - "aws-controltower-ConfigRecorderRole"
+            - "aws-controltower-ForwardSnsNotificationRole"
+            - "aws-controltower-ReadOnlyExecutionRole"
+            - "AWSControlTower_VPCFlowLogsRole"
+            - "AWSControlTowerExecution"
+            - "AWSAFTAdmin"
+            - "AWSAFTExecution"
+            - "AWSAFTService"
+        "iam_policy_*":
+          Regions:
+            - "*"
+          Resources:
+            - "AWSControlTowerServiceRolePolicy"
+        "s3_bucket_*":
+          Regions:
+            - "*"
+          Resources:
+            - "aws-controltower-logs-*"
+            - "aws-controltower-s3-access-logs-*"
+        "sns_*":
+          Regions:
+            - "*"
+          Resources:
+            - "aws-controltower-SecurityNotifications"
+        "vpc_*":
           Regions:
             - "*"
           Resources:
             - "*"
+          Tags:
+            - "Name=aws-controltower-VPC"

--- a/prowler/config/aws_mutelist.yaml
+++ b/prowler/config/aws_mutelist.yaml
@@ -5,62 +5,8 @@ Mutelist:
       ### The following entries includes all resources created by AWS Control Tower when setting up a landing zone ###
       # https://docs.aws.amazon.com/controltower/latest/userguide/how-control-tower-works.html #
       Checks:
-        "cloudwatch_log_group_*":
-          Regions:
-            - "*"
-          Resources:
-            - "/aws/lambda/aws-controltower-NotificationForwarder"
-            - "StackSet-AWSControlTowerBP-*"
-        "awslambda_function_*":
-          Regions:
-            - "*"
-          Resources:
-            - "aws-controltower-NotificationForwarder"
-        "cloudformation_stacks_*":
-          Regions:
-            - "*"
-          Resources:
-            - "StackSet-AWSControlTowerGuardrailAWS-*"
-            - "StackSet-AWSControlTowerBP-*"
-        "cloudtrail_*":
-          Regions:
-            - "*"
-          Resources:
-            - "aws-controltower-BaselineCloudTrail"
-        "iam_role_*":
-          Regions:
-            - "*"
-          Resources:
-            - "aws-controltower-AdministratorExecutionRole"
-            - "aws-controltower-CloudWatchLogsRole"
-            - "aws-controltower-ConfigRecorderRole"
-            - "aws-controltower-ForwardSnsNotificationRole"
-            - "aws-controltower-ReadOnlyExecutionRole"
-            - "AWSControlTower_VPCFlowLogsRole"
-            - "AWSControlTowerExecution"
-            - "AWSAFTAdmin"
-            - "AWSAFTExecution"
-            - "AWSAFTService"
-        "iam_policy_*":
-          Regions:
-            - "*"
-          Resources:
-            - "AWSControlTowerServiceRolePolicy"
-        "s3_bucket_*":
-          Regions:
-            - "*"
-          Resources:
-            - "aws-controltower-logs-*"
-            - "aws-controltower-s3-access-logs-*"
-        "sns_*":
-          Regions:
-            - "*"
-          Resources:
-            - "aws-controltower-SecurityNotifications"
-        "vpc_*":
+        "*":
           Regions:
             - "*"
           Resources:
             - "*"
-          Tags:
-            - "Name=aws-controltower-VPC"

--- a/prowler/lib/outputs/compliance/aws_well_architected_framework.py
+++ b/prowler/lib/outputs/compliance/aws_well_architected_framework.py
@@ -50,6 +50,7 @@ def write_compliance_row_aws_well_architected_framework(
                     StatusExtended=finding.status_extended,
                     ResourceId=finding.resource_id,
                     CheckId=finding.check_metadata.CheckID,
+                    Muted=finding.muted,
                 )
 
                 csv_writer.writerow(compliance_row.__dict__)

--- a/prowler/lib/outputs/compliance/cis.py
+++ b/prowler/lib/outputs/compliance/cis.py
@@ -1,3 +1,7 @@
+from colorama import Fore, Style
+from tabulate import tabulate
+
+from prowler.config.config import orange_color
 from prowler.lib.logger import logger
 from prowler.lib.outputs.compliance.cis_aws import generate_compliance_row_cis_aws
 from prowler.lib.outputs.compliance.cis_azure import generate_compliance_row_cis_azure
@@ -67,3 +71,121 @@ def write_compliance_row_cis(
         logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
+
+
+def get_cis_table(
+    findings: list,
+    bulk_checks_metadata: dict,
+    compliance_framework: str,
+    output_filename: str,
+    output_directory: str,
+    compliance_overview: bool,
+):
+    sections = {}
+    cis_compliance_table = {
+        "Provider": [],
+        "Section": [],
+        "Level 1": [],
+        "Level 2": [],
+        "Muted": [],
+    }
+    pass_count = []
+    fail_count = []
+    muted_count = []
+    for index, finding in enumerate(findings):
+        check = bulk_checks_metadata[finding.check_metadata.CheckID]
+        check_compliances = check.Compliance
+        for compliance in check_compliances:
+            if (
+                compliance.Framework == "CIS"
+                and compliance.Version in compliance_framework
+            ):
+                for requirement in compliance.Requirements:
+                    for attribute in requirement.Attributes:
+                        section = attribute.Section
+                        # Check if Section exists
+                        if section not in sections:
+                            sections[section] = {
+                                "Status": f"{Fore.GREEN}PASS{Style.RESET_ALL}",
+                                "Level 1": {"FAIL": 0, "PASS": 0},
+                                "Level 2": {"FAIL": 0, "PASS": 0},
+                                "Muted": 0,
+                            }
+                        if finding.muted:
+                            if index not in muted_count:
+                                muted_count.append(index)
+                                sections[section]["Muted"] += 1
+                        else:
+                            if finding.status == "FAIL" and index not in fail_count:
+                                fail_count.append(index)
+                            elif finding.status == "PASS" and index not in pass_count:
+                                pass_count.append(index)
+                        if "Level 1" in attribute.Profile:
+                            if not finding.muted:
+                                if finding.status == "FAIL":
+                                    sections[section]["Level 1"]["FAIL"] += 1
+                                else:
+                                    sections[section]["Level 1"]["PASS"] += 1
+                        elif "Level 2" in attribute.Profile:
+                            if not finding.muted:
+                                if finding.status == "FAIL":
+                                    sections[section]["Level 2"]["FAIL"] += 1
+                                else:
+                                    sections[section]["Level 2"]["PASS"] += 1
+
+    # Add results to table
+    sections = dict(sorted(sections.items()))
+    for section in sections:
+        cis_compliance_table["Provider"].append(compliance.Provider)
+        cis_compliance_table["Section"].append(section)
+        if sections[section]["Level 1"]["FAIL"] > 0:
+            cis_compliance_table["Level 1"].append(
+                f"{Fore.RED}FAIL({sections[section]['Level 1']['FAIL']}){Style.RESET_ALL}"
+            )
+        else:
+            cis_compliance_table["Level 1"].append(
+                f"{Fore.GREEN}PASS({sections[section]['Level 1']['PASS']}){Style.RESET_ALL}"
+            )
+        if sections[section]["Level 2"]["FAIL"] > 0:
+            cis_compliance_table["Level 2"].append(
+                f"{Fore.RED}FAIL({sections[section]['Level 2']['FAIL']}){Style.RESET_ALL}"
+            )
+        else:
+            cis_compliance_table["Level 2"].append(
+                f"{Fore.GREEN}PASS({sections[section]['Level 2']['PASS']}){Style.RESET_ALL}"
+            )
+        cis_compliance_table["Muted"].append(
+            f"{orange_color}{sections[section]['Muted']}{Style.RESET_ALL}"
+        )
+    if (
+        len(fail_count) + len(pass_count) + len(muted_count) > 1
+    ):  # If there are no resources, don't print the compliance table
+        print(
+            f"\nCompliance Status of {Fore.YELLOW}{compliance_framework.upper()}{Style.RESET_ALL} Framework:"
+        )
+        overview_table = [
+            [
+                f"{Fore.RED}{round(len(fail_count) / len(findings) * 100, 2)}% ({len(fail_count)}) FAIL{Style.RESET_ALL}",
+                f"{Fore.GREEN}{round(len(pass_count) / len(findings) * 100, 2)}% ({len(pass_count)}) PASS{Style.RESET_ALL}",
+                f"{orange_color}{round(len(muted_count) / len(findings) * 100, 2)}% ({len(muted_count)}) MUTED{Style.RESET_ALL}",
+            ]
+        ]
+        print(tabulate(overview_table, tablefmt="rounded_grid"))
+        if not compliance_overview:
+            print(
+                f"\nFramework {Fore.YELLOW}{compliance_framework.upper()}{Style.RESET_ALL} Results:"
+            )
+            print(
+                tabulate(
+                    cis_compliance_table,
+                    headers="keys",
+                    tablefmt="rounded_grid",
+                )
+            )
+            print(
+                f"{Style.BRIGHT}* Only sections containing results appear.{Style.RESET_ALL}"
+            )
+            print(f"\nDetailed results of {compliance_framework.upper()} are in:")
+            print(
+                f" - CSV: {output_directory}/compliance/{output_filename}_{compliance_framework}.csv\n"
+            )

--- a/prowler/lib/outputs/compliance/cis_aws.py
+++ b/prowler/lib/outputs/compliance/cis_aws.py
@@ -29,6 +29,7 @@ def generate_compliance_row_cis_aws(
         StatusExtended=finding.status_extended,
         ResourceId=finding.resource_id,
         CheckId=finding.check_metadata.CheckID,
+        Muted=finding.muted,
     )
     csv_header = generate_csv_fields(Check_Output_CSV_AWS_CIS)
 

--- a/prowler/lib/outputs/compliance/cis_azure.py
+++ b/prowler/lib/outputs/compliance/cis_azure.py
@@ -30,6 +30,7 @@ def generate_compliance_row_cis_azure(
         ResourceId=finding.resource_id,
         ResourceName=finding.resource_name,
         CheckId=finding.check_metadata.CheckID,
+        Muted=finding.muted,
     )
     csv_header = generate_csv_fields(Check_Output_CSV_AZURE_CIS)
 

--- a/prowler/lib/outputs/compliance/cis_gcp.py
+++ b/prowler/lib/outputs/compliance/cis_gcp.py
@@ -30,6 +30,7 @@ def generate_compliance_row_cis_gcp(
         ResourceId=finding.resource_id,
         ResourceName=finding.resource_name,
         CheckId=finding.check_metadata.CheckID,
+        Muted=finding.muted,
     )
     csv_header = generate_csv_fields(Check_Output_CSV_GCP_CIS)
 

--- a/prowler/lib/outputs/compliance/cis_kubernetes.py
+++ b/prowler/lib/outputs/compliance/cis_kubernetes.py
@@ -30,6 +30,7 @@ def generate_compliance_row_cis_kubernetes(
         StatusExtended=finding.status_extended,
         ResourceId=finding.resource_id,
         CheckId=finding.check_metadata.CheckID,
+        Muted=finding.muted,
     )
     csv_header = generate_csv_fields(Check_Output_CSV_KUBERNETES_CIS)
 

--- a/prowler/lib/outputs/compliance/compliance.py
+++ b/prowler/lib/outputs/compliance/compliance.py
@@ -168,9 +168,7 @@ def display_compliance_table(
             pass_count = []
             fail_count = []
             muted_count = []
-            value_finding = 0
-            for finding in findings:
-                value_finding += 1
+            for index, finding in enumerate(findings):
                 check = bulk_checks_metadata[finding.check_metadata.CheckID]
                 check_compliances = check.Compliance
                 for compliance in check_compliances:
@@ -194,24 +192,25 @@ def display_compliance_table(
                                         "Bajo": 0,
                                         "Muted": 0,
                                     }
-                                if finding.muted and value_finding not in muted_count:
-                                    muted_count.append(value_finding)
-                                    marcos[marco_categoria]["Muted"] += 1
+                                if finding.muted:
+                                    if index not in muted_count:
+                                        muted_count.append(index)
+                                        marcos[marco_categoria]["Muted"] += 1
                                 else:
                                     if finding.status == "FAIL":
                                         if (
                                             attribute.Tipo != "recomendacion"
-                                            and value_finding not in fail_count
+                                            and index not in fail_count
                                         ):
-                                            fail_count.append(value_finding)
-                                        marcos[marco_categoria][
-                                            "Estado"
-                                        ] = f"{Fore.RED}NO CUMPLE{Style.RESET_ALL}"
+                                            fail_count.append(index)
+                                            marcos[marco_categoria][
+                                                "Estado"
+                                            ] = f"{Fore.RED}NO CUMPLE{Style.RESET_ALL}"
                                     elif (
                                         finding.status == "PASS"
-                                        and value_finding not in pass_count
+                                        and index not in pass_count
                                     ):
-                                        pass_count.append(value_finding)
+                                        pass_count.append(index)
                                 if attribute.Nivel == "opcional":
                                     marcos[marco_categoria]["Opcional"] += 1
                                 elif attribute.Nivel == "alto":
@@ -287,9 +286,7 @@ def display_compliance_table(
             pass_count = []
             fail_count = []
             muted_count = []
-            value_finding = 0
-            for finding in findings:
-                value_finding += 1
+            for index, finding in enumerate(findings):
                 check = bulk_checks_metadata[finding.check_metadata.CheckID]
                 check_compliances = check.Compliance
                 for compliance in check_compliances:
@@ -308,20 +305,21 @@ def display_compliance_table(
                                         "Level 2": {"FAIL": 0, "PASS": 0},
                                         "Muted": 0,
                                     }
-                                if finding.muted and value_finding not in muted_count:
-                                    muted_count.append(value_finding)
-                                    sections[section]["Muted"] += 1
+                                if finding.muted:
+                                    if index not in muted_count:
+                                        muted_count.append(index)
+                                        sections[section]["Muted"] += 1
                                 else:
                                     if (
                                         finding.status == "FAIL"
-                                        and value_finding not in fail_count
+                                        and index not in fail_count
                                     ):
-                                        fail_count.append(value_finding)
+                                        fail_count.append(index)
                                     elif (
                                         finding.status == "PASS"
-                                        and value_finding not in pass_count
+                                        and index not in pass_count
                                     ):
-                                        pass_count.append(value_finding)
+                                        pass_count.append(index)
                                 if "Level 1" in attribute.Profile:
                                     if not finding.muted:
                                         if finding.status == "FAIL":
@@ -404,9 +402,7 @@ def display_compliance_table(
             pass_count = []
             fail_count = []
             muted_count = []
-            value_finding = 0
-            for finding in findings:
-                value_finding += 1
+            for index, finding in enumerate(findings):
                 check = bulk_checks_metadata[finding.check_metadata.CheckID]
                 check_compliances = check.Compliance
                 for compliance in check_compliances:
@@ -419,18 +415,18 @@ def display_compliance_table(
                                 if tactic not in tactics:
                                     tactics[tactic] = {"FAIL": 0, "PASS": 0, "Muted": 0}
                                 if finding.muted:
-                                    if value_finding not in muted_count:
-                                        muted_count.append(value_finding)
-                                    tactics[tactic]["Muted"] += 1
+                                    if index not in muted_count:
+                                        muted_count.append(index)
+                                        tactics[tactic]["Muted"] += 1
                                 else:
                                     if finding.status == "FAIL":
-                                        if value_finding not in fail_count:
-                                            fail_count.append(value_finding)
-                                        tactics[tactic]["FAIL"] += 1
+                                        if index not in fail_count:
+                                            fail_count.append(index)
+                                            tactics[tactic]["FAIL"] += 1
                                     elif finding.status == "PASS":
-                                        if value_finding not in pass_count:
-                                            pass_count.append(value_finding)
-                                        tactics[tactic]["PASS"] += 1
+                                        if index not in pass_count:
+                                            pass_count.append(index)
+                                            tactics[tactic]["PASS"] += 1
             # Add results to table
             tactics = dict(sorted(tactics.items()))
             for tactic in tactics:
@@ -486,9 +482,7 @@ def display_compliance_table(
             pass_count = []
             fail_count = []
             muted_count = []
-            value_finding = 0
-            for finding in findings:
-                value_finding += 1
+            for index, finding in enumerate(findings):
                 check = bulk_checks_metadata[finding.check_metadata.CheckID]
                 check_compliances = check.Compliance
                 for compliance in check_compliances:
@@ -500,19 +494,20 @@ def display_compliance_table(
                     ):
                         for requirement in compliance.Requirements:
                             for attribute in requirement.Attributes:
-                                if finding.muted and value_finding not in muted_count:
-                                    muted_count.append(value_finding)
+                                if finding.muted:
+                                    if index not in muted_count:
+                                        muted_count.append(index)
                                 else:
                                     if (
                                         finding.status == "FAIL"
-                                        and value_finding not in fail_count
+                                        and index not in fail_count
                                     ):
-                                        fail_count.append(value_finding)
+                                        fail_count.append(index)
                                     elif (
                                         finding.status == "PASS"
-                                        and value_finding not in pass_count
+                                        and index not in pass_count
                                     ):
-                                        pass_count.append(value_finding)
+                                        pass_count.append(index)
             if (
                 len(fail_count) + len(pass_count) + len(muted_count) > 1
             ):  # If there are no resources, don't print the compliance table

--- a/prowler/lib/outputs/compliance/ens_rd2022_aws.py
+++ b/prowler/lib/outputs/compliance/ens_rd2022_aws.py
@@ -1,6 +1,9 @@
 from csv import DictWriter
 
-from prowler.config.config import timestamp
+from colorama import Fore, Style
+from tabulate import tabulate
+
+from prowler.config.config import orange_color, timestamp
 from prowler.lib.outputs.compliance.models import Check_Output_CSV_ENS_RD2022
 from prowler.lib.outputs.csv.csv import generate_csv_fields
 from prowler.lib.utils.utils import outputs_unix_timestamp
@@ -47,3 +50,126 @@ def write_compliance_row_ens_rd2022_aws(
             )
 
             csv_writer.writerow(compliance_row.__dict__)
+
+
+def get_ens_rd2022_aws_table(
+    findings: list,
+    bulk_checks_metadata: dict,
+    compliance_framework: str,
+    output_filename: str,
+    output_directory: str,
+    compliance_overview: bool,
+):
+    marcos = {}
+    ens_compliance_table = {
+        "Proveedor": [],
+        "Marco/Categoria": [],
+        "Estado": [],
+        "Alto": [],
+        "Medio": [],
+        "Bajo": [],
+        "Opcional": [],
+        "Muted": [],
+    }
+    pass_count = []
+    fail_count = []
+    muted_count = []
+    for index, finding in enumerate(findings):
+        check = bulk_checks_metadata[finding.check_metadata.CheckID]
+        check_compliances = check.Compliance
+        for compliance in check_compliances:
+            if (
+                compliance.Framework == "ENS"
+                and compliance.Provider == "AWS"
+                and compliance.Version == "RD2022"
+            ):
+                for requirement in compliance.Requirements:
+                    for attribute in requirement.Attributes:
+                        marco_categoria = f"{attribute.Marco}/{attribute.Categoria}"
+                        # Check if Marco/Categoria exists
+                        if marco_categoria not in marcos:
+                            marcos[marco_categoria] = {
+                                "Estado": f"{Fore.GREEN}CUMPLE{Style.RESET_ALL}",
+                                "Opcional": 0,
+                                "Alto": 0,
+                                "Medio": 0,
+                                "Bajo": 0,
+                                "Muted": 0,
+                            }
+                        if finding.muted:
+                            if index not in muted_count:
+                                muted_count.append(index)
+                                marcos[marco_categoria]["Muted"] += 1
+                        else:
+                            if finding.status == "FAIL":
+                                if (
+                                    attribute.Tipo != "recomendacion"
+                                    and index not in fail_count
+                                ):
+                                    fail_count.append(index)
+                                    marcos[marco_categoria][
+                                        "Estado"
+                                    ] = f"{Fore.RED}NO CUMPLE{Style.RESET_ALL}"
+                            elif finding.status == "PASS" and index not in pass_count:
+                                pass_count.append(index)
+                        if attribute.Nivel == "opcional":
+                            marcos[marco_categoria]["Opcional"] += 1
+                        elif attribute.Nivel == "alto":
+                            marcos[marco_categoria]["Alto"] += 1
+                        elif attribute.Nivel == "medio":
+                            marcos[marco_categoria]["Medio"] += 1
+                        elif attribute.Nivel == "bajo":
+                            marcos[marco_categoria]["Bajo"] += 1
+
+    # Add results to table
+    for marco in sorted(marcos):
+        ens_compliance_table["Proveedor"].append(compliance.Provider)
+        ens_compliance_table["Marco/Categoria"].append(marco)
+        ens_compliance_table["Estado"].append(marcos[marco]["Estado"])
+        ens_compliance_table["Opcional"].append(
+            f"{Fore.BLUE}{marcos[marco]['Opcional']}{Style.RESET_ALL}"
+        )
+        ens_compliance_table["Alto"].append(
+            f"{Fore.LIGHTRED_EX}{marcos[marco]['Alto']}{Style.RESET_ALL}"
+        )
+        ens_compliance_table["Medio"].append(
+            f"{orange_color}{marcos[marco]['Medio']}{Style.RESET_ALL}"
+        )
+        ens_compliance_table["Bajo"].append(
+            f"{Fore.YELLOW}{marcos[marco]['Bajo']}{Style.RESET_ALL}"
+        )
+        ens_compliance_table["Muted"].append(
+            f"{orange_color}{marcos[marco]['Muted']}{Style.RESET_ALL}"
+        )
+    if (
+        len(fail_count) + len(pass_count) + len(muted_count) > 1
+    ):  # If there are no resources, don't print the compliance table
+        print(
+            f"\nEstado de Cumplimiento de {Fore.YELLOW}{compliance_framework.upper()}{Style.RESET_ALL}:"
+        )
+        overview_table = [
+            [
+                f"{Fore.RED}{round(len(fail_count) / len(findings) * 100, 2)}% ({len(fail_count)}) NO CUMPLE{Style.RESET_ALL}",
+                f"{Fore.GREEN}{round(len(pass_count) / len(findings) * 100, 2)}% ({len(pass_count)}) CUMPLE{Style.RESET_ALL}",
+                f"{orange_color}{round(len(muted_count) / len(findings) * 100, 2)}% ({len(muted_count)}) MUTED{Style.RESET_ALL}",
+            ]
+        ]
+        print(tabulate(overview_table, tablefmt="rounded_grid"))
+        if not compliance_overview:
+            print(
+                f"\nResultados de {Fore.YELLOW}{compliance_framework.upper()}{Style.RESET_ALL}:"
+            )
+            print(
+                tabulate(
+                    ens_compliance_table,
+                    headers="keys",
+                    tablefmt="rounded_grid",
+                )
+            )
+            print(
+                f"{Style.BRIGHT}* Solo aparece el Marco/Categoria que contiene resultados.{Style.RESET_ALL}"
+            )
+            print(f"\nResultados detallados de {compliance_framework.upper()} en:")
+            print(
+                f" - CSV: {output_directory}/compliance/{output_filename}_{compliance_framework}.csv\n"
+            )

--- a/prowler/lib/outputs/compliance/ens_rd2022_aws.py
+++ b/prowler/lib/outputs/compliance/ens_rd2022_aws.py
@@ -43,6 +43,7 @@ def write_compliance_row_ens_rd2022_aws(
                 StatusExtended=finding.status_extended,
                 ResourceId=finding.resource_id,
                 CheckId=finding.check_metadata.CheckID,
+                Muted=finding.muted,
             )
 
             csv_writer.writerow(compliance_row.__dict__)

--- a/prowler/lib/outputs/compliance/generic.py
+++ b/prowler/lib/outputs/compliance/generic.py
@@ -45,5 +45,6 @@ def write_compliance_row_generic(
                 StatusExtended=finding.status_extended,
                 ResourceId=finding.resource_id,
                 CheckId=finding.check_metadata.CheckID,
+                Muted=finding.muted,
             )
             csv_writer.writerow(compliance_row.__dict__)

--- a/prowler/lib/outputs/compliance/generic.py
+++ b/prowler/lib/outputs/compliance/generic.py
@@ -1,6 +1,9 @@
 from csv import DictWriter
 
-from prowler.config.config import timestamp
+from colorama import Fore, Style
+from tabulate import tabulate
+
+from prowler.config.config import orange_color, timestamp
 from prowler.lib.outputs.compliance.models import Check_Output_CSV_Generic_Compliance
 from prowler.lib.outputs.csv.csv import generate_csv_fields
 from prowler.lib.utils.utils import outputs_unix_timestamp
@@ -48,3 +51,55 @@ def write_compliance_row_generic(
                 Muted=finding.muted,
             )
             csv_writer.writerow(compliance_row.__dict__)
+
+
+def get_generic_compliance_table(
+    findings: list,
+    bulk_checks_metadata: dict,
+    compliance_framework: str,
+    output_filename: str,
+    output_directory: str,
+    compliance_overview: bool,
+):
+    pass_count = []
+    fail_count = []
+    muted_count = []
+    for index, finding in enumerate(findings):
+        check = bulk_checks_metadata[finding.check_metadata.CheckID]
+        check_compliances = check.Compliance
+        for compliance in check_compliances:
+            if (
+                compliance.Framework.upper()
+                in compliance_framework.upper().replace("_", "-")
+                and compliance.Version in compliance_framework.upper()
+                and compliance.Provider in compliance_framework.upper()
+            ):
+                for requirement in compliance.Requirements:
+                    for attribute in requirement.Attributes:
+                        if finding.muted:
+                            if index not in muted_count:
+                                muted_count.append(index)
+                        else:
+                            if finding.status == "FAIL" and index not in fail_count:
+                                fail_count.append(index)
+                            elif finding.status == "PASS" and index not in pass_count:
+                                pass_count.append(index)
+    if (
+        len(fail_count) + len(pass_count) + len(muted_count) > 1
+    ):  # If there are no resources, don't print the compliance table
+        print(
+            f"\nCompliance Status of {Fore.YELLOW}{compliance_framework.upper()}{Style.RESET_ALL} Framework:"
+        )
+        overview_table = [
+            [
+                f"{Fore.RED}{round(len(fail_count) / len(findings) * 100, 2)}% ({len(fail_count)}) FAIL{Style.RESET_ALL}",
+                f"{Fore.GREEN}{round(len(pass_count) / len(findings) * 100, 2)}% ({len(pass_count)}) PASS{Style.RESET_ALL}",
+                f"{orange_color}{round(len(muted_count) / len(findings) * 100, 2)}% ({len(muted_count)}) MUTED{Style.RESET_ALL}",
+            ]
+        ]
+        print(tabulate(overview_table, tablefmt="rounded_grid"))
+        if not compliance_overview:
+            print(f"\nDetailed results of {compliance_framework.upper()} are in:")
+            print(
+                f" - CSV: {output_directory}/compliance/{output_filename}_{compliance_framework}.csv\n"
+            )

--- a/prowler/lib/outputs/compliance/iso27001_2013_aws.py
+++ b/prowler/lib/outputs/compliance/iso27001_2013_aws.py
@@ -46,6 +46,7 @@ def write_compliance_row_iso27001_2013_aws(
                 StatusExtended=finding.status_extended,
                 ResourceId=finding.resource_id,
                 CheckId=finding.check_metadata.CheckID,
+                Muted=finding.muted,
             )
 
             csv_writer.writerow(compliance_row.__dict__)

--- a/prowler/lib/outputs/compliance/mitre_attack_aws.py
+++ b/prowler/lib/outputs/compliance/mitre_attack_aws.py
@@ -1,6 +1,9 @@
 from csv import DictWriter
 
-from prowler.config.config import timestamp
+from colorama import Fore, Style
+from tabulate import tabulate
+
+from prowler.config.config import orange_color, timestamp
 from prowler.lib.outputs.compliance.models import Check_Output_MITRE_ATTACK
 from prowler.lib.outputs.csv.csv import generate_csv_fields
 from prowler.lib.outputs.utils import unroll_list
@@ -66,3 +69,97 @@ def write_compliance_row_mitre_attack_aws(
         )
 
         csv_writer.writerow(compliance_row.__dict__)
+
+
+def get_mitre_attack_table(
+    findings: list,
+    bulk_checks_metadata: dict,
+    compliance_framework: str,
+    output_filename: str,
+    output_directory: str,
+    compliance_overview: bool,
+):
+    tactics = {}
+    mitre_compliance_table = {
+        "Provider": [],
+        "Tactic": [],
+        "Status": [],
+        "Muted": [],
+    }
+    pass_count = []
+    fail_count = []
+    muted_count = []
+    for index, finding in enumerate(findings):
+        check = bulk_checks_metadata[finding.check_metadata.CheckID]
+        check_compliances = check.Compliance
+        for compliance in check_compliances:
+            if (
+                "MITRE-ATTACK" in compliance.Framework
+                and compliance.Version in compliance_framework
+            ):
+                for requirement in compliance.Requirements:
+                    for tactic in requirement.Tactics:
+                        if tactic not in tactics:
+                            tactics[tactic] = {"FAIL": 0, "PASS": 0, "Muted": 0}
+                        if finding.muted:
+                            if index not in muted_count:
+                                muted_count.append(index)
+                                tactics[tactic]["Muted"] += 1
+                        else:
+                            if finding.status == "FAIL":
+                                if index not in fail_count:
+                                    fail_count.append(index)
+                                    tactics[tactic]["FAIL"] += 1
+                            elif finding.status == "PASS":
+                                if index not in pass_count:
+                                    pass_count.append(index)
+                                    tactics[tactic]["PASS"] += 1
+    # Add results to table
+    tactics = dict(sorted(tactics.items()))
+    for tactic in tactics:
+        mitre_compliance_table["Provider"].append(compliance.Provider)
+        mitre_compliance_table["Tactic"].append(tactic)
+        if tactics[tactic]["FAIL"] > 0:
+            mitre_compliance_table["Status"].append(
+                f"{Fore.RED}FAIL({tactics[tactic]['FAIL']}){Style.RESET_ALL}"
+            )
+        else:
+            mitre_compliance_table["Status"].append(
+                f"{Fore.GREEN}PASS({tactics[tactic]['PASS']}){Style.RESET_ALL}"
+            )
+        if tactics[tactic]["Muted"] > 0:
+            mitre_compliance_table["Muted"].append(
+                f"{orange_color}{tactics[tactic]['Muted']}{Style.RESET_ALL}"
+            )
+    if (
+        len(fail_count) + len(pass_count) + len(muted_count) > 1
+    ):  # If there are no resources, don't print the compliance table
+        print(
+            f"\nCompliance Status of {Fore.YELLOW}{compliance_framework.upper()}{Style.RESET_ALL} Framework:"
+        )
+        overview_table = [
+            [
+                f"{Fore.RED}{round(len(fail_count) / len(findings) * 100, 2)}% ({len(fail_count)}) FAIL{Style.RESET_ALL}",
+                f"{Fore.GREEN}{round(len(pass_count) / len(findings) * 100, 2)}% ({len(pass_count)}) PASS{Style.RESET_ALL}",
+                f"{orange_color}{round(len(muted_count) / len(findings) * 100, 2)}% ({len(muted_count)}) MUTED{Style.RESET_ALL}",
+            ]
+        ]
+        print(tabulate(overview_table, tablefmt="rounded_grid"))
+        if not compliance_overview:
+            print(
+                f"\nFramework {Fore.YELLOW}{compliance_framework.upper()}{Style.RESET_ALL} Results:"
+            )
+            print(
+                tabulate(
+                    mitre_compliance_table,
+                    headers="keys",
+                    tablefmt="rounded_grid",
+                )
+            )
+            print(
+                f"{Style.BRIGHT}* Only sections containing results appear.{Style.RESET_ALL}"
+            )
+            print(f"\nDetailed results of {compliance_framework.upper()} are in:")
+            print(
+                f" - CSV: {output_directory}/compliance/{output_filename}_{compliance_framework}.csv\n"
+            )

--- a/prowler/lib/outputs/compliance/mitre_attack_aws.py
+++ b/prowler/lib/outputs/compliance/mitre_attack_aws.py
@@ -62,6 +62,7 @@ def write_compliance_row_mitre_attack_aws(
             StatusExtended=finding.status_extended,
             ResourceId=finding.resource_id,
             CheckId=finding.check_metadata.CheckID,
+            Muted=finding.muted,
         )
 
         csv_writer.writerow(compliance_row.__dict__)

--- a/prowler/lib/outputs/compliance/models.py
+++ b/prowler/lib/outputs/compliance/models.py
@@ -29,6 +29,7 @@ class Check_Output_MITRE_ATTACK(BaseModel):
     StatusExtended: str
     ResourceId: str
     CheckId: str
+    Muted: bool
 
 
 class Check_Output_CSV_ENS_RD2022(BaseModel):
@@ -56,6 +57,7 @@ class Check_Output_CSV_ENS_RD2022(BaseModel):
     StatusExtended: str
     ResourceId: str
     CheckId: str
+    Muted: bool
 
 
 class Check_Output_CSV_AWS_CIS(BaseModel):
@@ -84,6 +86,7 @@ class Check_Output_CSV_AWS_CIS(BaseModel):
     StatusExtended: str
     ResourceId: str
     CheckId: str
+    Muted: bool
 
 
 class Check_Output_CSV_AZURE_CIS(BaseModel):
@@ -113,6 +116,7 @@ class Check_Output_CSV_AZURE_CIS(BaseModel):
     ResourceId: str
     ResourceName: str
     CheckId: str
+    Muted: bool
 
 
 class Check_Output_CSV_GCP_CIS(BaseModel):
@@ -142,6 +146,7 @@ class Check_Output_CSV_GCP_CIS(BaseModel):
     ResourceId: str
     ResourceName: str
     CheckId: str
+    Muted: bool
 
 
 class Check_Output_CSV_KUBERNETES_CIS(BaseModel):
@@ -171,6 +176,7 @@ class Check_Output_CSV_KUBERNETES_CIS(BaseModel):
     StatusExtended: str
     ResourceId: str
     CheckId: str
+    Muted: bool
 
 
 class Check_Output_CSV_Generic_Compliance(BaseModel):
@@ -194,6 +200,7 @@ class Check_Output_CSV_Generic_Compliance(BaseModel):
     StatusExtended: str
     ResourceId: str
     CheckId: str
+    Muted: bool
 
 
 class Check_Output_CSV_AWS_Well_Architected(BaseModel):
@@ -219,6 +226,7 @@ class Check_Output_CSV_AWS_Well_Architected(BaseModel):
     StatusExtended: str
     ResourceId: str
     CheckId: str
+    Muted: bool
 
 
 class Check_Output_CSV_AWS_ISO27001_2013(BaseModel):
@@ -239,3 +247,4 @@ class Check_Output_CSV_AWS_ISO27001_2013(BaseModel):
     StatusExtended: str
     ResourceId: str
     CheckId: str
+    Muted: bool


### PR DESCRIPTION
### Context

Muted info about findings is added to compliance outputs


### Description

Now, muted will appear in compliance-results: 
![Screenshot 2024-04-10 at 17 13 43](https://github.com/prowler-cloud/prowler/assets/56402503/3955a180-47d1-4d9d-92ab-3baba66b842b)

Also, csv outputs for compliance will have the column "MUTED"


*If an finding is muted, it won´t add value in fail/pass column*

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
