### PR TITLE
docs(index): fix docu about output modes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -212,7 +212,7 @@ prowler <provider>
 
 If you miss the former output you can use `--verbose` but Prowler v4 is smoking fast, so you won't see much ;
 
-By default, Prowler will generate CSV, JSON-ASFF, JSON-OCSF and HTML reports. JSON-ASFF is used by AWS Security Hub. You can generate a report with `-M` or `--output-modes`:
+By default, Prowler generates CSV, JSON-OCSF and HTML reports. However, you can generate a JSON-ASFF report (used by AWS Security Hub) with `-M` or `--output-modes`:
 
 ```console
 prowler <provider> -M csv json-asff json-ocsf html

--- a/docs/index.md
+++ b/docs/index.md
@@ -212,10 +212,10 @@ prowler <provider>
 
 If you miss the former output you can use `--verbose` but Prowler v4 is smoking fast, so you won't see much ;
 
-By default, Prowler will generate a CSV, JSON and HTML reports, however you can generate a JSON-ASFF (used by AWS Security Hub) report with `-M` or `--output-modes`:
+By default, Prowler will generate CSV, JSON-ASFF, JSON-OCSF and HTML reports. JSON-ASFF is used by AWS Security Hub. You can generate a report with `-M` or `--output-modes`:
 
 ```console
-prowler <provider> -M csv json json-asff html
+prowler <provider> -M csv json-asff json-ocsf html
 ```
 The html report will be located in the output directory as the other files and it will look like:
 


### PR DESCRIPTION
### Context

The output modes were described for Prowler v3 and not yet updated for Prowler v4.


### Description

I just described the output modes for Prowler v4.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
