### PR TITLE
docs(README): remove HTML deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ You can run Prowler from your workstation, a Kubernetes Job, a Google Compute En
 - The CSV output format is common for all the providers.
 
 We have deprecated some of our outputs formats:
-- The HTML is replaced for the new Prowler Dashboard, run `prowler dashboard`.
 - The native JSON is replaced for the JSON [OCSF](https://schema.ocsf.io/) v1.1.0, common for all the providers.
 
 ## AWS


### PR DESCRIPTION
### Description

Remove HTML deprecation from README.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
