### PR TITLE
fix(mutelist): if all fails are muted do exit 0

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -366,7 +366,11 @@ def prowler():
         remove_custom_checks_module(checks_folder, provider)
 
     # If there are failed findings exit code 3, except if -z is input
-    if not args.ignore_exit_code_3 and stats["total_fail"] > 0:
+    if (
+        not args.ignore_exit_code_3
+        and stats["total_fail"] > 0
+        and not stats["all_fails_are_muted"]
+    ):
         sys.exit(3)
 
 

--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -200,6 +200,7 @@ def extract_findings_statistics(findings: list) -> dict:
     total_fail = 0
     resources = set()
     findings_count = 0
+    all_fails_are_muted = True
 
     for finding in findings:
         # Save the resource_id
@@ -210,10 +211,13 @@ def extract_findings_statistics(findings: list) -> dict:
         if finding.status == "FAIL":
             total_fail += 1
             findings_count += 1
+            if not finding.muted and all_fails_are_muted:
+                all_fails_are_muted = False
 
     stats["total_pass"] = total_pass
     stats["total_fail"] = total_fail
     stats["resources_count"] = len(resources)
     stats["findings_count"] = findings_count
+    stats["all_fails_are_muted"] = all_fails_are_muted
 
     return stats

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -291,7 +291,7 @@ class TestOutputs:
         assert stats["resources_count"] == 1
         assert stats["findings_count"] == 2
 
-    def test_extract_findings_statistics_info_resources(self):
+    def test_extract_findings_statistics_manual_resources(self):
         finding_1 = mock.MagicMock()
         finding_1.status = "MANUAL"
         finding_1.resource_id = "test_resource_1"
@@ -314,6 +314,38 @@ class TestOutputs:
         assert stats["total_fail"] == 0
         assert stats["resources_count"] == 0
         assert stats["findings_count"] == 0
+
+    def test_extract_findings_statistics_all_fail_are_muted(self):
+        finding_1 = mock.MagicMock()
+        finding_1.status = "FAIL"
+        finding_1.muted = True
+        finding_1.resource_id = "test_resource_1"
+        findings = [finding_1]
+
+        stats = extract_findings_statistics(findings)
+        assert stats["total_pass"] == 0
+        assert stats["total_fail"] == 1
+        assert stats["resources_count"] == 1
+        assert stats["findings_count"] == 1
+        assert stats["all_fails_are_muted"]
+
+    def test_extract_findings_statistics_all_fail_are_not_muted(self):
+        finding_1 = mock.MagicMock()
+        finding_1.status = "FAIL"
+        finding_1.muted = True
+        finding_1.resource_id = "test_resource_1"
+        finding_2 = mock.MagicMock()
+        finding_2.status = "FAIL"
+        finding_2.muted = False
+        finding_2.resource_id = "test_resource_1"
+        findings = [finding_1, finding_2]
+
+        stats = extract_findings_statistics(findings)
+        assert stats["total_pass"] == 0
+        assert stats["total_fail"] == 2
+        assert stats["resources_count"] == 1
+        assert stats["findings_count"] == 2
+        assert not stats["all_fails_are_muted"]
 
     def test_get_check_compliance(self):
         bulk_check_metadata = [


### PR DESCRIPTION
### Context

In Prowler v3 the allowlist changed status from `PASS|FAIL|INFO` to muted. In v4 the original status is always kept and a new `muted` attribute is in place. For that reason we have to change the logic to check if all `FAIL` findings are muted.

Fixes #3721 

### Description

If all the `FAIL` findings are `muted` just exit with a 0 code instead of 3.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
