### PR TITLE
Add additional RDS TLS communications checks

### DIFF
--- a/prowler/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted.metadata.json
@@ -1,14 +1,14 @@
 {
   "Provider": "aws",
   "CheckID": "rds_instance_transport_encrypted",
-  "CheckTitle": "Check if RDS instances client connections are encrypted (Microsoft SQL Server and PostgreSQL).",
+  "CheckTitle": "Check if RDS instances client connections are encrypted (Microsoft SQL Server, PostgreSQL, MySQL, MariaDB, Aurora PostgreSQL, and Aurora MySQL).",
   "CheckType": [],
   "ServiceName": "rds",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-instance",
   "Severity": "high",
   "ResourceType": "AwsRdsDbInstance",
-  "Description": "Check if RDS instances client connections are encrypted (Microsoft SQL Server and PostgreSQL).",
+"Description": "Check if RDS instances client connections are encrypted (Microsoft SQL Server, PostgreSQL, MySQL, MariaDB, Aurora PostgreSQL, and Aurora MySQL).",
   "Risk": "If not enabled sensitive information at transit is not protected.",
   "RelatedUrl": "https://aws.amazon.com/premiumsupport/knowledge-center/rds-connect-ssl-connection/",
   "Remediation": {
@@ -19,7 +19,7 @@
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "Ensure that Microsoft SQL Server and PostgreSQL instances provisioned with Amazon RDS have Transport Encryption feature enabled in order to meet security and compliance requirements.",
+      "Text": "Ensure that instances provisioned with Amazon RDS have Transport Encryption feature enabled in order to meet security and compliance requirements.",
       "Url": "https://aws.amazon.com/premiumsupport/knowledge-center/rds-connect-ssl-connection/"
     }
   },


### PR DESCRIPTION
### Context

Add additional RDS transport level encrypted checks for support RDS versions

### Description

Added additional checks for ```MySQL, MariaDB, Aurora PostgreSQL, and Aurora MySQL``` DB instances.

Corrected Microsoft SQL Server checks as well to include all the engine versions available.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
