### PR TITLE
chore(docs): update remediation of custom checks metadata

### DIFF
--- a/docs/tutorials/custom-checks-metadata.md
+++ b/docs/tutorials/custom-checks-metadata.md
@@ -54,7 +54,7 @@ CustomChecksMetadata:
         RelatedUrl: https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html
         Remediation:
           Code:
-            CLI: aws s3api put-bucket-versioning --bucket <bucket-name> --versioning-configuration Status=Enabled
+            CLI: aws s3api put-bucket-versioning --bucket <bucket-name> --versioning-configuration Status=Enabled,MFADelete=Enabled
             NativeIaC: https://aws.amazon.com/es/s3/features/versioning/
             Other: https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html
             Terraform: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning


### PR DESCRIPTION
### Context

When working on the `s3_bucket_no_mfa_delete` finding, it was found that the prowler documentation is missing the resolution to enable MFADelete. Added it to the docs


### Description

Change AWS CLI command to enable MFADelete in versioning configuration for an S3 Bucket


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
