### PR TITLE
feat(gcp): add service account impersonation

### DIFF
--- a/docs/tutorials/gcp/authentication.md
+++ b/docs/tutorials/gcp/authentication.md
@@ -25,6 +25,16 @@ Prowler will follow the same credentials search as [Google authentication librar
 
 Those credentials must be associated to a user or service account with proper permissions to do all checks. To make sure, add the `Viewer` role to the member associated with the credentials.
 
+## Impersonate Service Account
+
+If you want to impersonate a GCP service account, you can use the `--impersonate-service-account` argument:
+
+```console
+prowler gcp --impersonate-service-account <service-account-email>
+```
+
+This argument will use the default credentials to impersonate the service account provided.
+
 # GCP Service APIs
 
 Prowler will use the Google Cloud APIs to get the information needed to perform the checks. Make sure that the following APIs are enabled in the project:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1605,13 +1605,13 @@ uritemplate = ">=3.0.1,<5"
 
 [[package]]
 name = "google-auth"
-version = "2.29.0"
+version = "2.30.0"
 description = "Google Authentication Library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-auth-2.29.0.tar.gz", hash = "sha256:672dff332d073227550ffc7457868ac4218d6c500b155fe6cc17d2b13602c360"},
-    {file = "google_auth-2.29.0-py2.py3-none-any.whl", hash = "sha256:d452ad095688cd52bae0ad6fafe027f6a6d6f560e810fec20914e17a09526415"},
+    {file = "google-auth-2.30.0.tar.gz", hash = "sha256:ab630a1320f6720909ad76a7dbdb6841cdf5c66b328d690027e4867bdfb16688"},
+    {file = "google_auth-2.30.0-py2.py3-none-any.whl", hash = "sha256:8df7da660f62757388b8a7f249df13549b3373f24388cb5d2f1dd91cc18180b5"},
 ]
 
 [package.dependencies]

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -214,7 +214,7 @@ class GcpProvider(Provider):
             logger.critical(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
-        sys.exit(1)
+            sys.exit(1)
 
     def __set_gcp_creds_env_var__(self, credentials_file):
         logger.info(

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -206,7 +206,6 @@ class GcpProvider(Provider):
                     source_credentials=credentials,
                     target_principal=service_account,
                     target_scopes=scopes,
-                    lifetime=3600,
                 )
                 logger.info(f"Impersonated credentials: {credentials}")
 

--- a/prowler/providers/gcp/lib/arguments/arguments.py
+++ b/prowler/providers/gcp/lib/arguments/arguments.py
@@ -12,6 +12,12 @@ def init_parser(self):
         metavar="FILE_PATH",
         help="Authenticate using a Google Service Account Application Credentials JSON file",
     )
+    gcp_auth_modes_group.add_argument(
+        "--impersonate-service-account",
+        nargs="?",
+        metavar="SERVICE_ACCOUNT",
+        help="Impersonate a Google Service Account",
+    )
     # Projects
     gcp_projects_subparser = gcp_parser.add_argument_group("Projects")
     gcp_projects_subparser.add_argument(

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -1229,6 +1229,14 @@ class Test_Parser:
         assert parsed.provider == "gcp"
         assert parsed.list_project_id
 
+    def test_parser_gcp_impersonate_service_account(self):
+        argument = "--impersonate-service-account"
+        service_account = "test@test.iam.gserviceaccount.com"
+        command = [prowler_command, "gcp", argument, service_account]
+        parsed = self.parser.parse(command)
+        assert parsed.provider == "gcp"
+        assert parsed.impersonate_service_account == service_account
+
     def test_parser_kubernetes_auth_kubeconfig_file(self):
         argument = "--kubeconfig-file"
         file = "config"

--- a/tests/providers/gcp/gcp_provider_test.py
+++ b/tests/providers/gcp/gcp_provider_test.py
@@ -20,6 +20,7 @@ class TestGCPProvider:
         arguments.excluded_project_id = []
         arguments.list_project_id = False
         arguments.credentials_file = ""
+        arguments.impersonate_service_account = ""
         arguments.config_file = default_config_file_path
         arguments.fixer_config = default_fixer_config_file_path
 
@@ -56,6 +57,7 @@ class TestGCPProvider:
         arguments.excluded_project_id = []
         arguments.list_project_id = False
         arguments.credentials_file = ""
+        arguments.impersonate_service_account = ""
         arguments.config_file = default_config_file_path
         arguments.fixer_config = default_fixer_config_file_path
 
@@ -128,6 +130,7 @@ class TestGCPProvider:
         arguments.excluded_project_id = []
         arguments.list_project_id = False
         arguments.credentials_file = ""
+        arguments.impersonate_service_account = ""
         arguments.config_file = default_config_file_path
         arguments.fixer_config = default_fixer_config_file_path
 


### PR DESCRIPTION
### Description

Add the ability of impersonate a GCP Service Account using the argument `--impersonate-service-account <service-account-email>`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
