### PR TITLE
fix(s3-integration): Store compliance outputs in their folder

### DIFF
--- a/prowler/providers/aws/lib/s3/s3.py
+++ b/prowler/providers/aws/lib/s3/s3.py
@@ -10,24 +10,25 @@ def send_to_s3_bucket(
     output_filename, output_directory, output_mode, output_bucket_name, audit_session
 ):
     try:
-        filename = ""
-        # Get only last part of the path
-        if output_mode == "csv":
-            filename = f"{output_filename}{csv_file_suffix}"
-        elif output_mode == "json-asff":
-            filename = f"{output_filename}{json_asff_file_suffix}"
-        elif output_mode == "json-ocsf":
-            filename = f"{output_filename}{json_ocsf_file_suffix}"
-        else:  # Compliance output mode
-            filename = f"{output_filename}_{output_mode}{csv_file_suffix}"
-
-        logger.info(f"Sending output file {filename} to S3 bucket {output_bucket_name}")
-        # File location
-        file_name = output_directory + "/" + filename
-
         # S3 Object name
         bucket_directory = get_s3_object_path(output_directory)
-        object_name = bucket_directory + "/" + output_mode + "/" + filename
+        filename = ""
+        # Get only last part of the path
+        if output_mode in ["csv", "json-asff", "json-ocsf"]:
+            if output_mode == "csv":
+                filename = f"{output_filename}{csv_file_suffix}"
+            elif output_mode == "json-asff":
+                filename = f"{output_filename}{json_asff_file_suffix}"
+            elif output_mode == "json-ocsf":
+                filename = f"{output_filename}{json_ocsf_file_suffix}"
+            file_name = output_directory + "/" + filename
+            object_name = bucket_directory + "/" + output_mode + "/" + filename
+        else:  # Compliance output mode
+            filename = f"{output_filename}_{output_mode}{csv_file_suffix}"
+            file_name = output_directory + "/compliance/" + filename
+            object_name = bucket_directory + "/compliance/" + filename
+
+        logger.info(f"Sending output file {filename} to S3 bucket {output_bucket_name}")
 
         s3_client = audit_session.client("s3")
         s3_client.upload_file(file_name, output_bucket_name, object_name)

--- a/tests/providers/aws/lib/s3/s3_test.py
+++ b/tests/providers/aws/lib/s3/s3_test.py
@@ -87,7 +87,7 @@ class TestS3:
         )
 
         bucket_directory = get_s3_object_path(output_directory)
-        object_name = f"{bucket_directory}/{OUTPUT_MODE_CIS_1_4_AWS}/{filename}_{OUTPUT_MODE_CIS_1_4_AWS}{csv_file_suffix}"
+        object_name = f"{bucket_directory}/compliance/{filename}_{OUTPUT_MODE_CIS_1_4_AWS}{csv_file_suffix}"
 
         assert (
             client.get_object(


### PR DESCRIPTION
### Description

Since Prowler v4 is adding compliance outputs inside the `/output/compliance` path it is needed to make some changes to add the outputs in the correct path inside the s3 bucket


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
