### PR TITLE
fix(vpc): solve subnet route key error

### DIFF
--- a/prowler/providers/aws/services/vpc/vpc_service.py
+++ b/prowler/providers/aws/services/vpc/vpc_service.py
@@ -345,7 +345,8 @@ class VPC(AWSService):
                                 if (
                                     "GatewayId" in route
                                     and "igw" in route["GatewayId"]
-                                    and route["DestinationCidrBlock"] == "0.0.0.0/0"
+                                    and route.get("DestinationCidrBlock", "")
+                                    == "0.0.0.0/0"
                                 ):
                                     # If the route table has a default route to an internet gateway, the subnet is public
                                     public = True


### PR DESCRIPTION
### Description

Solve subnet route KeyError `DestinationCidrBlock`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
