### PR TITLE
fix(entra): Change to correct service in `entra_user_with_vm_access_has_mfa` metadata

### DIFF
--- a/prowler/providers/azure/services/entra/entra_user_with_vm_access_has_mfa/entra_user_with_vm_access_has_mfa.metadata.json
+++ b/prowler/providers/azure/services/entra/entra_user_with_vm_access_has_mfa/entra_user_with_vm_access_has_mfa.metadata.json
@@ -3,7 +3,7 @@
   "CheckID": "entra_user_with_vm_access_has_mfa",
   "CheckTitle": "Ensure only MFA enabled identities can access privileged Virtual Machine",
   "CheckType": [],
-  "ServiceName": "iam",
+  "ServiceName": "entra",
   "SubServiceName": "",
   "ResourceIdTemplate": "",
   "Severity": "medium",


### PR DESCRIPTION
### Context

The wrong metadata was given a bad output in summary result table.

### Description

Change to correct service in metadata for check `entra_user_with_vm_access_has_mfa`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
