### PR TITLE
fix(defender): Add new parameter required by new API version

### DIFF
--- a/prowler/providers/azure/services/defender/defender_service.py
+++ b/prowler/providers/azure/services/defender/defender_service.py
@@ -31,7 +31,9 @@ class Defender(AzureService):
         pricings = {}
         for subscription_name, client in self.clients.items():
             try:
-                pricings_list = client.pricings.list()
+                pricings_list = client.pricings.list(
+                    scope_id=f"subscriptions/{self.subscriptions[subscription_name]}"
+                )
                 pricings.update({subscription_name: {}})
                 for pricing in pricings_list.value:
                     pricings[subscription_name].update(


### PR DESCRIPTION
### Context

New API version break the call to get defender pricings, comes from https://github.com/prowler-cloud/prowler/pull/4034

### Description

Add new required parameter to call.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
