### PR TITLE
chore(mutelist): Exclude resources from AFT

### DIFF
--- a/prowler/config/aws_mutelist.yaml
+++ b/prowler/config/aws_mutelist.yaml
@@ -50,6 +50,10 @@ Mutelist:
             - "AWSControlTowerAdminPolicy"
             - "AWSLoadBalancerControllerIAMPolicy"
             - "AWSControlTowerCloudTrailRolePolicy"
+            - "aws-controltower-AdministratorExecutionRole"
+            - "AWSAFTExecution"
+            - "AWSAFTService"
+            - "AWSControlTowerExecution"
         "iam_role_*":
           Regions:
             - "*"


### PR DESCRIPTION
### Context

Fixes #3810 

### Description

Exclude more resources from AWS Control Tower and AFT (Account Factory for Terraform) in the AWS mutelist.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
