### PR TITLE
chore(network): Reduce network watchers azure check findings

### DIFF
--- a/prowler/providers/azure/services/network/network_service.py
+++ b/prowler/providers/azure/services/network/network_service.py
@@ -7,7 +7,6 @@ from prowler.providers.azure.azure_provider import AzureProvider
 from prowler.providers.azure.lib.service.service import AzureService
 
 
-########################## SQLServer
 class Network(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(NetworkManagementClient, provider)

--- a/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.metadata.json
+++ b/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.metadata.json
@@ -15,12 +15,12 @@
     "Code": {
       "CLI": "",
       "NativeIaC": "",
-      "Other": "https://www.trendmicro.com/cloudoneconformity-staging/knowledge-base/azure/Network/enable-network-watcher.html#",
+      "Other": "https://www.trendmicro.com/cloudoneconformity-staging/knowledge-base/azure/Network/enable-network-watcher.html",
       "Terraform": ""
     },
     "Recommendation": {
       "Text": "Opting out of Network Watcher automatic enablement is a permanent change. Once you opt-out you cannot opt-in without contacting support.",
-      "Url": "https://docs.azure.cn/zh-cn/cli/network/watcher?view=azure-cli-latest#az_network_watcher_list"
+      "Url": "https://learn.microsoft.com/en-us/security/benchmark/azure/security-controls-v2-logging-threat-detection#lt-3-enable-logging-for-azure-network-activities"
     }
   },
   "Categories": [],

--- a/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.metadata.json
+++ b/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "azure",
   "CheckID": "network_watcher_enabled",
-  "CheckTitle": "Ensure that Network Watcher is 'Enabled'",
+  "CheckTitle": "Ensure that Network Watcher is 'Enabled' for all locations in the Azure subscription",
   "CheckType": [],
   "ServiceName": "network",
   "SubServiceName": "",

--- a/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.py
+++ b/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.py
@@ -18,10 +18,10 @@ class network_watcher_enabled(Check):
 
             if missing_locations:
                 report.status = "FAIL"
-                report.status_extended = f"Network Watcher is not enabled for the following locations in subscription '{subscription}': {', '.join(missing_locations)}"
+                report.status_extended = f"Network Watcher is not enabled for the following locations in subscription '{subscription}': {', '.join(missing_locations)}."
             else:
                 report.status = "PASS"
-                report.status_extended = f"Network Watcher is enabled for all locations in subscription '{subscription}'"
+                report.status_extended = f"Network Watcher is enabled for all locations in subscription '{subscription}'."
 
             findings.append(report)
 

--- a/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.py
+++ b/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.py
@@ -3,7 +3,7 @@ from prowler.providers.azure.services.network.network_client import network_clie
 
 
 class network_watcher_enabled(Check):
-    def execute(self) -> Check_Report_Azure:
+    def execute(self) -> list[Check_Report_Azure]:
         findings = []
         for subscription, network_watchers in network_client.network_watchers.items():
             report = Check_Report_Azure(self.metadata())
@@ -11,18 +11,17 @@ class network_watcher_enabled(Check):
             report.resource_name = "Network Watcher"
             report.location = "Global"
             report.resource_id = f"/subscriptions/{network_client.subscriptions[subscription]}/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_*"
-            report.status = "FAIL"
-            report.status_extended = f"Network Watcher is not enabled for all locations in subscription '{subscription}'."
 
-            if len(network_watchers) >= len(
-                network_client.locations[subscription]
-            ) and all(
-                location
-                in [network_watcher.location for network_watcher in network_watchers]
-                for location in network_client.locations[subscription]
-            ):
+            missing_locations = set(network_client.locations[subscription]) - set(
+                network_watcher.location for network_watcher in network_watchers
+            )
+
+            if missing_locations:
+                report.status = "FAIL"
+                report.status_extended = f"Network Watcher is not enabled for the following locations in subscription '{subscription}': {', '.join(missing_locations)}"
+            else:
                 report.status = "PASS"
-                report.status_extended = f"Network Watcher is enabled for all locations in subscription '{subscription}'."
+                report.status_extended = f"Network Watcher is enabled for all locations in subscription '{subscription}'"
 
             findings.append(report)
 

--- a/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.py
+++ b/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.py
@@ -5,24 +5,25 @@ from prowler.providers.azure.services.network.network_client import network_clie
 class network_watcher_enabled(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
-        nw_locations = []
         for subscription, network_watchers in network_client.network_watchers.items():
-            for network_watcher in network_watchers:
-                nw_locations.append(network_watcher.location)
-        for subscription, locations in network_client.locations.items():
-            for location in locations:
-                report = Check_Report_Azure(self.metadata())
-                report.subscription = subscription
-                report.resource_name = "Network Watcher"
-                report.location = location
-                report.resource_id = f"/subscriptions/{subscription}/providers/Microsoft.Network/networkWatchers/{location}"
-                if location not in nw_locations:
-                    report.status = "FAIL"
-                    report.status_extended = f"Network Watcher is not enabled for the location {location} in subscription {subscription}."
-                    findings.append(report)
-                else:
-                    report.status = "PASS"
-                    report.status_extended = f"Network Watcher is enabled for the location {location} in subscription {subscription}."
-                    findings.append(report)
+            report = Check_Report_Azure(self.metadata())
+            report.subscription = subscription
+            report.resource_name = "Network Watcher"
+            report.location = "Global"
+            report.resource_id = f"/subscriptions/{network_client.subscriptions[subscription]}/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_*"
+            report.status = "FAIL"
+            report.status_extended = f"Network Watcher is not enabled for all locations in subscription '{subscription}'."
+
+            if len(network_watchers) >= len(
+                network_client.locations[subscription]
+            ) and all(
+                location
+                in [network_watcher.location for network_watcher in network_watchers]
+                for location in network_client.locations[subscription]
+            ):
+                report.status = "PASS"
+                report.status_extended = f"Network Watcher is enabled for all locations in subscription '{subscription}'."
+
+            findings.append(report)
 
         return findings

--- a/tests/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled_test.py
+++ b/tests/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled_test.py
@@ -3,6 +3,7 @@ from unittest import mock
 from prowler.providers.azure.services.network.network_service import NetworkWatcher
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUBSCRIPTION_ID,
+    AZURE_SUBSCRIPTION_NAME,
     set_mocked_azure_provider,
 )
 
@@ -36,12 +37,13 @@ class Test_network_watcher_enabled:
     def test_network_invalid_network_watchers(self):
         network_client = mock.MagicMock
         locations = ["location"]
-        network_client.locations = {AZURE_SUBSCRIPTION_ID: locations}
+        network_client.locations = {AZURE_SUBSCRIPTION_NAME: locations}
+        network_client.subscriptions = {AZURE_SUBSCRIPTION_NAME: AZURE_SUBSCRIPTION_ID}
         network_watcher_name = "Network Watcher"
-        network_watcher_id = f"/subscriptions/{AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Network/networkWatchers/{locations[0]}"
+        network_watcher_id = f"/subscriptions/{AZURE_SUBSCRIPTION_ID}/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_*"
 
         network_client.network_watchers = {
-            AZURE_SUBSCRIPTION_ID: [
+            AZURE_SUBSCRIPTION_NAME: [
                 NetworkWatcher(
                     id=network_watcher_id,
                     name=network_watcher_name,
@@ -71,22 +73,23 @@ class Test_network_watcher_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Network Watcher is not enabled for the location {locations[0]} in subscription {AZURE_SUBSCRIPTION_ID}."
+                == f"Network Watcher is not enabled for all locations in subscription '{AZURE_SUBSCRIPTION_NAME}'."
             )
-            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].subscription == AZURE_SUBSCRIPTION_NAME
             assert result[0].resource_name == network_watcher_name
             assert result[0].resource_id == network_watcher_id
-            assert result[0].location == "location"
+            assert result[0].location == "Global"
 
     def test_network_valid_network_watchers(self):
         network_client = mock.MagicMock
         locations = ["location"]
-        network_client.locations = {AZURE_SUBSCRIPTION_ID: locations}
+        network_client.locations = {AZURE_SUBSCRIPTION_NAME: locations}
+        network_client.subscriptions = {AZURE_SUBSCRIPTION_NAME: AZURE_SUBSCRIPTION_ID}
         network_watcher_name = "Network Watcher"
-        network_watcher_id = f"/subscriptions/{AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Network/networkWatchers/{locations[0]}"
+        network_watcher_id = f"/subscriptions/{AZURE_SUBSCRIPTION_ID}/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_*"
 
         network_client.network_watchers = {
-            AZURE_SUBSCRIPTION_ID: [
+            AZURE_SUBSCRIPTION_NAME: [
                 NetworkWatcher(
                     id=network_watcher_id,
                     name=network_watcher_name,
@@ -116,9 +119,9 @@ class Test_network_watcher_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Network Watcher is enabled for the location {locations[0]} in subscription {AZURE_SUBSCRIPTION_ID}."
+                == f"Network Watcher is enabled for all locations in subscription '{AZURE_SUBSCRIPTION_NAME}'."
             )
-            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].subscription == AZURE_SUBSCRIPTION_NAME
             assert result[0].resource_name == network_watcher_name
             assert result[0].resource_id == network_watcher_id
-            assert result[0].location == "location"
+            assert result[0].location == "Global"

--- a/tests/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled_test.py
+++ b/tests/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled_test.py
@@ -73,7 +73,7 @@ class Test_network_watcher_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Network Watcher is not enabled for all locations in subscription '{AZURE_SUBSCRIPTION_NAME}'."
+                == f"Network Watcher is not enabled for the following locations in subscription '{AZURE_SUBSCRIPTION_NAME}': location."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_NAME
             assert result[0].resource_name == network_watcher_name


### PR DESCRIPTION
### Context

The check to ensure if network watchers was enabled in every region introduce some noise to the final report.

### Description

Check logic and tests have been changed to make only one report per subscription.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
