### PR TITLE
fix(aws): Extend opensearch_service_domains_use_cognito_authentication_for_kibana with SAML

### DIFF
--- a/prowler/providers/aws/services/opensearch/opensearch_service.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service.py
@@ -117,6 +117,9 @@ class OpenSearchService(AWSService):
                 domain.internal_user_database = describe_domain["DomainStatus"][
                     "AdvancedSecurityOptions"
                 ]["InternalUserDatabaseEnabled"]
+                domain.saml_enabled = describe_domain["DomainStatus"][
+                    "AdvancedSecurityOptions"
+                ]["SAMLOptions"]["Enabled"]
                 domain.update_available = describe_domain["DomainStatus"][
                     "ServiceSoftwareOptions"
                 ]["UpdateAvailable"]
@@ -159,6 +162,7 @@ class OpenSearchDomain(BaseModel):
     node_to_node_encryption: bool = None
     enforce_https: bool = None
     internal_user_database: bool = None
+    saml_enabled: bool = None
     update_available: bool = None
     version: str = None
     tags: Optional[list] = []

--- a/prowler/providers/aws/services/opensearch/opensearch_service_domains_use_cognito_authentication_for_kibana/opensearch_service_domains_use_cognito_authentication_for_kibana.metadata.json
+++ b/prowler/providers/aws/services/opensearch/opensearch_service_domains_use_cognito_authentication_for_kibana/opensearch_service_domains_use_cognito_authentication_for_kibana.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "opensearch_service_domains_use_cognito_authentication_for_kibana",
-  "CheckTitle": "Check if Amazon Elasticsearch/Opensearch Service domains has Amazon Cognito authentication for Kibana enabled",
+  "CheckTitle": "Check if Amazon Elasticsearch/Opensearch Service domains has either Amazon Cognito or SAML authentication for Kibana enabled",
   "CheckType": [
     "Identify",
     "Logging"
@@ -11,8 +11,8 @@
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
   "Severity": "high",
   "ResourceType": "AwsOpenSearchDomain",
-  "Description": "Check if Amazon Elasticsearch/Opensearch Service domains has Amazon Cognito authentication for Kibana enabled",
-  "Risk": "Amazon Elasticsearch Service supports Amazon Cognito for Kibana authentication.",
+  "Description": "Check if Amazon Elasticsearch/Opensearch Service domains has Amazon Cognito or SAML authentication for Kibana enabled",
+  "Risk": "Not enabling Amazon Cognito or SAML authentication for Kibana in AWS Elasticsearch/OpenSearch Service domains increases the likelihood of unauthorized access to sensitive data, potentially compromising system integrity.",
   "RelatedUrl": "",
   "Remediation": {
     "Code": {
@@ -22,7 +22,7 @@
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "If you do not configure Amazon Cognito authentication; you can still protect Kibana using an IP-based access policy and a proxy server; HTTP basic authentication; or SAML.",
+      "Text": "If you do not configure Amazon Cognito or SAML authentication; you can still protect Kibana using an IP-based access policy and a proxy server; HTTP basic authentication.",
       "Url": "https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-ac.html"
     }
   },

--- a/prowler/providers/aws/services/opensearch/opensearch_service_domains_use_cognito_authentication_for_kibana/opensearch_service_domains_use_cognito_authentication_for_kibana.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service_domains_use_cognito_authentication_for_kibana/opensearch_service_domains_use_cognito_authentication_for_kibana.py
@@ -14,10 +14,10 @@ class opensearch_service_domains_use_cognito_authentication_for_kibana(Check):
             report.resource_arn = domain.arn
             report.resource_tags = domain.tags
             report.status = "PASS"
-            report.status_extended = f"Opensearch domain {domain.name} has Amazon Cognito authentication for Kibana enabled."
-            if not domain.cognito_options:
+            report.status_extended = f"Opensearch domain {domain.name} has either Amazon Cognito or SAML authentication for Kibana enabled."
+            if not domain.cognito_options and not domain.saml_enabled:
                 report.status = "FAIL"
-                report.status_extended = f"Opensearch domain {domain.name} does not have Amazon Cognito authentication for Kibana enabled."
+                report.status_extended = f"Opensearch domain {domain.name} has neither Amazon Cognito nor SAML authentication for Kibana enabled."
 
             findings.append(report)
 

--- a/tests/providers/aws/services/opensearch/opensearch_service_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_test.py
@@ -79,7 +79,10 @@ def mock_make_api_call(self, operation_name, kwarg):
                 },
                 "ServiceSoftwareOptions": {"UpdateAvailable": True},
                 "DomainEndpointOptions": {"EnforceHTTPS": True},
-                "AdvancedSecurityOptions": {"InternalUserDatabaseEnabled": True},
+                "AdvancedSecurityOptions": {
+                    "InternalUserDatabaseEnabled": True,
+                    "SAMLOptions": {"Enabled": True},
+                },
             }
         }
     if operation_name == "ListTags":
@@ -166,6 +169,7 @@ class Test_OpenSearchService_Service:
         assert opensearch.opensearch_domains[0].node_to_node_encryption
         assert opensearch.opensearch_domains[0].enforce_https
         assert opensearch.opensearch_domains[0].internal_user_database
+        assert opensearch.opensearch_domains[0].saml_enabled
         assert opensearch.opensearch_domains[0].update_available
         assert opensearch.opensearch_domains[0].version == "opensearch-version1"
         assert opensearch.opensearch_domains[0].tags == [


### PR DESCRIPTION
### Context 

The check `opensearch_service_domains_use_cognito_authentication_for_kibana` fails if Amazon OpenSearch has Amazon Cognito authentication for Kibana **not** enabled. However, besides Cognito, AWS recommends to use **SAML** authentication for Kibana which means that Cognito must be disabled. Since the `opensearch_service_domains_use_cognito_authentication_for_kibana` does not test whether **either** Cognito **or** SAML is enabled, it will fail when SAML is enabled.


### Description

Therefore, I extended the check `opensearch_service_domains_use_cognito_authentication_for_kibana` in a way that it tests whether **either** Cognito **or** SAML is enabled for Kibana on AWS OpenSearch. If either is enabled, `opensearch_service_domains_use_cognito_authentication_for_kibana` will pass.
That's by the way also what the corresponding prowler v2 check `check_extra780` did at its time. See its corresponding [pull request](https://github.com/prowler-cloud/prowler/pull/1291) that had been merged into main at that time. It's a pity that this change hadn't been migrated neither to prowler v3 nor to v4.

For prowler v3 I opened a PR this morning which has been already merged. See https://github.com/prowler-cloud/prowler/pull/3861


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.