### PR TITLE
fix(ec2): handle non-existing private ip

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -261,7 +261,7 @@ class EC2(AWSService):
                         id=interface["NetworkInterfaceId"],
                         association=interface.get("Association", {}),
                         attachment=interface.get("Attachment", {}),
-                        private_ip=interface["PrivateIpAddress"],
+                        private_ip=interface.get("PrivateIpAddress"),
                         type=interface["InterfaceType"],
                         subnet_id=interface["SubnetId"],
                         vpc_id=interface["VpcId"],
@@ -524,7 +524,7 @@ class NetworkInterface(BaseModel):
     id: str
     association: dict
     attachment: dict
-    private_ip: str
+    private_ip: Optional[str]
     type: str
     subnet_id: str
     vpc_id: str


### PR DESCRIPTION
### Description

Handle non-existing Private IPs in Instances to solve `[KeyError[258]: 'PrivateIpAddress']`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
