### PR TITLE
fix(ocsf): Add compliance

### DIFF
--- a/docs/tutorials/reporting.md
+++ b/docs/tutorials/reporting.md
@@ -287,7 +287,7 @@ The following is the mapping between the native JSON and the Detection Finding f
 | Remediation.Code.Terraform | remediation.references |
 | Remediation.Code.CLI | remediation.references |
 | Remediation.Code.Other | remediation.references |
-| Compliance | _Not mapped yet_ |
+| Compliance | unmapped.compliance |
 | Categories | unmapped.categories |
 | DependsOn | unmapped.depends_on |
 | RelatedTo | unmapped.related_to |

--- a/prowler/lib/outputs/common_models.py
+++ b/prowler/lib/outputs/common_models.py
@@ -69,7 +69,7 @@ class FindingOutput(BaseModel):
     remediation_code_terraform: str
     remediation_code_cli: str
     remediation_code_other: str
-    compliance: str
+    compliance: dict
     categories: str
     depends_on: str
     related_to: str

--- a/prowler/lib/outputs/json_ocsf/json_ocsf.py
+++ b/prowler/lib/outputs/json_ocsf/json_ocsf.py
@@ -116,6 +116,7 @@ def fill_json_ocsf(finding_output: FindingOutput) -> DetectionFinding:
                 "depends_on": finding_output.depends_on,
                 "related_to": finding_output.related_to,
                 "notes": finding_output.notes,
+                "compliance": finding_output.compliance,
             },
         )
 

--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -125,23 +125,12 @@ def report(check_findings, provider):
                         csv_data = {}
                         csv_data.update(provider_data_mapping)
                         csv_data.update(common_finding_data)
-                        csv_data["compliance"] = unroll_dict(
-                            get_check_compliance(finding, provider.type, output_options)
+                        csv_data["compliance"] = get_check_compliance(
+                            finding, provider.type, output_options
                         )
                         finding_output = generate_provider_output(
                             provider, finding, csv_data
                         )
-
-                        # CSV
-                        if "csv" in file_descriptors:
-                            csv_writer = DictWriter(
-                                file_descriptors["csv"],
-                                fieldnames=generate_csv_fields(FindingOutput),
-                                delimiter=";",
-                            )
-
-                            csv_writer.writerow(finding_output.dict())
-
                         # JSON
                         if "json-ocsf" in file_descriptors:
                             detection_finding = fill_json_ocsf(finding_output)
@@ -150,6 +139,19 @@ def report(check_findings, provider):
                                 detection_finding.json(exclude_none=True, indent=4)
                             )
                             file_descriptors["json-ocsf"].write(",")
+
+                        # CSV
+                        if "csv" in file_descriptors:
+                            finding_output.compliance = unroll_dict(
+                                finding_output.compliance
+                            )
+                            csv_writer = DictWriter(
+                                file_descriptors["csv"],
+                                fieldnames=generate_csv_fields(FindingOutput),
+                                delimiter=";",
+                            )
+
+                            csv_writer.writerow(finding_output.dict())
 
         else:  # No service resources in the whole account
             color = set_report_color("MANUAL")

--- a/tests/lib/outputs/fixtures/fixtures.py
+++ b/tests/lib/outputs/fixtures/fixtures.py
@@ -45,7 +45,7 @@ def generate_finding_output(status, severity, muted, region) -> FindingOutput:
         remediation_code_terraform="",
         remediation_code_cli="",
         remediation_code_other="",
-        compliance="",
+        compliance={"test-compliance": "test-compliance"},
         categories="test-category",
         depends_on="test-dependency",
         related_to="test-related-to",

--- a/tests/lib/outputs/json_ocsf/json_ocsf_test.py
+++ b/tests/lib/outputs/json_ocsf/json_ocsf_test.py
@@ -82,6 +82,7 @@ class TestOutputJSONOCSF:
             "depends_on": finding_output.depends_on,
             "related_to": finding_output.related_to,
             "notes": finding_output.notes,
+            "compliance": finding_output.compliance,
         }
 
         # ResourceDetails


### PR DESCRIPTION
### Context

In the native JSON in v3 we had a `Compliance` key to store frameworks and requirements. We need that for the JSON OCSF.

Fixes #3742

### Description

Add a `unmapped.compliance` in the Detection Finding.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
