### PR TITLE
fix(network): solve network client locations KeyError

### DIFF
--- a/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.py
+++ b/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.py
@@ -12,9 +12,11 @@ class network_watcher_enabled(Check):
             report.location = "Global"
             report.resource_id = f"/subscriptions/{network_client.subscriptions[subscription]}/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_*"
 
-            missing_locations = set(network_client.locations[subscription]) - set(
-                network_watcher.location for network_watcher in network_watchers
-            )
+            missing_locations = set(
+                network_client.locations.get(
+                    network_client.subscriptions.get(subscription, ""), []
+                )
+            ) - set(network_watcher.location for network_watcher in network_watchers)
 
             if missing_locations:
                 report.status = "FAIL"

--- a/tests/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled_test.py
+++ b/tests/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled_test.py
@@ -33,7 +33,7 @@ class Test_network_watcher_enabled:
     def test_network_invalid_network_watchers(self):
         network_client = mock.MagicMock
         locations = ["location"]
-        network_client.locations = {AZURE_SUBSCRIPTION: locations}
+        network_client.locations = {AZURE_SUBSCRIPTION_ID: locations}
         network_client.subscriptions = {AZURE_SUBSCRIPTION: AZURE_SUBSCRIPTION_ID}
         network_watcher_name = "Network Watcher"
         network_watcher_id = f"/subscriptions/{AZURE_SUBSCRIPTION_ID}/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_*"
@@ -76,7 +76,7 @@ class Test_network_watcher_enabled:
     def test_network_valid_network_watchers(self):
         network_client = mock.MagicMock
         locations = ["location"]
-        network_client.locations = {AZURE_SUBSCRIPTION: locations}
+        network_client.locations = {AZURE_SUBSCRIPTION_ID: locations}
         network_client.subscriptions = {AZURE_SUBSCRIPTION: AZURE_SUBSCRIPTION_ID}
         network_watcher_name = "Network Watcher"
         network_watcher_id = f"/subscriptions/{AZURE_SUBSCRIPTION_ID}/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_*"


### PR DESCRIPTION

### Context

Network watcher enabled check was failing due to bad key searching for v3 version.


### Description

Use the subscription ID instead of subscription name as key.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
