### PR TITLE
fix(gcp): handle projects API Call error

### DIFF
--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -249,20 +249,20 @@ class GcpProvider(Provider):
                 )
 
         except HttpError as http_error:
-            if http_error.status_code == 403 and "organizations" in http_error.uri:
+            if "Cloud Resource Manager API has not been used" in str(http_error):
+                logger.critical(
+                    "Cloud Resource Manager API has not been used before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/ then retry."
+                )
+                sys.exit(1)
+            else:
                 logger.error(
-                    f"{http_error.__class__.__name__}[{http_error.__traceback__.tb_lineno}]: {http_error.error_details} to get Organizations data."
+                    f"{http_error.__class__.__name__}[{http_error.__traceback__.tb_lineno}]: {http_error}"
                 )
         except Exception as error:
             if error.__class__.__name__ == "RefreshError":
                 logger.critical(
                     "Google Cloud SDK has not been authenticated or the credentials have expired. Authenticate by running 'gcloud auth application-default login' then retry."
                 )
-            elif "Cloud Resource Manager API has not been used" in str(error):
-                logger.critical(
-                    "Cloud Resource Manager API has not been used before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/ then retry."
-                )
-                sys.exit(1)
             else:
                 logger.critical(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -294,7 +294,7 @@ class GcpProvider(Provider):
         except HttpError as http_error:
             if http_error.status_code == 403 and "organizations" in http_error.uri:
                 logger.error(
-                    f"{http_error.__class__.__name__}[{http_error.__traceback__.tb_lineno}]: {http_error.error_details} to get Organizations data."
+                    f"{http_error.__class__.__name__}[{http_error.__traceback__.tb_lineno}]: {http_error.error_details} to get Organizations display name."
                 )
             else:
                 logger.error(


### PR DESCRIPTION
### Description

Handle projects API Call error since the `Cloud Resource Manager API has not been used` problem was not being catch correctly.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
