### PR TITLE
fix(network_azure): handle capitalized protocols in security group rules

### DIFF
--- a/prowler/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted.py
@@ -23,7 +23,7 @@ class network_http_internet_access_restricted(Check):
                             and int(rule.destination_port_range.split("-")[1]) >= 80
                         )
                     )
-                    and rule.protocol in ["TCP", "*"]
+                    and rule.protocol in ["TCP", "Tcp", "*"]
                     and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
                     and rule.access == "Allow"
                     and rule.direction == "Inbound"

--- a/prowler/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted.py
@@ -23,7 +23,7 @@ class network_rdp_internet_access_restricted(Check):
                             and int(rule.destination_port_range.split("-")[1]) >= 3389
                         )
                     )
-                    and rule.protocol in ["TCP", "*"]
+                    and rule.protocol in ["TCP", "Tcp", "*"]
                     and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
                     and rule.access == "Allow"
                     and rule.direction == "Inbound"

--- a/prowler/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted.py
@@ -23,7 +23,7 @@ class network_ssh_internet_access_restricted(Check):
                             and int(rule.destination_port_range.split("-")[1]) >= 22
                         )
                     )
-                    and rule.protocol in ["TCP", "*"]
+                    and rule.protocol in ["TCP", "Tcp", "*"]
                     and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
                     and rule.access == "Allow"
                     and rule.direction == "Inbound"

--- a/prowler/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted.py
@@ -15,7 +15,7 @@ class network_udp_internet_access_restricted(Check):
                 report.location = security_group.location
                 report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has UDP internet access restricted."
                 rule_fail_condition = any(
-                    rule.protocol in ["UDP"]
+                    rule.protocol in ["UDP", "Udp"]
                     and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
                     and rule.access == "Allow"
                     and rule.direction == "Inbound"


### PR DESCRIPTION
### Context

Fixes #3802 

### Description

It seems that sometimes the protocol of a security rule from a network security group can have the name capitalized. This pr handles the case when this happens.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
