### PR TITLE
fix(mutelist): Handle exceptions before match

### DIFF
--- a/prowler/lib/mutelist/mutelist.py
+++ b/prowler/lib/mutelist/mutelist.py
@@ -211,14 +211,22 @@ def is_muted_in_check(
             # map lambda to awslambda
             muted_check = re.sub("^lambda", "awslambda", muted_check)
 
+            check_match = (
+                "*" == muted_check
+                or check == muted_check
+                or re.search(muted_check, check)
+            )
             # Check if the finding is excepted
             exceptions = muted_check_info.get("Exceptions")
-            if is_excepted(
-                exceptions,
-                audited_account,
-                finding_region,
-                finding_resource,
-                finding_tags,
+            if (
+                is_excepted(
+                    exceptions,
+                    audited_account,
+                    finding_region,
+                    finding_resource,
+                    finding_tags,
+                )
+                and check_match
             ):
                 # Break loop and return default value since is excepted
                 break
@@ -230,11 +238,7 @@ def is_muted_in_check(
             if not muted_tags:
                 muted_tags = "*"
             # If there is a *, it affects to all checks
-            if (
-                "*" == muted_check
-                or check == muted_check
-                or re.search(muted_check, check)
-            ):
+            if check_match:
                 muted_in_check = True
                 muted_in_region = is_muted_in_region(muted_regions, finding_region)
                 muted_in_resource = is_muted_in_resource(

--- a/tests/lib/mutelist/mutelist_test.py
+++ b/tests/lib/mutelist/mutelist_test.py
@@ -453,7 +453,7 @@ class TestMutelist:
         )
 
     def test_is_muted_exceptions_before_match(self):
-        # Allowlist example
+        # Mutelist example
         mutelist = {
             "Accounts": {
                 "*": {

--- a/tests/lib/mutelist/mutelist_test.py
+++ b/tests/lib/mutelist/mutelist_test.py
@@ -452,6 +452,41 @@ class TestMutelist:
             )
         )
 
+    def test_is_muted_exceptions_before_match(self):
+        # Allowlist example
+        mutelist = {
+            "Accounts": {
+                "*": {
+                    "Checks": {
+                        "accessanalyzer_enabled": {
+                            "Exceptions": {
+                                "Accounts": [],
+                                "Regions": [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1],
+                                "Resources": [],
+                                "Tags": [],
+                            },
+                            "Regions": ["*"],
+                            "Resources": ["*"],
+                            "Tags": ["*"],
+                        },
+                        "sns_*": {
+                            "Regions": ["*"],
+                            "Resources": ["aws-controltower-*"],
+                        },
+                    }
+                }
+            }
+        }
+
+        assert is_muted(
+            mutelist,
+            AWS_ACCOUNT_NUMBER,
+            "sns_topics_not_publicly_accessible",
+            AWS_REGION_EU_WEST_1,
+            "aws-controltower-AggregateSecurityNotifications",
+            "",
+        )
+
     def test_is_muted_all_and_single_account(self):
         # Mutelist example
         mutelist = {


### PR DESCRIPTION
### Description

Handle a case when the exceptions where matching before the real mutelist match.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
