### PR TITLE
fix(templates): solve broken GitHub issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: 🐞 Bug Report
 description: Create a report to help us improve
-title: ""
 labels: ["bug", "status/needs-triage"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,5 @@
 name: 💡 Feature Request
 description: Suggest an idea for this project
-title: ""
 labels: ["feature-request", "status/needs-triage"]
 
 body:


### PR DESCRIPTION
### Description

Solve broken GitHub issues templates by removing the title.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
