### PR TITLE
docs(developer guide): fix broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,4 @@
 Want some swag as appreciation for your contribution?
 
 # Prowler Developer Guide
-https://docs.prowler.cloud/en/latest/tutorials/developer-guide/
+https://docs.prowler.com/projects/prowler-open-source/en/latest/developer-guide/introduction/


### PR DESCRIPTION
Fixed a dead / broken link.

### Context

The link to information for contributing was dead / broken.


### Description

Dead link for contributing was updated to "https://docs.prowler.com/projects/prowler-open-source/en/latest/developer-guide/introduction/" which is active.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
