### PR TITLE
fix(dashboard): Handle encoding errors

### DIFF
--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -28,7 +28,10 @@ informational_color = "#3274d9"
 folder_path_overview = os.getcwd() + "/output"
 folder_path_compliance = os.getcwd() + "/output/compliance"
 
-# Encoding
-encoding_format = "utf-8"
+# Encoding, if the os is windows, use cp1252
+if os.name == "nt":
+    encoding_format = "cp1252"
+else:
+    encoding_format = "utf-8"
 # Error action, it is recommended to use "ignore" or "replace"
 error_action = "ignore"

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 # Emojis to be used in the compliance table
 pass_emoji = "✅"
@@ -28,8 +29,8 @@ informational_color = "#3274d9"
 folder_path_overview = os.getcwd() + "/output"
 folder_path_compliance = os.getcwd() + "/output/compliance"
 
-# Encoding, if the os is windows, use cp1252
-if os.name == "nt":
+# Encoding, if the os is windows, use cp1252. Use utf-8 if it is running using python3
+if os.name == "nt" and "python" not in sys.argv[0].lower():
     encoding_format = "cp1252"
 else:
     encoding_format = "utf-8"

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -30,7 +30,7 @@ folder_path_overview = os.getcwd() + "/output"
 folder_path_compliance = os.getcwd() + "/output/compliance"
 
 # Encoding, if the os is windows, use cp1252. Use utf-8 if it is running using python3
-if os.name == "nt" and "python" not in sys.argv[0].lower():
+if os.name == "nt" and ".py" not in sys.argv[0].lower():
     encoding_format = "cp1252"
 else:
     encoding_format = "utf-8"

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -30,3 +30,5 @@ folder_path_compliance = os.getcwd() + "/output/compliance"
 
 # Encoding
 encoding_format = "utf-8"
+# Error action, it is recommended to use "ignore" or "replace"
+error_action = "ignore"

--- a/dashboard/pages/compliance.py
+++ b/dashboard/pages/compliance.py
@@ -57,7 +57,7 @@ def load_csv_files(csv_files):
     dfs = []
     results = []
     for file in csv_files:
-        df = pd.read_csv(file, sep=";", on_bad_lines="skip")
+        df = pd.read_csv(file, sep=";", on_bad_lines="skip", encoding=encoding_format)
         if "CHECKID" in df.columns:
             dfs.append(df)
             result = file
@@ -245,7 +245,9 @@ def display_data(
         """Load CSV files into a single pandas DataFrame."""
         dfs = []
         for file in files:
-            df = pd.read_csv(file, sep=";", on_bad_lines="skip")
+            df = pd.read_csv(
+                file, sep=";", on_bad_lines="skip", encoding=encoding_format
+            )
             dfs.append(df.astype(str))
         return pd.concat(dfs, ignore_index=True)
 

--- a/dashboard/pages/compliance.py
+++ b/dashboard/pages/compliance.py
@@ -16,6 +16,7 @@ from dash.dependencies import Input, Output
 # Config import
 from dashboard.config import (
     encoding_format,
+    error_action,
     fail_color,
     folder_path_compliance,
     info_color,
@@ -38,7 +39,9 @@ warnings.filterwarnings("ignore")
 
 csv_files = []
 for file in glob.glob(os.path.join(folder_path_compliance, "*.csv")):
-    with open(file, "r", newline="", encoding=encoding_format) as csvfile:
+    with open(
+        file, "r", newline="", encoding=encoding_format, errors=error_action
+    ) as csvfile:
         reader = csv.reader(csvfile)
         num_rows = sum(1 for row in reader)
         if num_rows > 1:

--- a/dashboard/pages/compliance.py
+++ b/dashboard/pages/compliance.py
@@ -30,6 +30,7 @@ from dashboard.lib.dropdowns import (
     create_region_dropdown_compliance,
 )
 from dashboard.lib.layouts import create_layout_compliance
+from prowler.lib.logger import logger
 
 # Suppress warnings
 warnings.filterwarnings("ignore")
@@ -39,13 +40,16 @@ warnings.filterwarnings("ignore")
 
 csv_files = []
 for file in glob.glob(os.path.join(folder_path_compliance, "*.csv")):
-    with open(
-        file, "r", newline="", encoding=encoding_format, errors=error_action
-    ) as csvfile:
-        reader = csv.reader(csvfile)
-        num_rows = sum(1 for row in reader)
-        if num_rows > 1:
-            csv_files.append(file)
+    try:
+        with open(
+            file, "r", newline="", encoding=encoding_format, errors=error_action
+        ) as csvfile:
+            reader = csv.reader(csvfile)
+            num_rows = sum(1 for row in reader)
+            if num_rows > 1:
+                csv_files.append(file)
+    except UnicodeDecodeError:
+        logger.error(f"Error decoding file: {file}")
 
 
 def load_csv_files(csv_files):

--- a/dashboard/pages/overview.py
+++ b/dashboard/pages/overview.py
@@ -18,6 +18,7 @@ from dash.dependencies import Input, Output
 from dashboard.config import (
     critical_color,
     encoding_format,
+    error_action,
     fail_color,
     folder_path_overview,
     high_color,
@@ -51,7 +52,9 @@ warnings.filterwarnings("ignore")
 csv_files = []
 
 for file in glob.glob(os.path.join(folder_path_overview, "*.csv")):
-    with open(file, "r", newline="", encoding=encoding_format) as csvfile:
+    with open(
+        file, "r", newline="", encoding=encoding_format, errors=error_action
+    ) as csvfile:
         reader = csv.reader(csvfile)
         num_rows = sum(1 for row in reader)
         if num_rows > 1:

--- a/dashboard/pages/overview.py
+++ b/dashboard/pages/overview.py
@@ -84,7 +84,7 @@ def load_csv_files(csv_files):
     """Load CSV files into a single pandas DataFrame."""
     dfs = []
     for file in csv_files:
-        df = pd.read_csv(file, sep=";", on_bad_lines="skip")
+        df = pd.read_csv(file, sep=";", on_bad_lines="skip", encoding=encoding_format)
         if "CHECK_ID" in df.columns:
             if "TIMESTAMP" in df.columns or df["PROVIDER"].unique() == "aws":
                 dfs.append(df.astype(str))
@@ -463,7 +463,7 @@ def filter_data(
     # Select the files in the list_files that have the same date as the selected date
     list_files = []
     for file in csv_files:
-        df = pd.read_csv(file, sep=";", on_bad_lines="skip")
+        df = pd.read_csv(file, sep=";", on_bad_lines="skip", encoding=encoding_format)
         if "CHECK_ID" in df.columns:
             if "TIMESTAMP" in df.columns or df["PROVIDER"].unique() == "aws":
                 # This handles the case where we are using v3 outputs

--- a/dashboard/pages/overview.py
+++ b/dashboard/pages/overview.py
@@ -43,6 +43,7 @@ from dashboard.lib.dropdowns import (
     create_table_row_dropdown,
 )
 from dashboard.lib.layouts import create_layout_overview
+from prowler.lib.logger import logger
 
 # Suppress warnings
 warnings.filterwarnings("ignore")
@@ -55,10 +56,13 @@ for file in glob.glob(os.path.join(folder_path_overview, "*.csv")):
     with open(
         file, "r", newline="", encoding=encoding_format, errors=error_action
     ) as csvfile:
-        reader = csv.reader(csvfile)
-        num_rows = sum(1 for row in reader)
-        if num_rows > 1:
-            csv_files.append(file)
+        try:
+            reader = csv.reader(csvfile)
+            num_rows = sum(1 for row in reader)
+            if num_rows > 1:
+                csv_files.append(file)
+        except UnicodeDecodeError:
+            logger.error(f"Error decoding file: {file}")
 
 
 # Import logos providers


### PR DESCRIPTION
### Context

Fixes #3866

### Description

Errors related with encoding are solved, new  logic for encoding can be found in config.py file from dashboard.

Logic: for windows os, when installing Prowler from pip it is needed to use encoding `cp1252` but when using it with `python prowler.py dashboard` needs to use encoding `utf-8`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
