### PR TITLE
docs(devel-guide): Add provider section and remove audit_info section

### DIFF
--- a/docs/developer-guide/audit-info.md
+++ b/docs/developer-guide/audit-info.md
@@ -1,9 +1,0 @@
-# Audit Info
-
-In each Prowler provider we have a Python object called `audit_info` which is in charge of keeping the credentials, the configuration and the state of each audit, and it's passed to each service during the `__init__`.
-
-- AWS: https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/aws/lib/audit_info/models.py#L34-L54
-- GCP: https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/aws/lib/audit_info/models.py#L7-L30
-- Azure: https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/azure/lib/audit_info/models.py#L17-L31
-
-This `audit_info` object is shared during the Prowler execution and for that reason is important to mock it in each test to isolate them. See the [testing guide](./unit-testing.md) for more information.

--- a/docs/developer-guide/provider.md
+++ b/docs/developer-guide/provider.md
@@ -186,7 +186,7 @@ Due to the complexity and differences of each provider use the rest of the provi
 - [Azure](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/azure/azure_provider.py)
 - [Kubernetes](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/kubernetes/kubernetes_provider.py)
 
-To facilitate understanding here is a pseudocode of how could be the most basic provider could be with examples.
+To facilitate understanding here is a pseudocode of how the most basic provider could be with examples.
 
 ```python title="Provider Example Class"
 

--- a/docs/developer-guide/provider.md
+++ b/docs/developer-guide/provider.md
@@ -1,0 +1,37 @@
+
+# Create a new Provider for Prowler
+
+Here you can find how to create a new Provider in Prowler to give support for making all security checks needed and make your cloud safer!
+
+## Introduction
+
+Providers are the foundation on which Prowler is built, a simple definition for a cloud provider could be "third-party company that offers a platform where any IT resource you need is available at any time upon request". The most well-known cloud providers are Amazon Web Service, Azure from Microsoft and Google Cloud which are already supported by Prowler.
+
+To create a new provider that is not supported now by Prowler and add your security checks must create a new folder where store all related with it (services, checks, etc.). It must be store in route `prowler/providers/<new_provider_name>/`.
+
+Inside that folder, you MUST create the following files and folders:
+
+- A `lib` folder: to store all extra functions.
+- A `services` folder: to store all [services](./services.md) to audit.
+- An empty `__init__.py`: to make Python treat this service folder as a package.
+- A `<new_provider_name>_provider.py`, containing all the provider's logic necessary to get authenticated in the provider, configurations and extra data useful for final report.
+- A `models.py`, containing all the models necessary for the new provider.
+
+## Provider
+
+The Prowler's provider structure is the following and the way to use it is just in the generic service of each provider passing as a parameter of constructor to initialize all necessary session values.
+
+### Base Class
+
+All the providers in Prowler inherits from the same [base class](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/common/provider.py). It is an [abstract base class](https://docs.python.org/3/library/abc.html) that defines the interface for all provider classes in the auditing system.
+
+### Provider Class
+
+Due to the complexity and differencies of each provider use the rest of the providers as a template for the implementation.
+
+- [AWS](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/aws/aws_provider.py)
+- [GCP](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/gcp/gcp_provider.py)
+- [Azure](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/azure/azure_provider.py)
+- [Kubernetes](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/kubernetes/kubernetes_provider.py)
+
+Remember that this class must be used to get credentials and the configuration.

--- a/docs/developer-guide/provider.md
+++ b/docs/developer-guide/provider.md
@@ -5,9 +5,9 @@ Here you can find how to create a new Provider in Prowler to give support for ma
 
 ## Introduction
 
-Providers are the foundation on which Prowler is built, a simple definition for a cloud provider could be "third-party company that offers a platform where any IT resource you need is available at any time upon request". The most well-known cloud providers are Amazon Web Service, Azure from Microsoft and Google Cloud which are already supported by Prowler.
+Providers are the foundation on which Prowler is built, a simple definition for a cloud provider could be "third-party company that offers a platform where any IT resource you need is available at any time upon request". The most well-known cloud providers are Amazon Web Services, Azure from Microsoft and Google Cloud which are already supported by Prowler.
 
-To create a new provider that is not supported now by Prowler and add your security checks must create a new folder where store all related with it (services, checks, etc.). It must be store in route `prowler/providers/<new_provider_name>/`.
+To create a new provider that is not supported now by Prowler and add your security checks you must create a new folder to store all the related files within it (services, checks, etc.). It must be store in route `prowler/providers/<new_provider_name>/`.
 
 Inside that folder, you MUST create the following files and folders:
 
@@ -19,19 +19,263 @@ Inside that folder, you MUST create the following files and folders:
 
 ## Provider
 
-The Prowler's provider structure is the following and the way to use it is just in the generic service of each provider passing as a parameter of constructor to initialize all necessary session values.
+The structure for Prowler's providers is set up in such a way that they can be utilized through a generic service specific to each provider. This is achieved by passing the required parameters to the constructor, which in turn initializes all the necessary session values.
 
 ### Base Class
 
-All the providers in Prowler inherits from the same [base class](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/common/provider.py). It is an [abstract base class](https://docs.python.org/3/library/abc.html) that defines the interface for all provider classes in the auditing system.
+All the providers in Prowler inherits from the same [base class](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/common/provider.py). It is an [abstract base class](https://docs.python.org/3/library/abc.html) that defines the interface for all provider classes. The code of the class is the next:
+
+```python title="Provider Base Class"
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+class Provider(ABC):
+    """
+    The Provider class is an abstract base class that defines the interface for all provider classes in the auditing system.
+
+    Attributes:
+        type (property): The type of the provider.
+        identity (property): The identity of the provider for auditing.
+        session (property): The session of the provider for auditing.
+        audit_config (property): The audit configuration of the provider.
+        output_options (property): The output configuration of the provider for auditing.
+
+    Methods:
+        print_credentials(): Displays the provider's credentials used for auditing in the command-line interface.
+        setup_session(): Sets up the session for the provider.
+        get_output_mapping(): Returns the output mapping between the provider and the generic model.
+        validate_arguments(): Validates the arguments for the provider.
+        get_checks_to_execute_by_audit_resources(): Returns a set of checks based on the input resources to scan.
+
+    Note:
+        This is an abstract base class and should not be instantiated directly. Each provider should implement its own
+        version of the Provider class by inheriting from this base class and implementing the required methods and properties.
+    """
+
+    @property
+    @abstractmethod
+    def type(self) -> str:
+        """
+        type method stores the provider's type.
+
+        This method needs to be created in each provider.
+        """
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def identity(self) -> str:
+        """
+        identity method stores the provider's identity to audit.
+
+        This method needs to be created in each provider.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def setup_session(self) -> Any:
+        """
+        setup_session sets up the session for the provider.
+
+        This method needs to be created in each provider.
+        """
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def session(self) -> str:
+        """
+        session method stores the provider's session to audit.
+
+        This method needs to be created in each provider.
+        """
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def audit_config(self) -> str:
+        """
+        audit_config method stores the provider's audit configuration.
+
+        This method needs to be created in each provider.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def print_credentials(self) -> None:
+        """
+        print_credentials is used to display in the CLI the provider's credentials used to audit.
+
+        This method needs to be created in each provider.
+        """
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def output_options(self) -> str:
+        """
+        output_options method returns the provider's audit output configuration.
+
+        This method needs to be created in each provider.
+        """
+        raise NotImplementedError()
+
+    @output_options.setter
+    @abstractmethod
+    def output_options(self, value: str) -> Any:
+        """
+        output_options.setter sets the provider's audit output configuration.
+
+        This method needs to be created in each provider.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_output_mapping(self) -> dict:
+        """
+        get_output_mapping returns the output mapping between the provider and the generic model.
+
+        This method needs to be created in each provider.
+        """
+        raise NotImplementedError()
+
+    def validate_arguments(self) -> None:
+        """
+        validate_arguments validates the arguments for the provider.
+
+        This method can be overridden in each provider if needed.
+        """
+        raise NotImplementedError()
+
+    def get_checks_to_execute_by_audit_resources(self) -> set:
+        """
+        get_checks_to_execute_by_audit_resources returns a set of checks based on the input resources to scan.
+
+        This is a fallback that returns None if the service has not implemented this function.
+        """
+        return set()
+
+    @property
+    @abstractmethod
+    def mutelist(self):
+        """
+        mutelist method returns the provider's mutelist.
+
+        This method needs to be created in each provider.
+        """
+        raise NotImplementedError()
+
+    @mutelist.setter
+    @abstractmethod
+    def mutelist(self, path: str):
+        """
+        mutelist.setter sets the provider's mutelist.
+
+        This method needs to be created in each provider.
+        """
+        raise NotImplementedError()
+```
 
 ### Provider Class
 
-Due to the complexity and differencies of each provider use the rest of the providers as a template for the implementation.
+Due to the complexity and differences of each provider use the rest of the providers as a template for the implementation.
 
 - [AWS](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/aws/aws_provider.py)
 - [GCP](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/gcp/gcp_provider.py)
 - [Azure](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/azure/azure_provider.py)
 - [Kubernetes](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/kubernetes/kubernetes_provider.py)
 
-Remember that this class must be used to get credentials and the configuration.
+To facilitate understanding here is a pseudocode of how could be the most basic provider could be with examples.
+
+```python title="Provider Example Class"
+
+# Library imports to authenticate in the Provider
+
+from prowler.config.config import load_and_validate_config_file
+from prowler.lib.logger import logger
+from prowler.lib.mutelist.mutelist import parse_mutelist_file
+from prowler.lib.utils.utils import print_boxes
+from prowler.providers.common.models import Audit_Metadata
+from prowler.providers.common.provider import Provider
+from prowler.providers.<new_provider_name>.models import (
+    # All providers models needed
+    ProvierSessionModel,
+    ProvierIdentityModel,
+    ProvierOutputOptionsModel
+)
+
+class NewProvider(Provider):
+    # All properties from the class, some of this are properties in the base class
+    _type: str = "<provider_name>"
+    _session: <ProvierSessionModel>
+    _identity: <ProvierIdentityModel>
+    _audit_config: dict
+    _output_options: ProvierOutputOptionsModel
+    _mutelist: dict
+    audit_metadata: Audit_Metadata
+
+    def __init__(self, arguments):
+        """
+        Initializes the NewProvider instance.
+        Args:
+            arguments (dict): A dictionary containing configuration arguments.
+        """
+        logger.info("Setting <NewProviderName> provider ...")
+        # First get from arguments the necesary from the cloud acount (subscriptions or projects or whatever the provider use for storing services)
+
+        # Set the session with the method enforced by parent class
+        self._session = self.setup_session(credentials_file)
+
+        # Set the Identity class normaly the provider class give by Python provider library
+        self._identity = <ProvierIdentityModel>()
+
+        # Set the provider configuration
+        self._audit_config = load_and_validate_config_file(
+            self._type, arguments.config_file
+        )
+
+    # All enforced properties by the parent class
+    @property
+    def identity(self):
+        return self._identity
+
+    @property
+    def session(self):
+        return self._session
+
+    @property
+    def type(self):
+        return self._type
+
+    @property
+    def audit_config(self):
+        return self._audit_config
+
+    @property
+    def output_options(self):
+        return self._output_options
+
+    def setup_session(self, <all_needed_for_auth>):
+        """
+        Sets up the Provider session.
+
+        Args:
+            <all_needed_for_auth> Can include all necessary arguments to setup the session
+
+        Returns:
+            Credentials necesary to communicate with the provider.
+        """
+        pass
+
+    """
+    This method is enforced by parent class and is used to print all relevant
+    information during the prowler execution as a header of execution.
+    Normally the Account ID, User name or stuff like this is displayed in colors using the colorama module (Fore).
+    """
+    def print_credentials(self):
+        pass
+
+
+
+```

--- a/docs/developer-guide/services.md
+++ b/docs/developer-guide/services.md
@@ -29,7 +29,7 @@ Each class is used to initialize the credentials and the API's clients to be use
 
 ## Service Class
 
-Due to the complexity and differencies of each provider API we are going to use an example service to guide you in how can it be created.
+Due to the complexity and differences of each provider API we are going to use an example service to guide you in how can it be created.
 
 The following is the `<service>_service.py` file:
 

--- a/docs/developer-guide/services.md
+++ b/docs/developer-guide/services.md
@@ -20,9 +20,10 @@ The Prowler's service structure is the following and the way to initialise it is
 
 All the Prowler provider's services inherits from a base class depending on the provider used.
 
-- [AWS Service Base Class](https://github.com/prowler-cloud/prowler/blob/22f8855ad7dad2e976dabff78611b643e234beaf/prowler/providers/aws/lib/service/service.py)
-- [GCP Service Base Class](https://github.com/prowler-cloud/prowler/blob/22f8855ad7dad2e976dabff78611b643e234beaf/prowler/providers/gcp/lib/service/service.py)
-- [Azure Service Base Class](https://github.com/prowler-cloud/prowler/blob/22f8855ad7dad2e976dabff78611b643e234beaf/prowler/providers/azure/lib/service/service.py)
+- [AWS Service Base Class](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/aws/lib/service/service.py)
+- [GCP Service Base Class](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/azure/lib/service/service.py)
+- [Azure Service Base Class](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/gcp/lib/service/service.py)
+- [Kubernetes Service Base Class](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/kubernetes/lib/service/service.py)
 
 Each class is used to initialize the credentials and the API's clients to be used in the service. If some threading is used it must be coded there.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,7 @@ nav:
           - Projects: tutorials/gcp/projects.md
   - Developer Guide:
       - Introduction: developer-guide/introduction.md
-      - Audit Info: developer-guide/audit-info.md
+      - Audit Info: developer-guide/provider.md
       - Services: developer-guide/services.md
       - Checks: developer-guide/checks.md
       - Documentation: developer-guide/documentation.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,7 @@ nav:
           - Projects: tutorials/gcp/projects.md
   - Developer Guide:
       - Introduction: developer-guide/introduction.md
-      - Audit Info: developer-guide/provider.md
+      - Provider: developer-guide/provider.md
       - Services: developer-guide/services.md
       - Checks: developer-guide/checks.md
       - Documentation: developer-guide/documentation.md


### PR DESCRIPTION
### Context

The audit_info is no longer used in v4, change it for service section.


### Description

Remove the old `audit_info.md`, add new `provider.md`, changes in the nav bar and fix links from services adding the new k8s service.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
