### PR TITLE
chore(typo): Renames tags policies to tag policies

### DIFF
--- a/prowler/compliance/aws/ens_rd2022_aws.json
+++ b/prowler/compliance/aws/ens_rd2022_aws.json
@@ -672,7 +672,7 @@
         }
       ],
       "Checks": [
-        "organizations_tags_policies_enabled_and_attached"
+        "organizations_tag_policies_enabled_and_attached"
       ]
     },
     {
@@ -724,7 +724,7 @@
         }
       ],
       "Checks": [
-        "organizations_tags_policies_enabled_and_attached"
+        "organizations_tag_policies_enabled_and_attached"
       ]
     },
     {
@@ -1582,7 +1582,7 @@
         }
       ],
       "Checks": [
-        "organizations_tags_policies_enabled_and_attached"
+        "organizations_tag_policies_enabled_and_attached"
       ]
     },
     {
@@ -4499,7 +4499,7 @@
         }
       ],
       "Checks": [
-        "organizations_tags_policies_enabled_and_attached"
+        "organizations_tag_policies_enabled_and_attached"
       ]
     },
     {

--- a/prowler/providers/aws/services/organizations/organizations_tag_policies_enabled_and_attached/organizations_tag_policies_enabled_and_attached.metadata.json
+++ b/prowler/providers/aws/services/organizations/organizations_tag_policies_enabled_and_attached/organizations_tag_policies_enabled_and_attached.metadata.json
@@ -1,6 +1,6 @@
 {
   "Provider": "aws",
-  "CheckID": "organizations_tags_policies_enabled_and_attached",
+  "CheckID": "organizations_tag_policies_enabled_and_attached",
   "CheckTitle": "Check if an AWS Organization has tags policies enabled and attached.",
   "CheckType": [],
   "ServiceName": "organizations",

--- a/prowler/providers/aws/services/organizations/organizations_tag_policies_enabled_and_attached/organizations_tag_policies_enabled_and_attached.py
+++ b/prowler/providers/aws/services/organizations/organizations_tag_policies_enabled_and_attached/organizations_tag_policies_enabled_and_attached.py
@@ -4,7 +4,7 @@ from prowler.providers.aws.services.organizations.organizations_client import (
 )
 
 
-class organizations_tags_policies_enabled_and_attached(Check):
+class organizations_tag_policies_enabled_and_attached(Check):
     def execute(self):
         findings = []
 
@@ -22,7 +22,7 @@ class organizations_tags_policies_enabled_and_attached(Check):
                     # Access Denied to list_policies
                     continue
                 for policy in org.policies:
-                    # We only check SCP policies here
+                    # We only check tag policies here
                     if policy.type != "TAG_POLICY":
                         continue
 

--- a/tests/providers/aws/services/organizations/organizations_tag_policies_enabled_and_attached/organizations_tag_policies_enabled_and_attached_test.py
+++ b/tests/providers/aws/services/organizations/organizations_tag_policies_enabled_and_attached/organizations_tag_policies_enabled_and_attached_test.py
@@ -14,7 +14,7 @@ from tests.providers.aws.utils import (
 # Needs to Mock manually
 
 
-class Test_organizations_tags_policies_enabled_and_attached:
+class Test_organizations_tag_policies_enabled_and_attached:
     def test_organization_no_organization(self):
         organizations_client = mock.MagicMock
         organizations_client.region = AWS_REGION_EU_WEST_1
@@ -34,15 +34,15 @@ class Test_organizations_tags_policies_enabled_and_attached:
             return_value=aws_provider,
         ):
             with mock.patch(
-                "prowler.providers.aws.services.organizations.organizations_tags_policies_enabled_and_attached.organizations_tags_policies_enabled_and_attached.organizations_client",
+                "prowler.providers.aws.services.organizations.organizations_tag_policies_enabled_and_attached.organizations_tag_policies_enabled_and_attached.organizations_client",
                 new=organizations_client,
             ):
                 # Test Check
-                from prowler.providers.aws.services.organizations.organizations_tags_policies_enabled_and_attached.organizations_tags_policies_enabled_and_attached import (
-                    organizations_tags_policies_enabled_and_attached,
+                from prowler.providers.aws.services.organizations.organizations_tag_policies_enabled_and_attached.organizations_tag_policies_enabled_and_attached import (
+                    organizations_tag_policies_enabled_and_attached,
                 )
 
-                check = organizations_tags_policies_enabled_and_attached()
+                check = organizations_tag_policies_enabled_and_attached()
                 result = check.execute()
 
                 assert len(result) == 1
@@ -85,15 +85,15 @@ class Test_organizations_tags_policies_enabled_and_attached:
             return_value=aws_provider,
         ):
             with mock.patch(
-                "prowler.providers.aws.services.organizations.organizations_tags_policies_enabled_and_attached.organizations_tags_policies_enabled_and_attached.organizations_client",
+                "prowler.providers.aws.services.organizations.organizations_tag_policies_enabled_and_attached.organizations_tag_policies_enabled_and_attached.organizations_client",
                 new=organizations_client,
             ):
                 # Test Check
-                from prowler.providers.aws.services.organizations.organizations_tags_policies_enabled_and_attached.organizations_tags_policies_enabled_and_attached import (
-                    organizations_tags_policies_enabled_and_attached,
+                from prowler.providers.aws.services.organizations.organizations_tag_policies_enabled_and_attached.organizations_tag_policies_enabled_and_attached import (
+                    organizations_tag_policies_enabled_and_attached,
                 )
 
-                check = organizations_tags_policies_enabled_and_attached()
+                check = organizations_tag_policies_enabled_and_attached()
                 result = check.execute()
 
                 assert len(result) == 1
@@ -139,15 +139,15 @@ class Test_organizations_tags_policies_enabled_and_attached:
             return_value=aws_provider,
         ):
             with mock.patch(
-                "prowler.providers.aws.services.organizations.organizations_tags_policies_enabled_and_attached.organizations_tags_policies_enabled_and_attached.organizations_client",
+                "prowler.providers.aws.services.organizations.organizations_tag_policies_enabled_and_attached.organizations_tag_policies_enabled_and_attached.organizations_client",
                 new=organizations_client,
             ):
                 # Test Check
-                from prowler.providers.aws.services.organizations.organizations_tags_policies_enabled_and_attached.organizations_tags_policies_enabled_and_attached import (
-                    organizations_tags_policies_enabled_and_attached,
+                from prowler.providers.aws.services.organizations.organizations_tag_policies_enabled_and_attached.organizations_tag_policies_enabled_and_attached import (
+                    organizations_tag_policies_enabled_and_attached,
                 )
 
-                check = organizations_tags_policies_enabled_and_attached()
+                check = organizations_tag_policies_enabled_and_attached()
                 result = check.execute()
 
                 assert len(result) == 1


### PR DESCRIPTION
### Description

Renames tags policies to tag policies to align with [AWS documentation](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies.html)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
