### PR TITLE
chore(docs): update checks reference link

### DIFF
--- a/docs/developer-guide/checks.md
+++ b/docs/developer-guide/checks.md
@@ -319,7 +319,7 @@ Each Prowler check has metadata associated which is stored at the same level of 
 For the Remediation Code we use the following knowledge base to fill it:
 
 - Official documentation for the provider
-- https://docs.bridgecrew.io
+- https://docs.prowler.com/checks/checks-index
 - https://www.trendmicro.com/cloudoneconformity
 - https://github.com/cloudmatos/matos/tree/master/remediations
 


### PR DESCRIPTION
### Description

Update Checks reference link, `docs.bridgecrew.io` no longer exists.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
