### PR TITLE
fix(aws): aws check and metadata fixes

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_ebs_volume_snapshots_exists/ec2_ebs_volume_snapshots_exists.metadata.json
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_volume_snapshots_exists/ec2_ebs_volume_snapshots_exists.metadata.json
@@ -9,7 +9,7 @@
   "SubServiceName": "snapshot",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
   "Severity": "medium",
-  "ResourceType": "AwsEc2Snapshot",
+  "ResourceType": "AwsEc2Volume",
   "Description": "Check if EBS snapshots exists.",
   "Risk": "Ensure that your EBS volumes (available or in-use) have recent snapshots (taken weekly) available for point-in-time recovery for a better, more reliable data backup strategy.",
   "RelatedUrl": "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSSnapshots.html",

--- a/prowler/providers/aws/services/ec2/ec2_ebs_volume_snapshots_exists/ec2_ebs_volume_snapshots_exists.metadata.json
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_volume_snapshots_exists/ec2_ebs_volume_snapshots_exists.metadata.json
@@ -6,7 +6,7 @@
     "Data Protection"
   ],
   "ServiceName": "ec2",
-  "SubServiceName": "snapshot",
+  "SubServiceName": "volume",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
   "Severity": "medium",
   "ResourceType": "AwsEc2Volume",

--- a/prowler/providers/aws/services/sns/sns_topics_kms_encryption_at_rest_enabled/sns_topics_kms_encryption_at_rest_enabled.metadata.json
+++ b/prowler/providers/aws/services/sns/sns_topics_kms_encryption_at_rest_enabled/sns_topics_kms_encryption_at_rest_enabled.metadata.json
@@ -7,7 +7,7 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:sns:region:account-id:topic",
   "Severity": "high",
-  "ResourceType": "AwsSNSTopic",
+  "ResourceType": "AwsSnsTopic",
   "Description": "Ensure there are no SNS Topics unencrypted",
   "Risk": "If not enabled sensitive information at rest is not protected.",
   "RelatedUrl": "https://docs.aws.amazon.com/sns/latest/dg/sns-server-side-encryption.html",

--- a/prowler/providers/aws/services/sns/sns_topics_not_publicly_accessible/sns_topics_not_publicly_accessible.metadata.json
+++ b/prowler/providers/aws/services/sns/sns_topics_not_publicly_accessible/sns_topics_not_publicly_accessible.metadata.json
@@ -7,7 +7,7 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:sns:region:account-id:topic",
   "Severity": "high",
-  "ResourceType": "AwsSNSTopic",
+  "ResourceType": "AwsSnsTopic",
   "Description": "Check if SNS topics have policy set as Public",
   "Risk": "Publicly accessible services could expose sensitive data to bad actors.",
   "RelatedUrl": "https://docs.aws.amazon.com/config/latest/developerguide/sns-topic-policy.html",

--- a/prowler/providers/aws/services/ssm/ssm_service.py
+++ b/prowler/providers/aws/services/ssm/ssm_service.py
@@ -1,4 +1,5 @@
 import json
+import time
 from enum import Enum
 from typing import Optional
 
@@ -145,6 +146,7 @@ class SSM(AWSService):
                         id=resource_id,
                         region=regional_client.region,
                     )
+                time.sleep(0.1)
 
         except Exception as error:
             logger.error(

--- a/prowler/providers/aws/services/ssm/ssm_service.py
+++ b/prowler/providers/aws/services/ssm/ssm_service.py
@@ -146,6 +146,9 @@ class SSM(AWSService):
                         id=resource_id,
                         region=regional_client.region,
                     )
+                # boto3 does not properly handle throttling exceptions for
+                # ssm:DescribeInstanceInformation when there are large numbers of instances
+                # AWS support recommends manually reducing frequency of requests
                 time.sleep(0.1)
 
         except Exception as error:

--- a/tests/providers/aws/services/ec2/ec2_instance_managed_by_ssm/ec2_instance_managed_by_ssm_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_managed_by_ssm/ec2_instance_managed_by_ssm_test.py
@@ -157,3 +157,189 @@ class Test_ec2_instance_managed_by_ssm_test:
                 == f"EC2 Instance {instance.id} is managed by Systems Manager."
             )
             assert result[0].resource_id == instance.id
+
+    @mock_aws
+    def test_ec2_instance_managed_by_ssm_running(self):
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        instances_pending = ec2.create_instances(
+            ImageId=EXAMPLE_AMI_ID,
+            MinCount=2,
+            MaxCount=2,
+            UserData="This is some user_data",
+        )
+        instance_managed = ec2.Instance(instances_pending[0].id)
+        instance_unmanaged = ec2.Instance(instances_pending[1].id)
+        assert instance_managed.state["Name"] == "running"
+        assert instance_unmanaged.state["Name"] == "running"
+
+        ssm_client = mock.MagicMock
+        ssm_client.managed_instances = {
+            instance_managed.id: ManagedInstance(
+                arn=f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:instance/{instance_managed.id}",
+                id=instance_managed.id,
+                region=AWS_REGION_US_EAST_1,
+            )
+        }
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_service.SSM",
+            new=ssm_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_client.ssm_client",
+            new=ssm_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_managed_by_ssm.ec2_instance_managed_by_ssm.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.ec2.ec2_instance_managed_by_ssm.ec2_instance_managed_by_ssm import (
+                ec2_instance_managed_by_ssm,
+            )
+
+            check = ec2_instance_managed_by_ssm()
+            result = check.execute()
+
+            assert len(result) == 2
+            instance_managed_result = next(
+                (r for r in result if r.resource_id == instance_managed.id), None
+            )
+            assert instance_managed_result
+            assert instance_managed_result.status == "PASS"
+            assert instance_managed_result.region == AWS_REGION_US_EAST_1
+            assert instance_managed_result.resource_tags is None
+            assert (
+                instance_managed_result.status_extended
+                == f"EC2 Instance {instance_managed.id} is managed by Systems Manager."
+            )
+            instance_unmanaged_result = next(
+                (r for r in result if r.resource_id == instance_unmanaged.id), None
+            )
+            assert instance_unmanaged_result
+            assert instance_unmanaged_result.status == "FAIL"
+            assert instance_unmanaged_result.region == AWS_REGION_US_EAST_1
+            assert instance_unmanaged_result.resource_tags is None
+            assert (
+                instance_unmanaged_result.status_extended
+                == f"EC2 Instance {instance_unmanaged.id} is not managed by Systems Manager."
+            )
+
+    @mock_aws
+    def test_ec2_instance_managed_by_ssm_stopped(self):
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        instances_pending = ec2.create_instances(
+            ImageId=EXAMPLE_AMI_ID,
+            MinCount=1,
+            MaxCount=1,
+            UserData="This is some user_data",
+        )
+        instances_pending[0].stop()
+        instance = ec2.Instance(instances_pending[0].id)
+        assert instance.state["Name"] == "stopped"
+
+        ssm_client = mock.MagicMock
+        ssm_client.managed_instances = {}
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_service.SSM",
+            new=ssm_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_client.ssm_client",
+            new=ssm_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_managed_by_ssm.ec2_instance_managed_by_ssm.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.ec2.ec2_instance_managed_by_ssm.ec2_instance_managed_by_ssm import (
+                ec2_instance_managed_by_ssm,
+            )
+
+            check = ec2_instance_managed_by_ssm()
+            result = check.execute()
+
+            assert len(result) == 1
+            instance_result = next(
+                (r for r in result if r.resource_id == instance.id), None
+            )
+            assert instance_result
+            assert instance_result.status == "PASS"
+            assert instance_result.region == AWS_REGION_US_EAST_1
+            assert instance_result.resource_tags is None
+            assert (
+                instance_result.status_extended
+                == f"EC2 Instance {instance.id} is unmanaged by Systems Manager because it is stopped."
+            )
+
+    @mock_aws
+    def test_ec2_instance_managed_by_ssm_terminated(self):
+        ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
+        instances_pending = ec2.create_instances(
+            ImageId=EXAMPLE_AMI_ID,
+            MinCount=1,
+            MaxCount=1,
+            UserData="This is some user_data",
+        )
+        instances_pending[0].terminate()
+        instance = ec2.Instance(instances_pending[0].id)
+        assert instance.state["Name"] == "terminated"
+
+        ssm_client = mock.MagicMock
+        ssm_client.managed_instances = {}
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_service.SSM",
+            new=ssm_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_client.ssm_client",
+            new=ssm_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_managed_by_ssm.ec2_instance_managed_by_ssm.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.ec2.ec2_instance_managed_by_ssm.ec2_instance_managed_by_ssm import (
+                ec2_instance_managed_by_ssm,
+            )
+
+            check = ec2_instance_managed_by_ssm()
+            result = check.execute()
+
+            assert len(result) == 1
+            instance_result = next(
+                (r for r in result if r.resource_id == instance.id), None
+            )
+            assert instance_result
+            assert instance_result.status == "PASS"
+            assert instance_result.region == AWS_REGION_US_EAST_1
+            assert instance_result.resource_tags is None
+            assert (
+                instance_result.status_extended
+                == f"EC2 Instance {instance.id} is unmanaged by Systems Manager because it is terminated."
+            )

--- a/tests/providers/aws/services/ec2/ec2_instance_managed_by_ssm/ec2_instance_managed_by_ssm_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_managed_by_ssm/ec2_instance_managed_by_ssm_test.py
@@ -206,31 +206,27 @@ class Test_ec2_instance_managed_by_ssm_test:
             )
 
             check = ec2_instance_managed_by_ssm()
-            result = check.execute()
+            results = check.execute()
 
-            assert len(result) == 2
-            instance_managed_result = next(
-                (r for r in result if r.resource_id == instance_managed.id), None
-            )
-            assert instance_managed_result
-            assert instance_managed_result.status == "PASS"
-            assert instance_managed_result.region == AWS_REGION_US_EAST_1
-            assert instance_managed_result.resource_tags is None
-            assert (
-                instance_managed_result.status_extended
-                == f"EC2 Instance {instance_managed.id} is managed by Systems Manager."
-            )
-            instance_unmanaged_result = next(
-                (r for r in result if r.resource_id == instance_unmanaged.id), None
-            )
-            assert instance_unmanaged_result
-            assert instance_unmanaged_result.status == "FAIL"
-            assert instance_unmanaged_result.region == AWS_REGION_US_EAST_1
-            assert instance_unmanaged_result.resource_tags is None
-            assert (
-                instance_unmanaged_result.status_extended
-                == f"EC2 Instance {instance_unmanaged.id} is not managed by Systems Manager."
-            )
+            assert len(results) == 2
+            for result in results:
+                if result.resource_id == instance_managed.id:
+                    assert result.status == "PASS"
+                    assert result.region == AWS_REGION_US_EAST_1
+                    assert result.resource_tags is None
+                    assert (
+                        result.status_extended
+                        == f"EC2 Instance {instance_managed.id} is managed by Systems Manager."
+                    )
+
+                if result.resource_id == instance_unmanaged.id:
+                    assert result.status == "FAIL"
+                    assert result.region == AWS_REGION_US_EAST_1
+                    assert result.resource_tags is None
+                    assert (
+                        result.status_extended
+                        == f"EC2 Instance {instance_unmanaged.id} is not managed by Systems Manager."
+                    )
 
     @mock_aws
     def test_ec2_instance_managed_by_ssm_stopped(self):
@@ -276,15 +272,11 @@ class Test_ec2_instance_managed_by_ssm_test:
             result = check.execute()
 
             assert len(result) == 1
-            instance_result = next(
-                (r for r in result if r.resource_id == instance.id), None
-            )
-            assert instance_result
-            assert instance_result.status == "PASS"
-            assert instance_result.region == AWS_REGION_US_EAST_1
-            assert instance_result.resource_tags is None
+            assert result[0].status == "PASS"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags is None
             assert (
-                instance_result.status_extended
+                result[0].status_extended
                 == f"EC2 Instance {instance.id} is unmanaged by Systems Manager because it is stopped."
             )
 
@@ -332,14 +324,10 @@ class Test_ec2_instance_managed_by_ssm_test:
             result = check.execute()
 
             assert len(result) == 1
-            instance_result = next(
-                (r for r in result if r.resource_id == instance.id), None
-            )
-            assert instance_result
-            assert instance_result.status == "PASS"
-            assert instance_result.region == AWS_REGION_US_EAST_1
-            assert instance_result.resource_tags is None
+            assert result[0].status == "PASS"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags is None
             assert (
-                instance_result.status_extended
+                result[0].status_extended
                 == f"EC2 Instance {instance.id} is unmanaged by Systems Manager because it is terminated."
             )


### PR DESCRIPTION
### Context

Some fixes to AWS checks and check metadata


### Description

- Fix metadata for `ec2_ebs_volume_snapshots_exists` so that SecurityHub findings are created against the volume resource.  The resource id for the check is the volume but it was incorrectly identified as a snapshot.
- Fix `ec2_instance_managed_by_ssm` check to exclude stopped instances.  Stopped instances cannot report to SSM, and it doesn't make sense to flag them as unmanaged until they are started.  The behavior in Prowler 2 was to only check running instances, here I'm passing pending, terminated, and stopped instances that can't be managed.
- Fix metadata for `sns_topics_kms_encryption_at_rest_enabled` to use the correct ResourceType.  SecurityHub is case sensitive.
- Fix metadata for `sns_topics_not_publicly_accessible` to use the correct ResourceType.  SecurityHub is case sensitive.
- Mitigate pagination rate limit errors in large environments caused by `ssm:DescribeInstanceInformation` calls in `ssm_service.py`.  Boto3 pagination does not successfully handle the rate limiting exceptions on this action, and a short sleep between pages is the best option I've found to make it work consistently in accounts with hundreds or thousands of instances.  When these rate limit errors occur, any checks that depend on the ssm instance information such as `ec2_instance_managed_by_ssm` throw large numbers of false positives.  The added delay does not seem to be significant and it addresses the false positives.

All code checks are passing for these changes.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
