### PR TITLE
fix(azure): custom Prowler Role for Azure assignableScopes

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -73,6 +73,8 @@ To use each one you need to pass the proper flag to the execution. Prowler for A
 - **Subscription scope permissions**: Required to launch the checks against your resources, mandatory to launch the tool. It is required to add the following RBAC builtin roles per subscription to the entity that is going to be assumed by the tool:
     - `Reader`
     - `ProwlerRole` (custom role defined in [prowler-azure-custom-role](https://github.com/prowler-cloud/prowler/blob/master/permissions/prowler-azure-custom-role.json))
+    ???+ note
+        Please, notice that the field `assignableScopes` in the JSON custom role file must be changed to be the subscription or management group where the role is going to be assigned. The valid formats for the field are `/subscriptions/<subscription-id>` or `/providers/Microsoft.Management/managementGroups/<management-group-id>`.
 
 To assign the permissions, follow the instructions in the [Microsoft Entra ID permissions](../tutorials/azure/create-prowler-service-principal.md#assigning-the-proper-permissions) section and the [Azure subscriptions permissions](../tutorials/azure/subscriptions.md#assigning-proper-permissions) section, respectively.
 

--- a/permissions/prowler-azure-custom-role.json
+++ b/permissions/prowler-azure-custom-role.json
@@ -3,7 +3,7 @@
     "roleName": "ProwlerRole",
     "description": "Role used for checks that require read-only access to Azure resources and are not covered by the Reader role.",
     "assignableScopes": [
-      "/"
+      "/{'subscriptions', 'providers/Microsoft.Management/managementGroups'}/{Your Subscription or Management Group ID}"
     ],
     "permissions": [
       {


### PR DESCRIPTION
### Context

The current assignableScopes in the Prowler Custom Role for Azure is / which is not accepted, it should be indicated by the user, something like /"subscriptions" OR "providers/Microsoft.Management/managementGroups"/{Your Subscription or Management Group ID} should work.

### Description

Change the custom role in the JSON role file definition and let a note in documentation.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.