### PR TITLE
fix(output): Handle case for None organizations metadata

### DIFF
--- a/prowler/lib/outputs/utils.py
+++ b/prowler/lib/outputs/utils.py
@@ -5,7 +5,10 @@ def unroll_list(listed_items: list, separator: str = "|"):
             if not unrolled_items:
                 unrolled_items = f"{item}"
             else:
-                unrolled_items = f"{unrolled_items}{separator} {item}"
+                if separator == "|":
+                    unrolled_items = f"{unrolled_items} {separator} {item}"
+                else:
+                    unrolled_items = f"{unrolled_items}{separator} {item}"
 
     return unrolled_items
 

--- a/prowler/lib/outputs/utils.py
+++ b/prowler/lib/outputs/utils.py
@@ -5,7 +5,7 @@ def unroll_list(listed_items: list, separator: str = "|"):
             if not unrolled_items:
                 unrolled_items = f"{item}"
             else:
-                unrolled_items = f"{unrolled_items} {separator} {item}"
+                unrolled_items = f"{unrolled_items}{separator} {item}"
 
     return unrolled_items
 

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -308,7 +308,7 @@ class AwsProvider(Provider):
         - aws_account_id: is the AWS Account ID from which we want to get the AWS Organizations account metadata
 
         Returns:
-        - None if it is not unable to retrieve that data, and raises a logger.warning()
+        - AWSOrganizationsInfo object with the AWS Organizations metadata for the account to be audited.
         """
         try:
             logger.info(

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -328,6 +328,15 @@ class AwsProvider(Provider):
                     f"AWS Organizations metadata retrieved for account {aws_account_id}"
                 )
                 return organizations_metadata
+            else:
+                return AWSOrganizationsInfo(
+                    account_email="",
+                    account_name="",
+                    organization_account_arn="",
+                    organization_arn="",
+                    organization_id="",
+                    account_tags=[],
+                )
 
         except Exception as error:
             # If the account is not a delegated administrator for AWS Organizations a credentials error will be thrown

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -160,7 +160,7 @@ class TestOutputs:
     def test_unroll_list(self):
         list = ["test", "test1", "test2"]
 
-        assert unroll_list(list) == "test | test1 | test2"
+        assert unroll_list(list) == "test| test1| test2"
 
     def test_unroll_tags(self):
         dict_list = [

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -157,10 +157,15 @@ class TestOutputs:
 
         assert generate_csv_fields(FindingOutput) == expected
 
-    def test_unroll_list(self):
+    def test_unroll_list_no_separator(self):
         list = ["test", "test1", "test2"]
 
-        assert unroll_list(list) == "test| test1| test2"
+        assert unroll_list(list) == "test | test1 | test2"
+
+    def test_unroll_list_separator(self):
+        list = ["test", "test1", "test2"]
+
+        assert unroll_list(list, ",") == "test, test1, test2"
 
     def test_unroll_tags(self):
         dict_list = [

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -276,6 +276,19 @@ class TestAWSProvider:
         )
 
     @mock_aws
+    def test_aws_provider_organizations_none_organizations_metadata(self):
+        arguments = Namespace()
+        aws_provider = AwsProvider(arguments)
+
+        assert isinstance(aws_provider.organizations_metadata, AWSOrganizationsInfo)
+        assert aws_provider.organizations_metadata.account_email == ""
+        assert aws_provider.organizations_metadata.account_name == ""
+        assert aws_provider.organizations_metadata.account_tags == []
+        assert aws_provider.organizations_metadata.organization_account_arn == ""
+        assert aws_provider.organizations_metadata.organization_id == ""
+        assert aws_provider.organizations_metadata.organization_arn == ""
+
+    @mock_aws
     def test_aws_provider_organizations_with_role(self):
         iam_client = client("iam", region_name=AWS_REGION_EU_WEST_1)
         policy_name = "describe_organizations_policy"


### PR DESCRIPTION
### Context

Fixes #3909 
Fixes #3897 

### Description

Organizations metadata were None in some cases. This issue was generating empty Prowler outputs but in this pr the problem is solved.

Thanks @jfagoagas for the help!


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
