### PR TITLE
test(gcp): Add remaining CloudSQL tests

### DIFF
--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_user_connections_flag/cloudsql_instance_sqlserver_user_connections_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_user_connections_flag/cloudsql_instance_sqlserver_user_connections_flag.py
@@ -12,12 +12,12 @@ class cloudsql_instance_sqlserver_user_connections_flag(Check):
                 report.resource_id = instance.name
                 report.resource_name = instance.name
                 report.location = instance.region
-                report.status = "PASS"
-                report.status_extended = f"SQL Server Instance {instance.name} has 'user connections' flag set to '0'."
+                report.status = "FAIL"
+                report.status_extended = f"SQL Server Instance {instance.name} does not have 'user connections' flag set to '0'."
                 for flag in instance.flags:
                     if flag["name"] == "user connections" and flag["value"] == "0":
-                        report.status = "FAIL"
-                        report.status_extended = f"SQL Server Instance {instance.name} does not have 'user connections' flag set to '0'."
+                        report.status = "PASS"
+                        report.status_extended = f"SQL Server Instance {instance.name} has 'user connections' flag set to '0'."
                         break
                 findings.append(report)
 

--- a/tests/providers/gcp/gcp_fixtures.py
+++ b/tests/providers/gcp/gcp_fixtures.py
@@ -7,6 +7,9 @@ from prowler.providers.gcp.models import GCPIdentityInfo
 
 GCP_PROJECT_ID = "123456789012"
 
+GCP_EU1_LOCATION = "europe-west1"
+GCP_US_CENTER1_LOCATION = "us-central1"
+
 
 def set_mocked_gcp_provider(
     project_ids: list[str] = [], profile: str = ""

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_public_access/cloudsql_instance_public_access_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_public_access/cloudsql_instance_public_access_test.py
@@ -1,0 +1,119 @@
+from unittest import mock
+
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_EU1_LOCATION,
+    GCP_PROJECT_ID,
+    set_mocked_gcp_provider,
+)
+
+
+class Test_cloudsql_instance_public_access:
+    def test_no_cloudsql_instances(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_public_access.cloudsql_instance_public_access.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_public_access.cloudsql_instance_public_access import (
+                cloudsql_instance_public_access,
+            )
+
+            cloudsql_client.instances = []
+
+            check = cloudsql_instance_public_access()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_instance_no_public_access(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_public_access.cloudsql_instance_public_access.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_public_access.cloudsql_instance_public_access import (
+                cloudsql_instance_public_access,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="POSTGRES_15",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[{"value": "192.168.1.1/32"}],
+                    project_id=GCP_PROJECT_ID,
+                    flags=[],
+                )
+            ]
+
+            check = cloudsql_instance_public_access()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "Database Instance instance1 does not whitelist all Public IP Addresses."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
+    def test_cloudsql_instance_public_access(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_public_access.cloudsql_instance_public_access.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_public_access.cloudsql_instance_public_access import (
+                cloudsql_instance_public_access,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="POSTGRES_15",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[{"value": "0.0.0.0/0"}],
+                    project_id=GCP_PROJECT_ID,
+                    flags=[],
+                )
+            ]
+
+            check = cloudsql_instance_public_access()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "Database Instance instance1 whitelist all Public IP Addresses."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_public_ip/cloudsql_instance_public_ip_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_public_ip/cloudsql_instance_public_ip_test.py
@@ -1,0 +1,119 @@
+from unittest import mock
+
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_EU1_LOCATION,
+    GCP_PROJECT_ID,
+    set_mocked_gcp_provider,
+)
+
+
+class Test_cloudsql_instance_public_ip:
+    def test_no_cloudsql_instances(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_public_ip.cloudsql_instance_public_ip.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_public_ip.cloudsql_instance_public_ip import (
+                cloudsql_instance_public_ip,
+            )
+
+            cloudsql_client.instances = []
+
+            check = cloudsql_instance_public_ip()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_instance_no_public_ip(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_public_ip.cloudsql_instance_public_ip.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_public_ip.cloudsql_instance_public_ip import (
+                cloudsql_instance_public_ip,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="POSTGRES_15",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_public_ip()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "Database Instance instance1 does not have a public IP."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
+    def test_cloudsql_instance_public_ip(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_public_ip.cloudsql_instance_public_ip.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_public_ip.cloudsql_instance_public_ip import (
+                cloudsql_instance_public_ip,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="POSTGRES_15",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=True,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_public_ip()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "Database Instance instance1 has a public IP."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_contained_database_authentication_flag/cloudsql_instance_sqlserver_contained_database_authentication_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_contained_database_authentication_flag/cloudsql_instance_sqlserver_contained_database_authentication_flag_test.py
@@ -1,0 +1,159 @@
+from unittest import mock
+
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_EU1_LOCATION,
+    GCP_PROJECT_ID,
+    set_mocked_gcp_provider,
+)
+
+
+class Test_cloudsql_instance_sqlserver_contained_database_authentication_flag:
+    def test_no_cloudsql_instances(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_contained_database_authentication_flag.cloudsql_instance_sqlserver_contained_database_authentication_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_contained_database_authentication_flag.cloudsql_instance_sqlserver_contained_database_authentication_flag import (
+                cloudsql_instance_sqlserver_contained_database_authentication_flag,
+            )
+
+            cloudsql_client.instances = []
+
+            check = cloudsql_instance_sqlserver_contained_database_authentication_flag()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_postgres_instance(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_contained_database_authentication_flag.cloudsql_instance_sqlserver_contained_database_authentication_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_contained_database_authentication_flag.cloudsql_instance_sqlserver_contained_database_authentication_flag import (
+                cloudsql_instance_sqlserver_contained_database_authentication_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="POSTGRES_15",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_contained_database_authentication_flag()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_instance_contained_database_authentication_flag_on(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_contained_database_authentication_flag.cloudsql_instance_sqlserver_contained_database_authentication_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_contained_database_authentication_flag.cloudsql_instance_sqlserver_contained_database_authentication_flag import (
+                cloudsql_instance_sqlserver_contained_database_authentication_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019_STANDARD",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[
+                        {"name": "contained database authentication", "value": "on"}
+                    ],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_contained_database_authentication_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 has 'contained database authentication' flag set to 'on'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
+    def test_cloudsql_instance_contained_database_authentication_flag_off(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_contained_database_authentication_flag.cloudsql_instance_sqlserver_contained_database_authentication_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_contained_database_authentication_flag.cloudsql_instance_sqlserver_contained_database_authentication_flag import (
+                cloudsql_instance_sqlserver_contained_database_authentication_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019_STANDARD",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[
+                        {"name": "contained database authentication", "value": "off"}
+                    ],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_contained_database_authentication_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 has 'contained database authentication' flag set to 'off'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag/cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag/cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag_test.py
@@ -1,0 +1,155 @@
+from unittest import mock
+
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_EU1_LOCATION,
+    GCP_PROJECT_ID,
+    set_mocked_gcp_provider,
+)
+
+
+class Test_cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag:
+    def test_no_cloudsql_instances(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag import (
+                cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag,
+            )
+
+            cloudsql_client.instances = []
+
+            check = cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_postgres_instance(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag import (
+                cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="POSTGRES_15",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_instance_cross_db_ownership_flag_on(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag import (
+                cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[{"name": "cross db ownership", "value": "on"}],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 does not have 'cross db ownership' flag set to 'off'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
+    def test_cloudsql_instance_cross_db_ownership_flag_off(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag import (
+                cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[{"name": "cross db ownership", "value": "off"}],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 has 'cross db ownership' flag set to 'off'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_external_scripts_enabled_flag/cloudsql_instance_sqlserver_external_scripts_enabled_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_external_scripts_enabled_flag/cloudsql_instance_sqlserver_external_scripts_enabled_flag_test.py
@@ -1,0 +1,155 @@
+from unittest import mock
+
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_EU1_LOCATION,
+    GCP_PROJECT_ID,
+    set_mocked_gcp_provider,
+)
+
+
+class Test_cloudsql_instance_sqlserver_external_scripts_enabled_flag:
+    def test_no_cloudsql_instances(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_external_scripts_enabled_flag.cloudsql_instance_sqlserver_external_scripts_enabled_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_external_scripts_enabled_flag.cloudsql_instance_sqlserver_external_scripts_enabled_flag import (
+                cloudsql_instance_sqlserver_external_scripts_enabled_flag,
+            )
+
+            cloudsql_client.instances = []
+
+            check = cloudsql_instance_sqlserver_external_scripts_enabled_flag()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_postgres_instance(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_external_scripts_enabled_flag.cloudsql_instance_sqlserver_external_scripts_enabled_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_external_scripts_enabled_flag.cloudsql_instance_sqlserver_external_scripts_enabled_flag import (
+                cloudsql_instance_sqlserver_external_scripts_enabled_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="POSTGRES_15",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_external_scripts_enabled_flag()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_sqlserver_instance_external_scripts_enabled_flag_on(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_external_scripts_enabled_flag.cloudsql_instance_sqlserver_external_scripts_enabled_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_external_scripts_enabled_flag.cloudsql_instance_sqlserver_external_scripts_enabled_flag import (
+                cloudsql_instance_sqlserver_external_scripts_enabled_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[{"name": "external scripts enabled", "value": "on"}],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_external_scripts_enabled_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 does not have 'external scripts enabled' flag set to 'off'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
+    def test_cloudsql_sqlserver_instance_external_scripts_enabled_flag_off(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_external_scripts_enabled_flag.cloudsql_instance_sqlserver_external_scripts_enabled_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_external_scripts_enabled_flag.cloudsql_instance_sqlserver_external_scripts_enabled_flag import (
+                cloudsql_instance_sqlserver_external_scripts_enabled_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[{"name": "external scripts enabled", "value": "off"}],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_external_scripts_enabled_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 has 'external scripts enabled' flag set to 'off'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_remote_access_flag/cloudsql_instance_sqlserver_remote_access_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_remote_access_flag/cloudsql_instance_sqlserver_remote_access_flag_test.py
@@ -1,0 +1,155 @@
+from unittest import mock
+
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_EU1_LOCATION,
+    GCP_PROJECT_ID,
+    set_mocked_gcp_provider,
+)
+
+
+class Test_cloudsql_instance_sqlserver_remote_access_flag:
+    def test_no_cloudsql_instances(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_remote_access_flag.cloudsql_instance_sqlserver_remote_access_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_remote_access_flag.cloudsql_instance_sqlserver_remote_access_flag import (
+                cloudsql_instance_sqlserver_remote_access_flag,
+            )
+
+            cloudsql_client.instances = []
+
+            check = cloudsql_instance_sqlserver_remote_access_flag()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_postgres_instance(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_remote_access_flag.cloudsql_instance_sqlserver_remote_access_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_remote_access_flag.cloudsql_instance_sqlserver_remote_access_flag import (
+                cloudsql_instance_sqlserver_remote_access_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="POSTGRES_15",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_remote_access_flag()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_instance_remote_access_flag_on(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_remote_access_flag.cloudsql_instance_sqlserver_remote_access_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_remote_access_flag.cloudsql_instance_sqlserver_remote_access_flag import (
+                cloudsql_instance_sqlserver_remote_access_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[{"name": "remote access", "value": "on"}],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_remote_access_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 has 'remote access' flag set to 'on'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
+    def test_cloudsql_instance_remote_access_flag_off(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_remote_access_flag.cloudsql_instance_sqlserver_remote_access_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_remote_access_flag.cloudsql_instance_sqlserver_remote_access_flag import (
+                cloudsql_instance_sqlserver_remote_access_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[{"name": "remote access", "value": "off"}],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_remote_access_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 does not have 'remote access' flag set to 'on'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_trace_flag/cloudsql_instance_sqlserver_trace_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_trace_flag/cloudsql_instance_sqlserver_trace_flag_test.py
@@ -1,0 +1,155 @@
+from unittest import mock
+
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_EU1_LOCATION,
+    GCP_PROJECT_ID,
+    set_mocked_gcp_provider,
+)
+
+
+class Test_cloudsql_instance_sqlserver_trace_flag:
+    def test_no_cloudsql_instances(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_trace_flag.cloudsql_instance_sqlserver_trace_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_trace_flag.cloudsql_instance_sqlserver_trace_flag import (
+                cloudsql_instance_sqlserver_trace_flag,
+            )
+
+            cloudsql_client.instances = []
+
+            check = cloudsql_instance_sqlserver_trace_flag()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_postgres_instance(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_trace_flag.cloudsql_instance_sqlserver_trace_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_trace_flag.cloudsql_instance_sqlserver_trace_flag import (
+                cloudsql_instance_sqlserver_trace_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="POSTGRES_15",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_trace_flag()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_instance_trace_flag_off(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_trace_flag.cloudsql_instance_sqlserver_trace_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_trace_flag.cloudsql_instance_sqlserver_trace_flag import (
+                cloudsql_instance_sqlserver_trace_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[{"name": "3625", "value": "off"}],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_trace_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 has '3625 (trace flag)' flag set to 'off'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
+    def test_cloudsql_instance_trace_flag_on(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_trace_flag.cloudsql_instance_sqlserver_trace_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_trace_flag.cloudsql_instance_sqlserver_trace_flag import (
+                cloudsql_instance_sqlserver_trace_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[{"name": "3625", "value": "on"}],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_trace_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 has '3625 (trace flag)' flag set to 'on'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_user_connections_flag/cloudsql_instance_sqlserver_user_connections_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_user_connections_flag/cloudsql_instance_sqlserver_user_connections_flag_test.py
@@ -1,0 +1,155 @@
+from unittest import mock
+
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_EU1_LOCATION,
+    GCP_PROJECT_ID,
+    set_mocked_gcp_provider,
+)
+
+
+class Test_cloudsql_instance_sqlserver_user_connections_flag:
+    def test_no_cloudsql_instances(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_connections_flag.cloudsql_instance_sqlserver_user_connections_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_connections_flag.cloudsql_instance_sqlserver_user_connections_flag import (
+                cloudsql_instance_sqlserver_user_connections_flag,
+            )
+
+            cloudsql_client.instances = []
+
+            check = cloudsql_instance_sqlserver_user_connections_flag()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_postgres_instance(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_connections_flag.cloudsql_instance_sqlserver_user_connections_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_connections_flag.cloudsql_instance_sqlserver_user_connections_flag import (
+                cloudsql_instance_sqlserver_user_connections_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="POSTGRES_15",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_user_connections_flag()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_sqlserver_instance_user_connections_flag_off(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_connections_flag.cloudsql_instance_sqlserver_user_connections_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_connections_flag.cloudsql_instance_sqlserver_user_connections_flag import (
+                cloudsql_instance_sqlserver_user_connections_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[{"name": "user connections", "value": "1"}],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_user_connections_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 does not have 'user connections' flag set to '0'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
+    def test_cloudsql_sqlserver_instance_user_connections_flag_on(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_connections_flag.cloudsql_instance_sqlserver_user_connections_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_connections_flag.cloudsql_instance_sqlserver_user_connections_flag import (
+                cloudsql_instance_sqlserver_user_connections_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[{"name": "user connections", "value": "0"}],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_user_connections_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 has 'user connections' flag set to '0'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_user_options_flag/cloudsql_instance_sqlserver_user_options_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_user_options_flag/cloudsql_instance_sqlserver_user_options_flag_test.py
@@ -1,0 +1,200 @@
+from unittest import mock
+
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_EU1_LOCATION,
+    GCP_PROJECT_ID,
+    set_mocked_gcp_provider,
+)
+
+
+class Test_cloudsql_instance_sqlserver_user_options_flag:
+    def test_no_cloudsql_instances(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_options_flag.cloudsql_instance_sqlserver_user_options_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_options_flag.cloudsql_instance_sqlserver_user_options_flag import (
+                cloudsql_instance_sqlserver_user_options_flag,
+            )
+
+            cloudsql_client.instances = []
+
+            check = cloudsql_instance_sqlserver_user_options_flag()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_postgres_instance(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_options_flag.cloudsql_instance_sqlserver_user_options_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_options_flag.cloudsql_instance_sqlserver_user_options_flag import (
+                cloudsql_instance_sqlserver_user_options_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="POSTGRES_15",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_user_options_flag()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_sqlserver_instance_no_flags(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_options_flag.cloudsql_instance_sqlserver_user_options_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_options_flag.cloudsql_instance_sqlserver_user_options_flag import (
+                cloudsql_instance_sqlserver_user_options_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_user_options_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 does not have 'user options' flag set."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
+    def test_cloudsql_sqlserver_instance_user_options_flag_empty(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_options_flag.cloudsql_instance_sqlserver_user_options_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_options_flag.cloudsql_instance_sqlserver_user_options_flag import (
+                cloudsql_instance_sqlserver_user_options_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[{"name": "user options", "value": ""}],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_user_options_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 does not have 'user options' flag set."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
+    def test_cloudsql_sqlserver_instance_user_options_flag_set(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_options_flag.cloudsql_instance_sqlserver_user_options_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_options_flag.cloudsql_instance_sqlserver_user_options_flag import (
+                cloudsql_instance_sqlserver_user_options_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[{"name": "user options", "value": "some_value"}],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_user_options_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 has 'user options' flag set."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_ssl_connections/cloudsql_instance_ssl_connections_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_ssl_connections/cloudsql_instance_ssl_connections_test.py
@@ -1,0 +1,119 @@
+from unittest import mock
+
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_EU1_LOCATION,
+    GCP_PROJECT_ID,
+    set_mocked_gcp_provider,
+)
+
+
+class Test_cloudsql_instance_ssl_connections:
+    def test_no_cloudsql_instances(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_ssl_connections.cloudsql_instance_ssl_connections.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_ssl_connections.cloudsql_instance_ssl_connections import (
+                cloudsql_instance_ssl_connections,
+            )
+
+            cloudsql_client.instances = []
+
+            check = cloudsql_instance_ssl_connections()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_cloudsql_instance_ssl_connections_enabled(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_ssl_connections.cloudsql_instance_ssl_connections.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_ssl_connections.cloudsql_instance_ssl_connections import (
+                cloudsql_instance_ssl_connections,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="POSTGRES_15",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=True,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_ssl_connections()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "Database Instance instance1 requires SSL connections."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
+    def test_cloudsql_instance_ssl_connections_disabled(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_ssl_connections.cloudsql_instance_ssl_connections.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_ssl_connections.cloudsql_instance_ssl_connections import (
+                cloudsql_instance_ssl_connections,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="POSTGRES_15",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_ssl_connections()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "Database Instance instance1 does not require SSL connections."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID


### PR DESCRIPTION
### Context

There are some CloudSQL checks without testing


### Description

Added new tests for the remaining  checks with various test cases

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
