### PR TITLE
chore(execute_checks): remove mutelist since it is within the provider

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -54,8 +54,8 @@ from prowler.providers.common.quick_inventory import run_provider_quick_inventor
 
 
 def prowler():
-
     # Parse Arguments
+    # Refactor(CLI)
     parser = ProwlerArgumentParser()
     args = parser.parse()
 
@@ -219,7 +219,6 @@ def prowler():
             checks_to_execute,
             global_provider,
             custom_checks_metadata,
-            global_provider.mutelist_file_path,
             args.config_file,
         )
     else:

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -547,7 +547,6 @@ def execute_checks(
     checks_to_execute: list,
     global_provider: Any,
     custom_checks_metadata: Any,
-    mutelist_file: str,
     config_file: str,
 ) -> list:
     # List to store all the check's findings
@@ -612,9 +611,9 @@ def execute_checks(
     else:
         # Prepare your messages
         messages = [f"Config File: {Fore.YELLOW}{config_file}{Style.RESET_ALL}"]
-        if mutelist_file:
+        if global_provider.mutelist_file_path:
             messages.append(
-                f"Mutelist File: {Fore.YELLOW}{mutelist_file}{Style.RESET_ALL}"
+                f"Mutelist File: {Fore.YELLOW}{global_provider.mutelist_file_path}{Style.RESET_ALL}"
             )
         if global_provider.type == "aws":
             messages.append(
@@ -715,9 +714,11 @@ def execute(
                 check_findings,
             )
 
+        # Refactor(Outputs)
         # Report the check's findings
         report(check_findings, global_provider)
 
+        # Refactor(Outputs)
         if os.environ.get("PROWLER_REPORT_LIB_PATH"):
             try:
                 logger.info("Using custom report interface ...")


### PR DESCRIPTION
### Description

Remove `mutelist` from `execute_checks` as argument since it is within the `global_provider`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
