### PR TITLE
docs(mutelist): update reference to `aws_mutelist.yaml`

### DIFF
--- a/docs/tutorials/mutelist.md
+++ b/docs/tutorials/mutelist.md
@@ -116,7 +116,7 @@ If you want to mute failed findings only in specific regions, create a file with
 
 ### Default Mutelist
 For the AWS Provider, Prowler is executed with a default AWS Mutelist with the AWS Resources that should be muted such as all resources created by AWS Control Tower when setting up a landing zone that can be found in [AWS Documentation](https://docs.aws.amazon.com/controltower/latest/userguide/shared-account-resources.html).
-You can see this Mutelist file in [`prowler/config/aws_mutelist.yaml`](https://github.com/prowler-cloud/prowler/blob/master/prowler/config/aws_allowlist.yaml).
+You can see this Mutelist file in [`prowler/config/aws_mutelist.yaml`](https://github.com/prowler-cloud/prowler/blob/master/prowler/config/aws_mutelist.yaml).
 
 ### Supported Mutelist Locations
 


### PR DESCRIPTION
### Context

Wrong reference to `aws_mutelist.yaml`.


### Description

Small PR. Just fixes the wrong reference to `aws_mutelist.yaml`.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
