### PR TITLE
fix(output): handle `--unix-timestamp` flag

### DIFF
--- a/prowler/lib/outputs/common_models.py
+++ b/prowler/lib/outputs/common_models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic import BaseModel
 
@@ -29,7 +29,7 @@ class FindingOutput(BaseModel):
     """
 
     auth_method: str
-    timestamp: datetime
+    timestamp: Union[int, datetime]
     account_uid: str
     # Optional since depends on permissions
     account_name: Optional[str]

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -18,6 +18,7 @@ from prowler.lib.check.compliance_models import (
     Compliance_Requirement,
 )
 from prowler.lib.check.models import Check_Report, load_check_metadata
+from prowler.lib.outputs.common import generate_provider_output
 from prowler.lib.outputs.common_models import FindingOutput
 from prowler.lib.outputs.compliance.compliance import get_check_compliance
 from prowler.lib.outputs.csv.csv import generate_csv_fields
@@ -743,3 +744,183 @@ class TestOutputs:
             "CIS-2.0": ["2.1.3"],
             "CIS-2.1": ["2.1.3"],
         }
+
+    def test_generate_provider_output(self):
+        provider = mock.MagicMock()
+        provider.type = "aws"
+        finding = mock.MagicMock()
+        finding.resource_id = "test"
+        finding.resource_arn = "test-arn"
+        finding.region = "eu-west-1"
+        finding.check_metadata = mock.MagicMock()
+        finding.check_metadata.CheckID = "iam_user_accesskey_unused"
+        csv_data = {
+            "resource_uid": "test",
+            "resource_arn": "test-arn",
+            "region": "eu-west-1",
+            "account_uid": "123456789012",
+            "auth_method": "test",
+            "resource_name": "test",
+            "timestamp": "2022-01-01T00:00:00Z",
+            "provider": "aws",
+            "check_id": "iam_user_accesskey_unused",
+            "check_title": "IAM User Access Key Unused",
+            "check_type": "config",
+            "status": "PASS",
+            "status_extended": "This is a test",
+            "service_name": "iam",
+            "subservice_name": "user",
+            "severity": "low",
+            "resource_type": "aws_iam_user",
+            "resource_details": "Test resource details",
+            "resource_tags": "",
+            "description": "IAM User Access Key Unused",
+            "risk": "if an access key is not used, it should be removed",
+            "related_url": "",
+            "remediation_recommendation_text": "Remove unused access keys",
+            "remediation_recommendation_url": "",
+            "remediation_code_nativeiac": "",
+            "remediation_code_terraform": "",
+            "remediation_code_cli": "",
+            "remediation_code_other": "",
+            "compliance": {
+                "CIS": ["2.1.3"],
+                "NIST-800-53-Revision-5": ["sc_28_1"],
+            },
+            "categories": "security",
+            "depends_on": "",
+            "related_to": "",
+            "notes": "",
+            "finding_uid": "test-finding",
+        }
+
+        assert generate_provider_output(provider, finding, csv_data) == FindingOutput(
+            auth_method="profile: test",
+            account_uid="123456789012",
+            timestamp="2022-01-01T00:00:00Z",
+            account_name=None,
+            account_email=None,
+            account_organization_uid=None,
+            account_organization_name=None,
+            account_tags=None,
+            finding_uid="prowler-aws-iam_user_accesskey_unused-123456789012-eu-west-1-test",
+            provider="aws",
+            check_id="iam_user_accesskey_unused",
+            check_title="IAM User Access Key Unused",
+            check_type="config",
+            status="PASS",
+            status_extended="This is a test",
+            service_name="iam",
+            subservice_name="user",
+            severity="low",
+            resource_type="aws_iam_user",
+            resource_uid="test-arn",
+            resource_name="test",
+            resource_tags="",
+            resource_details="Test resource details",
+            region="eu-west-1",
+            description="IAM User Access Key Unused",
+            risk="if an access key is not used, it should be removed",
+            related_url="",
+            remediation_recommendation_text="Remove unused access keys",
+            remediation_recommendation_url="",
+            remediation_code_nativeiac="",
+            remediation_code_terraform="",
+            remediation_code_cli="",
+            remediation_code_other="",
+            compliance={"CIS": ["2.1.3"], "NIST-800-53-Revision-5": ["sc_28_1"]},
+            categories="security",
+            depends_on="",
+            related_to="",
+            notes="",
+        )
+
+    def test_generate_provider_output_unix_timestamp(self):
+        provider = mock.MagicMock()
+        provider.type = "aws"
+        finding = mock.MagicMock()
+        finding.resource_id = "test"
+        finding.resource_arn = "test-arn"
+        finding.region = "eu-west-1"
+        finding.check_metadata = mock.MagicMock()
+        finding.check_metadata.CheckID = "iam_user_accesskey_unused"
+        csv_data = {
+            "resource_uid": "test",
+            "resource_arn": "test-arn",
+            "region": "eu-west-1",
+            "account_uid": "123456789012",
+            "auth_method": "test",
+            "resource_name": "test",
+            "timestamp": 1640995200,
+            "provider": "aws",
+            "check_id": "iam_user_accesskey_unused",
+            "check_title": "IAM User Access Key Unused",
+            "check_type": "config",
+            "status": "PASS",
+            "status_extended": "This is a test",
+            "service_name": "iam",
+            "subservice_name": "user",
+            "severity": "low",
+            "resource_type": "aws_iam_user",
+            "resource_details": "Test resource details",
+            "resource_tags": "",
+            "description": "IAM User Access Key Unused",
+            "risk": "if an access key is not used, it should be removed",
+            "related_url": "",
+            "remediation_recommendation_text": "Remove unused access keys",
+            "remediation_recommendation_url": "",
+            "remediation_code_nativeiac": "",
+            "remediation_code_terraform": "",
+            "remediation_code_cli": "",
+            "remediation_code_other": "",
+            "compliance": {
+                "CIS": ["2.1.3"],
+                "NIST-800-53-Revision-5": ["sc_28_1"],
+            },
+            "categories": "security",
+            "depends_on": "",
+            "related_to": "",
+            "notes": "",
+            "finding_uid": "test-finding",
+        }
+
+        assert generate_provider_output(provider, finding, csv_data) == FindingOutput(
+            auth_method="profile: test",
+            account_uid="123456789012",
+            timestamp=1640995200,
+            account_name=None,
+            account_email=None,
+            account_organization_uid=None,
+            account_organization_name=None,
+            account_tags=None,
+            finding_uid="prowler-aws-iam_user_accesskey_unused-123456789012-eu-west-1-test",
+            provider="aws",
+            check_id="iam_user_accesskey_unused",
+            check_title="IAM User Access Key Unused",
+            check_type="config",
+            status="PASS",
+            status_extended="This is a test",
+            service_name="iam",
+            subservice_name="user",
+            severity="low",
+            resource_type="aws_iam_user",
+            resource_uid="test-arn",
+            resource_name="test",
+            resource_tags="",
+            resource_details="Test resource details",
+            region="eu-west-1",
+            description="IAM User Access Key Unused",
+            risk="if an access key is not used, it should be removed",
+            related_url="",
+            remediation_recommendation_text="Remove unused access keys",
+            remediation_recommendation_url="",
+            remediation_code_nativeiac="",
+            remediation_code_terraform="",
+            remediation_code_cli="",
+            remediation_code_other="",
+            compliance={"CIS": ["2.1.3"], "NIST-800-53-Revision-5": ["sc_28_1"]},
+            categories="security",
+            depends_on="",
+            related_to="",
+            notes="",
+        )


### PR DESCRIPTION
### Context

Fixes #4077


### Description

Modify FindingOutput class to make timestamp an int or datetime.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
