### PR TITLE
feat(ec2): improve EC2 Security Groups checks logic by checking if any instance is attached

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.py
@@ -9,6 +9,7 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22(Check):
         findings = []
         check_ports = [22]
         for security_group in ec2_client.security_groups:
+            sg_is_open = False
             # Check if ignoring flag is set and if the VPC and the SG is in use
             if ec2_client.provider.scan_unused_services or (
                 security_group.vpc_id in vpc_client.vpcs
@@ -30,8 +31,31 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22(Check):
                             ingress_rule, "tcp", check_ports, any_address=True
                         ):
                             report.status = "FAIL"
-                            report.status_extended = f"Security group {security_group.name} ({security_group.id}) has SSH port 22 open to the Internet."
+                            report.status_extended = f"Security group {security_group.name} ({security_group.id}) has SSH port 22 open to the Internet but it is not attached."
+                            report.check_metadata.Severity = "medium"
+                            sg_is_open = True
                             break
+                if sg_is_open:
+                    # Check if the security group is attached to any EC2 instance
+                    for network_interface in security_group.network_interfaces:
+                        instance_attached = network_interface.attachment.get(
+                            "InstanceId"
+                        )
+                        if instance_attached:
+                            report.status = "FAIL"
+                            report.check_metadata.Severity = "high"
+                            # Check if the EC2 instance has a public IP
+                            if not network_interface.association.get("PublicIp"):
+                                report.status_extended = f"EC2 Instance {instance_attached} has SSH exposed to 0.0.0.0/0 on private ip address {network_interface.private_ip}."
+                            else:
+                                report.status_extended = f"EC2 Instance {instance_attached} has SSH exposed to 0.0.0.0/0 on public ip address {network_interface.association.get('PublicIp')}."
+                                # Check if EC2 instance is in a public subnet
+                                if vpc_client.vpc_subnets[
+                                    network_interface.subnet_id
+                                ].public:
+                                    report.status_extended = f"EC2 Instance {instance_attached} has SSH exposed to 0.0.0.0/0 on public ip address {network_interface.association.get('PublicIp')} within public subnet {network_interface.subnet_id}."
+                                    report.check_metadata.Severity = "critical"
+
                 findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/vpc/vpc_service.py
+++ b/prowler/providers/aws/services/vpc/vpc_service.py
@@ -342,7 +342,12 @@ class VPC(AWSService):
                             for route in route_tables_for_subnet.get("RouteTables")[
                                 0
                             ].get("Routes"):
-                                if "GatewayId" in route and "igw" in route["GatewayId"]:
+                                if (
+                                    "GatewayId" in route
+                                    and "igw" in route["GatewayId"]
+                                    and route["DestinationCidrBlock"] == "0.0.0.0/0"
+                                ):
+                                    # If the route table has a default route to an internet gateway, the subnet is public
                                     public = True
                                 if "NatGatewayId" in route:
                                     nat_gateway = True

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22_test.py
@@ -331,6 +331,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
                         == f"EC2 Instance {instance_id} has SSH exposed to 0.0.0.0/0 on private ip address {network_interface.private_ip_address}."
                     )
                     assert sg.check_metadata.Severity == "high"
+                    assert sg.resource_details == instance_id
 
     @mock_aws
     def test_ec2_sg_attached_to_instance_with_public_ip(self):
@@ -414,6 +415,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
                         == f"EC2 Instance {instance_id} has SSH exposed to 0.0.0.0/0 on public ip address {public_ip}."
                     )
                     assert sg.check_metadata.Severity == "high"
+                    assert sg.resource_details == instance_id
 
     @mock_aws
     def test_ec2_sg_attached_to_instance_with_public_ip_in_public_subnet(self):
@@ -508,3 +510,127 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
                         == f"EC2 Instance {instance_id} has SSH exposed to 0.0.0.0/0 on public ip address {public_ip} within public subnet {subnet.id}."
                     )
                     assert sg.check_metadata.Severity == "critical"
+                    assert sg.resource_details == instance_id
+
+    @mock_aws
+    def test_ec2_sg_attached_to_2_instances_with_public_ip_in_public_subnet(self):
+        # Create EC2 Mocked Resources
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+        subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
+        network_interface = ec2.create_network_interface(SubnetId=subnet.id)
+        network_interface_2 = ec2.create_network_interface(SubnetId=subnet.id)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        # Create IGW and attach to VPC
+        igw = ec2.create_internet_gateway()
+        vpc.attach_internet_gateway(InternetGatewayId=igw.id)
+        # Set IGW as default route for public subnet
+        route_table = ec2.create_route_table(VpcId=vpc.id)
+        route_table.associate_with_subnet(SubnetId=subnet.id)
+        ec2_client.create_route(
+            RouteTableId=route_table.id,
+            DestinationCidrBlock="0.0.0.0/0",
+            GatewayId=igw.id,
+        )
+        # Associate public ip to network interfaces
+        ec2_client.associate_address(
+            AllocationId=ec2_client.allocate_address(Domain="vpc")["AllocationId"],
+            NetworkInterfaceId=network_interface.id,
+        )
+        ec2_client.associate_address(
+            AllocationId=ec2_client.allocate_address(Domain="vpc")["AllocationId"],
+            NetworkInterfaceId=network_interface_2.id,
+        )
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        # Attach 2 instances to default sg
+        instance_id = ec2.create_instances(
+            NetworkInterfaces=[
+                {
+                    "NetworkInterfaceId": network_interface.id,
+                    "DeviceIndex": 0,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            MinCount=1,
+            MaxCount=1,
+            SecurityGroupIds=[default_sg_id],
+        )[0].id
+        instance_id_2 = ec2.create_instances(
+            NetworkInterfaces=[
+                {
+                    "NetworkInterfaceId": network_interface_2.id,
+                    "DeviceIndex": 0,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            MinCount=1,
+            MaxCount=1,
+            SecurityGroupIds=[default_sg_id],
+        )[0].id
+        # Get Instances public ip
+        public_ip = ec2_client.describe_instances(InstanceIds=[instance_id])[
+            "Reservations"
+        ][0]["Instances"][0]["PublicIpAddress"]
+        public_ip_2 = ec2_client.describe_instances(InstanceIds=[instance_id_2])[
+            "Reservations"
+        ][0]["Instances"][0]["PublicIpAddress"]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1],
+        )
+
+        with mock.patch(
+            "prowler.providers.common.common.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_client",
+            new=EC2(aws_provider),
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.vpc_client",
+            new=VPC(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22 import (
+                ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22,
+            )
+
+            check = ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22()
+            result = check.execute()
+
+            # One default sg per region
+            assert len(result) == 3
+            # Search changed sg
+            for sg in result:
+                if sg.resource_id == default_sg_id:
+                    if instance_id == sg.resource_details:
+                        assert sg.status == "FAIL"
+                        assert sg.region == AWS_REGION_US_EAST_1
+                        assert (
+                            sg.status_extended
+                            == f"EC2 Instance {instance_id} has SSH exposed to 0.0.0.0/0 on public ip address {public_ip} within public subnet {subnet.id}."
+                        )
+                        assert sg.check_metadata.Severity == "critical"
+                    elif instance_id_2 == sg.resource_details:
+                        assert sg.status == "FAIL"
+                        assert sg.region == AWS_REGION_US_EAST_1
+                        assert (
+                            sg.status_extended
+                            == f"EC2 Instance {instance_id_2} has SSH exposed to 0.0.0.0/0 on public ip address {public_ip_2} within public subnet {subnet.id}."
+                        )
+                        assert sg.check_metadata.Severity == "critical"

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22_test.py
@@ -105,7 +105,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
                     assert sg.region == AWS_REGION_US_EAST_1
                     assert (
                         sg.status_extended
-                        == f"Security group {default_sg_name} ({default_sg_id}) has SSH port 22 open to the Internet."
+                        == f"Security group {default_sg_name} ({default_sg_id}) has SSH port 22 open to the Internet but it is not attached."
                     )
                     assert search(
                         "has SSH port 22 open to the Internet",
@@ -116,6 +116,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
                         == f"arn:{aws_provider.identity.partition}:ec2:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
+                    assert sg.check_metadata.Severity == "medium"
                     assert sg.resource_tags == []
 
     @mock_aws
@@ -256,3 +257,254 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_ec2_sg_attached_to_instance_with_private_ip(self):
+        # Create EC2 Mocked Resources
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+        subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
+        network_interface = ec2.create_network_interface(SubnetId=subnet.id)
+
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        # Attach instance to default sg
+        instance_id = ec2.create_instances(
+            NetworkInterfaces=[
+                {
+                    "NetworkInterfaceId": network_interface.id,
+                    "DeviceIndex": 0,
+                }
+            ],
+            MinCount=1,
+            MaxCount=1,
+            SecurityGroupIds=[default_sg_id],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1],
+        )
+
+        with mock.patch(
+            "prowler.providers.common.common.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_client",
+            new=EC2(aws_provider),
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.vpc_client",
+            new=VPC(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22 import (
+                ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22,
+            )
+
+            check = ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22()
+            result = check.execute()
+
+            # One default sg per region
+            assert len(result) == 2
+            # Search changed sg
+            for sg in result:
+                if sg.resource_id == default_sg_id:
+                    assert sg.status == "FAIL"
+                    assert sg.region == AWS_REGION_US_EAST_1
+                    assert (
+                        sg.status_extended
+                        == f"EC2 Instance {instance_id} has SSH exposed to 0.0.0.0/0 on private ip address {network_interface.private_ip_address}."
+                    )
+                    assert sg.check_metadata.Severity == "high"
+
+    @mock_aws
+    def test_ec2_sg_attached_to_instance_with_public_ip(self):
+        # Create EC2 Mocked Resources
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+        subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
+        network_interface = ec2.create_network_interface(SubnetId=subnet.id)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        # Associate public ip to network interface
+        ec2_client.associate_address(
+            AllocationId=ec2_client.allocate_address(Domain="vpc")["AllocationId"],
+            NetworkInterfaceId=network_interface.id,
+        )
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        # Attach instance to default sg
+        instance_id = ec2.create_instances(
+            NetworkInterfaces=[
+                {
+                    "NetworkInterfaceId": network_interface.id,
+                    "DeviceIndex": 0,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            MinCount=1,
+            MaxCount=1,
+            SecurityGroupIds=[default_sg_id],
+        )[0].id
+        # Get Instance public ip
+        public_ip = ec2_client.describe_instances(InstanceIds=[instance_id])[
+            "Reservations"
+        ][0]["Instances"][0]["PublicIpAddress"]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1],
+        )
+
+        with mock.patch(
+            "prowler.providers.common.common.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_client",
+            new=EC2(aws_provider),
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.vpc_client",
+            new=VPC(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22 import (
+                ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22,
+            )
+
+            check = ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22()
+            result = check.execute()
+
+            # One default sg per region
+            assert len(result) == 2
+            # Search changed sg
+            for sg in result:
+                if sg.resource_id == default_sg_id:
+                    assert sg.status == "FAIL"
+                    assert sg.region == AWS_REGION_US_EAST_1
+                    assert (
+                        sg.status_extended
+                        == f"EC2 Instance {instance_id} has SSH exposed to 0.0.0.0/0 on public ip address {public_ip}."
+                    )
+                    assert sg.check_metadata.Severity == "high"
+
+    @mock_aws
+    def test_ec2_sg_attached_to_instance_with_public_ip_in_public_subnet(self):
+        # Create EC2 Mocked Resources
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+        subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
+        network_interface = ec2.create_network_interface(SubnetId=subnet.id)
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        # Create IGW and attach to VPC
+        igw = ec2.create_internet_gateway()
+        vpc.attach_internet_gateway(InternetGatewayId=igw.id)
+        # Set IGW as default route for public subnet
+        route_table = ec2.create_route_table(VpcId=vpc.id)
+        route_table.associate_with_subnet(SubnetId=subnet.id)
+        ec2_client.create_route(
+            RouteTableId=route_table.id,
+            DestinationCidrBlock="0.0.0.0/0",
+            GatewayId=igw.id,
+        )
+        # Associate public ip to network interface
+        ec2_client.associate_address(
+            AllocationId=ec2_client.allocate_address(Domain="vpc")["AllocationId"],
+            NetworkInterfaceId=network_interface.id,
+        )
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        # Attach instance to default sg
+        instance_id = ec2.create_instances(
+            NetworkInterfaces=[
+                {
+                    "NetworkInterfaceId": network_interface.id,
+                    "DeviceIndex": 0,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            MinCount=1,
+            MaxCount=1,
+            SecurityGroupIds=[default_sg_id],
+        )[0].id
+        # Get Instance public ip
+        public_ip = ec2_client.describe_instances(InstanceIds=[instance_id])[
+            "Reservations"
+        ][0]["Instances"][0]["PublicIpAddress"]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1],
+        )
+
+        with mock.patch(
+            "prowler.providers.common.common.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_client",
+            new=EC2(aws_provider),
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.vpc_client",
+            new=VPC(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22 import (
+                ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22,
+            )
+
+            check = ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22()
+            result = check.execute()
+
+            # One default sg per region
+            assert len(result) == 2
+            # Search changed sg
+            for sg in result:
+                if sg.resource_id == default_sg_id:
+                    assert sg.status == "FAIL"
+                    assert sg.region == AWS_REGION_US_EAST_1
+                    assert (
+                        sg.status_extended
+                        == f"EC2 Instance {instance_id} has SSH exposed to 0.0.0.0/0 on public ip address {public_ip} within public subnet {subnet.id}."
+                    )
+                    assert sg.check_metadata.Severity == "critical"


### PR DESCRIPTION
### Description

Improve EC2 Security Groups checks logic by checking if any instance is attached.
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_any_port
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21
- [x] ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_tcp_udp_port_kerberos_88
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_tcp_udp_port_ldap_389_636
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cifs_139_445
- [ ] ec2_securitygroup_allow_ingress_from_internet_to_custom_tcp_port

Also changing the severity with the following cases:

1. medium -> Security group XXX has SSH port 22 open to the Internet but it is not attached.
2. high -> EC2 Instance XXX has SSH exposed to 0.0.0.0/0 on private ip address XXX.
3. high -> EC2 Instance XXX has SSH exposed to 0.0.0.0/0 on public ip address XXX.
4. critical -> EC2 Instance XXX has SSH exposed to 0.0.0.0/0 on public ip address XXX within public subnet XXX.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
