### PR TITLE
fix(glue): add getters for connection attributes

### DIFF
--- a/prowler/providers/aws/services/glue/glue_service.py
+++ b/prowler/providers/aws/services/glue/glue_service.py
@@ -42,9 +42,9 @@ class Glue(AWSService):
                         self.connections.append(
                             Connection(
                                 arn=arn,
-                                name=conn["Name"],
-                                type=conn["ConnectionType"],
-                                properties=conn["ConnectionProperties"],
+                                name=getattr(conn, "Name", ""),
+                                type=getattr(conn, "ConnectionType", ""),
+                                properties=getattr(conn, "ConnectionProperties", {}),
                                 region=regional_client.region,
                             )
                         )

--- a/prowler/providers/aws/services/glue/glue_service.py
+++ b/prowler/providers/aws/services/glue/glue_service.py
@@ -42,9 +42,9 @@ class Glue(AWSService):
                         self.connections.append(
                             Connection(
                                 arn=arn,
-                                name=getattr(conn, "Name", ""),
-                                type=getattr(conn, "ConnectionType", ""),
-                                properties=getattr(conn, "ConnectionProperties", {}),
+                                name=conn.get("Name", ""),
+                                type=conn.get("ConnectionType", ""),
+                                properties=conn.get("ConnectionProperties", {}),
                                 region=regional_client.region,
                             )
                         )


### PR DESCRIPTION
### Description

Add getters inside glue class to manage `KeyErrors` from connection attributes


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
