### PR TITLE
chore(ec2): rename EC2 any port check

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_all_ports/ec2_securitygroup_allow_ingress_from_internet_to_all_ports.metadata.json
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_all_ports/ec2_securitygroup_allow_ingress_from_internet_to_all_ports.metadata.json
@@ -1,9 +1,12 @@
 {
   "Provider": "aws",
-  "CheckID": "ec2_securitygroup_allow_ingress_from_internet_to_any_port",
+  "CheckID": "ec2_securitygroup_allow_ingress_from_internet_to_all_ports",
   "CheckTitle": "Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to any port.",
   "CheckType": [
     "Infrastructure Security"
+  ],
+  "CheckAliases": [
+    "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
   ],
   "ServiceName": "ec2",
   "SubServiceName": "securitygroup",

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_all_ports/ec2_securitygroup_allow_ingress_from_internet_to_all_ports.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_all_ports/ec2_securitygroup_allow_ingress_from_internet_to_all_ports.py
@@ -3,7 +3,7 @@ from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 from prowler.providers.aws.services.vpc.vpc_client import vpc_client
 
 
-class ec2_securitygroup_allow_ingress_from_internet_to_any_port(Check):
+class ec2_securitygroup_allow_ingress_from_internet_to_all_ports(Check):
     def execute(self):
         findings = []
         for security_group in ec2_client.security_groups:

--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -121,16 +121,16 @@ class EC2(AWSService):
                     ):
                         associated_sgs = []
                         # check if sg has public access to all ports
-                        all_public_ports = False
+                        public_access_to_all_ports = False
                         for ingress_rule in sg["IpPermissions"]:
                             if (
                                 check_security_group(
                                     ingress_rule, "-1", any_address=True
                                 )
-                                and "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+                                and "ec2_securitygroup_allow_ingress_from_internet_to_all_ports"
                                 in self.audited_checks
                             ):
-                                all_public_ports = True
+                                public_access_to_all_ports = True
                             # check associated security groups
                             for sg_group in ingress_rule.get("UserIdGroupPairs", []):
                                 if sg_group.get("GroupId"):
@@ -143,7 +143,7 @@ class EC2(AWSService):
                                 id=sg["GroupId"],
                                 ingress_rules=sg["IpPermissions"],
                                 egress_rules=sg["IpPermissionsEgress"],
-                                public_ports=all_public_ports,
+                                public_ports=public_access_to_all_ports,
                                 associated_sgs=associated_sgs,
                                 vpc_id=sg["VpcId"],
                                 tags=sg.get("Tags"),

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_all_ports/ec2_securitygroup_allow_ingress_from_internet_to_all_ports_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_all_ports/ec2_securitygroup_allow_ingress_from_internet_to_all_ports_test.py
@@ -11,7 +11,7 @@ from tests.providers.aws.utils import (
 )
 
 
-class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
+class Test_ec2_securitygroup_allow_ingress_from_internet_to_all_ports:
     @mock_aws
     def test_ec2_default_sgs(self):
         # Create EC2 Mocked Resources
@@ -23,7 +23,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
         aws_provider = set_mocked_aws_provider(
             [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
             expected_checks=[
-                "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+                "ec2_securitygroup_allow_ingress_from_internet_to_all_ports"
             ],
         )
 
@@ -31,18 +31,18 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
             "prowler.providers.common.common.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_client",
             new=EC2(aws_provider),
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port.vpc_client",
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.vpc_client",
             new=VPC(aws_provider),
         ):
             # Test Check
-            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port import (
-                ec2_securitygroup_allow_ingress_from_internet_to_any_port,
+            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports import (
+                ec2_securitygroup_allow_ingress_from_internet_to_all_ports,
             )
 
-            check = ec2_securitygroup_allow_ingress_from_internet_to_any_port()
+            check = ec2_securitygroup_allow_ingress_from_internet_to_all_ports()
             result = check.execute()
 
             # One default sg per region
@@ -77,7 +77,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
         aws_provider = set_mocked_aws_provider(
             [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
             expected_checks=[
-                "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+                "ec2_securitygroup_allow_ingress_from_internet_to_all_ports"
             ],
         )
 
@@ -85,18 +85,18 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
             "prowler.providers.common.common.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_client",
             new=EC2(aws_provider),
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port.vpc_client",
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.vpc_client",
             new=VPC(aws_provider),
         ):
             # Test Check
-            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port import (
-                ec2_securitygroup_allow_ingress_from_internet_to_any_port,
+            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports import (
+                ec2_securitygroup_allow_ingress_from_internet_to_all_ports,
             )
 
-            check = ec2_securitygroup_allow_ingress_from_internet_to_any_port()
+            check = ec2_securitygroup_allow_ingress_from_internet_to_all_ports()
             result = check.execute()
 
             # One default sg per region
@@ -142,7 +142,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
         aws_provider = set_mocked_aws_provider(
             [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
             expected_checks=[
-                "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+                "ec2_securitygroup_allow_ingress_from_internet_to_all_ports"
             ],
         )
 
@@ -150,18 +150,18 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
             "prowler.providers.common.common.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_client",
             new=EC2(aws_provider),
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port.vpc_client",
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.vpc_client",
             new=VPC(aws_provider),
         ):
             # Test Check
-            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port import (
-                ec2_securitygroup_allow_ingress_from_internet_to_any_port,
+            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports import (
+                ec2_securitygroup_allow_ingress_from_internet_to_all_ports,
             )
 
-            check = ec2_securitygroup_allow_ingress_from_internet_to_any_port()
+            check = ec2_securitygroup_allow_ingress_from_internet_to_all_ports()
             result = check.execute()
 
             # One default sg per region
@@ -212,7 +212,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
         aws_provider = set_mocked_aws_provider(
             [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
             expected_checks=[
-                "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+                "ec2_securitygroup_allow_ingress_from_internet_to_all_ports"
             ],
         )
 
@@ -220,18 +220,18 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
             "prowler.providers.common.common.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_client",
             new=EC2(aws_provider),
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port.vpc_client",
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.vpc_client",
             new=VPC(aws_provider),
         ):
             # Test Check
-            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port import (
-                ec2_securitygroup_allow_ingress_from_internet_to_any_port,
+            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports import (
+                ec2_securitygroup_allow_ingress_from_internet_to_all_ports,
             )
 
-            check = ec2_securitygroup_allow_ingress_from_internet_to_any_port()
+            check = ec2_securitygroup_allow_ingress_from_internet_to_all_ports()
             result = check.execute()
 
             # One default sg per region
@@ -263,7 +263,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
         aws_provider = set_mocked_aws_provider(
             [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
             expected_checks=[
-                "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+                "ec2_securitygroup_allow_ingress_from_internet_to_all_ports"
             ],
             scan_unused_services=False,
         )
@@ -272,18 +272,18 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
             "prowler.providers.common.common.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_client",
             new=EC2(aws_provider),
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port.vpc_client",
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.vpc_client",
             new=VPC(aws_provider),
         ):
             # Test Check
-            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port import (
-                ec2_securitygroup_allow_ingress_from_internet_to_any_port,
+            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports import (
+                ec2_securitygroup_allow_ingress_from_internet_to_all_ports,
             )
 
-            check = ec2_securitygroup_allow_ingress_from_internet_to_any_port()
+            check = ec2_securitygroup_allow_ingress_from_internet_to_all_ports()
             result = check.execute()
 
             assert len(result) == 0
@@ -306,7 +306,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
         aws_provider = set_mocked_aws_provider(
             [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
             expected_checks=[
-                "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+                "ec2_securitygroup_allow_ingress_from_internet_to_all_ports"
             ],
             scan_unused_services=False,
         )
@@ -315,18 +315,18 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_any_port:
             "prowler.providers.common.common.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_client",
             new=EC2(aws_provider),
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port.vpc_client",
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.vpc_client",
             new=VPC(aws_provider),
         ):
             # Test Check
-            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_any_port.ec2_securitygroup_allow_ingress_from_internet_to_any_port import (
-                ec2_securitygroup_allow_ingress_from_internet_to_any_port,
+            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports import (
+                ec2_securitygroup_allow_ingress_from_internet_to_all_ports,
             )
 
-            check = ec2_securitygroup_allow_ingress_from_internet_to_any_port()
+            check = ec2_securitygroup_allow_ingress_from_internet_to_all_ports()
             result = check.execute()
 
             assert len(result) == 1

--- a/tests/providers/aws/services/ec2/ec2_service_test.py
+++ b/tests/providers/aws/services/ec2/ec2_service_test.py
@@ -139,7 +139,7 @@ class Test_EC2_Service:
         aws_provider = set_mocked_aws_provider(
             [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1],
             expected_checks=[
-                "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+                "ec2_securitygroup_allow_ingress_from_internet_to_all_ports"
             ],
         )
         ec2 = EC2(aws_provider)

--- a/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
@@ -178,7 +178,7 @@ class Test_rds_instance_no_public_access:
 
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         aws_provider.audit_metadata.expected_checks = [
-            "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
+            "ec2_securitygroup_allow_ingress_from_internet_to_all_ports"
         ]
 
         with mock.patch(


### PR DESCRIPTION
### Description

Rename check `ec2_securitygroup_allow_ingress_from_internet_to_any_port` to `ec2_securitygroup_allow_ingress_from_internet_to_all_ports` for a more accurate naming.

Thanks @jchrisfarris for the idea!

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
