### PR TITLE
chore(cis): add CIS output class

### DIFF
--- a/prowler/lib/check/compliance.py
+++ b/prowler/lib/check/compliance.py
@@ -2,7 +2,7 @@ import sys
 
 from pydantic import parse_obj_as
 
-from prowler.lib.check.compliance_models import Compliance_Base_Model
+from prowler.lib.check.compliance_models import ComplianceBaseModel
 from prowler.lib.check.models import Check_Metadata_Model
 from prowler.lib.logger import logger
 
@@ -22,7 +22,7 @@ def update_checks_metadata_with_compliance(
                         # Include the requirement into the check's framework requirements
                         compliance_requirements.append(requirement)
                         # Create the Compliance_Model
-                        compliance = Compliance_Base_Model(
+                        compliance = ComplianceBaseModel(
                             Framework=framework.Framework,
                             Provider=framework.Provider,
                             Version=framework.Version,
@@ -43,7 +43,7 @@ def update_checks_metadata_with_compliance(
                 if not requirement.Checks:
                     compliance_requirements.append(requirement)
                     # Create the Compliance_Model
-                    compliance = Compliance_Base_Model(
+                    compliance = ComplianceBaseModel(
                         Framework=framework.Framework,
                         Provider=framework.Provider,
                         Version=framework.Version,

--- a/prowler/lib/check/compliance_models.py
+++ b/prowler/lib/check/compliance_models.py
@@ -189,8 +189,8 @@ class Compliance_Requirement(BaseModel):
     Checks: list[str]
 
 
-class Compliance_Base_Model(BaseModel):
-    """Compliance_Base_Model holds the base model for every compliance framework"""
+class ComplianceBaseModel(BaseModel):
+    """ComplianceBaseModel holds the base model for every compliance framework"""
 
     Framework: str
     Provider: str
@@ -218,10 +218,10 @@ class Compliance_Base_Model(BaseModel):
 # Testing Pending
 def load_compliance_framework(
     compliance_specification_file: str,
-) -> Compliance_Base_Model:
+) -> ComplianceBaseModel:
     """load_compliance_framework loads and parse a Compliance Framework Specification"""
     try:
-        compliance_framework = Compliance_Base_Model.parse_file(
+        compliance_framework = ComplianceBaseModel.parse_file(
             compliance_specification_file
         )
     except ValidationError as error:

--- a/prowler/lib/outputs/compliance/cis.py
+++ b/prowler/lib/outputs/compliance/cis.py
@@ -3,13 +3,11 @@ from tabulate import tabulate
 
 from prowler.config.config import orange_color
 from prowler.lib.logger import logger
-from prowler.lib.outputs.compliance.cis_aws import generate_compliance_row_cis_aws
 from prowler.lib.outputs.compliance.cis_azure import generate_compliance_row_cis_azure
 from prowler.lib.outputs.compliance.cis_gcp import generate_compliance_row_cis_gcp
 from prowler.lib.outputs.compliance.cis_kubernetes import (
     generate_compliance_row_cis_kubernetes,
 )
-from prowler.lib.outputs.csv.csv import write_csv
 
 
 def write_compliance_row_cis(
@@ -29,16 +27,7 @@ def write_compliance_row_cis(
         if compliance_output in str(input_compliance_frameworks):
             for requirement in compliance.Requirements:
                 for attribute in requirement.Attributes:
-                    if compliance.Provider == "AWS":
-                        (compliance_row, csv_header) = generate_compliance_row_cis_aws(
-                            finding,
-                            compliance,
-                            requirement,
-                            attribute,
-                            output_options,
-                            provider,
-                        )
-                    elif compliance.Provider == "Azure":
+                    if compliance.Provider == "Azure":
                         (compliance_row, csv_header) = (
                             generate_compliance_row_cis_azure(
                                 finding,
@@ -64,9 +53,9 @@ def write_compliance_row_cis(
                             )
                         )
 
-                    write_csv(
-                        file_descriptors[compliance_output], csv_header, compliance_row
-                    )
+                    # write_csv(
+                    #     file_descriptors[compliance_output], csv_header, compliance_row
+                    # )
     except Exception as error:
         logger.error(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"

--- a/prowler/lib/outputs/compliance/cis_aws.py
+++ b/prowler/lib/outputs/compliance/cis_aws.py
@@ -1,36 +1,67 @@
-from prowler.config.config import timestamp
-from prowler.lib.outputs.compliance.models import Check_Output_CSV_AWS_CIS
-from prowler.lib.outputs.csv.csv import generate_csv_fields
-from prowler.lib.utils.utils import outputs_unix_timestamp
+from csv import DictWriter
+from venv import logger
+
+from prowler.lib.check.compliance_models import ComplianceBaseModel
+from prowler.lib.outputs.compliance.compliance_output import ComplianceOutput
+from prowler.lib.outputs.compliance.models import AWS
+from prowler.lib.outputs.finding import Finding
 
 
-def generate_compliance_row_cis_aws(
-    finding, compliance, requirement, attribute, output_options, provider
-):
-    compliance_row = Check_Output_CSV_AWS_CIS(
-        Provider=finding.check_metadata.Provider,
-        Description=compliance.Description,
-        AccountId=provider.identity.account,
-        Region=finding.region,
-        AssessmentDate=outputs_unix_timestamp(output_options.unix_timestamp, timestamp),
-        Requirements_Id=requirement.Id,
-        Requirements_Description=requirement.Description,
-        Requirements_Attributes_Section=attribute.Section,
-        Requirements_Attributes_Profile=attribute.Profile,
-        Requirements_Attributes_AssessmentStatus=attribute.AssessmentStatus,
-        Requirements_Attributes_Description=attribute.Description,
-        Requirements_Attributes_RationaleStatement=attribute.RationaleStatement,
-        Requirements_Attributes_ImpactStatement=attribute.ImpactStatement,
-        Requirements_Attributes_RemediationProcedure=attribute.RemediationProcedure,
-        Requirements_Attributes_AuditProcedure=attribute.AuditProcedure,
-        Requirements_Attributes_AdditionalInformation=attribute.AdditionalInformation,
-        Requirements_Attributes_References=attribute.References,
-        Status=finding.status,
-        StatusExtended=finding.status_extended,
-        ResourceId=finding.resource_id,
-        CheckId=finding.check_metadata.CheckID,
-        Muted=finding.muted,
-    )
-    csv_header = generate_csv_fields(Check_Output_CSV_AWS_CIS)
+class AWSCIS(ComplianceOutput):
+    def transform(
+        self, findings: list[Finding], compliance: ComplianceBaseModel
+    ) -> None:
+        for finding in findings:
+            for requirement in compliance.Requirements:
+                for attribute in requirement.Attributes:
+                    compliance_row = AWS(
+                        Provider=finding.provider,
+                        Description=compliance.Description,
+                        AccountId=finding.account_uid,
+                        Region=finding.region,
+                        AssessmentDate=str(finding.timestamp),
+                        Requirements_Id=requirement.Id,
+                        Requirements_Description=requirement.Description,
+                        Requirements_Attributes_Section=attribute.Section,
+                        Requirements_Attributes_Profile=attribute.Profile,
+                        Requirements_Attributes_AssessmentStatus=attribute.AssessmentStatus,
+                        Requirements_Attributes_Description=attribute.Description,
+                        Requirements_Attributes_RationaleStatement=attribute.RationaleStatement,
+                        Requirements_Attributes_ImpactStatement=attribute.ImpactStatement,
+                        Requirements_Attributes_RemediationProcedure=attribute.RemediationProcedure,
+                        Requirements_Attributes_AuditProcedure=attribute.AuditProcedure,
+                        Requirements_Attributes_AdditionalInformation=attribute.AdditionalInformation,
+                        Requirements_Attributes_References=attribute.References,
+                        Status=finding.status,
+                        StatusExtended=finding.status_extended,
+                        ResourceId=finding.resource_uid,
+                        CheckId=finding.check_id,
+                        Muted=finding.muted,
+                    )
+                    self._data.append(compliance_row)
 
-    return compliance_row, csv_header
+    def batch_write_data_to_file(self, header: bool) -> None:
+        try:
+            if (
+                getattr(self, "_file_descriptor", None)
+                and not self._file_descriptor.closed
+                and self._data
+            ):
+                csv_writer = DictWriter(
+                    self._file_descriptor,
+                    fieldnames=[
+                        field.upper() for field in self._data[0].__dict__.keys()
+                    ],
+                    delimiter=";",
+                )
+                if header:
+                    csv_writer.writeheader()
+                for finding in self._data:
+                    for key in list(finding.__dict__.keys()):
+                        finding.__dict__[key.upper()] = finding.__dict__.pop(key)
+                    csv_writer.writerow(finding.dict())
+                self._file_descriptor.close()
+        except Exception as error:
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )

--- a/prowler/lib/outputs/compliance/cis_azure.py
+++ b/prowler/lib/outputs/compliance/cis_azure.py
@@ -1,37 +1,68 @@
-from prowler.config.config import timestamp
+from csv import DictWriter
+from venv import logger
+
+from prowler.lib.check.compliance_models import ComplianceBaseModel
+from prowler.lib.outputs.compliance.compliance_output import ComplianceOutput
 from prowler.lib.outputs.compliance.models import Azure
-from prowler.lib.outputs.csv.csv import generate_csv_fields
-from prowler.lib.utils.utils import outputs_unix_timestamp
+from prowler.lib.outputs.finding import Finding
 
 
-def generate_compliance_row_cis_azure(
-    finding, compliance, requirement, attribute, output_options
-):
-    compliance_row = Azure(
-        Provider=finding.check_metadata.Provider,
-        Description=compliance.Description,
-        Subscription=finding.subscription,
-        AssessmentDate=outputs_unix_timestamp(output_options.unix_timestamp, timestamp),
-        Requirements_Id=requirement.Id,
-        Requirements_Description=requirement.Description,
-        Requirements_Attributes_Section=attribute.Section,
-        Requirements_Attributes_Profile=attribute.Profile,
-        Requirements_Attributes_AssessmentStatus=attribute.AssessmentStatus,
-        Requirements_Attributes_Description=attribute.Description,
-        Requirements_Attributes_RationaleStatement=attribute.RationaleStatement,
-        Requirements_Attributes_ImpactStatement=attribute.ImpactStatement,
-        Requirements_Attributes_RemediationProcedure=attribute.RemediationProcedure,
-        Requirements_Attributes_AuditProcedure=attribute.AuditProcedure,
-        Requirements_Attributes_AdditionalInformation=attribute.AdditionalInformation,
-        Requirements_Attributes_DefaultValue=attribute.DefaultValue,
-        Requirements_Attributes_References=attribute.References,
-        Status=finding.status,
-        StatusExtended=finding.status_extended,
-        ResourceId=finding.resource_id,
-        ResourceName=finding.resource_name,
-        CheckId=finding.check_metadata.CheckID,
-        Muted=finding.muted,
-    )
-    csv_header = generate_csv_fields(Azure)
+class AzureCIS(ComplianceOutput):
+    def transform(
+        self, findings: list[Finding], compliance: ComplianceBaseModel
+    ) -> None:
+        for finding in findings:
+            for requirement in compliance.Requirements:
+                for attribute in requirement.Attributes:
+                    compliance_row = Azure(
+                        Provider=finding.provider,
+                        Description=compliance.Description,
+                        Subscription=finding.subscription,
+                        AssessmentDate=str(finding.timestamp),
+                        Requirements_Id=requirement.Id,
+                        Requirements_Description=requirement.Description,
+                        Requirements_Attributes_Section=attribute.Section,
+                        Requirements_Attributes_Profile=attribute.Profile,
+                        Requirements_Attributes_AssessmentStatus=attribute.AssessmentStatus,
+                        Requirements_Attributes_Description=attribute.Description,
+                        Requirements_Attributes_RationaleStatement=attribute.RationaleStatement,
+                        Requirements_Attributes_ImpactStatement=attribute.ImpactStatement,
+                        Requirements_Attributes_RemediationProcedure=attribute.RemediationProcedure,
+                        Requirements_Attributes_AuditProcedure=attribute.AuditProcedure,
+                        Requirements_Attributes_AdditionalInformation=attribute.AdditionalInformation,
+                        Requirements_Attributes_DefaultValue=attribute.DefaultValue,
+                        Requirements_Attributes_References=attribute.References,
+                        Status=finding.status,
+                        StatusExtended=finding.status_extended,
+                        ResourceId=finding.resource_id,
+                        ResourceName=finding.resource_name,
+                        CheckId=finding.check_id,
+                        Muted=finding.muted,
+                    )
+                    self._data.append(compliance_row)
 
-    return compliance_row, csv_header
+    def batch_write_data_to_file(self, header: bool) -> None:
+        try:
+            if (
+                getattr(self, "_file_descriptor", None)
+                and not self._file_descriptor.closed
+                and self._data
+            ):
+                csv_writer = DictWriter(
+                    self._file_descriptor,
+                    fieldnames=[
+                        field.upper() for field in self._data[0].__dict__.keys()
+                    ],
+                    delimiter=";",
+                )
+                if header:
+                    csv_writer.writeheader()
+                for finding in self._data:
+                    for key in list(finding.__dict__.keys()):
+                        finding.__dict__[key.upper()] = finding.__dict__.pop(key)
+                    csv_writer.writerow(finding.dict())
+                self._file_descriptor.close()
+        except Exception as error:
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )

--- a/prowler/lib/outputs/compliance/cis_azure.py
+++ b/prowler/lib/outputs/compliance/cis_azure.py
@@ -1,5 +1,5 @@
 from prowler.config.config import timestamp
-from prowler.lib.outputs.compliance.models import Check_Output_CSV_AZURE_CIS
+from prowler.lib.outputs.compliance.models import Azure
 from prowler.lib.outputs.csv.csv import generate_csv_fields
 from prowler.lib.utils.utils import outputs_unix_timestamp
 
@@ -7,7 +7,7 @@ from prowler.lib.utils.utils import outputs_unix_timestamp
 def generate_compliance_row_cis_azure(
     finding, compliance, requirement, attribute, output_options
 ):
-    compliance_row = Check_Output_CSV_AZURE_CIS(
+    compliance_row = Azure(
         Provider=finding.check_metadata.Provider,
         Description=compliance.Description,
         Subscription=finding.subscription,
@@ -32,6 +32,6 @@ def generate_compliance_row_cis_azure(
         CheckId=finding.check_metadata.CheckID,
         Muted=finding.muted,
     )
-    csv_header = generate_csv_fields(Check_Output_CSV_AZURE_CIS)
+    csv_header = generate_csv_fields(Azure)
 
     return compliance_row, csv_header

--- a/prowler/lib/outputs/compliance/cis_gcp.py
+++ b/prowler/lib/outputs/compliance/cis_gcp.py
@@ -1,5 +1,5 @@
 from prowler.config.config import timestamp
-from prowler.lib.outputs.compliance.models import Check_Output_CSV_GCP_CIS
+from prowler.lib.outputs.compliance.models import GCP
 from prowler.lib.outputs.csv.csv import generate_csv_fields
 from prowler.lib.utils.utils import outputs_unix_timestamp
 
@@ -7,7 +7,7 @@ from prowler.lib.utils.utils import outputs_unix_timestamp
 def generate_compliance_row_cis_gcp(
     finding, compliance, requirement, attribute, output_options
 ):
-    compliance_row = Check_Output_CSV_GCP_CIS(
+    compliance_row = GCP(
         Provider=finding.check_metadata.Provider,
         Description=compliance.Description,
         ProjectId=finding.project_id,
@@ -32,6 +32,6 @@ def generate_compliance_row_cis_gcp(
         CheckId=finding.check_metadata.CheckID,
         Muted=finding.muted,
     )
-    csv_header = generate_csv_fields(Check_Output_CSV_GCP_CIS)
+    csv_header = generate_csv_fields(GCP)
 
     return compliance_row, csv_header

--- a/prowler/lib/outputs/compliance/cis_gcp.py
+++ b/prowler/lib/outputs/compliance/cis_gcp.py
@@ -1,37 +1,68 @@
-from prowler.config.config import timestamp
+from csv import DictWriter
+from venv import logger
+
+from prowler.lib.check.compliance_models import ComplianceBaseModel
+from prowler.lib.outputs.compliance.compliance_output import ComplianceOutput
 from prowler.lib.outputs.compliance.models import GCP
-from prowler.lib.outputs.csv.csv import generate_csv_fields
-from prowler.lib.utils.utils import outputs_unix_timestamp
+from prowler.lib.outputs.finding import Finding
 
 
-def generate_compliance_row_cis_gcp(
-    finding, compliance, requirement, attribute, output_options
-):
-    compliance_row = GCP(
-        Provider=finding.check_metadata.Provider,
-        Description=compliance.Description,
-        ProjectId=finding.project_id,
-        Location=finding.location.lower(),
-        AssessmentDate=outputs_unix_timestamp(output_options.unix_timestamp, timestamp),
-        Requirements_Id=requirement.Id,
-        Requirements_Description=requirement.Description,
-        Requirements_Attributes_Section=attribute.Section,
-        Requirements_Attributes_Profile=attribute.Profile,
-        Requirements_Attributes_AssessmentStatus=attribute.AssessmentStatus,
-        Requirements_Attributes_Description=attribute.Description,
-        Requirements_Attributes_RationaleStatement=attribute.RationaleStatement,
-        Requirements_Attributes_ImpactStatement=attribute.ImpactStatement,
-        Requirements_Attributes_RemediationProcedure=attribute.RemediationProcedure,
-        Requirements_Attributes_AuditProcedure=attribute.AuditProcedure,
-        Requirements_Attributes_AdditionalInformation=attribute.AdditionalInformation,
-        Requirements_Attributes_References=attribute.References,
-        Status=finding.status,
-        StatusExtended=finding.status_extended,
-        ResourceId=finding.resource_id,
-        ResourceName=finding.resource_name,
-        CheckId=finding.check_metadata.CheckID,
-        Muted=finding.muted,
-    )
-    csv_header = generate_csv_fields(GCP)
+class GCPCIS(ComplianceOutput):
+    def transform(
+        self, findings: list[Finding], compliance: ComplianceBaseModel
+    ) -> None:
+        for finding in findings:
+            for requirement in compliance.Requirements:
+                for attribute in requirement.Attributes:
+                    compliance_row = GCP(
+                        Provider=finding.provider,
+                        Description=compliance.Description,
+                        ProjectId=finding.project_id,
+                        Location=finding.location.lower(),
+                        AssessmentDate=str(finding.timestamp),
+                        Requirements_Id=requirement.Id,
+                        Requirements_Description=requirement.Description,
+                        Requirements_Attributes_Section=attribute.Section,
+                        Requirements_Attributes_Profile=attribute.Profile,
+                        Requirements_Attributes_AssessmentStatus=attribute.AssessmentStatus,
+                        Requirements_Attributes_Description=attribute.Description,
+                        Requirements_Attributes_RationaleStatement=attribute.RationaleStatement,
+                        Requirements_Attributes_ImpactStatement=attribute.ImpactStatement,
+                        Requirements_Attributes_RemediationProcedure=attribute.RemediationProcedure,
+                        Requirements_Attributes_AuditProcedure=attribute.AuditProcedure,
+                        Requirements_Attributes_AdditionalInformation=attribute.AdditionalInformation,
+                        Requirements_Attributes_References=attribute.References,
+                        Status=finding.status,
+                        StatusExtended=finding.status_extended,
+                        ResourceId=finding.resource_id,
+                        ResourceName=finding.resource_name,
+                        CheckId=finding.check_id,
+                        Muted=finding.muted,
+                    )
+                    self._data.append(compliance_row)
 
-    return compliance_row, csv_header
+    def batch_write_data_to_file(self, header: bool) -> None:
+        try:
+            if (
+                getattr(self, "_file_descriptor", None)
+                and not self._file_descriptor.closed
+                and self._data
+            ):
+                csv_writer = DictWriter(
+                    self._file_descriptor,
+                    fieldnames=[
+                        field.upper() for field in self._data[0].__dict__.keys()
+                    ],
+                    delimiter=";",
+                )
+                if header:
+                    csv_writer.writeheader()
+                for finding in self._data:
+                    for key in list(finding.__dict__.keys()):
+                        finding.__dict__[key.upper()] = finding.__dict__.pop(key)
+                    csv_writer.writerow(finding.dict())
+                self._file_descriptor.close()
+        except Exception as error:
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )

--- a/prowler/lib/outputs/compliance/cis_kubernetes.py
+++ b/prowler/lib/outputs/compliance/cis_kubernetes.py
@@ -1,5 +1,5 @@
 from prowler.config.config import timestamp
-from prowler.lib.outputs.compliance.models import Check_Output_CSV_KUBERNETES_CIS
+from prowler.lib.outputs.compliance.models import Kubernetes
 from prowler.lib.outputs.csv.csv import generate_csv_fields
 from prowler.lib.utils.utils import outputs_unix_timestamp
 
@@ -7,7 +7,7 @@ from prowler.lib.utils.utils import outputs_unix_timestamp
 def generate_compliance_row_cis_kubernetes(
     finding, compliance, requirement, attribute, output_options, provider
 ):
-    compliance_row = Check_Output_CSV_KUBERNETES_CIS(
+    compliance_row = Kubernetes(
         Provider=finding.check_metadata.Provider,
         Description=compliance.Description,
         Context=provider.identity.context,
@@ -32,6 +32,6 @@ def generate_compliance_row_cis_kubernetes(
         CheckId=finding.check_metadata.CheckID,
         Muted=finding.muted,
     )
-    csv_header = generate_csv_fields(Check_Output_CSV_KUBERNETES_CIS)
+    csv_header = generate_csv_fields(Kubernetes)
 
     return compliance_row, csv_header

--- a/prowler/lib/outputs/compliance/cis_kubernetes.py
+++ b/prowler/lib/outputs/compliance/cis_kubernetes.py
@@ -1,37 +1,68 @@
-from prowler.config.config import timestamp
+from csv import DictWriter
+from venv import logger
+
+from prowler.lib.check.compliance_models import ComplianceBaseModel
+from prowler.lib.outputs.compliance.compliance_output import ComplianceOutput
 from prowler.lib.outputs.compliance.models import Kubernetes
-from prowler.lib.outputs.csv.csv import generate_csv_fields
-from prowler.lib.utils.utils import outputs_unix_timestamp
+from prowler.lib.outputs.finding import Finding
 
 
-def generate_compliance_row_cis_kubernetes(
-    finding, compliance, requirement, attribute, output_options, provider
-):
-    compliance_row = Kubernetes(
-        Provider=finding.check_metadata.Provider,
-        Description=compliance.Description,
-        Context=provider.identity.context,
-        Namespace=finding.namespace,
-        AssessmentDate=outputs_unix_timestamp(output_options.unix_timestamp, timestamp),
-        Requirements_Id=requirement.Id,
-        Requirements_Description=requirement.Description,
-        Requirements_Attributes_Section=attribute.Section,
-        Requirements_Attributes_Profile=attribute.Profile,
-        Requirements_Attributes_AssessmentStatus=attribute.AssessmentStatus,
-        Requirements_Attributes_Description=attribute.Description,
-        Requirements_Attributes_RationaleStatement=attribute.RationaleStatement,
-        Requirements_Attributes_ImpactStatement=attribute.ImpactStatement,
-        Requirements_Attributes_RemediationProcedure=attribute.RemediationProcedure,
-        Requirements_Attributes_AuditProcedure=attribute.AuditProcedure,
-        Requirements_Attributes_AdditionalInformation=attribute.AdditionalInformation,
-        Requirements_Attributes_References=attribute.References,
-        Requirements_Attributes_DefaultValue=attribute.DefaultValue,
-        Status=finding.status,
-        StatusExtended=finding.status_extended,
-        ResourceId=finding.resource_id,
-        CheckId=finding.check_metadata.CheckID,
-        Muted=finding.muted,
-    )
-    csv_header = generate_csv_fields(Kubernetes)
+class KubernetesCIS(ComplianceOutput):
+    def transform(
+        self, findings: list[Finding], compliance: ComplianceBaseModel
+    ) -> None:
+        for finding in findings:
+            for requirement in compliance.Requirements:
+                for attribute in requirement.Attributes:
+                    compliance_row = Kubernetes(
+                        Provider=finding.check_metadata.Provider,
+                        Description=compliance.Description,
+                        Context=finding.context,
+                        Namespace=finding.namespace,
+                        AssessmentDate=str(finding.timestamp),
+                        Requirements_Id=requirement.Id,
+                        Requirements_Description=requirement.Description,
+                        Requirements_Attributes_Section=attribute.Section,
+                        Requirements_Attributes_Profile=attribute.Profile,
+                        Requirements_Attributes_AssessmentStatus=attribute.AssessmentStatus,
+                        Requirements_Attributes_Description=attribute.Description,
+                        Requirements_Attributes_RationaleStatement=attribute.RationaleStatement,
+                        Requirements_Attributes_ImpactStatement=attribute.ImpactStatement,
+                        Requirements_Attributes_RemediationProcedure=attribute.RemediationProcedure,
+                        Requirements_Attributes_AuditProcedure=attribute.AuditProcedure,
+                        Requirements_Attributes_AdditionalInformation=attribute.AdditionalInformation,
+                        Requirements_Attributes_References=attribute.References,
+                        Requirements_Attributes_DefaultValue=attribute.DefaultValue,
+                        Status=finding.status,
+                        StatusExtended=finding.status_extended,
+                        ResourceId=finding.resource_id,
+                        CheckId=finding.check_id,
+                        Muted=finding.muted,
+                    )
+                    self._data.append(compliance_row)
 
-    return compliance_row, csv_header
+    def batch_write_data_to_file(self, header: bool) -> None:
+        try:
+            if (
+                getattr(self, "_file_descriptor", None)
+                and not self._file_descriptor.closed
+                and self._data
+            ):
+                csv_writer = DictWriter(
+                    self._file_descriptor,
+                    fieldnames=[
+                        field.upper() for field in self._data[0].__dict__.keys()
+                    ],
+                    delimiter=";",
+                )
+                if header:
+                    csv_writer.writeheader()
+                for finding in self._data:
+                    for key in list(finding.__dict__.keys()):
+                        finding.__dict__[key.upper()] = finding.__dict__.pop(key)
+                    csv_writer.writerow(finding.dict())
+                self._file_descriptor.close()
+        except Exception as error:
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )

--- a/prowler/lib/outputs/compliance/compliance_output.py
+++ b/prowler/lib/outputs/compliance/compliance_output.py
@@ -1,0 +1,85 @@
+from abc import ABC, abstractmethod
+from io import TextIOWrapper
+from typing import List
+
+from prowler.lib.check.compliance_models import ComplianceBaseModel
+from prowler.lib.logger import logger
+from prowler.lib.outputs.finding import Finding
+from prowler.lib.utils.utils import open_file
+
+
+class ComplianceOutput(ABC):
+    """
+    This class represents an abstract base class for defining different types of outputs for findings.
+
+    Attributes:
+        _data (list): A list to store transformed data from findings.
+        _file_descriptor (TextIOWrapper): A file descriptor to write data to a file.
+
+    Methods:
+        __init__: Initializes the Output class with findings, optionally creates a file descriptor.
+        data: Property to access the transformed data.
+        file_descriptor: Property to access the file descriptor.
+        transform: Abstract method to transform findings into a specific format.
+        batch_write_data_to_file: Abstract method to write data to a file in batches.
+        create_file_descriptor: Method to create a file descriptor for writing data to a file.
+    """
+
+    _data: list
+    _file_descriptor: TextIOWrapper
+
+    def __init__(
+        self,
+        findings: List[Finding],
+        compliance: ComplianceBaseModel,
+        create_file_descriptor: bool = False,
+        file_path: str = None,
+    ) -> None:
+        self._data = []
+        if findings:
+            self.transform(findings, compliance)
+            if create_file_descriptor:
+                self.create_file_descriptor(file_path)
+
+    @property
+    def data(self):
+        return self._data
+
+    @property
+    def file_descriptor(self):
+        return self._file_descriptor
+
+    @abstractmethod
+    def transform(self, findings: List[Finding], compliance: dict):
+        raise NotImplementedError
+
+    @abstractmethod
+    def batch_write_data_to_file(self, file_descriptor: TextIOWrapper) -> None:
+        raise NotImplementedError
+
+    def create_file_descriptor(self, file_path) -> None:
+        """
+        Creates a file descriptor for writing data to a file.
+
+        Parameters:
+            file_path (str): The path to the file where the data will be written.
+
+        Returns:
+            None
+
+        Raises:
+            Any exception that occurs during the file creation process will be caught and logged using the logger.
+
+        Note:
+            The file is opened in append mode ("a") to ensure data is written at the end of the file without overwriting existing content.
+        """
+        try:
+            mode = "a"
+            self._file_descriptor = open_file(
+                file_path,
+                mode,
+            )
+        except Exception as error:
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )

--- a/prowler/lib/outputs/compliance/models.py
+++ b/prowler/lib/outputs/compliance/models.py
@@ -32,11 +32,7 @@ class Check_Output_CSV_ENS_RD2022(BaseModel):
     Muted: bool
 
 
-class Check_Output_CSV_AWS_CIS(BaseModel):
-    """
-    Check_Output_CSV_CIS generates a finding's output in CSV CIS format.
-    """
-
+class CIS(BaseModel):
     Provider: str
     Description: str
     AccountId: str
@@ -61,94 +57,40 @@ class Check_Output_CSV_AWS_CIS(BaseModel):
     Muted: bool
 
 
-class Check_Output_CSV_AZURE_CIS(BaseModel):
+class AWS(CIS):
     """
     Check_Output_CSV_CIS generates a finding's output in CSV CIS format.
     """
 
-    Provider: str
-    Description: str
+    AccountId: str
+    Region: str
+
+
+class Azure(CIS):
+    """
+    Check_Output_CSV_CIS generates a finding's output in CSV CIS format.
+    """
+
     Subscription: str
-    AssessmentDate: str
-    Requirements_Id: str
-    Requirements_Description: str
-    Requirements_Attributes_Section: str
-    Requirements_Attributes_Profile: str
-    Requirements_Attributes_AssessmentStatus: str
-    Requirements_Attributes_Description: str
-    Requirements_Attributes_RationaleStatement: str
-    Requirements_Attributes_ImpactStatement: str
-    Requirements_Attributes_RemediationProcedure: str
-    Requirements_Attributes_AuditProcedure: str
-    Requirements_Attributes_AdditionalInformation: str
-    Requirements_Attributes_DefaultValue: str
-    Requirements_Attributes_References: str
-    Status: str
-    StatusExtended: str
-    ResourceId: str
-    ResourceName: str
-    CheckId: str
-    Muted: bool
+    Location: str
 
 
-class Check_Output_CSV_GCP_CIS(BaseModel):
+class GCP(CIS):
     """
     Check_Output_CSV_CIS generates a finding's output in CSV CIS format.
     """
 
-    Provider: str
-    Description: str
     ProjectId: str
     Location: str
-    AssessmentDate: str
-    Requirements_Id: str
-    Requirements_Description: str
-    Requirements_Attributes_Section: str
-    Requirements_Attributes_Profile: str
-    Requirements_Attributes_AssessmentStatus: str
-    Requirements_Attributes_Description: str
-    Requirements_Attributes_RationaleStatement: str
-    Requirements_Attributes_ImpactStatement: str
-    Requirements_Attributes_RemediationProcedure: str
-    Requirements_Attributes_AuditProcedure: str
-    Requirements_Attributes_AdditionalInformation: str
-    Requirements_Attributes_References: str
-    Status: str
-    StatusExtended: str
-    ResourceId: str
-    ResourceName: str
-    CheckId: str
-    Muted: bool
 
 
-class Check_Output_CSV_KUBERNETES_CIS(BaseModel):
+class Kubernetes(CIS):
     """
     Check_Output_CSV_CIS generates a finding's output in CSV CIS format.
     """
 
-    Provider: str
-    Description: str
     Context: str
     Namespace: str
-    AssessmentDate: str
-    Requirements_Id: str
-    Requirements_Description: str
-    Requirements_Attributes_Section: str
-    Requirements_Attributes_Profile: str
-    Requirements_Attributes_AssessmentStatus: str
-    Requirements_Attributes_Description: str
-    Requirements_Attributes_RationaleStatement: str
-    Requirements_Attributes_ImpactStatement: str
-    Requirements_Attributes_RemediationProcedure: str
-    Requirements_Attributes_AuditProcedure: str
-    Requirements_Attributes_AdditionalInformation: str
-    Requirements_Attributes_References: str
-    Requirements_Attributes_DefaultValue: str
-    Status: str
-    StatusExtended: str
-    ResourceId: str
-    CheckId: str
-    Muted: bool
 
 
 class Check_Output_CSV_Generic_Compliance(BaseModel):

--- a/prowler/lib/outputs/file_descriptors.py
+++ b/prowler/lib/outputs/file_descriptors.py
@@ -10,14 +10,12 @@ from prowler.lib.outputs.compliance.mitre_attack.models import (
     MitreAttackGCP,
 )
 from prowler.lib.outputs.compliance.models import (
-    Check_Output_CSV_AWS_CIS,
+    Azure,
     Check_Output_CSV_AWS_ISO27001_2013,
     Check_Output_CSV_AWS_Well_Architected,
-    Check_Output_CSV_AZURE_CIS,
     Check_Output_CSV_ENS_RD2022,
-    Check_Output_CSV_GCP_CIS,
     Check_Output_CSV_Generic_Compliance,
-    Check_Output_CSV_KUBERNETES_CIS,
+    Kubernetes,
 )
 from prowler.lib.outputs.csv.csv import generate_csv_fields
 from prowler.lib.outputs.output import Finding
@@ -74,15 +72,7 @@ def fill_file_descriptors(output_modes, output_directory, output_filename, provi
 
                 elif provider.type == "gcp":
                     filename = f"{output_directory}/compliance/{output_filename}_{output_mode}{csv_file_suffix}"
-                    if "cis_" in output_mode:
-                        file_descriptor = initialize_file_descriptor(
-                            filename,
-                            output_mode,
-                            provider.type,
-                            Check_Output_CSV_GCP_CIS,
-                        )
-                        file_descriptors.update({output_mode: file_descriptor})
-                    elif output_mode == "mitre_attack_gcp":
+                    if output_mode == "mitre_attack_gcp":
                         file_descriptor = initialize_file_descriptor(
                             filename,
                             output_mode,
@@ -106,7 +96,7 @@ def fill_file_descriptors(output_modes, output_directory, output_filename, provi
                             filename,
                             output_mode,
                             provider.type,
-                            Check_Output_CSV_KUBERNETES_CIS,
+                            Kubernetes,
                         )
                         file_descriptors.update({output_mode: file_descriptor})
                     else:
@@ -125,7 +115,7 @@ def fill_file_descriptors(output_modes, output_directory, output_filename, provi
                             filename,
                             output_mode,
                             provider.type,
-                            Check_Output_CSV_AZURE_CIS,
+                            Azure,
                         )
                         file_descriptors.update({output_mode: file_descriptor})
                     elif output_mode == "mitre_attack_azure":
@@ -157,15 +147,6 @@ def fill_file_descriptors(output_modes, output_directory, output_filename, provi
                         )
                         file_descriptors.update({output_mode: file_descriptor})
 
-                    elif "cis_" in output_mode:
-                        file_descriptor = initialize_file_descriptor(
-                            filename,
-                            output_mode,
-                            provider.type,
-                            Check_Output_CSV_AWS_CIS,
-                        )
-                        file_descriptors.update({output_mode: file_descriptor})
-
                     elif "aws_well_architected_framework" in output_mode:
                         file_descriptor = initialize_file_descriptor(
                             filename,
@@ -194,14 +175,15 @@ def fill_file_descriptors(output_modes, output_directory, output_filename, provi
                         file_descriptors.update({output_mode: file_descriptor})
 
                     else:
-                        # Generic Compliance framework
-                        file_descriptor = initialize_file_descriptor(
-                            filename,
-                            output_mode,
-                            provider.type,
-                            Check_Output_CSV_Generic_Compliance,
-                        )
-                        file_descriptors.update({output_mode: file_descriptor})
+                        if "cis_" not in output_mode:
+                            # Generic Compliance framework
+                            file_descriptor = initialize_file_descriptor(
+                                filename,
+                                output_mode,
+                                provider.type,
+                                Check_Output_CSV_Generic_Compliance,
+                            )
+                            file_descriptors.update({output_mode: file_descriptor})
 
     except Exception as error:
         logger.error(

--- a/tests/lib/check/compliance_check_test.py
+++ b/tests/lib/check/compliance_check_test.py
@@ -3,8 +3,8 @@ from prowler.lib.check.compliance_models import (
     CIS_Requirement_Attribute,
     CIS_Requirement_Attribute_AssessmentStatus,
     CIS_Requirement_Attribute_Profile,
-    Compliance_Base_Model,
     Compliance_Requirement,
+    ComplianceBaseModel,
 )
 from prowler.lib.check.models import Check_Metadata_Model
 
@@ -14,7 +14,7 @@ class TestCompliance:
 
     def get_custom_framework(self):
         return {
-            "framework1": Compliance_Base_Model(
+            "framework1": ComplianceBaseModel(
                 Framework="Framework1",
                 Provider="Provider1",
                 Version="1.0",

--- a/tests/lib/outputs/compliance/compliance_test.py
+++ b/tests/lib/outputs/compliance/compliance_test.py
@@ -2,15 +2,15 @@ from mock import MagicMock
 
 from prowler.lib.check.compliance_models import (
     CIS_Requirement_Attribute,
-    Compliance_Base_Model,
     Compliance_Requirement,
+    ComplianceBaseModel,
 )
 from prowler.lib.outputs.compliance.compliance import (
     get_check_compliance_frameworks_in_input,
 )
 
 CIS_1_4_AWS_NAME = "cis_1.4_aws"
-CIS_1_4_AWS = Compliance_Base_Model(
+CIS_1_4_AWS = ComplianceBaseModel(
     Framework="CIS",
     Provider="AWS",
     Version="1.4",
@@ -38,7 +38,7 @@ CIS_1_4_AWS = Compliance_Base_Model(
     ],
 )
 CIS_1_5_AWS_NAME = "cis_1.5_aws"
-CIS_1_5_AWS = Compliance_Base_Model(
+CIS_1_5_AWS = ComplianceBaseModel(
     Framework="CIS",
     Provider="AWS",
     Version="1.5",
@@ -67,7 +67,7 @@ CIS_1_5_AWS = Compliance_Base_Model(
 )
 
 NOT_PRESENT_COMPLIANCE_NAME = "not_present_compliance_name"
-NOT_PRESENT_COMPLIANCE = Compliance_Base_Model(
+NOT_PRESENT_COMPLIANCE = ComplianceBaseModel(
     Framework="NOT_EXISTENT",
     Provider="NOT_EXISTENT",
     Version="NOT_EXISTENT",

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -6,8 +6,8 @@ from colorama import Fore
 
 from prowler.lib.check.compliance_models import (
     CIS_Requirement_Attribute,
-    Compliance_Base_Model,
     Compliance_Requirement,
+    ComplianceBaseModel,
 )
 from prowler.lib.check.models import Check_Report, load_check_metadata
 from prowler.lib.outputs.compliance.compliance import get_check_compliance
@@ -329,7 +329,7 @@ class TestOutputs:
 
     def test_get_check_compliance_aws(self):
         bulk_check_metadata = [
-            Compliance_Base_Model(
+            ComplianceBaseModel(
                 Framework="CIS",
                 Provider="AWS",
                 Version="1.4",
@@ -356,7 +356,7 @@ class TestOutputs:
                     )
                 ],
             ),
-            Compliance_Base_Model(
+            ComplianceBaseModel(
                 Framework="CIS",
                 Provider="AWS",
                 Version="1.5",
@@ -413,7 +413,7 @@ class TestOutputs:
 
     def test_get_check_compliance_gcp(self):
         bulk_check_metadata = [
-            Compliance_Base_Model(
+            ComplianceBaseModel(
                 Framework="CIS",
                 Provider="GCP",
                 Version="2.0",
@@ -440,7 +440,7 @@ class TestOutputs:
                     )
                 ],
             ),
-            Compliance_Base_Model(
+            ComplianceBaseModel(
                 Framework="CIS",
                 Provider="GCP",
                 Version="2.1",
@@ -497,7 +497,7 @@ class TestOutputs:
 
     def test_get_check_compliance_azure(self):
         bulk_check_metadata = [
-            Compliance_Base_Model(
+            ComplianceBaseModel(
                 Framework="CIS",
                 Provider="Azure",
                 Version="2.0",
@@ -524,7 +524,7 @@ class TestOutputs:
                     )
                 ],
             ),
-            Compliance_Base_Model(
+            ComplianceBaseModel(
                 Framework="CIS",
                 Provider="Azure",
                 Version="2.1",
@@ -581,7 +581,7 @@ class TestOutputs:
 
     def test_get_check_compliance_kubernetes(self):
         bulk_check_metadata = [
-            Compliance_Base_Model(
+            ComplianceBaseModel(
                 Framework="CIS",
                 Provider="Kubernetes",
                 Version="2.0",
@@ -608,7 +608,7 @@ class TestOutputs:
                     )
                 ],
             ),
-            Compliance_Base_Model(
+            ComplianceBaseModel(
                 Framework="CIS",
                 Provider="Kubernetes",
                 Version="2.1",


### PR DESCRIPTION
### Description

CIS specific compliance output should have an isolated class

`get_check_compliance_frameworks_in_input` -> Should return a dict["check_id": "compliance"]

This way, inside the method transform from each provider cis class, should change from `for requirement in compliance.Requirements:` to `for requirement in compliance["check_id"]`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
