### PR TITLE
fix(security-hub): MUTED -> WARNING

### DIFF
--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -330,6 +330,7 @@ Detailed documentation at https://docs.prowler.com
             "--mutelist-file",
             "-w",
             nargs="?",
+            # TODO(PRWLR-3519): this has to be done in the provider class not here
             default=get_default_mute_file_path(provider),
             help="Path for mutelist yaml file. See example prowler/config/<provider>_mutelist.yaml for reference and format. For AWS provider, it also accepts AWS DynamoDB Table, Lambda ARNs or S3 URIs, see more in https://docs.prowler.cloud/en/latest/tutorials/mutelist/",
         )

--- a/prowler/lib/outputs/json_asff/json_asff.py
+++ b/prowler/lib/outputs/json_asff/json_asff.py
@@ -16,7 +16,9 @@ from prowler.lib.utils.utils import hash_sha512
 def generate_json_asff_status(status: str, muted: bool = False) -> str:
     json_asff_status = ""
     if muted:
-        json_asff_status = "MUTED"
+        # Per AWS Security Hub "MUTED" is not a valid status
+        # https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_Compliance.html
+        json_asff_status = "WARNING"
     else:
         if status == "PASS":
             json_asff_status = "PASSED"

--- a/prowler/providers/aws/lib/security_hub/security_hub.py
+++ b/prowler/providers/aws/lib/security_hub/security_hub.py
@@ -196,7 +196,6 @@ def __send_findings_to_security_hub__(
         for findings in list_chunked:
             batch_import = security_hub_client.batch_import_findings(Findings=findings)
             if batch_import["FailedCount"] > 0:
-                print(batch_import["FailedCount"])
                 failed_import = batch_import["FailedFindings"][0]
                 logger.error(
                     f"Failed to send findings to AWS Security Hub -- {failed_import['ErrorCode']} -- {failed_import['ErrorMessage']}"

--- a/tests/lib/outputs/json_asff/json_asff_test.py
+++ b/tests/lib/outputs/json_asff/json_asff_test.py
@@ -457,7 +457,7 @@ class TestOutputJSONASFF:
     def test_generate_json_asff_status(self):
         assert generate_json_asff_status("PASS") == "PASSED"
         assert generate_json_asff_status("FAIL") == "FAILED"
-        assert generate_json_asff_status("FAIL", True) == "MUTED"
+        assert generate_json_asff_status("FAIL", True) == "WARNING"
         assert generate_json_asff_status("SOMETHING ELSE") == "NOT_AVAILABLE"
 
     def test_generate_json_asff_resource_tags(self):


### PR DESCRIPTION
### Context

Per AWS Security Hub "MUTED" is not a valid status https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_Compliance.html.

### Description

- Set `WARNING` status if `finding.muted is True`.
- Remove wild print
- Add a TODO

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
