### PR TITLE
fix(trustedadvisor): handle AccessDenied exception

### DIFF
--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
@@ -25,7 +25,7 @@ class TrustedAdvisor(AWSService):
             self.client = self.session.client(self.service, region_name=support_region)
             self.client.region = support_region
             self.__describe_services__()
-            if self.premium_support.enabled:
+            if getattr(self.premium_support, "enabled", False):
                 self.__describe_trusted_advisor_checks__()
                 self.__describe_trusted_advisor_check_result__()
 


### PR DESCRIPTION
### Context

When running prowler, if there is an access denied when describing AWS Support services, the trusted advisor checks would not be completed.

### Description

Handle the Access Denied exception so the Trusted Advisor check can be executed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
