### PR TITLE
feat(rds): Add AWS RDS cluster transport encryption check

### DIFF
--- a/prowler/providers/aws/services/rds/rds_instance_deletion_protection/rds_instance_deletion_protection.py
+++ b/prowler/providers/aws/services/rds/rds_instance_deletion_protection/rds_instance_deletion_protection.py
@@ -11,28 +11,32 @@ class rds_instance_deletion_protection(Check):
             report.resource_id = db_instance.id
             report.resource_arn = db_instance.arn
             report.resource_tags = db_instance.tags
+            report.status = "FAIL"
+            report.status_extended = (
+                f"RDS Instance {db_instance.id} deletion protection is not enabled."
+            )
             # Check if is member of a cluster
-            if db_instance.cluster_id:
-                if (
-                    db_instance.cluster_arn in rds_client.db_clusters
-                    and rds_client.db_clusters[
-                        db_instance.cluster_arn
-                    ].deletion_protection
-                ):
-                    report.status = "PASS"
-                    report.status_extended = f"RDS Instance {db_instance.id} deletion protection is enabled at cluster {db_instance.cluster_id} level."
-                else:
-                    report.status = "FAIL"
-                    report.status_extended = f"RDS Instance {db_instance.id} deletion protection is not enabled at cluster {db_instance.cluster_id} level."
-            else:
+            if not db_instance.cluster_id:
                 if db_instance.deletion_protection:
                     report.status = "PASS"
                     report.status_extended = (
                         f"RDS Instance {db_instance.id} deletion protection is enabled."
                     )
-                else:
-                    report.status = "FAIL"
-                    report.status_extended = f"RDS Instance {db_instance.id} deletion protection is not enabled."
+
+                findings.append(report)
+
+        for db_cluster in rds_client.db_clusters:
+            report = Check_Report_AWS(self.metadata())
+            report.region = db_cluster.region
+            report.resource_id = db_cluster.id
+            report.resource_arn = db_cluster.arn
+            report.resource_tags = db_cluster.tags
+            report.status = "FAIL"
+            report.status_extended = f"RDS Cluster {db_instance.cluster_id} deletion protection is not enabled."
+            # Check if is member of a cluster
+            if db_cluster.deletion_protection == 1:
+                report.status = "PASS"
+                report.status_extended = f"RDS Cluster {db_instance.cluster_id} deletion protection is enabled."
 
             findings.append(report)
 

--- a/tests/providers/aws/services/rds/rds_instance_deletion_protection/rds_instance_deletion_protection_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_deletion_protection/rds_instance_deletion_protection_test.py
@@ -191,17 +191,19 @@ class Test_rds_instance_deletion_protection:
 
                 assert len(result) == 1
                 assert result[0].status == "FAIL"
-                assert search(
-                    "deletion protection is not enabled at cluster",
-                    result[0].status_extended,
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-1 deletion protection is not enabled."
                 )
-                assert result[0].resource_id == "db-master-1"
+                assert result[0].resource_id == "db-cluster-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
                 )
-                assert result[0].resource_tags == []
+                assert result[0].resource_tags == [
+                    {"Key": "test", "Value": "test"},
+                ]
 
     @mock_aws
     def test_rds_instance_with_cluster_deletion_protection(self):
@@ -249,14 +251,16 @@ class Test_rds_instance_deletion_protection:
 
                 assert len(result) == 1
                 assert result[0].status == "PASS"
-                assert search(
-                    "deletion protection is enabled at cluster",
-                    result[0].status_extended,
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-1 deletion protection is enabled."
                 )
-                assert result[0].resource_id == "db-master-1"
+                assert result[0].resource_id == "db-cluster-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
                 )
-                assert result[0].resource_tags == []
+                assert result[0].resource_tags == [
+                    {"Key": "test", "Value": "test"},
+                ]

--- a/tests/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted_test.py
@@ -112,6 +112,17 @@ class Test_rds_instance_transport_encrypted:
             DBParameterGroupFamily="default.aurora-postgresql14",
             Description="test parameter group",
         )
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DatabaseName="staging-postgres",
+            DeletionProtection=True,
+            DBClusterParameterGroupName="test",
+            MasterUsername="test",
+            MasterUserPassword="password",
+            Tags=[],
+        )
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -119,7 +130,7 @@ class Test_rds_instance_transport_encrypted:
             DBName="aurora-postgres",
             DBInstanceClass="db.m1.small",
             DBParameterGroupName="test",
-            DBClusterIdentifier="cluster-postgres",
+            DBClusterIdentifier="db-cluster-1",
         )
         from prowler.providers.aws.services.rds.rds_service import RDS
 
@@ -141,7 +152,19 @@ class Test_rds_instance_transport_encrypted:
                 check = rds_instance_transport_encrypted()
                 result = check.execute()
 
-                assert len(result) == 0
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-1 connections are not encrypted."
+                )
+                assert result[0].resource_id == "db-cluster-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+                )
+                assert result[0].resource_tags == []
 
     @mock_aws
     def test_postgres_rds_instance_no_ssl(self):
@@ -388,5 +411,149 @@ class Test_rds_instance_transport_encrypted:
                 assert (
                     result[0].resource_arn
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_rds_postgres_clustered_instance_ssl(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DatabaseName="staging-postgres",
+            DeletionProtection=True,
+            DBClusterParameterGroupName="test",
+            MasterUsername="test",
+            MasterUserPassword="password",
+            Tags=[],
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DBName="aurora-postgres",
+            DBInstanceClass="db.m1.small",
+            DBParameterGroupName="test",
+            DBClusterIdentifier="db-cluster-1",
+        )
+        conn.modify_db_parameter_group(
+            DBParameterGroupName="test",
+            Parameters=[
+                {
+                    "ParameterName": "rds.force_ssl",
+                    "ParameterValue": "1",
+                    "ApplyMethod": "immediate",
+                },
+            ],
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.common.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_transport_encrypted.rds_instance_transport_encrypted.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_transport_encrypted.rds_instance_transport_encrypted import (
+                    rds_instance_transport_encrypted,
+                )
+
+                check = rds_instance_transport_encrypted()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-1 connections use SSL encryption."
+                )
+                assert result[0].resource_id == "db-cluster-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_rds_aurora_mysql_clustered_instance_ssl(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.mysql8.0",
+            Description="test parameter group",
+        )
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            AllocatedStorage=10,
+            Engine="aurora-mysql",
+            DatabaseName="staging-mysql",
+            DeletionProtection=True,
+            DBClusterParameterGroupName="test",
+            MasterUsername="test",
+            MasterUserPassword="password",
+            Tags=[],
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="aurora-mysql",
+            DBName="aurora-mysql",
+            DBInstanceClass="db.m1.small",
+            DBParameterGroupName="test",
+            DBClusterIdentifier="db-cluster-1",
+        )
+        conn.modify_db_parameter_group(
+            DBParameterGroupName="test",
+            Parameters=[
+                {
+                    "ParameterName": "require_secure_transport",
+                    "ParameterValue": "ON",
+                    "ApplyMethod": "immediate",
+                },
+            ],
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.common.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_transport_encrypted.rds_instance_transport_encrypted.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_transport_encrypted.rds_instance_transport_encrypted import (
+                    rds_instance_transport_encrypted,
+                )
+
+                check = rds_instance_transport_encrypted()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-1 connections use SSL encryption."
+                )
+                assert result[0].resource_id == "db-cluster-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
                 )
                 assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_service_test.py
+++ b/tests/providers/aws/services/rds/rds_service_test.py
@@ -210,28 +210,25 @@ class Test_RDS_Service:
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         rds = RDS(aws_provider)
 
-        db_cluster_arn = f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:{cluster_id}"
-
         assert len(rds.db_clusters) == 1
-        assert rds.db_clusters[db_cluster_arn].id == "db-master-1"
-        assert rds.db_clusters[db_cluster_arn].engine == "postgres"
-        assert rds.db_clusters[db_cluster_arn].region == AWS_REGION_US_EAST_1
+        assert rds.db_clusters[0].id == "db-master-1"
+        assert rds.db_clusters[0].engine == "postgres"
+        assert rds.db_clusters[0].region == AWS_REGION_US_EAST_1
         assert (
-            f"{AWS_REGION_US_EAST_1}.rds.amazonaws.com"
-            in rds.db_clusters[db_cluster_arn].endpoint
+            f"{AWS_REGION_US_EAST_1}.rds.amazonaws.com" in rds.db_clusters[0].endpoint
         )
-        assert rds.db_clusters[db_cluster_arn].status == "available"
-        assert not rds.db_clusters[db_cluster_arn].public
-        assert rds.db_clusters[db_cluster_arn].encrypted
-        assert rds.db_clusters[db_cluster_arn].backup_retention_period == 1
-        assert rds.db_clusters[db_cluster_arn].cloudwatch_logs == ["audit", "error"]
-        assert rds.db_clusters[db_cluster_arn].deletion_protection
-        assert not rds.db_clusters[db_cluster_arn].auto_minor_version_upgrade
-        assert not rds.db_clusters[db_cluster_arn].multi_az
-        assert rds.db_clusters[db_cluster_arn].tags == [
+        assert rds.db_clusters[0].status == "available"
+        assert not rds.db_clusters[0].public
+        assert rds.db_clusters[0].encrypted
+        assert rds.db_clusters[0].backup_retention_period == 1
+        assert rds.db_clusters[0].cloudwatch_logs == ["audit", "error"]
+        assert rds.db_clusters[0].deletion_protection
+        assert not rds.db_clusters[0].auto_minor_version_upgrade
+        assert not rds.db_clusters[0].multi_az
+        assert rds.db_clusters[0].tags == [
             {"Key": "test", "Value": "test"},
         ]
-        assert rds.db_clusters[db_cluster_arn].parameter_group == "test"
+        assert rds.db_clusters[0].parameter_group == "test"
 
     # Test RDS Describe DB Cluster Snapshots
     @mock_aws


### PR DESCRIPTION
### Context

Add additional RDS cluster transport level encryption logic for supported RDS versions:

 >   For PostgreSQL and Aurora PostgreSQL clusters, if the rds.force_ssl parameter value is set to 0, the Transport Encryption feature is not enabled. For MySQL, Aurora MySQL and MariaDB clusters, if the require_secure_transport parameter value is set to OFF, the Transport Encryption feature is not enabled.

### Description

Added checks for MySQL, MariaDB, PostgreSQL, Aurora PostgreSQL, and Aurora MySQL DB clusters.

Had to modify rds_instance_deletion_protection check and test as well to deal the modification to the db_clusters which allows the parameters to be read.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
