### PR TITLE
fix(vpc): solve AWS principal key error

### DIFF
--- a/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
+++ b/prowler/providers/aws/services/vpc/vpc_endpoint_connections_trust_boundaries/vpc_endpoint_connections_trust_boundaries.py
@@ -55,10 +55,14 @@ class vpc_endpoint_connections_trust_boundaries(Check):
                             break
 
                     else:
-                        if isinstance(statement["Principal"]["AWS"], str):
-                            principals = [statement["Principal"]["AWS"]]
+                        if "AWS" in statement["Principal"]:
+                            if isinstance(statement["Principal"]["AWS"], str):
+                                principals = [statement["Principal"]["AWS"]]
+                            else:
+                                principals = statement["Principal"]["AWS"]
                         else:
-                            principals = statement["Principal"]["AWS"]
+                            # If the principal is not an AWS principal, we don't need to check it since it could be a service or a federated principal
+                            principals = []
                         for principal_arn in principals:
                             report = Check_Report_AWS(self.metadata())
                             report.region = endpoint.region


### PR DESCRIPTION
### Description

Handle the AWS KeyError when the VPC Endpoint policy does not contain an AWS principal.
If the principal is not an AWS principal, we don't need to check it since it could be a service or a federated principal.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
