### PR TITLE
chore(docs): remove unnecessary line

### DIFF
--- a/docs/developer-guide/unit-testing.md
+++ b/docs/developer-guide/unit-testing.md
@@ -191,9 +191,6 @@ class Test_iam_password_policy_uppercase:
         expiration=True,
     )
 
-    # We set a mocked aws_provider to unify providers, this way will isolate each test not to step on other tests configuration
-    aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
-
     # In this scenario we have to mock also the IAM service and the iam_client from the check to enforce    # that the iam_client used is the one created within this check because patch != import, and if you     # execute tests in parallel some objects can be already initialised hence the check won't be isolated.
     # In this case we don't use the Moto decorator, we use the mocked IAM client for both objects
     with mock.patch(


### PR DESCRIPTION
### Description

Remove unnecessary line of setting the mocked AWS provider when API calls are not covered.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
