### PR TITLE
fix(kubernetes): solve TypeError in Core NetRaw check

### DIFF
--- a/prowler/providers/kubernetes/services/core/core_minimize_net_raw_capability_admission/core_minimize_net_raw_capability_admission.py
+++ b/prowler/providers/kubernetes/services/core/core_minimize_net_raw_capability_admission/core_minimize_net_raw_capability_admission.py
@@ -18,7 +18,7 @@ class core_minimize_net_raw_capability_admission(Check):
                     capabilities = getattr(security_context, "capabilities", None)
                     if capabilities:
                         add_capabilities = getattr(capabilities, "add", [])
-                        if "NET_RAW" in add_capabilities:
+                        if add_capabilities and "NET_RAW" in add_capabilities:
                             report.status = "FAIL"
                             report.status_extended = f"Pod {pod.name} has NET_RAW capability in container {container.name}."
                             break


### PR DESCRIPTION
### Description

Solve the following error in the check `core_minimize_net_raw_capability_admission`:

> argument of type 'NoneType' is not iterable

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
