### PR TITLE
feat(rds): Add AWS RDS clusters to transport encryption check

### DIFF
--- a/prowler/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted.py
+++ b/prowler/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted.py
@@ -54,6 +54,25 @@ class rds_instance_transport_encrypted(Check):
                         ):
                             report.status = "PASS"
                             report.status_extended = f"RDS Instance {db_instance.id} connections use SSL encryption."
+
                 findings.append(report)
+
+        for db_cluster in rds_client.db_clusters:
+            report = Check_Report_AWS(self.metadata())
+            report.region = rds_client.db_clusters[db_cluster].region
+            report.resource_id = rds_client.db_clusters[db_cluster].id
+            report.resource_arn = db_cluster
+            report.resource_tags = rds_client.db_clusters[db_cluster].tags
+            report.status = "FAIL"
+            report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} connections are not encrypted."
+            # Check RDS Clusters that support TLS encryption
+            if rds_client.db_clusters[db_cluster].force_ssl:
+                report.status = "PASS"
+                report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} connections use SSL encryption."
+            if rds_client.db_clusters[db_cluster].require_secure_transport:
+                report.status = "PASS"
+                report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} connections use SSL encryption."
+
+            findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted.py
+++ b/prowler/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted.py
@@ -66,10 +66,10 @@ class rds_instance_transport_encrypted(Check):
             report.status = "FAIL"
             report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} connections are not encrypted."
             # Check RDS Clusters that support TLS encryption
-            if rds_client.db_clusters[db_cluster].force_ssl:
+            if rds_client.db_clusters[db_cluster].force_ssl == "1":
                 report.status = "PASS"
                 report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} connections use SSL encryption."
-            if rds_client.db_clusters[db_cluster].require_secure_transport:
+            if rds_client.db_clusters[db_cluster].require_secure_transport == "ON":
                 report.status = "PASS"
                 report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} connections use SSL encryption."
 

--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -221,20 +221,21 @@ class RDS(AWSService):
                                 DBParameterGroupName=cluster["DBClusterParameterGroup"]
                             ):
                                 for parameter in page["Parameters"]:
-                                    if (
-                                        parameter["ParameterName"] == "rds.force_ssl"
-                                        and parameter["ParameterValue"] == "1"
-                                    ):
-                                        db_cluster.force_ssl = True
+                                    if parameter["ParameterName"] == "rds.force_ssl":
+                                        db_cluster.force_ssl = parameter[
+                                            "ParameterValue"
+                                        ]
                                     if (
                                         parameter["ParameterName"]
                                         == "require_secure_transport"
-                                        and parameter["ParameterValue"] == "ON"
                                     ):
-                                        db_cluster.require_secure_transport = "ON"
+                                        db_cluster.require_secure_transport = parameter[
+                                            "ParameterValue"
+                                        ]
 
                             # We must use a unique value as the dict key to have unique keys
                             self.db_clusters[db_cluster_arn] = db_cluster
+
         except Exception as error:
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"

--- a/tests/providers/aws/services/rds/rds_instance_deletion_protection/rds_instance_deletion_protection_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_deletion_protection/rds_instance_deletion_protection_test.py
@@ -147,12 +147,18 @@ class Test_rds_instance_deletion_protection:
     @mock_aws
     def test_rds_instance_without_cluster_deletion_protection(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.mysql8.0",
+            Description="test parameter group",
+        )
         conn.create_db_cluster(
             DBClusterIdentifier="db-cluster-1",
             AllocatedStorage=10,
             Engine="postgres",
             DatabaseName="staging-postgres",
             DeletionProtection=False,
+            DBClusterParameterGroupName="test",
             MasterUsername="test",
             MasterUserPassword="password",
             Tags=[
@@ -205,12 +211,18 @@ class Test_rds_instance_deletion_protection:
     @mock_aws
     def test_rds_instance_with_cluster_deletion_protection(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.mysql8.0",
+            Description="test parameter group",
+        )
         conn.create_db_cluster(
             DBClusterIdentifier="db-cluster-1",
             AllocatedStorage=10,
             Engine="postgres",
             DatabaseName="staging-postgres",
             DeletionProtection=True,
+            DBClusterParameterGroupName="test",
             MasterUsername="test",
             MasterUserPassword="password",
             Tags=[

--- a/tests/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted_test.py
@@ -112,6 +112,17 @@ class Test_rds_instance_transport_encrypted:
             DBParameterGroupFamily="default.aurora-postgresql14",
             Description="test parameter group",
         )
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DatabaseName="staging-postgres",
+            DeletionProtection=True,
+            DBClusterParameterGroupName="test",
+            MasterUsername="test",
+            MasterUserPassword="password",
+            Tags=[],
+        )
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
             AllocatedStorage=10,
@@ -119,7 +130,7 @@ class Test_rds_instance_transport_encrypted:
             DBName="aurora-postgres",
             DBInstanceClass="db.m1.small",
             DBParameterGroupName="test",
-            DBClusterIdentifier="cluster-postgres",
+            DBClusterIdentifier="db-cluster-1",
         )
         from prowler.providers.aws.services.rds.rds_service import RDS
 
@@ -141,7 +152,19 @@ class Test_rds_instance_transport_encrypted:
                 check = rds_instance_transport_encrypted()
                 result = check.execute()
 
-                assert len(result) == 0
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-1 connections are not encrypted."
+                )
+                assert result[0].resource_id == "db-cluster-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+                )
+                assert result[0].resource_tags == []
 
     @mock_aws
     def test_postgres_rds_instance_no_ssl(self):
@@ -388,5 +411,131 @@ class Test_rds_instance_transport_encrypted:
                 assert (
                     result[0].resource_arn
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_rds_postgres_clustered_instance_ssl(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DatabaseName="staging-postgres",
+            DeletionProtection=True,
+            DBClusterParameterGroupName="test",
+            MasterUsername="test",
+            MasterUserPassword="password",
+            Tags=[],
+        )
+        conn.modify_db_parameter_group(
+            DBParameterGroupName="test",
+            Parameters=[
+                {
+                    "ParameterName": "rds.force_ssl",
+                    "ParameterValue": "1",
+                    "ApplyMethod": "immediate",
+                },
+            ],
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_transport_encrypted.rds_instance_transport_encrypted.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_transport_encrypted.rds_instance_transport_encrypted import (
+                    rds_instance_transport_encrypted,
+                )
+
+                check = rds_instance_transport_encrypted()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-1 connections use SSL encryption."
+                )
+                assert result[0].resource_id == "db-cluster-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_rds_aurora_mysql_clustered_instance_ssl(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.mysql8.0",
+            Description="test parameter group",
+        )
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            AllocatedStorage=10,
+            Engine="aurora-mysql",
+            DatabaseName="staging-mysql",
+            DeletionProtection=True,
+            DBClusterParameterGroupName="test",
+            MasterUsername="test",
+            MasterUserPassword="password",
+            Tags=[],
+        )
+        conn.modify_db_parameter_group(
+            DBParameterGroupName="test",
+            Parameters=[
+                {
+                    "ParameterName": "require_secure_transport",
+                    "ParameterValue": "ON",
+                    "ApplyMethod": "immediate",
+                },
+            ],
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_transport_encrypted.rds_instance_transport_encrypted.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_transport_encrypted.rds_instance_transport_encrypted import (
+                    rds_instance_transport_encrypted,
+                )
+
+                check = rds_instance_transport_encrypted()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-1 connections use SSL encryption."
+                )
+                assert result[0].resource_id == "db-cluster-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
                 )
                 assert result[0].resource_tags == []


### PR DESCRIPTION
### Context

Add additional RDS cluster transport level encryption logic for supported RDS versions:

 >   For PostgreSQL and Aurora PostgreSQL clusters, if the rds.force_ssl parameter value is set to 0, the Transport Encryption feature is not enabled. For MySQL, Aurora MySQL and MariaDB clusters, if the require_secure_transport parameter value is set to OFF, the Transport Encryption feature is not enabled.

### Description

Added checks for MySQL, MariaDB, PostgreSQL, Aurora PostgreSQL, and Aurora MySQL DB clusters.

Had to modify rds_instance_deletion_protection check and test as well to deal the modification to the db_clusters which allows the parameters to be read.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
