### PR TITLE
docs(longpaths): add info about longpaths in windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ poetry install
 python prowler.py -v
 ```
 ???+ note
-  If you want to clone Prowler from windows, use `git config core.longpaths true` to allow longpaths.
+  If you want to clone Prowler from Windows, use `git config core.longpaths true` to allow long file paths.
 # 📐✏️ High level architecture
 
 You can run Prowler from your workstation, a Kubernetes Job, a Google Compute Engine, an Azure VM, an EC2 instance, Fargate or any other container, CloudShell and many more.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ poetry install
 python prowler.py -v
 ```
 ???+ note
-  If you want to run Prowler from windows, use `git config core.longpaths true` to allow longpaths.
+  If you want to clone Prowler from windows, use `git config core.longpaths true` to allow longpaths.
 # 📐✏️ High level architecture
 
 You can run Prowler from your workstation, a Kubernetes Job, a Google Compute Engine, an Azure VM, an EC2 instance, Fargate or any other container, CloudShell and many more.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ poetry shell
 poetry install
 python prowler.py -v
 ```
-
+???+ note
+  If you want to run Prowler from windows, use `git config core.longpaths true` to allow longpaths.
 # 📐✏️ High level architecture
 
 You can run Prowler from your workstation, a Kubernetes Job, a Google Compute Engine, an Azure VM, an EC2 instance, Fargate or any other container, CloudShell and many more.

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,8 @@ Prowler is available as a project in [PyPI](https://pypi.org/project/prowler/), 
     poetry install
     python prowler.py -v
     ```
+    ???+ note
+        If you want to run Prowler from windows, use `git config core.longpaths true` to allow longpaths.
 
 === "Amazon Linux 2"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,7 +91,7 @@ Prowler is available as a project in [PyPI](https://pypi.org/project/prowler/), 
     python prowler.py -v
     ```
     ???+ note
-        If you want to run Prowler from windows, use `git config core.longpaths true` to allow longpaths.
+        If you want to clone Prowler from windows, use `git config core.longpaths true` to allow longpaths.
 
 === "Amazon Linux 2"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,7 +91,7 @@ Prowler is available as a project in [PyPI](https://pypi.org/project/prowler/), 
     python prowler.py -v
     ```
     ???+ note
-        If you want to clone Prowler from windows, use `git config core.longpaths true` to allow longpaths.
+        If you want to clone Prowler from Windows, use `git config core.longpaths true` to allow long file paths.
 
 === "Amazon Linux 2"
 


### PR DESCRIPTION
### Description

It's needed to run git config core.longpaths true to clone prowler in a Windows oss


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
