### PR TITLE
chore(templates): update to remove titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: 🐞 Bug Report
 description: Create a report to help us improve
-title: "[Bug]: "
+title: ""
 labels: ["bug", "status/needs-triage"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,7 @@
-name:  💡 Feature Request
+name: 💡 Feature Request
 description: Suggest an idea for this project
+title: ""
 labels: ["feature-request", "status/needs-triage"]
-
 
 body:
   - type: textarea


### PR DESCRIPTION
### Description

Remove default titles from Github templates since we use tags/labels.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
