### PR TITLE
chore(iam): Downgrade AWS IAM check severity

### DIFF
--- a/prowler/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption.metadata.json
+++ b/prowler/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption.metadata.json
@@ -12,7 +12,7 @@
   "ResourceType": "AwsIamPolicy",
   "Description": "Ensure that no custom IAM policies exist which allow permissive role assumption (e.g. sts:AssumeRole on *)",
   "Risk": "If not restricted unintended access could happen.",
-  "RelatedUrl": "",
+  "RelatedUrl": "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_permissions-to-switch.html#roles-usingrole-createpolicy",
   "Remediation": {
     "Code": {
       "CLI": "",

--- a/prowler/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption.metadata.json
+++ b/prowler/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption.metadata.json
@@ -8,7 +8,7 @@
   "ServiceName": "iam",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
-  "Severity": "critical",
+  "Severity": "high",
   "ResourceType": "AwsIamPolicy",
   "Description": "Ensure that no custom IAM policies exist which allow permissive role assumption (e.g. sts:AssumeRole on *)",
   "Risk": "If not restricted unintended access could happen.",


### PR DESCRIPTION
### Context

Corrects inconsistent check severity, fixes #4142.

### Description

Changes severity of `iam_no_custom_policy_permissive_role_assumption` from `Critical` to `High` to align with other existing permission-related checks.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
