### PR TITLE
fix(slack): Use global provider object

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -242,7 +242,7 @@ def prowler():
                 environ["SLACK_API_TOKEN"],
                 environ["SLACK_CHANNEL_ID"],
                 stats,
-                provider,
+                global_provider,
             )
         else:
             logger.critical(


### PR DESCRIPTION
### Context

Fixes #3769


### Description

The Slack integration should use the `global_provider` instead of the `provider` which is just a string.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
