### PR TITLE
fix(efs): change public EFS check metadata

### DIFF
--- a/prowler/providers/aws/services/efs/efs_not_publicly_accessible/efs_not_publicly_accessible.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_not_publicly_accessible/efs_not_publicly_accessible.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "efs_not_publicly_accessible",
-  "CheckTitle": "Check if EFS have policies which allow access to everyone",
+  "CheckTitle": "Check if EFS have policies which allow access to any client within the VPC",
   "CheckType": [
     "Protect",
     "Data protection"
@@ -9,10 +9,10 @@
   "ServiceName": "efs",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
-  "Severity": "critical",
+  "Severity": "medium",
   "ResourceType": "AwsEFSFileSystem",
-  "Description": "Check if EFS have policies which allow access to everyone",
-  "Risk": "EFS accessible to everyone could expose sensitive data to bad actors",
+  "Description": "Check if EFS have policies which allow access to any client within the VPC",
+  "Risk": "Restricting access to EFS file systems is a security best practice. Allowing access to any client within the VPC can lead to unauthorized access to the file system.",
   "RelatedUrl": "",
   "Remediation": {
     "Code": {

--- a/prowler/providers/aws/services/efs/efs_not_publicly_accessible/efs_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/efs/efs_not_publicly_accessible/efs_not_publicly_accessible.py
@@ -13,21 +13,17 @@ class efs_not_publicly_accessible(Check):
             report.resource_arn = fs.arn
             report.resource_tags = fs.tags
             report.status = "PASS"
-            report.status_extended = (
-                f"EFS {fs.id} has a policy which does not allow access to everyone."
-            )
+            report.status_extended = f"EFS {fs.id} has a policy which does not allow access to any client within the VPC."
             if not fs.policy:
                 report.status = "FAIL"
-                report.status_extended = f"EFS {fs.id} doesn't have any policy which means it grants full access to any client."
+                report.status_extended = f"EFS {fs.id} doesn't have any policy which means it grants full access to any client within the VPC."
             else:
                 for statement in fs.policy.get("Statement", []):
                     if statement.get("Effect") == "Allow" and is_public_access_allowed(
                         statement
                     ):
                         report.status = "FAIL"
-                        report.status_extended = (
-                            f"EFS {fs.id} has a policy which allows access to everyone."
-                        )
+                        report.status_extended = f"EFS {fs.id} has a policy which allows access to any client within the VPC."
                         break
             findings.append(report)
         return findings

--- a/tests/providers/aws/services/efs/efs_not_publicly_accessible/efs_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/efs/efs_not_publicly_accessible/efs_not_publicly_accessible_test.py
@@ -102,7 +102,7 @@ class Test_efs_not_publicly_accessible:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"EFS {file_system_id} has a policy which does not allow access to everyone."
+                == f"EFS {file_system_id} has a policy which does not allow access to any client within the VPC."
             )
             assert result[0].resource_id == file_system_id
             assert result[0].resource_arn == efs_arn
@@ -136,7 +136,7 @@ class Test_efs_not_publicly_accessible:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"EFS {file_system_id} has a policy which does not allow access to everyone."
+                == f"EFS {file_system_id} has a policy which does not allow access to any client within the VPC."
             )
             assert result[0].resource_id == file_system_id
             assert result[0].resource_arn == efs_arn
@@ -170,7 +170,7 @@ class Test_efs_not_publicly_accessible:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"EFS {file_system_id} has a policy which does not allow access to everyone."
+                == f"EFS {file_system_id} has a policy which does not allow access to any client within the VPC."
             )
             assert result[0].resource_id == file_system_id
             assert result[0].resource_arn == efs_arn
@@ -205,7 +205,7 @@ class Test_efs_not_publicly_accessible:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"EFS {file_system_id} has a policy which allows access to everyone."
+                == f"EFS {file_system_id} has a policy which allows access to any client within the VPC."
             )
             assert result[0].resource_id == file_system_id
             assert result[0].resource_arn == efs_arn
@@ -239,7 +239,7 @@ class Test_efs_not_publicly_accessible:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"EFS {file_system_id} doesn't have any policy which means it grants full access to any client."
+                == f"EFS {file_system_id} doesn't have any policy which means it grants full access to any client within the VPC."
             )
             assert result[0].resource_id == file_system_id
             assert result[0].resource_arn == efs_arn


### PR DESCRIPTION
### Description

Speaking with AWS Support, they confirmed that the EFS would only be accessed to any principal within the VPC not to the public internet. That is why, we have to change the metadata as well as the severity. 

Thanks @rieck-srlabs for the catch! 

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
