### PR TITLE
 fix(rds): ParameterValue MySQL and MariaDB RDS Instances

### DIFF
--- a/prowler/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted.py
+++ b/prowler/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted.py
@@ -50,7 +50,7 @@ class rds_instance_transport_encrypted(Check):
                     for parameter in db_instance.parameters:
                         if (
                             parameter["ParameterName"] == "require_secure_transport"
-                            and parameter.get("ParameterValue", "OFF") == "ON"
+                            and parameter.get("ParameterValue", "0") == "1"
                         ):
                             report.status = "PASS"
                             report.status_extended = f"RDS Instance {db_instance.id} connections use SSL encryption."

--- a/tests/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted_test.py
@@ -250,7 +250,7 @@ class Test_rds_instance_transport_encrypted:
             Parameters=[
                 {
                     "ParameterName": "require_secure_transport",
-                    "ParameterValue": "OFF",
+                    "ParameterValue": "0",
                     "ApplyMethod": "immediate",
                 },
             ],
@@ -312,7 +312,7 @@ class Test_rds_instance_transport_encrypted:
             Parameters=[
                 {
                     "ParameterName": "require_secure_transport",
-                    "ParameterValue": "ON",
+                    "ParameterValue": "1",
                     "ApplyMethod": "immediate",
                 },
             ],


### PR DESCRIPTION
### Context

MySQL and MariaDB Instances use a ```require_secure_transport = 1``` while the clusters use ```require_secure_transport = ON``` to set the ParameterValue for requiring encryption.

### Description

The current checks have been updated for DB Instances to check for  ```require_secure_transport = ON``` which will not provide the correct information. 

![RDS MySQL Cluster Encryption Required](https://github.com/prowler-cloud/prowler/assets/107269923/6df366b6-3b67-497d-b308-cf6d97339e4b)

![RDS MySQL DB Instance Encryption Required](https://github.com/prowler-cloud/prowler/assets/107269923/5f2bec30-809d-416e-809b-5e5e6ab42954)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
