### PR TITLE
fix(docs): Fix option name in gcp tutorial

### DIFF
--- a/docs/tutorials/gcp/projects.md
+++ b/docs/tutorials/gcp/projects.md
@@ -18,11 +18,11 @@ prowler gcp --project-ids project-id1 project-id2
 
 ### Exclude Projects
 
-If you want to exclude some projects from the scan, you can use the `--exclude-project-ids` argument.
+If you want to exclude some projects from the scan, you can use the `--excluded-project-ids` argument.
 
 ```console
-prowler gcp --exclude-project-ids project-id1 project-id2
+prowler gcp --excluded-project-ids project-id1 project-id2
 ```
 
 ???+ note
-    You can use asterisk `*` to exclude projects that match a pattern. For example, `prowler gcp --exclude-project-ids "sys*"` will exclude all the projects that start with `sys`.
+    You can use asterisk `*` to exclude projects that match a pattern. For example, `prowler gcp --excluded-project-ids "sys*"` will exclude all the projects that start with `sys`.


### PR DESCRIPTION
### Context

There are some incorrect option name in  a document.
https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/gcp/projects/#exclude-projects

### Description

Fix option names in the document.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
