### PR TITLE
fix(allowlist): Handle items starting by *

### DIFF
--- a/prowler/providers/aws/lib/allowlist/allowlist.py
+++ b/prowler/providers/aws/lib/allowlist/allowlist.py
@@ -342,14 +342,15 @@ def __is_item_matched__(matched_items, finding_items):
         is_item_matched = False
         if matched_items and (finding_items or finding_items == ""):
             for item in matched_items:
-                if item == "*":
-                    item = ".*"
+                if item.startswith("*"):
+                    item = ".*" + item[1:]
                 if re.search(item, finding_items):
                     is_item_matched = True
                     break
         return is_item_matched
     except Exception as error:
-        logger.critical(
+        logger.error(
             f"{error.__class__.__name__} -- {error}[{error.__traceback__.tb_lineno}]"
         )
-        sys.exit(1)
+        # If something unexpected happens return not matched, thus False
+        return False

--- a/tests/providers/aws/lib/allowlist/allowlist_test.py
+++ b/tests/providers/aws/lib/allowlist/allowlist_test.py
@@ -1318,3 +1318,8 @@ class Test_Allowlist:
         assert is_allowlisted_in_resource(allowlist_resources, "prowler-test")
         assert is_allowlisted_in_resource(allowlist_resources, "test-prowler")
         assert not is_allowlisted_in_resource(allowlist_resources, "random")
+
+    def test_is_allowlisted_in_resource_starting_by_star(self):
+        allowlist_resources = ["*.es"]
+
+        assert is_allowlisted_in_resource(allowlist_resources, "google.es")


### PR DESCRIPTION
### Context

We are aborting the execution if the allowlist regex fails unexpectedly and also not handling right when the pattern starts by `*` which is not a valid regex.


### Description

- Change `critical` log to `error`
- Return `False` if something not handled happens.
- If the pattern starts by `*` add a `.` in front of it.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
