### PR TITLE
fix PR 3962 ec2_securitygroup_allow_ingress_from_internet_to_any_port

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port.py
@@ -22,14 +22,9 @@ class ec2_securitygroup_allow_ingress_from_internet_to_any_port(Check):
                 report.resource_id = security_group.id
                 report.resource_arn = security_group.arn
                 report.resource_tags = security_group.tags
-                if not security_group.public_ports:
-                    # Loop through every security group's ingress rule and check it
-                    for ingress_rule in security_group.ingress_rules:
-                        if check_security_group(
-                            ingress_rule, "-1", ports=None, any_address=True
-                        ):
-                            report.status = "FAIL"
-                            report.status_extended = f"Security group {security_group.name} ({security_group.id}) has at least one port open to the Internet."
+                if security_group.public_ports:
+                    report.status = "FAIL"
+                    report.status_extended = f"Security group {security_group.name} ({security_group.id}) has at least one port open to the Internet."
                 findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port.py
@@ -1,6 +1,5 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.ec2.ec2_client import ec2_client
-from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
 from prowler.providers.aws.services.vpc.vpc_client import vpc_client
 
 

--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -134,7 +134,7 @@ class EC2(AWSService):
                                 check_security_group(
                                     ingress_rule, "-1", any_address=True
                                 )
-                                and "ec2_securitygroup_allow_ingress_from_internet_to_all_ports"
+                                and "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
                                 in self.audited_checks
                             ):
                                 all_public_ports = True

--- a/prowler/providers/aws/services/ec2/lib/security_groups.py
+++ b/prowler/providers/aws/services/ec2/lib/security_groups.py
@@ -76,7 +76,7 @@ def check_security_group(
                 if len(set(ingress_port_range)) == 65536:
                     return True
                 # If None input ports check if any port is open
-                if ports is None:
+                if ports is None or not ports:
                     return True
 
         # IPv6
@@ -94,7 +94,7 @@ def check_security_group(
                 if len(set(ingress_port_range)) == 65536:
                     return True
                 # If None input ports check if any port is open
-                if ports is None:
+                if ports is None or not ports:
                     return True
 
     return False


### PR DESCRIPTION
### Context

As  mentioned on [prowlers slack channel](https://prowler-workspace.slack.com/archives/C0451NDLC4X/p1715349265915979?thread_ts=1715115373.241189&cid=C0451NDLC4X), I think the PR #3962 contained some semantic glitches and redundant code that this PR fixes.


### Description

I think the newly introduced check `ec2_securitygroup_allow_ingress_from_internet_to_any_port` does not need to call again for each security group, respectively for each of their rules, the method `check_security_group` because this had been done already beforehand when collecting all data about security groups and their rules.
However, I had to sligthly modify the method `check_security_group` in `security_groups.py` to return not only `True` if `ports` is `None` but also if `ports` is an empty list.
Doing so, `security_group.public_ports` becomes `True` on security groups without ingress filtering (0.0.0.0/0) and as such the check `ec2_securitygroup_allow_ingress_from_internet_to_any_port` does not need to iterate all security groups, respectively their rules again, to let FAIL the check in case of open ports.
Last but not least, the method `__describe_security_groups__` in `ec2_service.py` needs to test whether check `ec2_securitygroup_allow_ingress_from_internet_to_any_port` is being executed (and not `ec2_securitygroup_allow_ingress_from_internet_to_all_ports`) because `ec2_securitygroup_allow_ingress_from_internet_to_any_port` may set `all_public_ports` to `True`.

All 60 unit tests from within `aws_provider_test.py` were executed successfully.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
