### PR TITLE
fix(custom_checks): workaround to fix execution

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -181,7 +181,16 @@ def prowler():
     # Import custom checks from folder
     if checks_folder:
         custom_checks = parse_checks_from_folder(global_provider, checks_folder)
-        checks_to_execute.update(custom_checks)
+        # Workaround to be able to execute custom checks alongside all checks if nothing is explicitly set
+        if (
+            not checks_file
+            and not checks
+            and not services
+            and not severities
+            and not compliance_framework
+            and not categories
+        ):
+            checks_to_execute.update(custom_checks)
 
     # Exclude checks if -e/--excluded-checks
     if excluded_checks:

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -127,6 +127,7 @@ def parse_checks_from_file(input_file: str, provider: str) -> set:
 
 # Load checks from custom folder
 def parse_checks_from_folder(provider, input_folder: str) -> set:
+    # TODO: move the AWS-specific code into the provider
     try:
         custom_checks = set()
         # Check if input folder is a S3 URI


### PR DESCRIPTION
### Context

Fixes #4253

### Description

Since https://github.com/prowler-cloud/prowler/pull/4202 Prowler is not able to execute custom checks if some checks/services/compliance are being set explictly.

Please @kagahd @sejimhp could you please test this thoughtfully? Thanks!

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
