### PR TITLE
chore(dependabot): Run daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
     target-branch: master
     labels:
@@ -17,14 +17,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
     target-branch: master
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
     target-branch: v3
     labels:
@@ -34,7 +34,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
     target-branch: v3
     labels:


### PR DESCRIPTION
### Context

We are tired to just run dependabot on a weekly basis since each Tuesday we have more than 30 PRs to review, let's give the daily schedule a try.


### Description

Run dependabot on a daily basis.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
