### PR TITLE
chore(iam): Improve status extended adding the resource type

### DIFF
--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges.py
@@ -13,7 +13,17 @@ class iam_inline_policy_no_administrative_privileges(Check):
                 report.resource_id = f"{policy.entity}/{policy.name}"
                 report.resource_tags = policy.tags
                 report.status = "PASS"
-                report.status_extended = f"{policy.type} policy {policy.name} for IAM identity {policy.arn} does not allow '*:*' administrative privileges."
+
+                if "role" in report.resource_arn:
+                    resource_type_str = "role"
+                elif "group" in report.resource_arn:
+                    resource_type_str = "group"
+                elif "user" in report.resource_arn:
+                    resource_type_str = "user"
+                else:
+                    resource_type_str = "resource"
+
+                report.status_extended = f"{policy.type} policy {policy.name} attached to {resource_type_str} {report.resource_arn} does not allow '*:*' administrative privileges."
                 if policy.document:
                     # Check the statements, if one includes *:* stop iterating over the rest
                     if not isinstance(policy.document["Statement"], list):
@@ -35,7 +45,7 @@ class iam_inline_policy_no_administrative_privileges(Check):
                             )
                         ):
                             report.status = "FAIL"
-                            report.status_extended = f"{policy.type} policy {policy.name} for IAM identity {policy.arn} allows '*:*' administrative privileges."
+                            report.status_extended = f"{policy.type} policy {policy.name} attached to {resource_type_str} {report.resource_arn} allows '*:*' administrative privileges."
                             break
                 findings.append(report)
         return findings

--- a/tests/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges_test.py
+++ b/tests/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges_test.py
@@ -103,7 +103,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert results[0].status == "FAIL"
             assert (
                 results[0].status_extended
-                == f"Inline policy {policy_name} for IAM identity {group_arn} allows '*:*' administrative privileges."
+                == f"Inline policy {policy_name} attached to group {group_arn} allows '*:*' administrative privileges."
             )
 
     @mock_aws
@@ -147,7 +147,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert results[0].status == "PASS"
             assert (
                 results[0].status_extended
-                == f"Inline policy {policy_name} for IAM identity {group_arn} does not allow '*:*' administrative privileges."
+                == f"Inline policy {policy_name} attached to group {group_arn} does not allow '*:*' administrative privileges."
             )
 
     @mock_aws
@@ -201,7 +201,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
                     assert result.status == "FAIL"
                     assert (
                         result.status_extended
-                        == f"Inline policy {policy_name_admin} for IAM identity {group_arn} allows '*:*' administrative privileges."
+                        == f"Inline policy {policy_name_admin} attached to group {group_arn} allows '*:*' administrative privileges."
                     )
 
                 elif result.resource_id == policy_name_not_admin:
@@ -212,7 +212,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
                     assert result.status == "PASS"
                     assert (
                         result.status_extended
-                        == f"Inline policy {policy_name_not_admin} for IAM identity {group_arn} does not allow '*:*' administrative privileges."
+                        == f"Inline policy {policy_name_not_admin} attached to group {group_arn} does not allow '*:*' administrative privileges."
                     )
 
     # Roles
@@ -291,7 +291,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert results[0].status == "FAIL"
             assert (
                 results[0].status_extended
-                == f"Inline policy {policy_name} for IAM identity {role_arn} allows '*:*' administrative privileges."
+                == f"Inline policy {policy_name} attached to role {role_arn} allows '*:*' administrative privileges."
             )
 
     @mock_aws
@@ -338,7 +338,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert results[0].status == "PASS"
             assert (
                 results[0].status_extended
-                == f"Inline policy {policy_name} for IAM identity {role_arn} does not allow '*:*' administrative privileges."
+                == f"Inline policy {policy_name} attached to role {role_arn} does not allow '*:*' administrative privileges."
             )
 
     @mock_aws
@@ -394,7 +394,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
                     assert result.status == "FAIL"
                     assert (
                         result.status_extended
-                        == f"Inline policy {policy_name_admin} for IAM identity {role_arn} allows '*:*' administrative privileges."
+                        == f"Inline policy {policy_name_admin} attached to group {role_arn} allows '*:*' administrative privileges."
                     )
 
                 elif result.resource_id == policy_name_not_admin:
@@ -405,7 +405,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
                     assert result.status == "PASS"
                     assert (
                         result.status_extended
-                        == f"Inline policy {policy_name_not_admin} for IAM identity {role_arn} does not allow '*:*' administrative privileges."
+                        == f"Inline policy {policy_name_not_admin} attached to group {role_arn} does not allow '*:*' administrative privileges."
                     )
 
     # Users
@@ -484,7 +484,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert results[0].status == "FAIL"
             assert (
                 results[0].status_extended
-                == f"Inline policy {policy_name} for IAM identity {user_arn} allows '*:*' administrative privileges."
+                == f"Inline policy {policy_name} attached to user {user_arn} allows '*:*' administrative privileges."
             )
 
     @mock_aws
@@ -532,7 +532,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert results[0].status == "PASS"
             assert (
                 results[0].status_extended
-                == f"Inline policy {policy_name} for IAM identity {user_arn} does not allow '*:*' administrative privileges."
+                == f"Inline policy {policy_name} attached to user {user_arn} does not allow '*:*' administrative privileges."
             )
 
     @mock_aws
@@ -589,7 +589,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
                     assert result.status == "FAIL"
                     assert (
                         result.status_extended
-                        == f"Inline policy {policy_name_admin} for IAM identity {user_arn} allows '*:*' administrative privileges."
+                        == f"Inline policy {policy_name_admin} attached to user {user_arn} allows '*:*' administrative privileges."
                     )
 
                 elif result.resource_id == policy_name_not_admin:
@@ -600,5 +600,5 @@ class Test_iam_inline_policy_no_administrative_privileges:
                     assert result.status == "PASS"
                     assert (
                         result.status_extended
-                        == f"Inline policy {policy_name_not_admin} for IAM identity {user_arn} does not allow '*:*' administrative privileges."
+                        == f"Inline policy {policy_name_not_admin} attached to user {user_arn} does not allow '*:*' administrative privileges."
                     )


### PR DESCRIPTION
### Context

Actual status_extended for inline policy does not include the type of resource attached in the status extended.


### Description

Changed the status_extended in checks and tests.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
