### PR TITLE
chore(get_tagged_resources): Add return value type hint

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -630,7 +630,7 @@ class AwsProvider(Provider):
                 audited_regions.add(region)
         return audited_regions
 
-    def get_tagged_resources(self, input_resource_tags: list[str]) -> list[dict]:
+    def get_tagged_resources(self, input_resource_tags: list[str]) -> list[str]:
         """
         Returns a list of the resources that are going to be scanned based on the given input tags.
 

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -630,7 +630,7 @@ class AwsProvider(Provider):
                 audited_regions.add(region)
         return audited_regions
 
-    def get_tagged_resources(self, input_resource_tags: list[str]):
+    def get_tagged_resources(self, input_resource_tags: list[str]) -> list[dict]:
         """
         Returns a list of the resources that are going to be scanned based on the given input tags.
 


### PR DESCRIPTION
### Context

Adding missing PEP 484 compliant type hints.


### Description

Function get_tagged_resources was missing type hint for returned value.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
