### PR TITLE
docs(env): move warning about env files

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ It contains hundreds of controls covering CIS, NIST 800, NIST CSF, CISA, RBI, Fe
 
 Prowler App can be installed in different ways, depending on your environment:
 
-> See how to use Prowler App in the [Prowler App](tutorials/prowler-app.md) section.
+> See how to use Prowler App in the [Prowler App Tutorial](tutorials/prowler-app.md) section.
 
 === "Docker Compose"
 
@@ -64,6 +64,9 @@ Prowler App can be installed in different ways, depending on your environment:
     * `poetry` installed: [poetry installation](https://python-poetry.org/docs/#installation).
     * `npm` installed: [npm installation](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
     * `Docker Compose` installed: https://docs.docker.com/compose/install/.
+
+    ???+ warning
+        Make sure to have `api/.env` and `ui/.env.local` files with the required environment variables. You can find the required environment variables in the [`api/.env.template`](https://github.com/prowler-cloud/prowler/blob/master/api/.env.example) and [`ui/.env.template`](https://github.com/prowler-cloud/prowler/blob/master/ui/.env.template) files.
 
     _Commands to run the API_:
 
@@ -106,9 +109,6 @@ Prowler App can be installed in different ways, depending on your environment:
     ```
 
     > Enjoy Prowler App at http://localhost:3000 by signing up with your email and password.
-
-    ???+ warning
-        Make sure to have `api/.env` and `ui/.env.local` files with the required environment variables. You can find the required environment variables in the [`api/.env.template`](https://github.com/prowler-cloud/prowler/blob/master/api/.env.example) and [`ui/.env.template`](https://github.com/prowler-cloud/prowler/blob/master/ui/.env.template) files.
 
     ???+ warning
         Google and GitHub authentication is only available in [Prowler Cloud](https://prowler.com).


### PR DESCRIPTION
### Context

Fix #6031 

### Description

Move warning about `.env` files before the development commands.
### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.