### PR TITLE
fix(html): fix status from HTML outputs

### DIFF
--- a/prowler/lib/outputs/html/html.py
+++ b/prowler/lib/outputs/html/html.py
@@ -135,7 +135,7 @@ def add_html_header(file_descriptor, provider):
 def fill_html(file_descriptor, finding):
     try:
         row_class = "p-3 mb-2 bg-success-custom"
-        finding_status = finding.status
+        finding_status = finding.status.split(".")[0]
         # Change the status of the finding if it's muted
         if finding.muted:
             finding_status = f"MUTED ({finding.status})"

--- a/prowler/lib/outputs/html/html.py
+++ b/prowler/lib/outputs/html/html.py
@@ -138,7 +138,7 @@ def fill_html(file_descriptor, finding):
         finding_status = finding.status.split(".")[0]
         # Change the status of the finding if it's muted
         if finding.muted:
-            finding_status = f"MUTED ({finding.status})"
+            finding_status = f"MUTED ({finding_status})"
             row_class = "table-warning"
         if finding.status == "MANUAL":
             row_class = "table-info"


### PR DESCRIPTION
### Description

Finding status were showing with a bad format on HTML outputs
<img width="465" alt="Screenshot 2024-06-07 at 12 09 11" src="https://github.com/prowler-cloud/prowler/assets/56402503/9cc97b85-f991-4b84-b1b3-450b58cc5179">


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
