### PR TITLE
fix(mutelist): Be called whatever the provider

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -215,7 +215,7 @@ def prowler():
             checks_to_execute,
             global_provider,
             custom_checks_metadata,
-            getattr(args, "mutelist_file", None),
+            global_provider.mutelist_file_path,
             args.config_file,
         )
     else:

--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -70,10 +70,11 @@ def get_default_mute_file_path(provider: str):
     """
     get_default_mute_file_path returns the default mute file path for the provider
     """
-    # TODO: crate default mutelist file for kubernetes, azure and gcp
-    if provider == "aws":
-        return f"{pathlib.Path(os.path.dirname(os.path.realpath(__file__)))}/{provider}_mutelist.yaml"
-    return None
+    # TODO: create default mutelist file for kubernetes, azure and gcp
+    mutelist_path = f"{pathlib.Path(os.path.dirname(os.path.realpath(__file__)))}/{provider}_mutelist.yaml"
+    if not os.path.isfile(mutelist_path):
+        mutelist_path = None
+    return mutelist_path
 
 
 def check_current_version():

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -10,7 +10,6 @@ from prowler.config.config import (
     default_fixer_config_file_path,
     default_output_directory,
     finding_statuses,
-    get_default_mute_file_path,
     valid_severities,
 )
 from prowler.providers.common.arguments import (
@@ -326,14 +325,11 @@ Detailed documentation at https://docs.prowler.com
 
     def __init_mutelist_parser__(self):
         mutelist_subparser = self.common_providers_parser.add_argument_group("Mutelist")
-        provider = sys.argv[1] if len(sys.argv) > 1 else "aws"
         mutelist_subparser.add_argument(
             "--mutelist-file",
             "-w",
             nargs="?",
-            # TODO(PRWLR-3519): this has to be done in the provider class not here
-            default=get_default_mute_file_path(provider),
-            help="Path for mutelist yaml file. See example prowler/config/<provider>_mutelist.yaml for reference and format. For AWS provider, it also accepts AWS DynamoDB Table, Lambda ARNs or S3 URIs, see more in https://docs.prowler.cloud/en/latest/tutorials/mutelist/",
+            help="Path for mutelist YAML file. See example prowler/config/<provider>_mutelist.yaml for reference and format. For AWS provider, it also accepts AWS DynamoDB Table, Lambda ARNs or S3 URIs, see more in https://docs.prowler.cloud/en/latest/tutorials/mutelist/",
         )
 
     def __init_config_parser__(self):

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -17,7 +17,6 @@ from prowler.config.config import (
 )
 from prowler.lib.check.check import list_modules, recover_checks_from_service
 from prowler.lib.logger import logger
-from prowler.lib.mutelist.mutelist import parse_mutelist_file
 from prowler.lib.utils.utils import open_file, parse_json_file, print_boxes
 from prowler.providers.aws.config import (
     AWS_STS_GLOBAL_ENDPOINT_REGION,
@@ -54,7 +53,6 @@ class AwsProvider(Provider):
     _audit_config: dict
     _scan_unused_services: bool = False
     _enabled_regions: set = set()
-    _mutelist: dict = {}
     _output_options: AWSOutputOptions
     # TODO: this is not optional, enforce for all providers
     audit_metadata: Audit_Metadata
@@ -283,20 +281,6 @@ class AwsProvider(Provider):
         self._output_options = AWSOutputOptions(
             arguments, bulk_checks_metadata, self._identity
         )
-
-    @property
-    def mutelist(self):
-        return self._mutelist
-
-    @mutelist.setter
-    def mutelist(self, mutelist_path):
-        if mutelist_path:
-            mutelist = parse_mutelist_file(
-                mutelist_path, self._session.current_session, self._identity.account
-            )
-        else:
-            mutelist = {}
-        self._mutelist = mutelist
 
     @property
     def get_output_mapping(self):

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -10,7 +10,6 @@ from msgraph import GraphServiceClient
 
 from prowler.config.config import load_and_validate_config_file
 from prowler.lib.logger import logger
-from prowler.lib.mutelist.mutelist import parse_mutelist_file
 from prowler.lib.utils.utils import print_boxes
 from prowler.providers.azure.lib.regions.regions import get_regions_config
 from prowler.providers.azure.models import (
@@ -131,19 +130,6 @@ class AzureProvider(Provider):
             # "account_tags": "organizations_metadata.account_details_tags",
             "partition": "region_config.name",
         }
-
-    @property
-    def mutelist(self):
-        return self._mutelist
-
-    @mutelist.setter
-    def mutelist(self, mutelist_path):
-        if mutelist_path:
-            mutelist = parse_mutelist_file(mutelist_path)
-        else:
-            mutelist = {}
-
-        self._mutelist = mutelist
 
     # TODO: this should be moved to the argparse, if not we need to enforce it from the Provider
     # previously was using the AzureException

--- a/prowler/providers/common/provider.py
+++ b/prowler/providers/common/provider.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
+from prowler.config.config import get_default_mute_file_path
+from prowler.lib.mutelist.mutelist import parse_mutelist_file
+
 # TODO: with this we can enforce that all classes ending with "Provider" needs to inherint from the Provider class
 # class ProviderMeta:
 #     def __init__(cls, name, bases, dct):
@@ -15,6 +18,8 @@ from typing import Any
 
 # TODO: enforce audit_metadata for all the providers
 class Provider(ABC):
+    _mutelist: dict
+    _mutelist_file_path: str
     """
     The Provider class is an abstract base class that defines the interface for all provider classes in the auditing system.
 
@@ -142,21 +147,31 @@ class Provider(ABC):
         return set()
 
     @property
-    @abstractmethod
     def mutelist(self):
         """
         mutelist method returns the provider's mutelist.
-
-        This method needs to be created in each provider.
         """
-        raise NotImplementedError()
+        return self._mutelist
+
+    @property
+    def mutelist_file_path(self):
+        """
+        mutelist method returns the provider's mutelist file path.
+        """
+        return self._mutelist_file_path
 
     @mutelist.setter
-    @abstractmethod
-    def mutelist(self, path: str):
+    def mutelist(self, mutelist_path):
         """
         mutelist.setter sets the provider's mutelist.
-
-        This method needs to be created in each provider.
         """
-        raise NotImplementedError()
+        # Set default mutelist path if none is set
+        if not mutelist_path:
+            mutelist_path = get_default_mute_file_path(self.type)
+        if mutelist_path:
+            mutelist = parse_mutelist_file(mutelist_path)
+        else:
+            mutelist = {}
+
+        self._mutelist = mutelist
+        self._mutelist_file_path = mutelist_path

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -10,7 +10,6 @@ from googleapiclient.errors import HttpError
 
 from prowler.config.config import load_and_validate_config_file
 from prowler.lib.logger import logger
-from prowler.lib.mutelist.mutelist import parse_mutelist_file
 from prowler.lib.utils.utils import print_boxes
 from prowler.providers.common.models import Audit_Metadata
 from prowler.providers.common.provider import Provider
@@ -168,18 +167,6 @@ class GcpProvider(Provider):
             # "account_tags": "organizations_metadata.account_details_tags",
             # "partition": "identity.partition",
         }
-
-    @property
-    def mutelist(self):
-        return self._mutelist
-
-    @mutelist.setter
-    def mutelist(self, mutelist_path):
-        if mutelist_path:
-            mutelist = parse_mutelist_file(mutelist_path)
-        else:
-            mutelist = {}
-        self._mutelist = mutelist
 
     def setup_session(self, credentials_file):
         try:

--- a/prowler/providers/kubernetes/kubernetes_provider.py
+++ b/prowler/providers/kubernetes/kubernetes_provider.py
@@ -7,7 +7,6 @@ from colorama import Fore, Style
 from kubernetes import client, config
 from prowler.config.config import load_and_validate_config_file
 from prowler.lib.logger import logger
-from prowler.lib.mutelist.mutelist import parse_mutelist_file
 from prowler.lib.utils.utils import print_boxes
 from prowler.providers.common.models import Audit_Metadata
 from prowler.providers.common.provider import Provider
@@ -112,18 +111,6 @@ class KubernetesProvider(Provider):
             # "account_tags": "organizations_metadata.account_details_tags",
             # "partition": "identity.partition",
         }
-
-    @property
-    def mutelist(self):
-        return self._mutelist
-
-    @mutelist.setter
-    def mutelist(self, mutelist_path):
-        if mutelist_path:
-            mutelist = parse_mutelist_file(mutelist_path)
-        else:
-            mutelist = {}
-        self._mutelist = mutelist
 
     def setup_session(self, kubeconfig_file, input_context) -> KubernetesSession:
         """

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -548,7 +548,12 @@ aws:
     def test_aws_provider_mutelist_none(self):
         arguments = Namespace()
         aws_provider = AwsProvider(arguments)
-        aws_provider.mutelist = None
+
+        with patch(
+            "prowler.providers.common.provider.get_default_mute_file_path",
+            return_value=None,
+        ):
+            aws_provider.mutelist = None
 
         assert aws_provider.mutelist == {}
 


### PR DESCRIPTION
### Context

Currently the mutelist is not being loaded if no provider is set, which means `aws` is executed. No trouble if a provider is set as the first argument.


### Description

- Move the mutelist logic to the provider class since this is common for all the providers.
- Create a new attribute to get the mutelist file path.
- Handle if the allowlist file is set for whatever the provider.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
