### PR TITLE
fix(cloudtrail): check if trails exist in service

### DIFF
--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -37,7 +37,7 @@ class Cloudtrail(AWSService):
             trails_count = 0
             for trail in describe_trails:
                 # If a multi region trail was already retrieved in another region
-                if trail["TrailARN"] in self.trails.keys():
+                if self.trails and trail["TrailARN"] in self.trails.keys():
                     continue
 
                 if not self.audit_resources or (


### PR DESCRIPTION
### Description

To avoid accessing an empty dictionary and getting the following error, check if the trails exist first:

`2024-06-03 16:31:23,383 [File: cloudtrail_service.py:90]        [Module: cloudtrail_service]     ERROR: us-east-1 -- AttributeError[40]: 'NoneType' object has no attribute 'keys'`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
