### PR TITLE
feat(docs): added link from app guide to app installation

### DIFF
--- a/docs/tutorials/prowler-app.md
+++ b/docs/tutorials/prowler-app.md
@@ -2,7 +2,7 @@
 
 The **Prowler App** is a user-friendly interface for the Prowler CLI, providing a visual dashboard to monitor your cloud security posture. This tutorial will guide you through setting up and using the Prowler App.
 
-After installing the **Prowler App**, access it at [http://localhost:3000](http://localhost:3000).
+After [installing][./index.md] the **Prowler App**, access it at [http://localhost:3000](http://localhost:3000).
 You can also access to the auto-generated **Prowler API** documentation at [http://localhost:8080/api/v1/docs](http://localhost:8080/api/v1/docs) to see all the available endpoints, parameters and responses.
 
 ## **Step 1: Sign Up**

--- a/docs/tutorials/prowler-app.md
+++ b/docs/tutorials/prowler-app.md
@@ -2,7 +2,7 @@
 
 The **Prowler App** is a user-friendly interface for the Prowler CLI, providing a visual dashboard to monitor your cloud security posture. This tutorial will guide you through setting up and using the Prowler App.
 
-After [installing][./index.md] the **Prowler App**, access it at [http://localhost:3000](http://localhost:3000).
+After [installing](./index.md) the **Prowler App**, access it at [http://localhost:3000](http://localhost:3000).
 You can also access to the auto-generated **Prowler API** documentation at [http://localhost:8080/api/v1/docs](http://localhost:8080/api/v1/docs) to see all the available endpoints, parameters and responses.
 
 ## **Step 1: Sign Up**

--- a/docs/tutorials/prowler-app.md
+++ b/docs/tutorials/prowler-app.md
@@ -2,7 +2,7 @@
 
 The **Prowler App** is a user-friendly interface for the Prowler CLI, providing a visual dashboard to monitor your cloud security posture. This tutorial will guide you through setting up and using the Prowler App.
 
-After [installing](../index.md) the **Prowler App**, access it at [http://localhost:3000](http://localhost:3000).
+After [installing](../index.md#prowler-app-installation) the **Prowler App**, access it at [http://localhost:3000](http://localhost:3000).
 You can also access to the auto-generated **Prowler API** documentation at [http://localhost:8080/api/v1/docs](http://localhost:8080/api/v1/docs) to see all the available endpoints, parameters and responses.
 
 ## **Step 1: Sign Up**

--- a/docs/tutorials/prowler-app.md
+++ b/docs/tutorials/prowler-app.md
@@ -2,7 +2,7 @@
 
 The **Prowler App** is a user-friendly interface for the Prowler CLI, providing a visual dashboard to monitor your cloud security posture. This tutorial will guide you through setting up and using the Prowler App.
 
-After [installing](./index.md) the **Prowler App**, access it at [http://localhost:3000](http://localhost:3000).
+After [installing](../index.md) the **Prowler App**, access it at [http://localhost:3000](http://localhost:3000).
 You can also access to the auto-generated **Prowler API** documentation at [http://localhost:8080/api/v1/docs](http://localhost:8080/api/v1/docs) to see all the available endpoints, parameters and responses.
 
 ## **Step 1: Sign Up**


### PR DESCRIPTION
### Context

Previously, navigation was only possible from the installation section to the app guide, but not the other way around.

### Description

This issue has been resolved, and navigation is now bidirectional, ensuring seamless movement between the installation and app guide sections.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.