### PR TITLE
fix(json-ocsf): Remove risk field from unmapped

### DIFF
--- a/docs/tutorials/reporting.md
+++ b/docs/tutorials/reporting.md
@@ -279,7 +279,7 @@ The following is the mapping between the native JSON and the Detection Finding f
 | ResourceType | resources.type |
 | ResourceDetails | _Not mapped yet_ |
 | Description | finding_info.desc |
-| Risk | _Not mapped yet_ |
+| Risk | risk_details _Available from OCSF 1.2_ |
 | RelatedUrl | unmapped.related_url |
 | Remediation.Recommendation.Text | remediation.desc |
 | Remediation.Recommendation.Url | remediation.references |

--- a/docs/tutorials/reporting.md
+++ b/docs/tutorials/reporting.md
@@ -279,7 +279,7 @@ The following is the mapping between the native JSON and the Detection Finding f
 | ResourceType | resources.type |
 | ResourceDetails | _Not mapped yet_ |
 | Description | finding_info.desc |
-| Risk | unmapped.risk |
+| Risk | _Not mapped yet_ |
 | RelatedUrl | unmapped.related_url |
 | Remediation.Recommendation.Text | remediation.desc |
 | Remediation.Recommendation.Url | remediation.references |

--- a/prowler/lib/outputs/json_ocsf/json_ocsf.py
+++ b/prowler/lib/outputs/json_ocsf/json_ocsf.py
@@ -110,7 +110,6 @@ def fill_json_ocsf(finding_output: FindingOutput) -> DetectionFinding:
             type_name=DetectionFindingTypeID.Create.name,
             unmapped={
                 "check_type": finding_output.check_type,
-                "risk": finding_output.risk,
                 "related_url": finding_output.related_url,
                 "categories": finding_output.categories,
                 "depends_on": finding_output.depends_on,

--- a/tests/lib/outputs/json_ocsf/json_ocsf_test.py
+++ b/tests/lib/outputs/json_ocsf/json_ocsf_test.py
@@ -76,7 +76,6 @@ class TestOutputJSONOCSF:
         # Unmapped Data
         assert finding_json_ocsf.unmapped == {
             "check_type": finding_output.check_type,
-            "risk": finding_output.risk,
             "related_url": finding_output.related_url,
             "categories": finding_output.categories,
             "depends_on": finding_output.depends_on,


### PR DESCRIPTION
### Description

Since new field 'risk_details' has been added to json-ocsf https://github.com/ocsf/ocsf-schema/pull/1032 it is needed to remove it from the unmapped field


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
