### PR TITLE
fix(html): make Prowler logo resizable

### DIFF
--- a/prowler/lib/outputs/html/html.py
+++ b/prowler/lib/outputs/html/html.py
@@ -58,7 +58,7 @@ def add_html_header(file_descriptor, provider):
             <a href="{html_logo_url}"><img class="float-left card-img-left mt-4 mr-4 ml-4"
                         src={square_logo_img}
                         alt="prowler-logo"
-                        style="width: 300px; height:auto;"/></a>
+                        style="width: 15rem; height:auto;"/></a>
             <div class="card">
             <div class="card-header">
                 Report Information


### PR DESCRIPTION
### Description

This pr makes Prowler logo resizable depending on the screen size
<img width="1724" alt="Screenshot 2024-06-04 at 16 24 43" src="https://github.com/prowler-cloud/prowler/assets/56402503/608b76c6-4a08-4aa4-bc34-81cbb2f104a9">


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
