### PR TITLE
fix(rds): solve TypeError and make Certificate class

### DIFF
--- a/prowler/providers/aws/services/rds/rds_instance_certificate_expiration/rds_instance_certificate_expiration.py
+++ b/prowler/providers/aws/services/rds/rds_instance_certificate_expiration/rds_instance_certificate_expiration.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from dateutil import parser, relativedelta
+from dateutil import relativedelta
 from pytz import utc
 
 from prowler.lib.check.models import Check, Check_Report_AWS
@@ -28,33 +28,44 @@ class rds_instance_certificate_expiration(Check):
 
             # Check only RDS DB instances that support parameter group encryption
             for cert in db_instance.cert:
-                if cert["CustomerOverride"] == 0:
-                    valid_till = parser.parse(cert["ValidTill"])
-                    if valid_till > datetime.now(utc) + relativedelta.relativedelta(
-                        months=6
-                    ):
+                if not cert.customer_override:
+                    if cert.valid_till > datetime.now(
+                        utc
+                    ) + relativedelta.relativedelta(months=6):
                         report.status = "PASS"
                         report.check_metadata.Severity = "informational"
                         report.status_extended = f"RDS Instance {db_instance.id} certificate has over 6 months of validity left."
-                    elif valid_till < datetime.now(utc) + relativedelta.relativedelta(
+                    elif cert.valid_till < datetime.now(
+                        utc
+                    ) + relativedelta.relativedelta(
                         months=6
-                    ) and valid_till > datetime.now(utc) + relativedelta.relativedelta(
+                    ) and cert.valid_till > datetime.now(
+                        utc
+                    ) + relativedelta.relativedelta(
                         months=3
                     ):
                         report.status = "PASS"
                         report.check_metadata.Severity = "low"
                         report.status_extended = f"RDS Instance {db_instance.id} certificate has between 3 and 6 months of validity."
-                    elif valid_till < datetime.now(utc) + relativedelta.relativedelta(
+                    elif cert.valid_till < datetime.now(
+                        utc
+                    ) + relativedelta.relativedelta(
                         months=3
-                    ) and valid_till > datetime.now(utc) + relativedelta.relativedelta(
+                    ) and cert.valid_till > datetime.now(
+                        utc
+                    ) + relativedelta.relativedelta(
                         months=1
                     ):
                         report.status = "FAIL"
                         report.check_metadata.Severity = "medium"
                         report.status_extended = f"RDS Instance {db_instance.id} certificate less than 3 months of validity."
-                    elif valid_till < datetime.now(utc) + relativedelta.relativedelta(
+                    elif cert.valid_till < datetime.now(
+                        utc
+                    ) + relativedelta.relativedelta(
                         months=1
-                    ) and valid_till > datetime.now(utc):
+                    ) and cert.valid_till > datetime.now(
+                        utc
+                    ):
                         report.status = "FAIL"
                         report.check_metadata.Severity = "high"
                         report.status_extended = f"RDS Instance {db_instance.id} certificate less than 1 month of validity."
@@ -65,20 +76,17 @@ class rds_instance_certificate_expiration(Check):
                             f"RDS Instance {db_instance.id} certificate has expired."
                         )
                 else:
-                    customer_override_valid_till = parser.parse(
-                        cert["CustomerOverrideValidTill"]
-                    )
-                    if customer_override_valid_till > datetime.now(
+                    if cert.valid_till > datetime.now(
                         utc
                     ) + relativedelta.relativedelta(months=6):
                         report.status = "PASS"
                         report.check_metadata.Severity = "informational"
                         report.status_extended = f"RDS Instance {db_instance.id} custom certificate has over 6 months of validity left."
-                    elif customer_override_valid_till < datetime.now(
+                    elif cert.valid_till < datetime.now(
                         utc
                     ) + relativedelta.relativedelta(
                         months=6
-                    ) and customer_override_valid_till > datetime.now(
+                    ) and cert.valid_till > datetime.now(
                         utc
                     ) + relativedelta.relativedelta(
                         months=3
@@ -86,11 +94,11 @@ class rds_instance_certificate_expiration(Check):
                         report.status = "PASS"
                         report.check_metadata.Severity = "low"
                         report.status_extended = f"RDS Instance {db_instance.id} custom certificate has between 3 and 6 months of validity."
-                    elif customer_override_valid_till < datetime.now(
+                    elif cert.valid_till < datetime.now(
                         utc
                     ) + relativedelta.relativedelta(
                         months=3
-                    ) and customer_override_valid_till > datetime.now(
+                    ) and cert.valid_till > datetime.now(
                         utc
                     ) + relativedelta.relativedelta(
                         months=1
@@ -98,11 +106,11 @@ class rds_instance_certificate_expiration(Check):
                         report.status = "FAIL"
                         report.check_metadata.Severity = "medium"
                         report.status_extended = f"RDS Instance {db_instance.id} custom certificate less than 3 months of validity."
-                    elif customer_override_valid_till < datetime.now(
+                    elif cert.valid_till < datetime.now(
                         utc
                     ) + relativedelta.relativedelta(
                         months=1
-                    ) and customer_override_valid_till > datetime.now(
+                    ) and cert.valid_till > datetime.now(
                         utc
                     ):
                         report.status = "FAIL"

--- a/tests/providers/aws/services/rds/rds_instance_certificate_expiration/rds_instance_certificate_expiration_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_certificate_expiration/rds_instance_certificate_expiration_test.py
@@ -6,7 +6,7 @@ from dateutil import relativedelta
 from moto import mock_aws
 from pytz import utc
 
-from prowler.providers.aws.services.rds.rds_service import DBInstance
+from prowler.providers.aws.services.rds.rds_service import Certificate, DBInstance
 
 AWS_ACCOUNT_NUMBER_CON = "123456789012"
 AWS_REGION = "us-east-1"
@@ -79,14 +79,15 @@ class Test_rds_instance_certificate_expiration:
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
                 cert=[
-                    {
-                        "CertificateIdentifier": "rds-ca-rsa2048-g1",
-                        "CertificateType": "CA",
-                        "ValidFrom": f"{valid_from}",
-                        "ValidTill": f"{valid_till}",
-                        "CustomerOverride": False,
-                        "CustomerOverrideValidTill": f"{customer_override_valid}",
-                    }
+                    Certificate(
+                        id="rds-ca-rsa2048-g1",
+                        arn=f"arn:aws:rds:{AWS_REGION}::cert:rds-ca-2019",
+                        type="CA",
+                        valid_from=valid_from,
+                        valid_till=valid_till,
+                        customer_override=False,
+                        customer_override_valid_till=customer_override_valid,
+                    )
                 ],
             )
         ]
@@ -147,14 +148,15 @@ class Test_rds_instance_certificate_expiration:
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
                 cert=[
-                    {
-                        "CertificateIdentifier": "rds-ca-rsa2048-g1",
-                        "CertificateType": "CA",
-                        "ValidFrom": f"{valid_from}",
-                        "ValidTill": f"{valid_till}",
-                        "CustomerOverride": False,
-                        "CustomerOverrideValidTill": f"{customer_override_valid}",
-                    }
+                    Certificate(
+                        id="rds-ca-rsa2048-g1",
+                        arn=f"arn:aws:rds:{AWS_REGION}::cert:rds-ca-2019",
+                        type="CA",
+                        valid_from=valid_from,
+                        valid_till=valid_till,
+                        customer_override=False,
+                        customer_override_valid_till=customer_override_valid,
+                    )
                 ],
             )
         ]
@@ -214,14 +216,15 @@ class Test_rds_instance_certificate_expiration:
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
                 cert=[
-                    {
-                        "CertificateIdentifier": "rds-ca-rsa2048-g1",
-                        "CertificateType": "CA",
-                        "ValidFrom": f"{valid_from}",
-                        "ValidTill": f"{valid_till}",
-                        "CustomerOverride": False,
-                        "CustomerOverrideValidTill": f"{customer_override_valid}",
-                    }
+                    Certificate(
+                        id="rds-ca-rsa2048-g1",
+                        arn=f"arn:aws:rds:{AWS_REGION}::cert:rds-ca-2019",
+                        type="CA",
+                        valid_from=valid_from,
+                        valid_till=valid_till,
+                        customer_override=False,
+                        customer_override_valid_till=customer_override_valid,
+                    )
                 ],
             )
         ]
@@ -281,14 +284,15 @@ class Test_rds_instance_certificate_expiration:
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
                 cert=[
-                    {
-                        "CertificateIdentifier": "rds-ca-rsa2048-g1",
-                        "CertificateType": "CA",
-                        "ValidFrom": f"{valid_from}",
-                        "ValidTill": f"{valid_till}",
-                        "CustomerOverride": False,
-                        "CustomerOverrideValidTill": f"{customer_override_valid}",
-                    }
+                    Certificate(
+                        id="rds-ca-rsa2048-g1",
+                        arn=f"arn:aws:rds:{AWS_REGION}::cert:rds-ca-2019",
+                        type="CA",
+                        valid_from=valid_from,
+                        valid_till=valid_till,
+                        customer_override=False,
+                        customer_override_valid_till=customer_override_valid,
+                    )
                 ],
             )
         ]
@@ -348,14 +352,15 @@ class Test_rds_instance_certificate_expiration:
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
                 cert=[
-                    {
-                        "CertificateIdentifier": "rds-ca-rsa2048-g1",
-                        "CertificateType": "CA",
-                        "ValidFrom": f"{valid_from}",
-                        "ValidTill": f"{valid_till}",
-                        "CustomerOverride": True,
-                        "CustomerOverrideValidTill": f"{customer_override_valid}",
-                    }
+                    Certificate(
+                        id="rds-ca-rsa2048-g1",
+                        arn=f"arn:aws:rds:{AWS_REGION}::cert:rds-ca-2019",
+                        type="CA",
+                        valid_from=valid_from,
+                        valid_till=valid_till,
+                        customer_override=True,
+                        customer_override_valid_till=customer_override_valid,
+                    )
                 ],
             )
         ]
@@ -415,14 +420,15 @@ class Test_rds_instance_certificate_expiration:
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
                 cert=[
-                    {
-                        "CertificateIdentifier": "rds-ca-rsa2048-g1",
-                        "CertificateType": "CA",
-                        "ValidFrom": f"{valid_from}",
-                        "ValidTill": f"{valid_till}",
-                        "CustomerOverride": True,
-                        "CustomerOverrideValidTill": f"{customer_override_valid}",
-                    }
+                    Certificate(
+                        id="rds-ca-rsa2048-g1",
+                        arn=f"arn:aws:rds:{AWS_REGION}::cert:rds-ca-2019",
+                        type="CA",
+                        valid_from=valid_from,
+                        valid_till=valid_till,
+                        customer_override=True,
+                        customer_override_valid_till=customer_override_valid,
+                    )
                 ],
             )
         ]
@@ -482,14 +488,15 @@ class Test_rds_instance_certificate_expiration:
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
                 cert=[
-                    {
-                        "CertificateIdentifier": "rds-ca-rsa2048-g1",
-                        "CertificateType": "CA",
-                        "ValidFrom": f"{valid_from}",
-                        "ValidTill": f"{valid_till}",
-                        "CustomerOverride": True,
-                        "CustomerOverrideValidTill": f"{customer_override_valid}",
-                    }
+                    Certificate(
+                        id="rds-ca-rsa2048-g1",
+                        arn=f"arn:aws:rds:{AWS_REGION}::cert:rds-ca-2019",
+                        type="CA",
+                        valid_from=valid_from,
+                        valid_till=valid_till,
+                        customer_override=True,
+                        customer_override_valid_till=customer_override_valid,
+                    )
                 ],
             )
         ]
@@ -549,14 +556,15 @@ class Test_rds_instance_certificate_expiration:
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
                 cert=[
-                    {
-                        "CertificateIdentifier": "rds-ca-rsa2048-g1",
-                        "CertificateType": "CA",
-                        "ValidFrom": f"{valid_from}",
-                        "ValidTill": f"{valid_till}",
-                        "CustomerOverride": True,
-                        "CustomerOverrideValidTill": f"{customer_override_valid}",
-                    }
+                    Certificate(
+                        id="rds-ca-rsa2048-g1",
+                        arn=f"arn:aws:rds:{AWS_REGION}::cert:rds-ca-2019",
+                        type="CA",
+                        valid_from=valid_from,
+                        valid_till=valid_till,
+                        customer_override=True,
+                        customer_override_valid_till=customer_override_valid,
+                    )
                 ],
             )
         ]
@@ -616,14 +624,15 @@ class Test_rds_instance_certificate_expiration:
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
                 cert=[
-                    {
-                        "CertificateIdentifier": "rds-ca-rsa2048-g1",
-                        "CertificateType": "CA",
-                        "ValidFrom": f"{valid_from}",
-                        "ValidTill": f"{valid_till}",
-                        "CustomerOverride": True,
-                        "CustomerOverrideValidTill": f"{customer_override_valid}",
-                    }
+                    Certificate(
+                        id="rds-ca-rsa2048-g1",
+                        arn=f"arn:aws:rds:{AWS_REGION}::cert:rds-ca-2019",
+                        type="CA",
+                        valid_from=valid_from,
+                        valid_till=valid_till,
+                        customer_override=True,
+                        customer_override_valid_till=customer_override_valid,
+                    )
                 ],
             )
         ]


### PR DESCRIPTION
### Description

Solve TypeError since `valid_till` is already a datetime and make Certificate class for better handling.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
