### PR TITLE
chore(iam): Remove unnecesary attached policy in a inline policy

### DIFF
--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges.py
@@ -6,7 +6,7 @@ class iam_inline_policy_no_administrative_privileges(Check):
     def execute(self) -> Check_Report_AWS:
         findings = []
         for policy in iam_client.policies:
-            if policy.attached and policy.type == "Inline":
+            if policy.type == "Inline":
                 report = Check_Report_AWS(self.metadata())
                 report.region = iam_client.region
                 report.resource_arn = policy.arn


### PR DESCRIPTION
### Context

Ensure if a inline policy is attached when they are always attached.


### Description

Removed the unnecessary verification from `iam_inline_policy_no_administrative_privileges` check.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
