### PR TITLE
chore(rds): improve rds public instance check

### DIFF
--- a/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py
+++ b/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py
@@ -35,7 +35,7 @@ class rds_instance_no_public_access(Check):
                                         any_address=True,
                                     ):
                                         report.status = "FAIL"
-                                        report.status_extended = f"RDS Instance {db_instance.id} is set as publicly accessible AND security group {security_group.name} ({security_group.id}) has {db_instance.engine} port {db_instance_port} open to the Internet."
+                                        report.status_extended = f"RDS Instance {db_instance.id} is set as publicly accessible AND security group {security_group.name} ({security_group.id}) has {db_instance.engine} port {db_instance_port} open to the Internet in endpoint {db_instance.endpoint.get('Address')}."
                                         break
             findings.append(report)
 

--- a/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py
+++ b/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py
@@ -1,5 +1,6 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
 from prowler.providers.aws.services.rds.rds_client import rds_client
 
 
@@ -17,18 +18,25 @@ class rds_instance_no_public_access(Check):
                 f"RDS Instance {db_instance.id} is not publicly accessible."
             )
             if db_instance.public:
+                report.status_extended = f"RDS Instance {db_instance.id} is set as publicly accessible, but is not publicly exposed."
                 # Check if any DB Instance Security Group is publicly open
                 if db_instance.security_groups:
                     report.status = "PASS"
-                    report.status_extended = f"RDS Instance {db_instance.id} is public but filtered with security groups."
-                    for security_group in ec2_client.security_groups:
-                        if (
-                            security_group.id in db_instance.security_groups
-                            and security_group.public_ports
-                        ):
-                            report.status = "FAIL"
-                            report.status_extended = f"RDS Instance {db_instance.id} is set as publicly accessible."
-                            break
+                    report.status_extended = f"RDS Instance {db_instance.id} is set as publicly accessible but filtered with security groups."
+                    db_instance_port = db_instance.endpoint.get("Port")
+                    if db_instance_port:
+                        for security_group in ec2_client.security_groups:
+                            if security_group.id in db_instance.security_groups:
+                                for ingress_rule in security_group.ingress_rules:
+                                    if check_security_group(
+                                        ingress_rule,
+                                        "tcp",
+                                        [db_instance_port],
+                                        any_address=True,
+                                    ):
+                                        report.status = "FAIL"
+                                        report.status_extended = f"RDS Instance {db_instance.id} is set as publicly accessible AND security group {security_group.name} ({security_group.id}) has {db_instance.engine} port {db_instance_port} open to the Internet."
+                                        break
             findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py
+++ b/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py
@@ -35,7 +35,7 @@ class rds_instance_no_public_access(Check):
                                         any_address=True,
                                     ):
                                         report.status = "FAIL"
-                                        report.status_extended = f"RDS Instance {db_instance.id} is set as publicly accessible AND security group {security_group.name} ({security_group.id}) has {db_instance.engine} port {db_instance_port} open to the Internet in endpoint {db_instance.endpoint.get('Address')}."
+                                        report.status_extended = f"RDS Instance {db_instance.id} is set as publicly accessible and security group {security_group.name} ({security_group.id}) has {db_instance.engine} port {db_instance_port} open to the Internet at endpoint {db_instance.endpoint.get('Address')}."
                                         break
             findings.append(report)
 

--- a/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
@@ -204,7 +204,7 @@ class Test_rds_instance_no_public_access:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"RDS Instance db-master-1 is set as publicly accessible AND security group default ({default_sg_id}) has postgres port 5432 open to the Internet."
+                    == f"RDS Instance db-master-1 is set as publicly accessible AND security group default ({default_sg_id}) has postgres port 5432 open to the Internet in endpoint db-master-1.aaaaaaaaaa.us-east-1.rds.amazonaws.com."
                 )
                 assert result[0].resource_id == "db-master-1"
                 assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
@@ -204,7 +204,7 @@ class Test_rds_instance_no_public_access:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"RDS Instance db-master-1 is set as publicly accessible AND security group default ({default_sg_id}) has postgres port 5432 open to the Internet in endpoint db-master-1.aaaaaaaaaa.us-east-1.rds.amazonaws.com."
+                    == f"RDS Instance db-master-1 is set as publicly accessible and security group default ({default_sg_id}) has postgres port 5432 open to the Internet at endpoint db-master-1.aaaaaaaaaa.us-east-1.rds.amazonaws.com."
                 )
                 assert result[0].resource_id == "db-master-1"
                 assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
@@ -1,4 +1,3 @@
-from re import search
 from unittest import mock
 
 import botocore
@@ -88,9 +87,9 @@ class Test_rds_instance_no_public_access:
 
                 assert len(result) == 1
                 assert result[0].status == "PASS"
-                assert search(
-                    "is not publicly accessible",
-                    result[0].status_extended,
+                assert (
+                    result[0].status_extended
+                    == "RDS Instance db-master-1 is not publicly accessible."
                 )
                 assert result[0].resource_id == "db-master-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
@@ -134,9 +133,9 @@ class Test_rds_instance_no_public_access:
 
                 assert len(result) == 1
                 assert result[0].status == "PASS"
-                assert search(
-                    "is not publicly accessible",
-                    result[0].status_extended,
+                assert (
+                    result[0].status_extended
+                    == "RDS Instance db-master-1 is set as publicly accessible, but is not publicly exposed."
                 )
                 assert result[0].resource_id == "db-master-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
@@ -203,9 +202,9 @@ class Test_rds_instance_no_public_access:
 
                 assert len(result) == 1
                 assert result[0].status == "FAIL"
-                assert search(
-                    "is set as publicly accessible",
-                    result[0].status_extended,
+                assert (
+                    result[0].status_extended
+                    == f"RDS Instance db-master-1 is set as publicly accessible AND security group default ({default_sg_id}) has postgres port 5432 open to the Internet."
                 )
                 assert result[0].resource_id == "db-master-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
@@ -264,9 +263,9 @@ class Test_rds_instance_no_public_access:
 
                 assert len(result) == 1
                 assert result[0].status == "PASS"
-                assert search(
-                    "is public but filtered with security groups",
-                    result[0].status_extended,
+                assert (
+                    result[0].status_extended
+                    == "RDS Instance db-master-1 is set as publicly accessible but filtered with security groups."
                 )
                 assert result[0].resource_id == "db-master-1"
                 assert result[0].region == AWS_REGION_US_EAST_1


### PR DESCRIPTION
### Description

Improve RDS public instance check `rds_instance_no_public_access` by adding the logic of checking if the DB Instance port is actual opened in the Security Group.

Thanks @jchrisfarris for the idea!

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
