### PR TITLE
fix(config/html): handle encoding issues and improve error handling in config and HTML file loading functions

### DIFF
--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -106,9 +106,6 @@ def load_and_validate_config_file(provider: str, config_file_path: str) -> dict:
 
     Returns:
         dict: The configuration dictionary for the specified provider.
-
-    Raises:
-        SystemExit: If there is an error reading or parsing the configuration file.
     """
     try:
         with open(config_file_path, "r", encoding="utf-8") as f:
@@ -128,13 +125,15 @@ def load_and_validate_config_file(provider: str, config_file_path: str) -> dict:
 
     except FileNotFoundError:
         logger.error(
-            f"FileNotFoundError: The config file {config_file_path} was not found."
+            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
         )
     except yaml.YAMLError as error:
-        logger.error(f"YAMLError: Error parsing the YAML config file: {error}")
+        logger.error(
+            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
+        )
     except UnicodeDecodeError as error:
         logger.error(
-            f"UnicodeDecodeError: Error decoding the file {config_file_path}: {error}"
+            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
         )
     except Exception as error:
         logger.error(
@@ -167,13 +166,15 @@ def load_and_validate_fixer_config_file(
 
     except FileNotFoundError:
         logger.error(
-            f"FileNotFoundError: The config file {fixer_config_file_path} was not found."
+            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
         )
     except yaml.YAMLError as error:
-        logger.error(f"YAMLError: Error parsing the YAML config file: {error}")
+        logger.error(
+            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
+        )
     except UnicodeDecodeError as error:
         logger.error(
-            f"UnicodeDecodeError: Error decoding the file {fixer_config_file_path}: {error}"
+            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
         )
     except Exception as error:
         logger.error(

--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -141,7 +141,9 @@ def load_and_validate_config_file(provider: str, config_file_path: str) -> dict:
         )
         sys.exit(1)
     except Exception as error:
-        logger.critical(f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}")
+        logger.critical(
+            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
+        )
         sys.exit(1)
 
 
@@ -180,5 +182,7 @@ def load_and_validate_fixer_config_file(
         )
         sys.exit(1)
     except Exception as error:
-        logger.critical(f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}")
+        logger.critical(
+            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
+        )
         sys.exit(1)

--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -1,6 +1,5 @@
 import os
 import pathlib
-import sys
 from datetime import datetime, timezone
 from os import getcwd
 
@@ -128,23 +127,21 @@ def load_and_validate_config_file(provider: str, config_file_path: str) -> dict:
             return config
 
     except FileNotFoundError:
-        logger.critical(
+        logger.error(
             f"FileNotFoundError: The config file {config_file_path} was not found."
         )
-        sys.exit(1)
     except yaml.YAMLError as error:
-        logger.critical(f"YAMLError: Error parsing the YAML config file: {error}")
-        sys.exit(1)
+        logger.error(f"YAMLError: Error parsing the YAML config file: {error}")
     except UnicodeDecodeError as error:
-        logger.critical(
+        logger.error(
             f"UnicodeDecodeError: Error decoding the file {config_file_path}: {error}"
         )
-        sys.exit(1)
     except Exception as error:
-        logger.critical(
+        logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
         )
-        sys.exit(1)
+
+    return {}
 
 
 def load_and_validate_fixer_config_file(
@@ -169,20 +166,18 @@ def load_and_validate_fixer_config_file(
             return fixer_config_file.get(provider, {})
 
     except FileNotFoundError:
-        logger.critical(
+        logger.error(
             f"FileNotFoundError: The config file {fixer_config_file_path} was not found."
         )
-        sys.exit(1)
     except yaml.YAMLError as error:
-        logger.critical(f"YAMLError: Error parsing the YAML config file: {error}")
-        sys.exit(1)
+        logger.error(f"YAMLError: Error parsing the YAML config file: {error}")
     except UnicodeDecodeError as error:
-        logger.critical(
+        logger.error(
             f"UnicodeDecodeError: Error decoding the file {fixer_config_file_path}: {error}"
         )
-        sys.exit(1)
     except Exception as error:
-        logger.critical(
+        logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
         )
-        sys.exit(1)
+
+    return {}

--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -99,52 +99,72 @@ def check_current_version():
 
 def load_and_validate_config_file(provider: str, config_file_path: str) -> dict:
     """
-    load_and_validate_config_file reads the Prowler config file in YAML format from the default location or the file passed with the --config-file flag
+    Reads the Prowler config file in YAML format from the default location or the file passed with the --config-file flag.
+    
+    Args:
+        provider (str): The provider name (e.g., 'aws', 'gcp', 'azure', 'kubernetes').
+        config_file_path (str): The path to the configuration file.
+    
+    Returns:
+        dict: The configuration dictionary for the specified provider.
+    
+    Raises:
+        SystemExit: If there is an error reading or parsing the configuration file.
     """
     try:
-        with open(config_file_path) as f:
-            config = {}
+        with open(config_file_path, 'r', encoding='utf-8') as f:
             config_file = yaml.safe_load(f)
 
-            # Not to introduce a breaking change we have to allow the old format config file without any provider keys
-            # and a new format with a key for each provider to include their configuration values within
-            # Check if the new format is passed
-            if (
-                "aws" in config_file
-                or "gcp" in config_file
-                or "azure" in config_file
-                or "kubernetes" in config_file
-            ):
+            # Not to introduce a breaking change, allow the old format config file without any provider keys
+            # and a new format with a key for each provider to include their configuration values within.
+            if any(key in config_file for key in ["aws", "gcp", "azure", "kubernetes"]):
                 config = config_file.get(provider, {})
             else:
                 config = config_file if config_file else {}
-                # Not to break Azure, K8s and GCP does not support neither use the old config format
+                # Not to break Azure, K8s and GCP does not support or use the old config format
                 if provider in ["azure", "gcp", "kubernetes"]:
                     config = {}
 
             return config
 
-    except Exception as error:
-        logger.critical(
-            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
-        )
-        sys.exit(1)
+    except FileNotFoundError:
+        logger.critical(f"FileNotFoundError: The config file {config_file_path} was not found.")
+    except yaml.YAMLError as e:
+        logger.critical(f"YAMLError: Error parsing the YAML config file: {e}")
+    except UnicodeDecodeError as e:
+        logger.critical(f"UnicodeDecodeError: Error decoding the file {config_file_path}: {e}")
+    except Exception as e:
+        logger.critical(f"{e.__class__.__name__}[{e.__traceback__.tb_lineno}] -- {e}")
+    
+    sys.exit(1)
 
 
-def load_and_validate_fixer_config_file(
-    provider: str, fixer_config_file_path: str
-) -> dict:
+def load_and_validate_fixer_config_file(provider: str, fixer_config_file_path: str) -> dict:
     """
-    load_and_validate_fixer_config_file reads the Prowler fixer config file in YAML format from the default location or the file passed with the --fixer-config flag
+    Reads the Prowler fixer config file in YAML format from the default location or the file passed with the --fixer-config flag.
+    
+    Args:
+        provider (str): The provider name (e.g., 'aws', 'gcp', 'azure', 'kubernetes').
+        fixer_config_file_path (str): The path to the fixer configuration file.
+    
+    Returns:
+        dict: The fixer configuration dictionary for the specified provider.
+    
+    Raises:
+        SystemExit: If there is an error reading or parsing the fixer configuration file.
     """
     try:
-        with open(fixer_config_file_path) as f:
+        with open(fixer_config_file_path, 'r', encoding='utf-8') as f:
             fixer_config_file = yaml.safe_load(f)
-
             return fixer_config_file.get(provider, {})
 
-    except Exception as error:
-        logger.critical(
-            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
-        )
-        sys.exit(1)
+    except FileNotFoundError:
+        logger.critical(f"FileNotFoundError: The config file {fixer_config_file_path} was not found.")
+    except yaml.YAMLError as e:
+        logger.critical(f"YAMLError: Error parsing the YAML config file: {e}")
+    except UnicodeDecodeError as e:
+        logger.critical(f"UnicodeDecodeError: Error decoding the file {fixer_config_file_path}: {e}")
+    except Exception as e:
+        logger.critical(f"{e.__class__.__name__}[{e.__traceback__.tb_lineno}] -- {e}")
+    
+    sys.exit(1)

--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -131,16 +131,18 @@ def load_and_validate_config_file(provider: str, config_file_path: str) -> dict:
         logger.critical(
             f"FileNotFoundError: The config file {config_file_path} was not found."
         )
+        sys.exit(1)
     except yaml.YAMLError as error:
         logger.critical(f"YAMLError: Error parsing the YAML config file: {error}")
+        sys.exit(1)
     except UnicodeDecodeError as error:
         logger.critical(
             f"UnicodeDecodeError: Error decoding the file {config_file_path}: {error}"
         )
+        sys.exit(1)
     except Exception as error:
         logger.critical(f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}")
-
-    sys.exit(1)
+        sys.exit(1)
 
 
 def load_and_validate_fixer_config_file(
@@ -168,13 +170,15 @@ def load_and_validate_fixer_config_file(
         logger.critical(
             f"FileNotFoundError: The config file {fixer_config_file_path} was not found."
         )
+        sys.exit(1)
     except yaml.YAMLError as error:
         logger.critical(f"YAMLError: Error parsing the YAML config file: {error}")
+        sys.exit(1)
     except UnicodeDecodeError as error:
         logger.critical(
             f"UnicodeDecodeError: Error decoding the file {fixer_config_file_path}: {error}"
         )
+        sys.exit(1)
     except Exception as error:
         logger.critical(f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}")
-
-    sys.exit(1)
+        sys.exit(1)

--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -123,7 +123,7 @@ def load_and_validate_config_file(provider: str, config_file_path: str) -> dict:
 
             return config
 
-    except FileNotFoundError:
+    except FileNotFoundError as error:
         logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
         )
@@ -164,7 +164,7 @@ def load_and_validate_fixer_config_file(
             fixer_config_file = yaml.safe_load(f)
             return fixer_config_file.get(provider, {})
 
-    except FileNotFoundError:
+    except FileNotFoundError as error:
         logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
         )

--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -100,19 +100,19 @@ def check_current_version():
 def load_and_validate_config_file(provider: str, config_file_path: str) -> dict:
     """
     Reads the Prowler config file in YAML format from the default location or the file passed with the --config-file flag.
-    
+
     Args:
         provider (str): The provider name (e.g., 'aws', 'gcp', 'azure', 'kubernetes').
         config_file_path (str): The path to the configuration file.
-    
+
     Returns:
         dict: The configuration dictionary for the specified provider.
-    
+
     Raises:
         SystemExit: If there is an error reading or parsing the configuration file.
     """
     try:
-        with open(config_file_path, 'r', encoding='utf-8') as f:
+        with open(config_file_path, "r", encoding="utf-8") as f:
             config_file = yaml.safe_load(f)
 
             # Not to introduce a breaking change, allow the old format config file without any provider keys
@@ -128,43 +128,53 @@ def load_and_validate_config_file(provider: str, config_file_path: str) -> dict:
             return config
 
     except FileNotFoundError:
-        logger.critical(f"FileNotFoundError: The config file {config_file_path} was not found.")
-    except yaml.YAMLError as e:
-        logger.critical(f"YAMLError: Error parsing the YAML config file: {e}")
-    except UnicodeDecodeError as e:
-        logger.critical(f"UnicodeDecodeError: Error decoding the file {config_file_path}: {e}")
-    except Exception as e:
-        logger.critical(f"{e.__class__.__name__}[{e.__traceback__.tb_lineno}] -- {e}")
-    
+        logger.critical(
+            f"FileNotFoundError: The config file {config_file_path} was not found."
+        )
+    except yaml.YAMLError as error:
+        logger.critical(f"YAMLError: Error parsing the YAML config file: {error}")
+    except UnicodeDecodeError as error:
+        logger.critical(
+            f"UnicodeDecodeError: Error decoding the file {config_file_path}: {error}"
+        )
+    except Exception as error:
+        logger.critical(f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}")
+
     sys.exit(1)
 
 
-def load_and_validate_fixer_config_file(provider: str, fixer_config_file_path: str) -> dict:
+def load_and_validate_fixer_config_file(
+    provider: str, fixer_config_file_path: str
+) -> dict:
     """
     Reads the Prowler fixer config file in YAML format from the default location or the file passed with the --fixer-config flag.
-    
+
     Args:
         provider (str): The provider name (e.g., 'aws', 'gcp', 'azure', 'kubernetes').
         fixer_config_file_path (str): The path to the fixer configuration file.
-    
+
     Returns:
         dict: The fixer configuration dictionary for the specified provider.
-    
+
     Raises:
         SystemExit: If there is an error reading or parsing the fixer configuration file.
     """
     try:
-        with open(fixer_config_file_path, 'r', encoding='utf-8') as f:
+        with open(fixer_config_file_path, "r", encoding="utf-8") as f:
             fixer_config_file = yaml.safe_load(f)
             return fixer_config_file.get(provider, {})
 
     except FileNotFoundError:
-        logger.critical(f"FileNotFoundError: The config file {fixer_config_file_path} was not found.")
-    except yaml.YAMLError as e:
-        logger.critical(f"YAMLError: Error parsing the YAML config file: {e}")
-    except UnicodeDecodeError as e:
-        logger.critical(f"UnicodeDecodeError: Error decoding the file {fixer_config_file_path}: {e}")
-    except Exception as e:
-        logger.critical(f"{e.__class__.__name__}[{e.__traceback__.tb_lineno}] -- {e}")
-    
+        logger.critical(
+            f"FileNotFoundError: The config file {fixer_config_file_path} was not found."
+        )
+    except yaml.YAMLError as error:
+        logger.critical(f"YAMLError: Error parsing the YAML config file: {error}")
+    except UnicodeDecodeError as error:
+        logger.critical(
+            f"UnicodeDecodeError: Error decoding the file {fixer_config_file_path}: {error}"
+        )
+    except Exception as error:
+        logger.critical(f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}")
+
     sys.exit(1)

--- a/prowler/lib/outputs/html/html.py
+++ b/prowler/lib/outputs/html/html.py
@@ -173,7 +173,7 @@ def fill_html(file_descriptor, finding):
 def fill_html_overview_statistics(stats, output_filename, output_directory):
     try:
         filename = f"{output_directory}/{output_filename}{html_file_suffix}"
-        
+
         # Read file
         if path.isfile(filename):
             with open(filename, "r", encoding="utf-8") as file:
@@ -188,7 +188,7 @@ def fill_html_overview_statistics(stats, output_filename, output_directory):
             filedata = filedata.replace("TOTAL_PASS", str(stats.get("total_pass", 0)))
             # TOTAL_FAIL
             filedata = filedata.replace("TOTAL_FAIL", str(stats.get("total_fail", 0)))
-            
+
             # Write file
             with open(filename, "w", encoding="utf-8") as file:
                 file.write(filedata)

--- a/prowler/lib/outputs/html/html.py
+++ b/prowler/lib/outputs/html/html.py
@@ -198,18 +198,13 @@ def fill_html_overview_statistics(stats, output_filename, output_directory):
                 file.write(filedata)
 
     except FileNotFoundError:
-        logger.critical(f"FileNotFoundError: The file {filename} was not found.")
-        sys.exit(1)
+        logger.error(f"FileNotFoundError: The file {filename} was not found.")
     except UnicodeDecodeError as error:
-        logger.critical(
-            f"UnicodeDecodeError: Error decoding the file {filename}: {error}"
-        )
-        sys.exit(1)
+        logger.error(f"UnicodeDecodeError: Error decoding the file {filename}: {error}")
     except Exception as error:
-        logger.critical(
+        logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
         )
-        sys.exit(1)
 
 
 def add_html_footer(output_filename, output_directory):

--- a/prowler/lib/outputs/html/html.py
+++ b/prowler/lib/outputs/html/html.py
@@ -197,7 +197,7 @@ def fill_html_overview_statistics(stats, output_filename, output_directory):
             with open(filename, "w", encoding="utf-8") as file:
                 file.write(filedata)
 
-    except FileNotFoundError:
+    except FileNotFoundError as error:
         logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
         )

--- a/prowler/lib/outputs/html/html.py
+++ b/prowler/lib/outputs/html/html.py
@@ -195,10 +195,10 @@ def fill_html_overview_statistics(stats, output_filename, output_directory):
 
     except FileNotFoundError:
         logger.critical(f"FileNotFoundError: The file {filename} was not found.")
-    except UnicodeDecodeError as e:
-        logger.critical(f"UnicodeDecodeError: Error decoding the file {filename}: {e}")
-    except Exception as e:
-        logger.critical(f"{e.__class__.__name__}[{e.__traceback__.tb_lineno}] -- {e}")
+    except UnicodeDecodeError as error:
+        logger.critical(f"UnicodeDecodeError: Error decoding the file {filename}: {error}")
+    except Exception as error:
+        logger.critical(f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}")
     
     sys.exit(1)
 

--- a/prowler/lib/outputs/html/html.py
+++ b/prowler/lib/outputs/html/html.py
@@ -181,9 +181,13 @@ def fill_html_overview_statistics(stats, output_filename, output_directory):
 
             # Replace statistics
             # TOTAL_FINDINGS
-            filedata = filedata.replace("TOTAL_FINDINGS", str(stats.get("findings_count", 0)))
+            filedata = filedata.replace(
+                "TOTAL_FINDINGS", str(stats.get("findings_count", 0))
+            )
             # TOTAL_RESOURCES
-            filedata = filedata.replace("TOTAL_RESOURCES", str(stats.get("resources_count", 0)))
+            filedata = filedata.replace(
+                "TOTAL_RESOURCES", str(stats.get("resources_count", 0))
+            )
             # TOTAL_PASS
             filedata = filedata.replace("TOTAL_PASS", str(stats.get("total_pass", 0)))
             # TOTAL_FAIL
@@ -197,10 +201,14 @@ def fill_html_overview_statistics(stats, output_filename, output_directory):
         logger.critical(f"FileNotFoundError: The file {filename} was not found.")
         sys.exit(1)
     except UnicodeDecodeError as error:
-        logger.critical(f"UnicodeDecodeError: Error decoding the file {filename}: {error}")
+        logger.critical(
+            f"UnicodeDecodeError: Error decoding the file {filename}: {error}"
+        )
         sys.exit(1)
     except Exception as error:
-        logger.critical(f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}")
+        logger.critical(
+            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
+        )
         sys.exit(1)
 
 

--- a/prowler/lib/outputs/html/html.py
+++ b/prowler/lib/outputs/html/html.py
@@ -195,12 +195,13 @@ def fill_html_overview_statistics(stats, output_filename, output_directory):
 
     except FileNotFoundError:
         logger.critical(f"FileNotFoundError: The file {filename} was not found.")
+        sys.exit(1)
     except UnicodeDecodeError as error:
         logger.critical(f"UnicodeDecodeError: Error decoding the file {filename}: {error}")
+        sys.exit(1)
     except Exception as error:
         logger.critical(f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}")
-    
-    sys.exit(1)
+        sys.exit(1)
 
 
 def add_html_footer(output_filename, output_directory):

--- a/prowler/lib/outputs/html/html.py
+++ b/prowler/lib/outputs/html/html.py
@@ -198,9 +198,13 @@ def fill_html_overview_statistics(stats, output_filename, output_directory):
                 file.write(filedata)
 
     except FileNotFoundError:
-        logger.error(f"FileNotFoundError: The file {filename} was not found.")
+        logger.error(
+            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
+        )
     except UnicodeDecodeError as error:
-        logger.error(f"UnicodeDecodeError: Error decoding the file {filename}: {error}")
+        logger.error(
+            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
+        )
     except Exception as error:
         logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"

--- a/prowler/lib/outputs/html/html.py
+++ b/prowler/lib/outputs/html/html.py
@@ -173,33 +173,34 @@ def fill_html(file_descriptor, finding):
 def fill_html_overview_statistics(stats, output_filename, output_directory):
     try:
         filename = f"{output_directory}/{output_filename}{html_file_suffix}"
-        #  Read file
+        
+        # Read file
         if path.isfile(filename):
-            with open(filename, "r") as file:
+            with open(filename, "r", encoding="utf-8") as file:
                 filedata = file.read()
 
             # Replace statistics
             # TOTAL_FINDINGS
-            filedata = filedata.replace(
-                "TOTAL_FINDINGS", str(stats.get("findings_count"))
-            )
+            filedata = filedata.replace("TOTAL_FINDINGS", str(stats.get("findings_count", 0)))
             # TOTAL_RESOURCES
-            filedata = filedata.replace(
-                "TOTAL_RESOURCES", str(stats.get("resources_count"))
-            )
+            filedata = filedata.replace("TOTAL_RESOURCES", str(stats.get("resources_count", 0)))
             # TOTAL_PASS
-            filedata = filedata.replace("TOTAL_PASS", str(stats.get("total_pass")))
+            filedata = filedata.replace("TOTAL_PASS", str(stats.get("total_pass", 0)))
             # TOTAL_FAIL
-            filedata = filedata.replace("TOTAL_FAIL", str(stats.get("total_fail")))
+            filedata = filedata.replace("TOTAL_FAIL", str(stats.get("total_fail", 0)))
+            
             # Write file
-            with open(filename, "w") as file:
+            with open(filename, "w", encoding="utf-8") as file:
                 file.write(filedata)
 
-    except Exception as error:
-        logger.critical(
-            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
-        )
-        sys.exit(1)
+    except FileNotFoundError:
+        logger.critical(f"FileNotFoundError: The file {filename} was not found.")
+    except UnicodeDecodeError as e:
+        logger.critical(f"UnicodeDecodeError: Error decoding the file {filename}: {e}")
+    except Exception as e:
+        logger.critical(f"{e.__class__.__name__}[{e.__traceback__.tb_lineno}] -- {e}")
+    
+    sys.exit(1)
 
 
 def add_html_footer(output_filename, output_directory):

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 from unittest import mock
 
+import pytest
 from requests import Response
 
 from prowler.config.config import (
@@ -164,7 +165,7 @@ class Test_Config:
         assert load_and_validate_config_file("azure", config_test_file) == {}
         assert load_and_validate_config_file("kubernetes", config_test_file) == {}
 
-    def test_load_and_validate_config_file_invalid_config_file_path(caplog):
+    def test_load_and_validate_config_file_invalid_config_file_path(self, caplog):
         provider = "aws"
         config_file_path = "invalid/path/to/fixer_config.yaml"
 
@@ -172,6 +173,8 @@ class Test_Config:
             result = load_and_validate_config_file(provider, config_file_path)
             assert "FileNotFoundError" in caplog.text
             assert result == {}
+
+        assert pytest is not None
 
     def test_load_and_validate_fixer_config_aws(self):
         path = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
@@ -201,7 +204,7 @@ class Test_Config:
 
         assert load_and_validate_fixer_config_file(provider, config_test_file) == {}
 
-    def test_load_and_validate_fixer_config_invalid_fixer_config_path(caplog):
+    def test_load_and_validate_fixer_config_invalid_fixer_config_path(self, caplog):
         provider = "aws"
         fixer_config_path = "invalid/path/to/fixer_config.yaml"
 
@@ -209,3 +212,5 @@ class Test_Config:
             result = load_and_validate_fixer_config_file(provider, fixer_config_path)
             assert "FileNotFoundError" in caplog.text
             assert result == {}
+
+        assert pytest is not None

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -2,7 +2,6 @@ import os
 import pathlib
 from unittest import mock
 
-import pytest
 from requests import Response
 
 from prowler.config.config import (
@@ -166,10 +165,10 @@ class Test_Config:
 
     def test_load_and_validate_config_file_invalid_config_file_path(self):
         provider = "aws"
-        config_file_path = "invalid/path/to/fixer_config.yaml"
+        config_file_path = "invalid/path/to/config.yaml"
 
-        with pytest.raises(SystemExit):
-            load_and_validate_config_file(provider, config_file_path)
+        config = load_and_validate_config_file(provider, config_file_path)
+        assert config == {}
 
     def test_load_and_validate_fixer_config_aws(self):
         path = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
@@ -203,5 +202,5 @@ class Test_Config:
         provider = "aws"
         fixer_config_path = "invalid/path/to/fixer_config.yaml"
 
-        with pytest.raises(SystemExit):
-            load_and_validate_fixer_config_file(provider, fixer_config_path)
+        fixer_config = load_and_validate_fixer_config_file(provider, fixer_config_path)
+        assert fixer_config == {}

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 from unittest import mock
@@ -163,12 +164,14 @@ class Test_Config:
         assert load_and_validate_config_file("azure", config_test_file) == {}
         assert load_and_validate_config_file("kubernetes", config_test_file) == {}
 
-    def test_load_and_validate_config_file_invalid_config_file_path(self):
+    def test_load_and_validate_config_file_invalid_config_file_path(caplog):
         provider = "aws"
-        config_file_path = "invalid/path/to/config.yaml"
+        config_file_path = "invalid/path/to/fixer_config.yaml"
 
-        config = load_and_validate_config_file(provider, config_file_path)
-        assert config == {}
+        with caplog.at_level(logging.ERROR):
+            result = load_and_validate_config_file(provider, config_file_path)
+            assert "FileNotFoundError" in caplog.text
+            assert result == {}
 
     def test_load_and_validate_fixer_config_aws(self):
         path = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
@@ -198,9 +201,11 @@ class Test_Config:
 
         assert load_and_validate_fixer_config_file(provider, config_test_file) == {}
 
-    def test_load_and_validate_fixer_config_invalid_fixer_config_path(self):
+    def test_load_and_validate_fixer_config_invalid_fixer_config_path(caplog):
         provider = "aws"
         fixer_config_path = "invalid/path/to/fixer_config.yaml"
 
-        fixer_config = load_and_validate_fixer_config_file(provider, fixer_config_path)
-        assert fixer_config == {}
+        with caplog.at_level(logging.ERROR):
+            result = load_and_validate_fixer_config_file(provider, fixer_config_path)
+            assert "FileNotFoundError" in caplog.text
+            assert result == {}


### PR DESCRIPTION
### Context

This pull request addresses issues related to file encoding and error handling in configuration file loading functions (`load_and_validate_config_file` and `load_and_validate_fixer_config_file`) and the HTML output generation function (`fill_html_overview_statistics`). The changes ensure that files are read and written with the correct encoding, preventing `UnicodeDecodeError`.


### Description

1. Encoding Handling:

- Updated `load_and_validate_config_file`, `load_and_validate_fixer_config_file`, and `fill_html_overview_statistics` to open files with `encoding='utf-8'` to ensure they are read and written correctly as UTF-8 encoded text.

- This change prevents `UnicodeDecodeError` caused by incorrect or unsupported file encodings.

2. Specific Exception Handling:

- Added specific exception handling for `FileNotFoundError`, `yaml.YAMLError`, and `UnicodeDecodeError` in the configuration file loading functions.
- Added specific exception handling for `FileNotFoundError` and `UnicodeDecodeError` in the HTML output generation function.
- This provides clearer error messages and makes debugging easier.

3. Default Values:

- Used default values in `stats.get()` in `fill_html_overview_statistics` to handle cases where keys might be missing.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
