### PR TITLE
fix(encoding): set utf-8 encoding for csv

### DIFF
--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 # Emojis to be used in the compliance table
 pass_emoji = "✅"
@@ -29,10 +28,6 @@ informational_color = "#3274d9"
 folder_path_overview = os.getcwd() + "/output"
 folder_path_compliance = os.getcwd() + "/output/compliance"
 
-# Encoding, if the os is windows, use cp1252. Use utf-8 if it is running using python3
-if os.name == "nt" and ".py" not in sys.argv[0].lower():
-    encoding_format = "cp1252"
-else:
-    encoding_format = "utf-8"
+encoding_format = "utf-8"
 # Error action, it is recommended to use "ignore" or "replace"
 error_action = "ignore"

--- a/prowler/lib/utils/utils.py
+++ b/prowler/lib/utils/utils.py
@@ -28,7 +28,7 @@ from prowler.lib.logger import logger
 def open_file(input_file: str, mode: str = "r") -> TextIOWrapper:
     """open_file returns a handler to the file using the specified mode."""
     try:
-        f = open(input_file, mode)
+        f = open(input_file, mode, encoding="utf-8")
     except OSError as os_error:
         if os_error.strerror == "Too many open files":
             logger.critical(


### PR DESCRIPTION
### Description

An encoding format is set to make outputs use"utf-8" without depending on the os that is running Prowler.

Thanks @jfagoagas for the help debugging the issue.
### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
