### PR TITLE
fix(html): add correct color for manual findings

### DIFF
--- a/prowler/lib/outputs/html/html.py
+++ b/prowler/lib/outputs/html/html.py
@@ -136,7 +136,7 @@ def fill_html(file_descriptor, finding):
     try:
         row_class = "p-3 mb-2 bg-success-custom"
         finding.status = finding.status.split(".")[0]
-        if finding.status == "INFO":
+        if finding.status == "MANUAL":
             row_class = "table-info"
         elif finding.status == "FAIL":
             row_class = "table-danger"


### PR DESCRIPTION
### Description
Correct colors are shown for manual findings
![Screenshot 2024-06-04 at 16 06 26](https://github.com/prowler-cloud/prowler/assets/56402503/4fd9c837-6d60-4a84-8c82-f5758059c4a3)



### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
