### PR TITLE
fix(mutelist): return False if something fails

### DIFF
--- a/prowler/lib/mutelist/mutelist.py
+++ b/prowler/lib/mutelist/mutelist.py
@@ -115,7 +115,7 @@ def parse_mutelist_file(
 def mutelist_findings(
     global_provider: Any,
     check_findings: list[Any],
-):
+) -> list[Any]:
     # Check if finding is muted
     for finding in check_findings:
         # TODO: Move this mapping to the execute_check function and pass that output to the mutelist and the report
@@ -167,7 +167,21 @@ def is_muted(
     finding_region: str,
     finding_resource: str,
     finding_tags,
-):
+) -> bool:
+    """
+    Check if the provided finding is muted for the audited account, check, region, resource and tags.
+
+    Args:
+        mutelist (dict): Dictionary containing information about muted checks for different accounts.
+        audited_account (str): The account being audited.
+        check (str): The check to be evaluated for muting.
+        finding_region (str): The region where the finding occurred.
+        finding_resource (str): The resource related to the finding.
+        finding_tags: The tags associated with the finding.
+
+    Returns:
+        bool: True if the finding is muted for the audited account, check, region, resource and tags., otherwise False.
+    """
     try:
         # By default is not muted
         is_finding_muted = False
@@ -189,10 +203,10 @@ def is_muted(
 
         return is_finding_muted
     except Exception as error:
-        logger.critical(
+        logger.error(
             f"{error.__class__.__name__} -- {error}[{error.__traceback__.tb_lineno}]"
         )
-        sys.exit(1)
+        return False
 
 
 def is_muted_in_check(
@@ -202,7 +216,21 @@ def is_muted_in_check(
     finding_region,
     finding_resource,
     finding_tags,
-):
+) -> bool:
+    """
+    Check if the provided check is muted.
+
+    Args:
+        muted_checks (dict): Dictionary containing information about muted checks.
+        audited_account (str): The account to be audited.
+        check (str): The check to be evaluated for muting.
+        finding_region (str): The region where the finding occurred.
+        finding_resource (str): The resource related to the finding.
+        finding_tags (str): The tags associated with the finding.
+
+    Returns:
+        bool: True if the check is muted, otherwise False.
+    """
     try:
         # Default value is not muted
         is_check_muted = False
@@ -263,44 +291,74 @@ def is_muted_in_check(
 
         return is_check_muted
     except Exception as error:
-        logger.critical(
+        logger.error(
             f"{error.__class__.__name__} -- {error}[{error.__traceback__.tb_lineno}]"
         )
-        sys.exit(1)
+        return False
 
 
 def is_muted_in_region(
     mutelist_regions,
     finding_region,
-):
+) -> bool:
+    """
+    Check if the finding_region is present in the mutelist_regions.
+
+    Args:
+        mutelist_regions (list): List of regions in the mute list.
+        finding_region (str): Region to check if it is muted.
+
+    Returns:
+        bool: True if the finding_region is muted in any of the mutelist_regions, otherwise False.
+    """
     try:
         return __is_item_matched__(mutelist_regions, finding_region)
     except Exception as error:
-        logger.critical(
+        logger.error(
             f"{error.__class__.__name__} -- {error}[{error.__traceback__.tb_lineno}]"
         )
-        sys.exit(1)
+        return False
 
 
-def is_muted_in_tags(muted_tags, finding_tags):
+def is_muted_in_tags(muted_tags, finding_tags) -> bool:
+    """
+    Check if any of the muted tags are present in the finding tags.
+
+    Args:
+        muted_tags (list): List of muted tags to be checked.
+        finding_tags (str): String containing tags to search for muted tags.
+
+    Returns:
+        bool: True if any of the muted tags are present in the finding tags, otherwise False.
+    """
     try:
         return __is_item_matched__(muted_tags, finding_tags)
     except Exception as error:
-        logger.critical(
+        logger.error(
             f"{error.__class__.__name__} -- {error}[{error.__traceback__.tb_lineno}]"
         )
-        sys.exit(1)
+        return False
 
 
-def is_muted_in_resource(muted_resources, finding_resource):
+def is_muted_in_resource(muted_resources, finding_resource) -> bool:
+    """
+    Check if any of the muted_resources are present in the finding_resource.
+
+    Args:
+        muted_resources (list): List of muted resources to be checked.
+        finding_resource (str): Resource to search for muted resources.
+
+    Returns:
+        bool: True if any of the muted_resources are present in the finding_resource, otherwise False.
+    """
     try:
         return __is_item_matched__(muted_resources, finding_resource)
 
     except Exception as error:
-        logger.critical(
+        logger.error(
             f"{error.__class__.__name__} -- {error}[{error.__traceback__.tb_lineno}]"
         )
-        sys.exit(1)
+        return False
 
 
 def is_excepted(
@@ -309,8 +367,20 @@ def is_excepted(
     finding_region,
     finding_resource,
     finding_tags,
-):
-    """is_excepted returns True if the account, region, resource and tags are excepted"""
+) -> bool:
+    """
+    Check if the provided account, region, resource, and tags are excepted based on the exceptions dictionary.
+
+    Args:
+        exceptions (dict): Dictionary containing exceptions for different attributes like Accounts, Regions, Resources, and Tags.
+        audited_account (str): The account to be audited.
+        finding_region (str): The region where the finding occurred.
+        finding_resource (str): The resource related to the finding.
+        finding_tags (str): The tags associated with the finding.
+
+    Returns:
+        bool: True if the account, region, resource, and tags are excepted based on the exceptions, otherwise False.
+    """
     try:
         excepted = False
         is_account_excepted = False
@@ -350,14 +420,23 @@ def is_excepted(
                 excepted = True
         return excepted
     except Exception as error:
-        logger.critical(
+        logger.error(
             f"{error.__class__.__name__} -- {error}[{error.__traceback__.tb_lineno}]"
         )
-        sys.exit(1)
+        return False
 
 
 def __is_item_matched__(matched_items, finding_items):
-    """__is_item_matched__ return True if any of the matched_items are present in the finding_items, otherwise returns False."""
+    """
+    Check if any of the items in matched_items are present in finding_items.
+
+    Args:
+        matched_items (list): List of items to be matched.
+        finding_items (str): String to search for matched items.
+
+    Returns:
+        bool: True if any of the matched_items are present in finding_items, otherwise False.
+    """
     try:
         is_item_matched = False
         if matched_items and (finding_items or finding_items == ""):
@@ -369,7 +448,7 @@ def __is_item_matched__(matched_items, finding_items):
                     break
         return is_item_matched
     except Exception as error:
-        logger.critical(
+        logger.error(
             f"{error.__class__.__name__} -- {error}[{error.__traceback__.tb_lineno}]"
         )
-        sys.exit(1)
+        return False


### PR DESCRIPTION
### Description

Remove the `logger.critical` and `sys.exit()` from the Mutelist logic.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
