### PR TITLE
test(gcp): Add Compute client the project_ids parameter

### DIFF
--- a/tests/providers/gcp/services/compute/compute_service_test.py
+++ b/tests/providers/gcp/services/compute/compute_service_test.py
@@ -18,7 +18,9 @@ class TestComputeService:
             "prowler.providers.gcp.lib.service.service.GCPService.__generate_client__",
             new=mock_api_client,
         ):
-            compute_client = Compute(set_mocked_gcp_audit_info([GCP_PROJECT_ID]))
+            compute_client = Compute(
+                set_mocked_gcp_audit_info(project_ids=[GCP_PROJECT_ID])
+            )
             assert compute_client.service == "compute"
             assert compute_client.project_ids == [GCP_PROJECT_ID]
 


### PR DESCRIPTION
### Context

Compute service test was failing

### Description

Add parameter name to indicate the project_ids to mocking function

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
