### PR TITLE
docs(reporting): fix mapping of json-ocsf field cloud.account.type

### DIFF
--- a/docs/tutorials/reporting.md
+++ b/docs/tutorials/reporting.md
@@ -333,7 +333,7 @@ The following is the mapping between the native JSON and the Detection Finding f
 | --- |---|
 | AssessmentStartTime | event_time |
 | FindingUniqueId | finding_info.uid |
-| Provider | cloud.account.type |
+| Provider | cloud.provider |
 | CheckID | metadata.event_code |
 | CheckTitle | finding_info.title |
 | CheckType | unmapped.check_type |


### PR DESCRIPTION
### Context

The documentation of the mapping between the native JSON Prowler v3 and JSON-OCSF in Prowler v4 was wrong.


### Description

The Prowler v3 field `Provider` was mapped in documentation to Prowler v4 field `cloud.account.type`.
I think that's wrong because if the v3 field `Provider` contained for example the value `aws`, the v4 field `cloud.account.type` would have be `AWS_Account`. So I changed the v4 mapping from `cloud.account.type` to `cloud.provider` which contains also `aws` like the v3 field `Provider` in this case.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
