### PR TITLE
fix(elasticache): handle empty cluster subnets

### DIFF
--- a/prowler/providers/aws/services/elasticache/elasticache_service.py
+++ b/prowler/providers/aws/services/elasticache/elasticache_service.py
@@ -101,5 +101,5 @@ class Cluster(BaseModel):
     arn: str
     region: str
     cache_subnet_group_id: Optional[str]
-    subnets: Optional[list]
+    subnets: list = []
     tags: Optional[list]


### PR DESCRIPTION
### Description

Handle Elasticache clusters when they don't have any subnet.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
