### PR TITLE
refactor(run_check): Simplify and add tests

### DIFF
--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -700,7 +700,7 @@ def execute(
         # Run check
         verbose = (
             global_provider.output_options.verbose
-            or global_provider.output_options.verbose
+            or global_provider.output_options.fixer
         )
         check_findings = run_check(
             check_class, verbose, global_provider.output_options.only_logs

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -438,7 +438,7 @@ def import_check(check_path: str) -> ModuleType:
     return lib
 
 
-def run_check(check: Check, output_options) -> list:
+def run_check(check: Check, verbose: bool = False, only_logs: bool = False) -> list:
     """
     Run the check and return the findings
     Args:
@@ -448,7 +448,7 @@ def run_check(check: Check, output_options) -> list:
         list: list of findings
     """
     findings = []
-    if output_options.verbose or output_options.fixer:
+    if verbose:
         print(
             f"\nCheck ID: {check.CheckID} - {Fore.MAGENTA}{check.ServiceName}{Fore.YELLOW} [{check.Severity}]{Style.RESET_ALL}"
         )
@@ -456,7 +456,7 @@ def run_check(check: Check, output_options) -> list:
     try:
         findings = check.execute()
     except Exception as error:
-        if not output_options.only_logs:
+        if not only_logs:
             print(
                 f"Something went wrong in {check.CheckID}, please use --log-level ERROR"
             )
@@ -698,7 +698,13 @@ def execute(
             )
 
         # Run check
-        check_findings = run_check(check_class, global_provider.output_options)
+        verbose = (
+            global_provider.output_options.verbose
+            or global_provider.output_options.verbose
+        )
+        check_findings = run_check(
+            check_class, verbose, global_provider.output_options.only_logs
+        )
 
         # Update Audit Status
         services_executed.add(service)

--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -102,7 +102,7 @@ class Check(ABC, Check_Metadata_Model):
         return self.json()
 
     @abstractmethod
-    def execute(self):
+    def execute(self) -> list:
         """Execute the check's logic"""
 
 

--- a/prowler/lib/outputs/compliance/compliance.py
+++ b/prowler/lib/outputs/compliance/compliance.py
@@ -221,7 +221,7 @@ def get_check_compliance(finding, provider_type, output_options) -> dict:
                         check_compliance[compliance_fw].append(requirement.Id)
         return check_compliance
     except Exception as error:
-        logger.critical(
+        logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
         )
-        sys.exit(1)
+        return {}

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -1,12 +1,15 @@
 import os
 import pathlib
+import traceback
 from argparse import Namespace
 from importlib.machinery import FileFinder
+from logging import DEBUG, ERROR
 from pkgutil import ModuleInfo
 
 from boto3 import client
+from colorama import Fore, Style
 from fixtures.bulk_checks_metadata import test_bulk_checks_metadata
-from mock import patch
+from mock import Mock, patch
 from moto import mock_aws
 
 from prowler.lib.check.check import (
@@ -21,6 +24,7 @@ from prowler.lib.check.check import (
     recover_checks_from_provider,
     recover_checks_from_service,
     remove_custom_checks_module,
+    run_check,
     update_audit_metadata,
 )
 from prowler.lib.check.models import load_check_metadata
@@ -786,3 +790,89 @@ class TestCheck:
             checks_json
             == '{\n  "aws": [\n    "awslambda_function_invoke_api_operations_cloudtrail_logging_enabled",\n    "awslambda_function_no_secrets_in_code",\n    "awslambda_function_no_secrets_in_variables",\n    "awslambda_function_not_publicly_accessible",\n    "awslambda_function_url_cors_policy",\n    "awslambda_function_url_public",\n    "awslambda_function_using_supported_runtimes"\n  ]\n}'
         )
+
+    def test_run_check(self, caplog):
+        caplog.set_level(DEBUG)
+
+        findings = []
+        check = Mock()
+        check.CheckID = "test-check"
+        check.execute = Mock(return_value=findings)
+
+        with patch("prowler.lib.check.check.execute", return_value=findings):
+            assert run_check(check) == findings
+            assert caplog.record_tuples == [
+                (
+                    "root",
+                    DEBUG,
+                    f"Executing check: {check.CheckID}",
+                )
+            ]
+
+    def test_run_check_verbose(self, capsys):
+
+        findings = []
+        check = Mock()
+        check.CheckID = "test-check"
+        check.ServiceName = "test-service"
+        check.Severity = "test-severity"
+        check.execute = Mock(return_value=findings)
+
+        with patch("prowler.lib.check.check.execute", return_value=findings):
+            assert run_check(check, verbose=True) == findings
+            assert (
+                capsys.readouterr().out
+                == f"\nCheck ID: {check.CheckID} - {Fore.MAGENTA}{check.ServiceName}{Fore.YELLOW} [{check.Severity}]{Style.RESET_ALL}\n"
+            )
+
+    def test_run_check_exception_only_logs(self, caplog):
+        caplog.set_level(ERROR)
+
+        findings = []
+        check = Mock()
+        check.CheckID = "test-check"
+        check.ServiceName = "test-service"
+        check.Severity = "test-severity"
+        error = Exception()
+        check.execute = Mock(side_effect=error)
+
+        with patch("prowler.lib.check.check.execute", return_value=findings):
+            assert run_check(check, only_logs=True) == findings
+            assert caplog.record_tuples == [
+                (
+                    "root",
+                    ERROR,
+                    f"{check.CheckID} -- {error.__class__.__name__}[{traceback.extract_tb(error.__traceback__)[-1].lineno}]: {error}",
+                )
+            ]
+
+    def test_run_check_exception(self, caplog, capsys):
+        caplog.set_level(ERROR)
+
+        findings = []
+        check = Mock()
+        check.CheckID = "test-check"
+        check.ServiceName = "test-service"
+        check.Severity = "test-severity"
+        error = Exception()
+        check.execute = Mock(side_effect=error)
+
+        with patch("prowler.lib.check.check.execute", return_value=findings):
+            assert (
+                run_check(
+                    check,
+                    verbose=False,
+                )
+                == findings
+            )
+            assert caplog.record_tuples == [
+                (
+                    "root",
+                    ERROR,
+                    f"{check.CheckID} -- {error.__class__.__name__}[{traceback.extract_tb(error.__traceback__)[-1].lineno}]: {error}",
+                )
+            ]
+            assert (
+                capsys.readouterr().out
+                == f"Something went wrong in {check.CheckID}, please use --log-level ERROR\n"
+            )


### PR DESCRIPTION
### Description

- Simplify and add tests for the `run_check` function.
- Remove a `sys.exit()` while getting the check's compliance `dict` and return `{}` if some exception is raised.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
