### PR TITLE
fix(ocsf): Improve mapping based on recommendations

### DIFF
--- a/prowler/lib/outputs/ocsf/ocsf.py
+++ b/prowler/lib/outputs/ocsf/ocsf.py
@@ -72,6 +72,7 @@ class OCSF(Output):
                         title=finding.check_title,
                         uid=finding.finding_uid,
                         product_uid="prowler",
+                        types=[finding.check_type],
                     ),
                     event_time=finding.timestamp,
                     remediation=Remediation(
@@ -120,7 +121,6 @@ class OCSF(Output):
                     type_uid=DetectionFindingTypeID.Create,
                     type_name=DetectionFindingTypeID.Create.name,
                     unmapped={
-                        "check_type": finding.check_type,
                         "related_url": finding.related_url,
                         "categories": finding.categories,
                         "depends_on": finding.depends_on,
@@ -220,8 +220,12 @@ class OCSF(Output):
             StatusID: The StatusID based on the status and muted values
         """
         status_id = StatusID.Other
-        if status == "FAIL":
+
+        if status == "PASS":
+            status_id = StatusID.Resolved
+        elif status == "FAIL":
             status_id = StatusID.New
+
         if muted:
             status_id = StatusID.Suppressed
         return status_id

--- a/tests/lib/outputs/ocsf/ocsf_test.py
+++ b/tests/lib/outputs/ocsf/ocsf_test.py
@@ -50,6 +50,7 @@ class TestOCSF:
         assert output_data.finding_info.title == findings[0].check_title
         assert output_data.finding_info.uid == findings[0].finding_uid
         assert output_data.finding_info.product_uid == "prowler"
+        assert output_data.finding_info.types == [findings[0].check_type]
         assert output_data.event_time == findings[0].timestamp
         assert (
             output_data.remediation.desc == findings[0].remediation_recommendation_text
@@ -78,7 +79,6 @@ class TestOCSF:
         assert output_data.type_uid == DetectionFindingTypeID.Create
         assert output_data.type_name == DetectionFindingTypeID.Create.name
         assert output_data.unmapped == {
-            "check_type": findings[0].check_type,
             "related_url": findings[0].related_url,
             "categories": findings[0].categories,
             "depends_on": findings[0].depends_on,
@@ -122,7 +122,6 @@ class TestOCSF:
                 "status_detail": "status extended",
                 "status_id": 1,
                 "unmapped": {
-                    "check_type": "test-type",
                     "related_url": "test-url",
                     "categories": "test-category",
                     "depends_on": "test-dependency",
@@ -138,6 +137,7 @@ class TestOCSF:
                     "product_uid": "prowler",
                     "title": "test-check-id",
                     "uid": "test-unique-finding",
+                    "types": ["test-type"],
                 },
                 "resources": [
                     {
@@ -381,7 +381,7 @@ class TestOCSF:
     def test_other_when_status_whatever_and_not_muted(self):
         status = "PASS"
         muted = False
-        assert OCSF.get_finding_status_id(status, muted) == StatusID.Other
+        assert OCSF.get_finding_status_id(status, muted) == StatusID.Resolved
 
     # Returns StatusID.Suppresed when status is PASS and muted is True
     def test_other_when_status_whatever_and_muted(self):
@@ -398,5 +398,11 @@ class TestOCSF:
     # Returns StatusID.Other when muted is False and status is not "FAIL"
     def test_other_when_status_pass_and_not_muted(self):
         status = "PASS"
+        muted = False
+        assert OCSF.get_finding_status_id(status, muted) == StatusID.Resolved
+
+    # Returns StatusID.Other anything else
+    def test_other_when_status_manual(self):
+        status = "MANUAL"
         muted = False
         assert OCSF.get_finding_status_id(status, muted) == StatusID.Other


### PR DESCRIPTION
### Context

This PR needs https://github.com/ocsf/examples/pull/78 to be merged first since we need to validate that the current OCSF format we are generating is valid.

### Description

- Move `unmapped.check_type` to `finding_info.check_types`
- Change `status` from `Other` to `Resolved` if the finding has a `PASS` status.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
