### PR TITLE
fix(custom): execute custom checks

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -180,7 +180,8 @@ def prowler():
 
     # Import custom checks from folder
     if checks_folder:
-        parse_checks_from_folder(global_provider, checks_folder)
+        custom_checks = parse_checks_from_folder(global_provider, checks_folder)
+        checks_to_execute.update(custom_checks)
 
     # Exclude checks if -e/--excluded-checks
     if excluded_checks:

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -126,9 +126,9 @@ def parse_checks_from_file(input_file: str, provider: str) -> set:
 
 
 # Load checks from custom folder
-def parse_checks_from_folder(provider, input_folder: str) -> int:
+def parse_checks_from_folder(provider, input_folder: str) -> set:
     try:
-        imported_checks = 0
+        custom_checks = set()
         # Check if input folder is a S3 URI
         if provider.type == "aws" and re.search(
             "^s3://([^/]+)/(.*?([^/]+))/$", input_folder
@@ -156,8 +156,8 @@ def parse_checks_from_folder(provider, input_folder: str) -> int:
                     if os.path.exists(prowler_module):
                         shutil.rmtree(prowler_module)
                     shutil.copytree(check_module, prowler_module)
-                    imported_checks += 1
-        return imported_checks
+                    custom_checks.add(check.name)
+        return custom_checks
     except Exception as error:
         logger.critical(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -453,14 +453,14 @@ class TestCheck:
                     "path": test_checks_folder,
                     "provider": "aws",
                 },
-                "expected": {'check11', 'check12', 'check7777'},
+                "expected": {"check11", "check12", "check7777"},
             },
             {
                 "input": {
                     "path": "s3://test/checks_folder/",
                     "provider": "aws",
                 },
-                "expected": {'check11', 'check12', 'check7777'},
+                "expected": {"check11", "check12", "check7777"},
             },
         ]
 

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -453,14 +453,14 @@ class TestCheck:
                     "path": test_checks_folder,
                     "provider": "aws",
                 },
-                "expected": 3,
+                "expected": {'check11', 'check12', 'check7777'},
             },
             {
                 "input": {
                     "path": "s3://test/checks_folder/",
                     "provider": "aws",
                 },
-                "expected": 3,
+                "expected": {'check11', 'check12', 'check7777'},
             },
         ]
 


### PR DESCRIPTION
### Context

Custom rules were not available and I would like to to fix it.

It is caused by copying the custom checks folder after loading the checks.
so, added when files are copied

### Description

copying the custom check in the `parse_checks_from_folder` function [here](https://github.com/prowler-cloud/prowler/blob/master/prowler/__main__.py#L181-L183)
But check loading is called in [load_checks_to_execute](https://github.com/prowler-cloud/prowler/blob/master/prowler/__main__.py#L150-L161) before that

There was no process to assign a custom check for that transition, so the custom check was not executed!

Added support for updating pre-loaded sets at the time of copying custom check folders.

### Check

Here is an example of gcp.
Prepare the following directory structure rules.

```
custom_rule
└── cloudsql_test_custom_rule
    ├── __init__.py
    ├── cloudsql_test_custom_rule.metadata.json
    └── cloudsql_test_custom_rule.py
```

Execute the following command

without custome rule scan
```
prowler gcp --project-ids {project_id}
```

with custome rule scan
```
prowler gcp --project-ids {project_id} -x custom_rule
```

Confirmed that the number of scans performed and the number of compliant evaluations changes

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
