### PR TITLE
fix(rds): use correct API call for cluster parameters

### DIFF
--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -434,8 +434,8 @@ class DBCluster(BaseModel):
     auto_minor_version_upgrade: bool
     multi_az: bool
     parameter_group: str
-    force_ssl: Optional[str] = "0"
-    require_secure_transport: Optional[str] = "OFF"
+    force_ssl: str = "0"
+    require_secure_transport: str = "OFF"
     region: str
     tags: Optional[list] = []
 

--- a/tests/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_transport_encrypted/rds_instance_transport_encrypted_test.py
@@ -11,6 +11,9 @@ from tests.providers.aws.utils import (
 )
 
 make_api_call = botocore.client.BaseClient._make_api_call
+cluster_arn = (
+    f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+)
 
 
 def mock_make_api_call(self, operation_name, kwarg):
@@ -160,10 +163,7 @@ class Test_rds_instance_transport_encrypted:
                 )
                 assert result[0].resource_id == "db-cluster-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
-                assert (
-                    result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
-                )
+                assert result[0].resource_arn == cluster_arn
                 assert result[0].resource_tags == []
 
     @mock_aws
@@ -433,16 +433,6 @@ class Test_rds_instance_transport_encrypted:
             MasterUserPassword="password",
             Tags=[],
         )
-        conn.modify_db_parameter_group(
-            DBParameterGroupName="test",
-            Parameters=[
-                {
-                    "ParameterName": "rds.force_ssl",
-                    "ParameterValue": "1",
-                    "ApplyMethod": "immediate",
-                },
-            ],
-        )
         from prowler.providers.aws.services.rds.rds_service import RDS
 
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
@@ -454,12 +444,14 @@ class Test_rds_instance_transport_encrypted:
             with mock.patch(
                 "prowler.providers.aws.services.rds.rds_instance_transport_encrypted.rds_instance_transport_encrypted.rds_client",
                 new=RDS(aws_provider),
-            ):
+            ) as rds_client:
                 # Test Check
                 from prowler.providers.aws.services.rds.rds_instance_transport_encrypted.rds_instance_transport_encrypted import (
                     rds_instance_transport_encrypted,
                 )
 
+                # Change DB Cluster parameter group to support SSL since Moto does not support it
+                rds_client.db_clusters[cluster_arn].require_secure_transport = "ON"
                 check = rds_instance_transport_encrypted()
                 result = check.execute()
 
@@ -471,10 +463,7 @@ class Test_rds_instance_transport_encrypted:
                 )
                 assert result[0].resource_id == "db-cluster-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
-                assert (
-                    result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
-                )
+                assert result[0].resource_arn == cluster_arn
                 assert result[0].resource_tags == []
 
     @mock_aws
@@ -517,12 +506,14 @@ class Test_rds_instance_transport_encrypted:
             with mock.patch(
                 "prowler.providers.aws.services.rds.rds_instance_transport_encrypted.rds_instance_transport_encrypted.rds_client",
                 new=RDS(aws_provider),
-            ):
+            ) as rds_client:
                 # Test Check
                 from prowler.providers.aws.services.rds.rds_instance_transport_encrypted.rds_instance_transport_encrypted import (
                     rds_instance_transport_encrypted,
                 )
 
+                # Change DB Cluster parameter group to support SSL since Moto does not support it
+                rds_client.db_clusters[cluster_arn].require_secure_transport = "ON"
                 check = rds_instance_transport_encrypted()
                 result = check.execute()
 
@@ -534,8 +525,5 @@ class Test_rds_instance_transport_encrypted:
                 )
                 assert result[0].resource_id == "db-cluster-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
-                assert (
-                    result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
-                )
+                assert result[0].resource_arn == cluster_arn
                 assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_service_test.py
+++ b/tests/providers/aws/services/rds/rds_service_test.py
@@ -211,8 +211,8 @@ class Test_RDS_Service:
     def test__describe_db_clusters__(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         cluster_id = "db-master-1"
-        conn.create_db_parameter_group(
-            DBParameterGroupName="test",
+        conn.create_db_cluster_parameter_group(
+            DBClusterParameterGroupName="test",
             DBParameterGroupFamily="default.postgres9.3",
             Description="test parameter group",
         )
@@ -260,6 +260,8 @@ class Test_RDS_Service:
             {"Key": "test", "Value": "test"},
         ]
         assert rds.db_clusters[db_cluster_arn].parameter_group == "test"
+        assert rds.db_clusters[db_cluster_arn].force_ssl == "0"
+        assert rds.db_clusters[db_cluster_arn].require_secure_transport == "OFF"
 
     # Test RDS Describe DB Cluster Snapshots
     @mock_aws


### PR DESCRIPTION
### Context

We were using an invalid API Call to describe the parameters of a DB Cluster.

### Description

Use `describe_db_cluster_parameters` call and separate it into a new function.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
