### PR TITLE
chore(vpc): add scan unused services logic to VPC checks

### DIFF
--- a/docs/tutorials/scan-unused-services.md
+++ b/docs/tutorials/scan-unused-services.md
@@ -69,3 +69,7 @@ You should enable Public Access Block at the account level to prevent the exposu
 VPC Flow Logs provide visibility into network traffic that traverses the VPC and can be used to detect anomalous traffic or insight during security workflows. Nevertheless, Prowler will only check if the Flow Logs are enabled for those VPCs that are in use, in other words, only the VPCs where you have ENIs (network interfaces).
 
   - `vpc_flow_logs_enabled`
+
+VPC subnets must not have public IP addresses by default to prevent the exposure of your resources to the internet. Prowler will only check this configuration for those VPCs that are in use, in other words, only the VPCs where you have ENIs (network interfaces).
+
+  - `vpc_subnet_no_public_ip_by_default`

--- a/docs/tutorials/scan-unused-services.md
+++ b/docs/tutorials/scan-unused-services.md
@@ -73,3 +73,11 @@ VPC Flow Logs provide visibility into network traffic that traverses the VPC and
 VPC subnets must not have public IP addresses by default to prevent the exposure of your resources to the internet. Prowler will only check this configuration for those VPCs that are in use, in other words, only the VPCs where you have ENIs (network interfaces).
 
   - `vpc_subnet_no_public_ip_by_default`
+
+VPCs should have separate private and public subnets to prevent the exposure of your resources to the internet. Prowler will only check this configuration for those VPCs that are in use, in other words, only the VPCs where you have ENIs (network interfaces).
+
+  - `vpc_subnet_separate_private_public`
+
+VPCs should have subnets in different availability zones to prevent a single point of failure. Prowler will only check this configuration for those VPCs that are in use, in other words, only the VPCs where you have ENIs (network interfaces).
+
+  - `vpc_subnet_different_az`

--- a/prowler/providers/aws/services/vpc/vpc_subnet_different_az/vpc_subnet_different_az.py
+++ b/prowler/providers/aws/services/vpc/vpc_subnet_different_az/vpc_subnet_different_az.py
@@ -6,28 +6,29 @@ class vpc_subnet_different_az(Check):
     def execute(self):
         findings = []
         for vpc in vpc_client.vpcs.values():
-            report = Check_Report_AWS(self.metadata())
-            report.region = vpc.region
-            report.resource_tags = vpc.tags
-            report.status = "FAIL"
-            report.status_extended = (
-                f"VPC {vpc.name if vpc.name else vpc.id} has no subnets."
-            )
-            report.resource_id = vpc.id
-            report.resource_arn = vpc.arn
-            if vpc.subnets:
-                availability_zone = None
-                for subnet in vpc.subnets:
-                    if (
-                        availability_zone
-                        and subnet.availability_zone != availability_zone
-                    ):
-                        report.status = "PASS"
-                        report.status_extended = f"VPC {vpc.name if vpc.name else vpc.id} has subnets in more than one availability zone."
-                        break
-                    availability_zone = subnet.availability_zone
-                    report.status_extended = f"VPC {vpc.name if vpc.name else vpc.id} has only subnets in {availability_zone}."
+            if vpc_client.provider.scan_unused_services or vpc.in_use:
+                report = Check_Report_AWS(self.metadata())
+                report.region = vpc.region
+                report.resource_tags = vpc.tags
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"VPC {vpc.name if vpc.name else vpc.id} has no subnets."
+                )
+                report.resource_id = vpc.id
+                report.resource_arn = vpc.arn
+                if vpc.subnets:
+                    availability_zone = None
+                    for subnet in vpc.subnets:
+                        if (
+                            availability_zone
+                            and subnet.availability_zone != availability_zone
+                        ):
+                            report.status = "PASS"
+                            report.status_extended = f"VPC {vpc.name if vpc.name else vpc.id} has subnets in more than one availability zone."
+                            break
+                        availability_zone = subnet.availability_zone
+                        report.status_extended = f"VPC {vpc.name if vpc.name else vpc.id} has only subnets in {availability_zone}."
 
-            findings.append(report)
+                findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/vpc/vpc_subnet_no_public_ip_by_default/vpc_subnet_no_public_ip_by_default.py
+++ b/prowler/providers/aws/services/vpc/vpc_subnet_no_public_ip_by_default/vpc_subnet_no_public_ip_by_default.py
@@ -7,7 +7,6 @@ class vpc_subnet_no_public_ip_by_default(Check):
         findings = []
         for vpc in vpc_client.vpcs.values():
             for subnet in vpc.subnets:
-                print(subnet.in_use)
                 # Check if ignoring flag is set and if the VPC Subnet is in use
                 if vpc_client.provider.scan_unused_services or subnet.in_use:
                     report = Check_Report_AWS(self.metadata())

--- a/prowler/providers/aws/services/vpc/vpc_subnet_no_public_ip_by_default/vpc_subnet_no_public_ip_by_default.py
+++ b/prowler/providers/aws/services/vpc/vpc_subnet_no_public_ip_by_default/vpc_subnet_no_public_ip_by_default.py
@@ -7,17 +7,20 @@ class vpc_subnet_no_public_ip_by_default(Check):
         findings = []
         for vpc in vpc_client.vpcs.values():
             for subnet in vpc.subnets:
-                report = Check_Report_AWS(self.metadata())
-                report.region = subnet.region
-                report.resource_tags = subnet.tags
-                report.resource_id = subnet.id
-                report.resource_arn = subnet.arn
-                if subnet.mapPublicIpOnLaunch:
-                    report.status = "FAIL"
-                    report.status_extended = f"VPC subnet {subnet.name if subnet.name else subnet.id} assigns public IP by default."
-                else:
-                    report.status = "PASS"
-                    report.status_extended = f"VPC subnet {subnet.name if subnet.name else subnet.id} does NOT assign public IP by default."
-                findings.append(report)
+                print(subnet.in_use)
+                # Check if ignoring flag is set and if the VPC Subnet is in use
+                if vpc_client.provider.scan_unused_services or subnet.in_use:
+                    report = Check_Report_AWS(self.metadata())
+                    report.region = subnet.region
+                    report.resource_tags = subnet.tags
+                    report.resource_id = subnet.id
+                    report.resource_arn = subnet.arn
+                    if subnet.mapPublicIpOnLaunch:
+                        report.status = "FAIL"
+                        report.status_extended = f"VPC subnet {subnet.name if subnet.name else subnet.id} assigns public IP by default."
+                    else:
+                        report.status = "PASS"
+                        report.status_extended = f"VPC subnet {subnet.name if subnet.name else subnet.id} does NOT assign public IP by default."
+                    findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/vpc/vpc_subnet_separate_private_public/vpc_subnet_separate_private_public.py
+++ b/prowler/providers/aws/services/vpc/vpc_subnet_separate_private_public/vpc_subnet_separate_private_public.py
@@ -6,28 +6,29 @@ class vpc_subnet_separate_private_public(Check):
     def execute(self):
         findings = []
         for vpc in vpc_client.vpcs.values():
-            report = Check_Report_AWS(self.metadata())
-            report.region = vpc.region
-            report.resource_tags = vpc.tags
-            report.status = "FAIL"
-            report.status_extended = (
-                f"VPC {vpc.name if vpc.name else vpc.id} has no subnets."
-            )
-            report.resource_id = vpc.id
-            report.resource_arn = vpc.arn
-            if vpc.subnets:
-                public = False
-                private = False
-                for subnet in vpc.subnets:
-                    if subnet.public:
-                        public = True
-                        report.status_extended = f"VPC {vpc.name if vpc.name else vpc.id} has only public subnets."
-                    if not subnet.public:
-                        private = True
-                        report.status_extended = f"VPC {vpc.name if vpc.name else vpc.id} has only private subnets."
-                    if public and private:
-                        report.status = "PASS"
-                        report.status_extended = f"VPC {vpc.name if vpc.name else vpc.id} has private and public subnets."
-            findings.append(report)
+            if vpc_client.provider.scan_unused_services or vpc.in_use:
+                report = Check_Report_AWS(self.metadata())
+                report.region = vpc.region
+                report.resource_tags = vpc.tags
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"VPC {vpc.name if vpc.name else vpc.id} has no subnets."
+                )
+                report.resource_id = vpc.id
+                report.resource_arn = vpc.arn
+                if vpc.subnets:
+                    public = False
+                    private = False
+                    for subnet in vpc.subnets:
+                        if subnet.public:
+                            public = True
+                            report.status_extended = f"VPC {vpc.name if vpc.name else vpc.id} has only public subnets."
+                        if not subnet.public:
+                            private = True
+                            report.status_extended = f"VPC {vpc.name if vpc.name else vpc.id} has only private subnets."
+                        if public and private:
+                            report.status = "PASS"
+                            report.status_extended = f"VPC {vpc.name if vpc.name else vpc.id} has private and public subnets."
+                findings.append(report)
 
         return findings

--- a/tests/providers/aws/services/vpc/vpc_subnet_different_az/vpc_subnet_different_az_test.py
+++ b/tests/providers/aws/services/vpc/vpc_subnet_different_az/vpc_subnet_different_az_test.py
@@ -166,3 +166,31 @@ class Test_vpc_subnet_different_az:
                         assert result.region == AWS_REGION_US_EAST_1
                 if not found:
                     assert False
+
+    @mock_aws
+    def test_vpc_no_subnets_but_unused(self):
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_client.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
+
+        from prowler.providers.aws.services.vpc.vpc_service import VPC
+
+        aws_provider = set_mocked_aws_provider(
+            audited_regions=[AWS_REGION_US_EAST_1], scan_unused_services=False
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.vpc.vpc_subnet_different_az.vpc_subnet_different_az.vpc_client",
+                new=VPC(aws_provider),
+            ):
+                from prowler.providers.aws.services.vpc.vpc_subnet_different_az.vpc_subnet_different_az import (
+                    vpc_subnet_different_az,
+                )
+
+                check = vpc_subnet_different_az()
+                results = check.execute()
+
+                assert len(results) == 0

--- a/tests/providers/aws/services/vpc/vpc_subnet_no_public_ip_by_default/vpc_subnet_no_public_ip_by_default_test.py
+++ b/tests/providers/aws/services/vpc/vpc_subnet_no_public_ip_by_default/vpc_subnet_no_public_ip_by_default_test.py
@@ -102,3 +102,51 @@ class Test_vpc_subnet_no_public_ip_by_default:
                             result.status_extended
                             == f"VPC subnet {subnet_private['Subnet']['SubnetId']} does NOT assign public IP by default."
                         )
+
+    @mock_aws
+    def test_vpc_with_map_ip_on_launch_but_unused(self):
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        vpc = ec2_client.create_vpc(
+            CidrBlock="172.28.7.0/24", InstanceTenancy="default"
+        )
+        subnet_private = ec2_client.create_subnet(
+            VpcId=vpc["Vpc"]["VpcId"],
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=f"{AWS_REGION_US_EAST_1}a",
+            TagSpecifications=[
+                {
+                    "ResourceType": "subnet",
+                    "Tags": [
+                        {"Key": "Name", "Value": "subnet_name"},
+                    ],
+                },
+            ],
+        )
+
+        ec2_client.modify_subnet_attribute(
+            SubnetId=subnet_private["Subnet"]["SubnetId"],
+            MapPublicIpOnLaunch={"Value": True},
+        )
+
+        from prowler.providers.aws.services.vpc.vpc_service import VPC
+
+        aws_provider = set_mocked_aws_provider(
+            audited_regions=[AWS_REGION_US_EAST_1], scan_unused_services=False
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.vpc.vpc_subnet_no_public_ip_by_default.vpc_subnet_no_public_ip_by_default.vpc_client",
+                new=VPC(aws_provider),
+            ):
+                from prowler.providers.aws.services.vpc.vpc_subnet_no_public_ip_by_default.vpc_subnet_no_public_ip_by_default import (
+                    vpc_subnet_no_public_ip_by_default,
+                )
+
+                check = vpc_subnet_no_public_ip_by_default()
+                results = check.execute()
+
+                assert len(results) == 0


### PR DESCRIPTION
### Description

Add logic of unused services to VPC checks:

```
vpc_subnet_no_public_ip_by_default

vpc_subnet_separate_private_public

vpc_subnet_different_az
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
