### PR TITLE
fix(rds): handle not existing endpoint

### DIFF
--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -57,7 +57,7 @@ class RDS(AWSService):
                                 DBInstance(
                                     id=instance["DBInstanceIdentifier"],
                                     arn=arn,
-                                    endpoint=instance.get("Endpoint"),
+                                    endpoint=instance.get("Endpoint", {}),
                                     engine=instance["Engine"],
                                     engine_version=instance["EngineVersion"],
                                     status=instance["DBInstanceStatus"],
@@ -226,7 +226,7 @@ class RDS(AWSService):
                                     db_cluster = DBCluster(
                                         id=cluster["DBClusterIdentifier"],
                                         arn=db_cluster_arn,
-                                        endpoint=cluster.get("Endpoint"),
+                                        endpoint=cluster.get("Endpoint", ""),
                                         engine=cluster["Engine"],
                                         status=cluster["Status"],
                                         public=cluster.get("PubliclyAccessible", False),
@@ -475,7 +475,7 @@ class DBInstance(BaseModel):
     id: str
     # arn:{partition}:rds:{region}:{account}:db:{resource_id}
     arn: str
-    endpoint: Optional[dict]
+    endpoint: dict
     engine: str
     engine_version: str
     status: str
@@ -504,7 +504,7 @@ class DBInstance(BaseModel):
 class DBCluster(BaseModel):
     id: str
     arn: str
-    endpoint: Optional[str]
+    endpoint: str
     engine: str
     status: str
     public: bool

--- a/tests/providers/aws/services/rds/rds_instance_certificate_expiration/rds_instance_certificate_expiration_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_certificate_expiration/rds_instance_certificate_expiration_test.py
@@ -80,6 +80,7 @@ class Test_rds_instance_certificate_expiration:
                 iam_auth=False,
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
+                endpoint={},
                 cert=[
                     Certificate(
                         id="rds-ca-rsa2048-g1",
@@ -151,6 +152,7 @@ class Test_rds_instance_certificate_expiration:
                 iam_auth=False,
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
+                endpoint={},
                 cert=[
                     Certificate(
                         id="rds-ca-rsa2048-g1",
@@ -221,6 +223,7 @@ class Test_rds_instance_certificate_expiration:
                 iam_auth=False,
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
+                endpoint={},
                 cert=[
                     Certificate(
                         id="rds-ca-rsa2048-g1",
@@ -291,6 +294,7 @@ class Test_rds_instance_certificate_expiration:
                 iam_auth=False,
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
+                endpoint={},
                 cert=[
                     Certificate(
                         id="rds-ca-rsa2048-g1",
@@ -361,6 +365,7 @@ class Test_rds_instance_certificate_expiration:
                 iam_auth=False,
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
+                endpoint={},
                 cert=[
                     Certificate(
                         id="rds-ca-rsa2048-g1",
@@ -431,6 +436,7 @@ class Test_rds_instance_certificate_expiration:
                 iam_auth=False,
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
+                endpoint={},
                 cert=[
                     Certificate(
                         id="rds-ca-rsa2048-g1",
@@ -501,6 +507,7 @@ class Test_rds_instance_certificate_expiration:
                 iam_auth=False,
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
+                endpoint={},
                 cert=[
                     Certificate(
                         id="rds-ca-rsa2048-g1",
@@ -571,6 +578,7 @@ class Test_rds_instance_certificate_expiration:
                 iam_auth=False,
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
+                endpoint={},
                 cert=[
                     Certificate(
                         id="rds-ca-rsa2048-g1",
@@ -641,6 +649,7 @@ class Test_rds_instance_certificate_expiration:
                 iam_auth=False,
                 region=AWS_REGION,
                 ca_cert="rds-ca-rsa2048-g1",
+                endpoint={},
                 cert=[
                     Certificate(
                         id="rds-ca-rsa2048-g1",


### PR DESCRIPTION
### Description

Handle not existing endpoint by setting it as an empty value and avoid the following error:
`rds_instance_no_public_access -- AttributeError[26]: 'NoneType' object has no attribute 'get'`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
