### PR TITLE
fix(gcp): Not all gcp projects have name

### DIFF
--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -265,7 +265,7 @@ class GcpProvider(Provider):
                     gcp_project = GCPProject(
                         number=project["projectNumber"],
                         id=project_id,
-                        name=project["name"],
+                        name=project.get("name", project_id),
                         lifecycle_state=project["lifecycleState"],
                         labels=labels,
                     )


### PR DESCRIPTION
### Context

When I scanning GCP with Prowler, the following message appears:

```
2024-07-05 15:57:51,692 [File: gcp_provider.py:267] 	[Module: gcp_provider]	 CRITICAL: KeyError[231]: 'name'

2024-07-05 15:57:51,694 [File: gcp_provider.py:80] 	[Module: gcp_provider]	 CRITICAL: No Input Project IDs can be accessed via Google Credentials.
```

Turns out the project from the response of resource manager API may not contain `name` field.


### Description

This will fallback to project ID if project name is not provided.

I have retested the modified code again and works.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
