### PR TITLE
fix(execute_check): Handle ModuleNotFoundError

### DIFF
--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -735,6 +735,11 @@ def execute(
                 )
             except Exception:
                 sys.exit(1)
+    except ModuleNotFoundError:
+        logger.error(
+            f"Check '{check_name}' was not found for the {global_provider.type.upper()} provider"
+        )
+        check_findings = []
     except Exception as error:
         logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"


### PR DESCRIPTION
### Description

Handle `ModuleNotFoundError` when calling the `execute_checks` function.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
