### PR TITLE
fix(aws): Include record names for dangling IPs

### DIFF
--- a/prowler/providers/aws/services/route53/route53_dangling_ip_subdomain_takeover/route53_dangling_ip_subdomain_takeover.py
+++ b/prowler/providers/aws/services/route53/route53_dangling_ip_subdomain_takeover/route53_dangling_ip_subdomain_takeover.py
@@ -38,18 +38,18 @@ class route53_dangling_ip_subdomain_takeover(Check):
                         ].tags
                         report.region = record_set.region
                         report.status = "PASS"
-                        report.status_extended = f"Route53 record {record} in Hosted Zone {route53_client.hosted_zones[record_set.hosted_zone_id].name} is not a dangling IP."
+                        report.status_extended = f"Route53 record {record} (name: {record_set.name}) in Hosted Zone {route53_client.hosted_zones[record_set.hosted_zone_id].name} is not a dangling IP."
                         # If Public IP check if it is in the AWS Account
                         if (
                             not ip_address(record).is_private
                             and record not in public_ips
                         ):
-                            report.status_extended = f"Route53 record {record} in Hosted Zone {route53_client.hosted_zones[record_set.hosted_zone_id].name} does not belong to AWS and it is not a dangling IP."
+                            report.status_extended = f"Route53 record {record} (name: {record_set.name}) in Hosted Zone {route53_client.hosted_zones[record_set.hosted_zone_id].name} does not belong to AWS and it is not a dangling IP."
                             # Check if potential dangling IP is within AWS Ranges
                             aws_ip_ranges = awsipranges.get_ranges()
                             if aws_ip_ranges.get(record):
                                 report.status = "FAIL"
-                                report.status_extended = f"Route53 record {record} in Hosted Zone {route53_client.hosted_zones[record_set.hosted_zone_id].name} is a dangling IP which can lead to a subdomain takeover attack."
+                                report.status_extended = f"Route53 record {record} (name: {record_set.name}) in Hosted Zone {route53_client.hosted_zones[record_set.hosted_zone_id].name} is a dangling IP which can lead to a subdomain takeover attack."
                         findings.append(report)
 
         return findings


### PR DESCRIPTION
### Context

Fixes #3820

Improves the "Status Extended" output field for the `route53_dangling_ip_subdomain_takeover` check.

### Description

This PR adds record set names to the "Status Extended" output of the check that identifies dangling IPs in AWS Route 53. It fixes an issue where currently identical findings are produced if one dangling IP is mapped to multiple record names in Route 53 and improves the rule's output in all cases. See #3820 for more information.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
