### PR TITLE
docs(audit_info): update docs about audit info and new testing

### DIFF
--- a/docs/developer-guide/services.md
+++ b/docs/developer-guide/services.md
@@ -58,7 +58,7 @@ from prowler.providers.<provider>.lib.service.service import ServiceParentClass
 # Create a class for the Service
 ################## <Service>
 class <Service>(ServiceParentClass):
-    def __init__(self, provicer):
+    def __init__(self, provider):
         # Call Service Parent Class __init__
         # We use the __class__.__name__ to get it automatically
         # from the Service Class name but you can pass a custom

--- a/docs/developer-guide/services.md
+++ b/docs/developer-guide/services.md
@@ -223,10 +223,10 @@ Each Prowler service requires a service client to use the service in the checks.
 The following is the `<new_service_name>_client.py` containing the initialization of the service's class we have just created so the service's checks can use them:
 
 ```python
-from prowler.providers.common.common.get_global_provider import set_mocked_<provider>_provider
+from prowler.providers.common.common import get_global_provider
 from prowler.providers.<provider>.services.<new_service_name>.<new_service_name>_service import <Service>
 
-<new_service_name>_client = <Service>(set_mocked_<provider>_provider([<region>]))
+<new_service_name>_client = <Service>(get_global_provider())
 ```
 
 ## Permissions

--- a/docs/developer-guide/services.md
+++ b/docs/developer-guide/services.md
@@ -58,12 +58,12 @@ from prowler.providers.<provider>.lib.service.service import ServiceParentClass
 # Create a class for the Service
 ################## <Service>
 class <Service>(ServiceParentClass):
-    def __init__(self, audit_info):
+    def __init__(self, provicer):
         # Call Service Parent Class __init__
         # We use the __class__.__name__ to get it automatically
         # from the Service Class name but you can pass a custom
         # string if the provider's API service name is different
-        super().__init__(__class__.__name__, audit_info)
+        super().__init__(__class__.__name__, provider)
 
         # Create an empty dictionary of items to be gathered,
         # using the unique ID as the dictionary key
@@ -223,10 +223,10 @@ Each Prowler service requires a service client to use the service in the checks.
 The following is the `<new_service_name>_client.py` containing the initialization of the service's class we have just created so the service's checks can use them:
 
 ```python
-from prowler.providers.<provider>.lib.audit_info.audit_info import audit_info
+from prowler.providers.common.common.get_global_provider import set_mocked_<provider>_provider
 from prowler.providers.<provider>.services.<new_service_name>.<new_service_name>_service import <Service>
 
-<new_service_name>_client = <Service>(audit_info)
+<new_service_name>_client = <Service>(set_mocked_<provider>_provider([<region>]))
 ```
 
 ## Permissions

--- a/docs/developer-guide/unit-testing.md
+++ b/docs/developer-guide/unit-testing.md
@@ -345,7 +345,7 @@ A useful read about this topic can be found in the following article: https://st
 
 Mocking a service client using the following code ...
 
-Since we are mocking the provider, it can me customized setting multiple attributes to the provider:
+Since we are mocking the provider, it can be customized setting multiple attributes to the provider:
 ```python
 def set_mocked_aws_provider(
     audited_regions: list[str] = [],

--- a/docs/developer-guide/unit-testing.md
+++ b/docs/developer-guide/unit-testing.md
@@ -104,8 +104,8 @@ class Test_iam_password_policy_uppercase:
     # policy we want to set to False the RequireUppercaseCharacters
     iam_client.update_account_password_policy(RequireUppercaseCharacters=False)
 
-    # We set a mocked aws_provider info for AWS not to share the same info
-    # between tests
+    # The aws_provider is mocked using set_mocked_aws_provider to use it as the return of the get_global_provider method.
+    # this mocked provider is defined in fixtures
     aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 
     # The Prowler service import MUST be made within the decorated
@@ -191,8 +191,8 @@ class Test_iam_password_policy_uppercase:
         expiration=True,
     )
 
-    # We set a mocked aws_provider info for AWS not to share the same info
-    # between tests
+    # We set a mocked aws_provider to unify providers, this way will share provider info
+    # between tests
     aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 
     # In this scenario we have to mock also the IAM service and the iam_client from the check to enforce    # that the iam_client used is the one created within this check because patch != import, and if you     # execute tests in parallel some objects can be already initialised hence the check won't be isolated.
@@ -325,7 +325,7 @@ from prowler.providers.<provider>.services.<service>.<service>_client import <se
 ```
 2. `<service>_client.py`:
 ```python
-from prowler.providers.common.common.get_global_provider import mocked_provider
+from prowler.providers.common.common import get_global_provider
 from prowler.providers.<provider>.services.<service>.<service>_service import <SERVICE>
 
 <service>_client = <SERVICE>(mocked_provider)

--- a/docs/developer-guide/unit-testing.md
+++ b/docs/developer-guide/unit-testing.md
@@ -288,7 +288,7 @@ Note that this does not use Moto, to keep it simple, but if you use any `moto`-d
 
 #### Mocking more than one service
 
-Since we are mocking the provider, it can me customized setting multiple attributes to the provider:
+Since we are mocking the provider, it can be customized setting multiple attributes to the provider:
 ```python
 def set_mocked_aws_provider(
     audited_regions: list[str] = [],

--- a/docs/developer-guide/unit-testing.md
+++ b/docs/developer-guide/unit-testing.md
@@ -191,8 +191,7 @@ class Test_iam_password_policy_uppercase:
         expiration=True,
     )
 
-    # We set a mocked aws_provider to unify providers, this way will share provider info
-    # between tests
+    # We set a mocked aws_provider to unify providers, this way will isolate each test not to step on other tests configuration
     aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 
     # In this scenario we have to mock also the IAM service and the iam_client from the check to enforce    # that the iam_client used is the one created within this check because patch != import, and if you     # execute tests in parallel some objects can be already initialised hence the check won't be isolated.
@@ -346,6 +345,29 @@ A useful read about this topic can be found in the following article: https://st
 
 Mocking a service client using the following code ...
 
+Since we are mocking the provider, it can me customized setting multiple attributes to the provider:
+```python
+def set_mocked_aws_provider(
+    audited_regions: list[str] = [],
+    audited_account: str = AWS_ACCOUNT_NUMBER,
+    audited_account_arn: str = AWS_ACCOUNT_ARN,
+    audited_partition: str = AWS_COMMERCIAL_PARTITION,
+    expected_checks: list[str] = [],
+    profile_region: str = None,
+    audit_config: dict = {},
+    fixer_config: dict = {},
+    scan_unused_services: bool = True,
+    audit_session: session.Session = session.Session(
+        profile_name=None,
+        botocore_session=None,
+    ),
+    original_session: session.Session = None,
+    enabled_regions: set = None,
+    arguments: Namespace = Namespace(),
+    create_default_organization: bool = True,
+) -> AwsProvider:
+```
+Once the needed attributes are set, you can use the mocked provider:
 ```python title="Mocking the service_client"
 with mock.patch(
     "prowler.providers.common.common.get_global_provider",

--- a/docs/developer-guide/unit-testing.md
+++ b/docs/developer-guide/unit-testing.md
@@ -288,6 +288,29 @@ Note that this does not use Moto, to keep it simple, but if you use any `moto`-d
 
 #### Mocking more than one service
 
+Since we are mocking the provider, it can me customized setting multiple attributes to the provider:
+```python
+def set_mocked_aws_provider(
+    audited_regions: list[str] = [],
+    audited_account: str = AWS_ACCOUNT_NUMBER,
+    audited_account_arn: str = AWS_ACCOUNT_ARN,
+    audited_partition: str = AWS_COMMERCIAL_PARTITION,
+    expected_checks: list[str] = [],
+    profile_region: str = None,
+    audit_config: dict = {},
+    fixer_config: dict = {},
+    scan_unused_services: bool = True,
+    audit_session: session.Session = session.Session(
+        profile_name=None,
+        botocore_session=None,
+    ),
+    original_session: session.Session = None,
+    enabled_regions: set = None,
+    arguments: Namespace = Namespace(),
+    create_default_organization: bool = True,
+) -> AwsProvider:
+```
+
 If the test your are creating belongs to a check that uses more than one provider service, you should mock each of the services used. For example, the check `cloudtrail_logs_s3_bucket_access_logging_enabled` requires the CloudTrail and the S3 client, hence the service's mock part of the test will be as follows:
 
 
@@ -345,29 +368,7 @@ A useful read about this topic can be found in the following article: https://st
 
 Mocking a service client using the following code ...
 
-Since we are mocking the provider, it can be customized setting multiple attributes to the provider:
-```python
-def set_mocked_aws_provider(
-    audited_regions: list[str] = [],
-    audited_account: str = AWS_ACCOUNT_NUMBER,
-    audited_account_arn: str = AWS_ACCOUNT_ARN,
-    audited_partition: str = AWS_COMMERCIAL_PARTITION,
-    expected_checks: list[str] = [],
-    profile_region: str = None,
-    audit_config: dict = {},
-    fixer_config: dict = {},
-    scan_unused_services: bool = True,
-    audit_session: session.Session = session.Session(
-        profile_name=None,
-        botocore_session=None,
-    ),
-    original_session: session.Session = None,
-    enabled_regions: set = None,
-    arguments: Namespace = Namespace(),
-    create_default_organization: bool = True,
-) -> AwsProvider:
-```
-Once the needed attributes are set, you can use the mocked provider:
+Once the needed attributes are set for the mocked provider, you can use the mocked provider:
 ```python title="Mocking the service_client"
 with mock.patch(
     "prowler.providers.common.common.get_global_provider",

--- a/tests/providers/gcp/services/compute/compute_public_address_shodan/compute_public_address_shodan_test.py
+++ b/tests/providers/gcp/services/compute/compute_public_address_shodan/compute_public_address_shodan_test.py
@@ -8,7 +8,6 @@ class Test_compute_public_address_shodan:
     def test_no_public_ip_addresses(self):
         compute_client = mock.MagicMock
         compute_client.addresses = {}
-        compute_client.audit_info = mock.MagicMock
 
         with mock.patch(
             "prowler.providers.common.common.get_global_provider",
@@ -37,7 +36,6 @@ class Test_compute_public_address_shodan:
             "isp": "Microsoft Corporation",
             "country_name": "country_name",
         }
-        compute_client.audit_info = mock.MagicMock
 
         compute_client.addresses = [
             Address(


### PR DESCRIPTION
### Description

Audit info is deprecated, docs should be updated with the new provider and removing audit_info


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
