### PR TITLE
chore(cloudformation): Update related URL

### DIFF
--- a/prowler/providers/aws/services/cloudformation/cloudformation_stack_outputs_find_secrets/cloudformation_stack_outputs_find_secrets.metadata.json
+++ b/prowler/providers/aws/services/cloudformation/cloudformation_stack_outputs_find_secrets/cloudformation_stack_outputs_find_secrets.metadata.json
@@ -10,7 +10,7 @@
   "ResourceType": "AwsCloudFormationStack",
   "Description": "Find secrets in CloudFormation outputs",
   "Risk": "Secrets hardcoded into CloudFormation outputs can be used by malware and bad actors to gain lateral access to other services.",
-  "RelatedUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-secretsmanager-secret-generatesecretstring.html",
+  "RelatedUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html",
   "Remediation": {
     "Code": {
       "CLI": "https://docs.prowler.com/checks/aws/secrets-policies/bc_aws_secrets_2#cli-command",


### PR DESCRIPTION
### Context

The `"RelatedURL"` for the `cloudformation_stack_outputs_find_secrets` check is not really helpful currently.

### Description

Replaces the `"RelatedURL"` to point to AWS documentation describing CloudFormation outputs. The AWS documentation contains a warning stating that no secrets should be output.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
