### PR TITLE
docs(compliance): Add notes about compliance output

### DIFF
--- a/docs/tutorials/compliance.md
+++ b/docs/tutorials/compliance.md
@@ -14,6 +14,9 @@ Standard results will be shown and additionally the framework information as the
 
 <img src="../img/compliance/compliance-cis-sample1.png"/>
 
+???+ note
+    **If Prowler can't find a resource related with a check from a compliance requirement, this requirement won't appear on the output**
+
 ## List Available Compliance Frameworks
 In order to see which compliance frameworks are cover by Prowler, you can use option `--list-compliance`:
 ```sh


### PR DESCRIPTION
### Description

Details for compliance are added to docs. If no resources are found for a requirement from a compliance, this requirement won't be shown on the output.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
