### PR TITLE
chore(RLS): Improve policy comparison

### DIFF
--- a/api/src/backend/api/migrations/0001_initial.py
+++ b/api/src/backend/api/migrations/0001_initial.py
@@ -1155,7 +1155,6 @@ class Migration(migrations.Migration):
             model_name="Finding",
             name="default",
         ),
-        # NOTE: the RLS policy needs to be explicitly set on the partitions
         migrations.AddConstraint(
             model_name="finding",
             constraint=api.rls.RowLevelSecurityConstraint(

--- a/api/src/backend/api/rls.py
+++ b/api/src/backend/api/rls.py
@@ -79,7 +79,7 @@ class RowLevelSecurityConstraint(models.BaseConstraint):
         grant_queries = ""
         for statement in self.statements:
             # SELECT and DELETE uses USING since applies to rows selected
-            # INSERT uses WITH CHECK becauseonly applies in cases where records are being added
+            # INSERT uses WITH CHECK because only applies in cases where records are being added
             # UPDATE requires USING and WITH CHECK but if only a USING clause is specified, then that clause will be used for both USING and WITH CHECK cases.
             # https://www.postgresql.org/docs/current/sql-createpolicy.html
             clause = f"{'WITH CHECK' if statement == 'INSERT' else 'USING'}"

--- a/api/src/backend/api/rls.py
+++ b/api/src/backend/api/rls.py
@@ -2,8 +2,7 @@ from typing import Any
 from uuid import uuid4
 
 from django.core.exceptions import ValidationError
-from django.db import DEFAULT_DB_ALIAS
-from django.db import models
+from django.db import DEFAULT_DB_ALIAS, models
 from django.db.backends.ddl_references import Statement, Table
 
 from api.db_utils import DB_USER, POSTGRES_TENANT_VAR
@@ -45,10 +44,7 @@ class RowLevelSecurityConstraint(models.BaseConstraint):
         FOR {statement}
         TO %(db_user)s
         {clause} (
-            CASE
-                WHEN current_setting('%(tenant_setting)s', True) IS NULL THEN FALSE
-                ELSE %(field_column)s = current_setting('%(tenant_setting)s')::uuid
-            END
+            (SELECT current_setting('%(tenant_setting)s', True)::uuid) = %(field_column)s
         );
     """
 
@@ -131,7 +127,9 @@ class RowLevelSecurityConstraint(models.BaseConstraint):
         path, _, kwargs = super().deconstruct()
         return (path, (self.target_field,), kwargs)
 
-    def validate(self, model, instance, exclude=None, using=DEFAULT_DB_ALIAS):  # noqa: F841
+    def validate(
+        self, model, instance, exclude=None, using=DEFAULT_DB_ALIAS
+    ):  # noqa: F841
         if not hasattr(instance, "tenant_id"):
             raise ValidationError(f"{model.__name__} does not have a tenant_id field.")
 

--- a/api/src/backend/api/rls.py
+++ b/api/src/backend/api/rls.py
@@ -78,6 +78,10 @@ class RowLevelSecurityConstraint(models.BaseConstraint):
         policy_queries = ""
         grant_queries = ""
         for statement in self.statements:
+            # SELECT and DELETE uses USING since applies to rows selected
+            # INSERT uses WITH CHECK becauseonly applies in cases where records are being added
+            # UPDATE requires USING and WITH CHECK but if only a USING clause is specified, then that clause will be used for both USING and WITH CHECK cases.
+            # https://www.postgresql.org/docs/current/sql-createpolicy.html
             clause = f"{'WITH CHECK' if statement == 'INSERT' else 'USING'}"
             policy_queries = f"{policy_queries}{self.policy_sql_query.format(statement=statement, clause=clause)}"
             grant_queries = (


### PR DESCRIPTION
### Motivation

When an RLS policy is applied to a query, the conditions specified in the policy are evaluated for each row that the query touches. In queries affecting thousands of rows, this behavior can drastically reduce query performance, as the overhead of executing these functions adds up quickly. -- https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0003_auth_rls_initplan#the-performance-issue
### Description

Improve Postgres Row Level Security policies:
- Remove the `CASE` since it is not needed, a comparison with `null` returns `false`, so calling `current_setting('setting', True)` is more than enough.
- Wrap `current_setting` in a subquery to be executed in an `InitPlan` which will be executed just once and then the result will be cached for the rest of the rows.

### TODO
- [ ] Pending to create migrations to replace these policies.


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed. -> **Not needed.**

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.