### PR TITLE
chore(slack): change Slack channel name env variable

### DIFF
--- a/docs/tutorials/integrations.md
+++ b/docs/tutorials/integrations.md
@@ -11,7 +11,7 @@ prowler <provider> --slack
 ![Prowler Slack Message](img/slack-prowler-message.png)
 
 ???+ note
-    Slack integration needs SLACK_API_TOKEN and SLACK_CHANNEL_ID environment variables.
+    Slack integration needs SLACK_API_TOKEN and SLACK_CHANNEL_NAME environment variables.
 
 ### Configuration
 
@@ -35,4 +35,4 @@ To configure the Slack Integration, follow the next steps:
 
 4. Set the following environment variables that Prowler will read:
     - `SLACK_API_TOKEN`: the *Slack App OAuth Token* that was previously get.
-    - `SLACK_CHANNEL_ID`: the name of your Slack Channel where Prowler will send the message.
+    - `SLACK_CHANNEL_NAME`: the name of your Slack Channel where Prowler will send the message.

--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -248,16 +248,22 @@ def prowler():
     stats = extract_findings_statistics(findings)
 
     if args.slack:
-        if "SLACK_API_TOKEN" in environ and "SLACK_CHANNEL_ID" in environ:
+        if "SLACK_API_TOKEN" in environ and (
+            "SLACK_CHANNEL_NAME" in environ or "SLACK_CHANNEL_ID" in environ
+        ):
             _ = send_slack_message(
                 environ["SLACK_API_TOKEN"],
-                environ["SLACK_CHANNEL_ID"],
+                (
+                    environ["SLACK_CHANNEL_NAME"]
+                    if "SLACK_CHANNEL_NAME" in environ
+                    else environ["SLACK_CHANNEL_ID"]
+                ),
                 stats,
                 global_provider,
             )
         else:
             logger.critical(
-                "Slack integration needs SLACK_API_TOKEN and SLACK_CHANNEL_ID environment variables (see more in https://docs.prowler.cloud/en/latest/tutorials/integrations/#slack)."
+                "Slack integration needs SLACK_API_TOKEN and SLACK_CHANNEL_NAME environment variables (see more in https://docs.prowler.cloud/en/latest/tutorials/integrations/#slack)."
             )
             sys.exit(1)
 

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -375,5 +375,5 @@ Detailed documentation at https://docs.prowler.com
         third_party_subparser.add_argument(
             "--slack",
             action="store_true",
-            help="Send a summary of the execution with a Slack APP in your channel. Environment variables SLACK_API_TOKEN and SLACK_CHANNEL_ID are required (see more in https://docs.prowler.cloud/en/latest/tutorials/integrations/#slack).",
+            help="Send a summary of the execution with a Slack APP in your channel. Environment variables SLACK_API_TOKEN and SLACK_CHANNEL_NAME are required (see more in https://docs.prowler.cloud/en/latest/tutorials/integrations/#slack).",
         )


### PR DESCRIPTION
### Description

Change Slack channel name environment variable from `SLACK_CHANNEL_ID` to `SLACK_CHANNEL_NAME` to avoid confusions.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
