### PR TITLE
fix(mutelist): Handle items starting by *

### DIFF
--- a/prowler/lib/mutelist/mutelist.py
+++ b/prowler/lib/mutelist/mutelist.py
@@ -362,8 +362,8 @@ def __is_item_matched__(matched_items, finding_items):
         is_item_matched = False
         if matched_items and (finding_items or finding_items == ""):
             for item in matched_items:
-                if item == "*":
-                    item = ".*"
+                if item.startswith("*"):
+                    item = ".*" + item[1:]
                 if re.search(item, finding_items):
                     is_item_matched = True
                     break

--- a/tests/lib/mutelist/mutelist_test.py
+++ b/tests/lib/mutelist/mutelist_test.py
@@ -1323,3 +1323,8 @@ class TestMutelist:
         assert is_muted_in_resource(mutelist_resources, "prowler-test")
         assert is_muted_in_resource(mutelist_resources, "test-prowler")
         assert not is_muted_in_resource(mutelist_resources, "random")
+
+    def test_is_muted_in_resource_starting_by_star(self):
+        allowlist_resources = ["*.es"]
+
+        assert is_muted_in_resource(allowlist_resources, "google.es")


### PR DESCRIPTION
### Context

We are aborting the execution if the allowlist regex fails unexpectedly and also not handling right when the pattern starts by `*` which is not a valid regex.


### Description

- Change `critical` log to `error`
- Return `False` if something not handled happens.
- If the pattern starts by `*` add a `.` in front of it.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
