### PR TITLE
chore(mutelist): improve default AWS mutelist with ControlTower

### DIFF
--- a/docs/tutorials/mutelist.md
+++ b/docs/tutorials/mutelist.md
@@ -115,7 +115,7 @@ If you want to mute failed findings only in specific regions, create a file with
               - "*"
 
 ### Default Mutelist
-For the AWS Provider, Prowler is executed with a Default AWS Mutelist with the AWS Resources that should be muted such as all resources created by AWS Control Tower when setting up a landing zone.
+For the AWS Provider, Prowler is executed with a default AWS Mutelist with the AWS Resources that should be muted such as all resources created by AWS Control Tower when setting up a landing zone that can be found in [AWS Documentation](https://docs.aws.amazon.com/controltower/latest/userguide/shared-account-resources.html).
 You can see this Mutelist file in [`prowler/config/aws_mutelist.yaml`](https://github.com/prowler-cloud/prowler/blob/master/prowler/config/aws_allowlist.yaml).
 
 ### Supported Mutelist Locations

--- a/prowler/config/aws_mutelist.yaml
+++ b/prowler/config/aws_mutelist.yaml
@@ -27,11 +27,25 @@ Mutelist:
             - "*"
           Resources:
             - "aws-controltower-BaselineCloudTrail"
+        "cloudwatch_log_group_*":
+          Regions:
+            - "*"
+          Resources:
+            - "aws-controltower/CloudTrailLogs"
+        "iam_inline_policy_no_administrative_privileges":
+          Regions:
+            - "*"
+          Resources:
+            - "aws-controltower-ForwardSnsNotificationRole/sns"
+            - "aws-controltower-AuditAdministratorRole/AssumeRole-aws-controltower-AuditAdministratorRole"
+            - "aws-controltower-AuditReadOnlyRole/AssumeRole-aws-controltower-AuditReadOnlyRole"
         "iam_role_*":
           Regions:
             - "*"
           Resources:
             - "aws-controltower-AdministratorExecutionRole"
+            - "aws-controltower-AuditAdministratorRole"
+            - "aws-controltower-AuditReadOnlyRole"
             - "aws-controltower-CloudWatchLogsRole"
             - "aws-controltower-ConfigRecorderRole"
             - "aws-controltower-ForwardSnsNotificationRole"
@@ -56,6 +70,8 @@ Mutelist:
           Regions:
             - "*"
           Resources:
+            - "aws-controltower-AggregateSecurityNotifications"
+            - "aws-controltower-AllConfigNotifications"
             - "aws-controltower-SecurityNotifications"
         "vpc_*":
           Regions:

--- a/prowler/config/aws_mutelist.yaml
+++ b/prowler/config/aws_mutelist.yaml
@@ -3,14 +3,8 @@ Mutelist:
     "*":
       ########################### AWS CONTROL TOWER ###########################
       ### The following entries includes all resources created by AWS Control Tower when setting up a landing zone ###
-      # https://docs.aws.amazon.com/controltower/latest/userguide/how-control-tower-works.html #
+      # https://docs.aws.amazon.com/controltower/latest/userguide/shared-account-resources.html #
       Checks:
-        "cloudwatch_log_group_*":
-          Regions:
-            - "*"
-          Resources:
-            - "/aws/lambda/aws-controltower-NotificationForwarder"
-            - "StackSet-AWSControlTowerBP-*"
         "awslambda_function_*":
           Regions:
             - "*"
@@ -21,7 +15,6 @@ Mutelist:
             - "*"
           Resources:
             - "StackSet-AWSControlTowerGuardrailAWS-*"
-            - "StackSet-AWSControlTowerGuardrailAWS-GR-*"
             - "StackSet-AWSControlTowerBP-*"
             - "StackSet-AWSControlTowerSecurityResources-*"
             - "StackSet-AWSControlTowerLoggingResources-*"
@@ -38,6 +31,8 @@ Mutelist:
             - "*"
           Resources:
             - "aws-controltower/CloudTrailLogs"
+            - "/aws/lambda/aws-controltower-NotificationForwarder"
+            - "StackSet-AWSControlTowerBP-*"
         "iam_inline_policy_no_administrative_privileges":
           Regions:
             - "*"
@@ -72,7 +67,6 @@ Mutelist:
             - "AWSControlTowerAccountServiceRolePolicy"
             - "AWSControlTowerServiceRolePolicy"
             - "AWSControlTowerStackSetRolePolicy"
-            - "AWSControlTowerCloudTrailRolePolicy"
             - "AWSControlTowerAdminPolicy"
             - "AWSLoadBalancerControllerIAMPolicy"
             - "AWSControlTowerCloudTrailRolePolicy"

--- a/prowler/config/aws_mutelist.yaml
+++ b/prowler/config/aws_mutelist.yaml
@@ -16,12 +16,14 @@ Mutelist:
             - "*"
           Resources:
             - "aws-controltower-NotificationForwarder"
-        "cloudformation_stacks_*":
+        "cloudformation_stack*":
           Regions:
             - "*"
           Resources:
             - "StackSet-AWSControlTowerGuardrailAWS-*"
             - "StackSet-AWSControlTowerBP-*"
+            - "StackSet-AWSControlTowerSecurityResources-*"
+            - "StackSet-AWSControlTowerLoggingResources-*"
         "cloudtrail_*":
           Regions:
             - "*"
@@ -55,7 +57,7 @@ Mutelist:
             - "AWSAFTAdmin"
             - "AWSAFTExecution"
             - "AWSAFTService"
-        "iam_policy_*":
+        "iam_*_policy_*":
           Regions:
             - "*"
           Resources:

--- a/prowler/config/aws_mutelist.yaml
+++ b/prowler/config/aws_mutelist.yaml
@@ -21,9 +21,13 @@ Mutelist:
             - "*"
           Resources:
             - "StackSet-AWSControlTowerGuardrailAWS-*"
+            - "StackSet-AWSControlTowerGuardrailAWS-GR-*"
             - "StackSet-AWSControlTowerBP-*"
             - "StackSet-AWSControlTowerSecurityResources-*"
             - "StackSet-AWSControlTowerLoggingResources-*"
+            - "StackSet-AWSControlTowerExecutionRole-*"
+            - "AWSControlTowerBP-BASELINE-CLOUDTRAIL-MASTER"
+            - "AWSControlTowerBP-BASELINE-CONFIG-MASTER"
         "cloudtrail_*":
           Regions:
             - "*"
@@ -54,6 +58,10 @@ Mutelist:
             - "aws-controltower-ReadOnlyExecutionRole"
             - "AWSControlTower_VPCFlowLogsRole"
             - "AWSControlTowerExecution"
+            - "AWSControlTowerCloudTrailRole"
+            - "AWSControlTowerConfigAggregatorRoleForOrganizations"
+            - "AWSControlTowerStackSetRole"
+            - "AWSControlTowerAdmin"
             - "AWSAFTAdmin"
             - "AWSAFTExecution"
             - "AWSAFTService"
@@ -61,7 +69,13 @@ Mutelist:
           Regions:
             - "*"
           Resources:
+            - "AWSControlTowerAccountServiceRolePolicy"
             - "AWSControlTowerServiceRolePolicy"
+            - "AWSControlTowerStackSetRolePolicy"
+            - "AWSControlTowerCloudTrailRolePolicy"
+            - "AWSControlTowerAdminPolicy"
+            - "AWSLoadBalancerControllerIAMPolicy"
+            - "AWSControlTowerCloudTrailRolePolicy"
         "s3_bucket_*":
           Regions:
             - "*"

--- a/prowler/config/aws_mutelist.yaml
+++ b/prowler/config/aws_mutelist.yaml
@@ -40,6 +40,16 @@ Mutelist:
             - "aws-controltower-ForwardSnsNotificationRole/sns"
             - "aws-controltower-AuditAdministratorRole/AssumeRole-aws-controltower-AuditAdministratorRole"
             - "aws-controltower-AuditReadOnlyRole/AssumeRole-aws-controltower-AuditReadOnlyRole"
+        "iam.*policy_*":
+          Regions:
+            - "*"
+          Resources:
+            - "AWSControlTowerAccountServiceRolePolicy"
+            - "AWSControlTowerServiceRolePolicy"
+            - "AWSControlTowerStackSetRolePolicy"
+            - "AWSControlTowerAdminPolicy"
+            - "AWSLoadBalancerControllerIAMPolicy"
+            - "AWSControlTowerCloudTrailRolePolicy"
         "iam_role_*":
           Regions:
             - "*"
@@ -60,16 +70,6 @@ Mutelist:
             - "AWSAFTAdmin"
             - "AWSAFTExecution"
             - "AWSAFTService"
-        "iam_*_policy_*":
-          Regions:
-            - "*"
-          Resources:
-            - "AWSControlTowerAccountServiceRolePolicy"
-            - "AWSControlTowerServiceRolePolicy"
-            - "AWSControlTowerStackSetRolePolicy"
-            - "AWSControlTowerAdminPolicy"
-            - "AWSLoadBalancerControllerIAMPolicy"
-            - "AWSControlTowerCloudTrailRolePolicy"
         "s3_bucket_*":
           Regions:
             - "*"


### PR DESCRIPTION
### Description

Improve default AWS mutelist with more ControlTower resources.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
