### PR TITLE
fix(html): handle muted status to html outputs

### DIFF
--- a/prowler/lib/outputs/html/html.py
+++ b/prowler/lib/outputs/html/html.py
@@ -139,14 +139,11 @@ def fill_html(file_descriptor, finding):
         # Change the status of the finding if it's muted
         if finding.muted:
             finding.status = f"Muted({finding.status})"
+            row_class = "table-warning"
         if finding.status == "MANUAL":
             row_class = "table-info"
         elif finding.status == "FAIL":
             row_class = "table-danger"
-        elif finding.status == "WARNING":
-            row_class = "table-warning"
-        elif "Muted" in finding.status:
-            row_class = "table-secondary"
 
         file_descriptor.write(
             f"""

--- a/prowler/lib/outputs/html/html.py
+++ b/prowler/lib/outputs/html/html.py
@@ -138,7 +138,7 @@ def fill_html(file_descriptor, finding):
         finding.status = finding.status.split(".")[0]
         # Change the status of the finding if it's muted
         if finding.muted:
-            finding.status = f"Muted({finding.status})"
+            finding.status = f"MUTED ({finding.status})"
             row_class = "table-warning"
         if finding.status == "MANUAL":
             row_class = "table-info"

--- a/prowler/lib/outputs/html/html.py
+++ b/prowler/lib/outputs/html/html.py
@@ -136,12 +136,17 @@ def fill_html(file_descriptor, finding):
     try:
         row_class = "p-3 mb-2 bg-success-custom"
         finding.status = finding.status.split(".")[0]
+        # Change the status of the finding if it's muted
+        if finding.muted:
+            finding.status = f"Muted({finding.status})"
         if finding.status == "MANUAL":
             row_class = "table-info"
         elif finding.status == "FAIL":
             row_class = "table-danger"
         elif finding.status == "WARNING":
             row_class = "table-warning"
+        elif "Muted" in finding.status:
+            row_class = "table-secondary"
 
         file_descriptor.write(
             f"""


### PR DESCRIPTION
### Context

Fixes #4181


### Description

Muted FIndings appeared as Pass/Fail/Manual, it's necessary to handle the case when the finding it's muted on HTML outputs.

Thanks @alanrickman-keysight for the report 🥇 


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
