### PR TITLE
docs(azure): improve tutorials for Prowler App

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -38,16 +38,19 @@ If your IAM entity enforces MFA you can use `--mfa` and Prowler will ask you to 
 
 ## Azure
 
-Prowler for Azure supports the following authentication types:
+Prowler for Azure supports the following authentication types. To use each one you need to pass the proper flag to the execution:
 
-- [Service principal application](https://learn.microsoft.com/en-us/entra/identity-platform/app-objects-and-service-principals?tabs=browser#service-principal-object) by environment variables (recommended)
-- Current az cli credentials stored
-- Interactive browser authentication
-- [Managed identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview) authentication
+- [Service principal application](https://learn.microsoft.com/en-us/entra/identity-platform/app-objects-and-service-principals?tabs=browser#service-principal-object) (recommended).
+- Current az cli credentials stored.
+- Interactive browser authentication.
+- [Managed identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview) authentication.
 
-### Service Principal authentication
+???+ warning
+    For Prowler App only the Service Principal authentication method is supported.
 
-To allow Prowler assume the service principal identity to start the scan it is needed to configure the following environment variables:
+### Service Principal Application authentication
+
+To allow Prowler assume the service principal application identity to start the scan it is needed to configure the following environment variables:
 
 ```console
 export AZURE_CLIENT_ID="XXXXXXXXX"
@@ -56,23 +59,23 @@ export AZURE_CLIENT_SECRET="XXXXXXX"
 ```
 
 If you try to execute Prowler with the `--sp-env-auth` flag and those variables are empty or not exported, the execution is going to fail.
-Follow the instructions in the [Create Prowler Service Principal](../tutorials/azure/create-prowler-service-principal.md) section to create a service principal.
+Follow the instructions in the [Create Prowler Service Principal](../tutorials/azure/create-prowler-service-principal.md#how-to-create-prowler-service-principal) section to create a service principal.
 
 ### AZ CLI / Browser / Managed Identity authentication
 
 The other three cases does not need additional configuration, `--az-cli-auth` and `--managed-identity-auth` are automated options. To use `--browser-auth`  the user needs to authenticate against Azure using the default browser to start the scan, also `tenant-id` is required.
 
-### Permissions
+### Needed permissions
 
-To use each one you need to pass the proper flag to the execution. Prowler for Azure handles two types of permission scopes, which are:
+Prowler for Azure needs two types of permission scopes to be set:
 
-- **Microsoft Entra ID permissions**: Used to retrieve metadata from the identity assumed by Prowler and specific Entra checks (not mandatory to have access to execute the tool). The permissions required by the tool are the following:
+- **Microsoft Entra ID permissions**: used to retrieve metadata from the identity assumed by Prowler and specific Entra checks (not mandatory to have access to execute the tool). The permissions required by the tool are the following:
     - `Directory.Read.All`
     - `Policy.Read.All`
-    - `UserAuthenticationMethod.Read.All`
-- **Subscription scope permissions**: Required to launch the checks against your resources, mandatory to launch the tool. It is required to add the following RBAC builtin roles per subscription to the entity that is going to be assumed by the tool:
+    - `UserAuthenticationMethod.Read.All` (used only for the Entra checks related with multifactor authentication)
+- **Subscription scope permissions**: required to launch the checks against your resources, mandatory to launch the tool. It is required to add the following RBAC builtin roles per subscription to the entity that is going to be assumed by the tool:
     - `Reader`
-    - `ProwlerRole` (custom role defined in [prowler-azure-custom-role](https://github.com/prowler-cloud/prowler/blob/master/permissions/prowler-azure-custom-role.json))
+    - `ProwlerRole` (custom role with minimal permissions defined in [prowler-azure-custom-role](https://github.com/prowler-cloud/prowler/blob/master/permissions/prowler-azure-custom-role.json))
     ???+ note
         Please, notice that the field `assignableScopes` in the JSON custom role file must be changed to be the subscription or management group where the role is going to be assigned. The valid formats for the field are `/subscriptions/<subscription-id>` or `/providers/Microsoft.Management/managementGroups/<management-group-id>`.
 
@@ -80,7 +83,7 @@ To assign the permissions, follow the instructions in the [Microsoft Entra ID pe
 
 #### Checks that require ProwlerRole
 
-The following checks require the `ProwlerRole` custom role to be executed, if you want to run them, make sure you have assigned the role to the identity that is going to be assumed by Prowler:
+The following checks require the `ProwlerRole` permissions to be executed, if you want to run them, make sure you have assigned the role to the identity that is going to be assumed by Prowler:
 
 - `app_function_access_keys_configured`
 - `app_function_ftps_deployment_disabled`

--- a/docs/tutorials/azure/create-prowler-service-principal.md
+++ b/docs/tutorials/azure/create-prowler-service-principal.md
@@ -1,6 +1,10 @@
-# How to create Prowler Service Principal
+# How to create Prowler Service Principal Application
 
-To allow Prowler assume an identity to start the scan with the required privileges is necesary to create a Service Principal. To create one follow the next steps:
+To allow Prowler assume an identity to start the scan with the required privileges is necesary to create a Service Principal. This Service Principal is going to be used to authenticate against Azure and retrieve the metadata needed to perform the checks.
+
+To create a Service Principal Application you can use the Azure Portal or the Azure CLI.
+
+## From Azure Portal
 
 1. Access to Microsoft Entra ID
 2. In the left menu bar, go to "App registrations"
@@ -13,9 +17,39 @@ To allow Prowler assume an identity to start the scan with the required privileg
 
 ![Register an Application page](../img/create-sp.gif)
 
-## Assigning the proper permissions
+## From Azure CLI
 
-To allow Prowler to retrieve metadata from the identity assumed and specific Entra checks, it is needed to assign the following permissions:
+To create a Service Principal using the Azure CLI, follow the next steps:
+
+1. Open a terminal and execute the following command to create a new Service Principal application:
+```console
+az ad sp create-for-rbac --name "ProwlerApp"
+```
+2. The output of the command is going to be similar to the following:
+```json
+{
+"appId": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+"displayName": "ProwlerApp",
+"password": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+"tenant": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+}
+```
+3. Save the values of `appId`, `password` and `tenant` to be used as credentials in Prowler.
+
+# Assigning the proper permissions
+
+To allow Prowler to retrieve metadata from the identity assumed and run specific Entra checks, it is needed to assign the following permissions:
+
+- `Directory.Read.All`
+- `Policy.Read.All`
+- `UserAuthenticationMethod.Read.All` (used only for the Entra checks related with multifactor authentication)
+
+To assign the permissions you can make it from the Azure Portal or using the Azure CLI.
+
+???+ note
+    Once you have created and assigned the proper Entra permissions to the application, you can go to this [tutorial](../azure/subscriptions.md) to add the subscription permissions to the application and start scanning your resources.
+
+## From Azure Portal
 
 1. Access to Microsoft Entra ID
 2. In the left menu bar, go to "App registrations"
@@ -28,7 +62,18 @@ To allow Prowler to retrieve metadata from the identity assumed and specific Ent
     - `Policy.Read.All`
     - `UserAuthenticationMethod.Read.All`
 8. Click on "Add permissions" to apply the new permissions.
-9. Finally, click on "Grant admin consent for [your tenant]" to apply the permissions.
+9. Finally, an admin should click on "Grant admin consent for [your tenant]" to apply the permissions.
 
 
 ![EntraID Permissions](../../img/AAD-permissions.png)
+
+## From Azure CLI
+
+1. Open a terminal and execute the following command to assign the permissions to the Service Principal:
+```console
+az ad app permission add --id {appId} --api 00000003-0000-0000-c000-000000000000 --api-permissions 7ab1d382-f21e-4acd-a863-ba3e13f7da61=Role 246dd0d5-5bd0-4def-940b-0421030a5b68=Role 38d9df27-64da-44fd-b7c5-a6fbac20248f=Role
+```
+2. The admin consent is needed to apply the permissions, an admin should execute the following command:
+```console
+az ad app permission admin-consent --id {appId}
+```

--- a/docs/tutorials/azure/subscriptions.md
+++ b/docs/tutorials/azure/subscriptions.md
@@ -1,6 +1,8 @@
 # Azure subscriptions scope
 
-By default, Prowler is multisubscription, which means that is going to scan all the subscriptions is able to list. If you only assign permissions to one subscription, it is going to scan a single one.
+The main target for performing the scans in Azure is the subscription scope. Prowler needs to have the proper permissions to access the subscription and retrieve the metadata needed to perform the checks.
+
+By default, Prowler is multi-subscription, which means that is going to scan all the subscriptions is able to list. If you only assign permissions to one subscription, it is going to scan a single one.
 Prowler also has the ability to limit the subscriptions to scan to a set passed as input argument, to do so:
 
 ```console
@@ -9,35 +11,124 @@ prowler azure --az-cli-auth --subscription-ids <subscription ID 1> <subscription
 
 Where you can pass from 1 up to N subscriptions to be scanned.
 
-## Assigning proper permissions
+???+ warning
+    The multi-subscription feature is only available for the CLI, in the case of Prowler App is only possible to scan one subscription per scan.
 
-Regarding the subscription scope, Prowler by default scans all subscriptions that it is able to list, so it is necessary to add the `Reader` RBAC built-in roles per subscription or management group (recommended for multiple subscriptions, see it in the [next section](#recommendation-for-multiple-subscriptions)) to the entity that will be adopted by the tool:
+## Assign the appropriate permissions to the identity that is going to be assumed by Prowler
 
-To assign this roles, follow the instructions:
 
-1. Access your subscription, then select your subscription.
-2. Select "Access control (IAM)".
-3. In the overview, select "Roles".
-4. Click on "+ Add" and select "Add role assignment".
-5. In the search bar, type `Reader`, select it and click on "Next".
-6. In the Members tab, click on "+ Select members" and add the members you want to assign this role.
-7. Click on "Review + assign" to apply the new role.
+Regarding the subscription scope, Prowler, by default, scans all subscriptions it can access. Therefore, it is necessary to add a `Reader` role assignment for each subscription you want to audit. To make it easier and less repetitive to assign roles in environments with multiple subscriptions check the [following section](#recommendation-for-multiple-subscriptions).
+
+### From Azure Portal
+
+1. Access to the subscription you want to scan with Prowler.
+2. Select "Access control (IAM)" in the left menu.
+3. Click on "+ Add" and select "Add role assignment".
+4. In the search bar, type `Reader`, select it and click on "Next".
+5. In the Members tab, click on "+ Select members" and add the members you want to assign this role.
+6. Click on "Review + assign" to apply the new role.
 
 ![Add reader role to subscription](../../img/add-reader-role.gif)
 
-Moreover, some additional read-only permissions are needed for some checks, for this kind of checks that are not covered by built-in roles we use a custom role. This role is defined in [prowler-azure-custom-role](https://github.com/prowler-cloud/prowler/blob/master/permissions/prowler-azure-custom-role.json). Once the cusotm role is created, repeat the steps mentioned above to assign the new `ProwlerRole` to an identity.
+### From Azure CLI
+
+1. Open a terminal and execute the following command to assign the `Reader` role to the identity that is going to be assumed by Prowler:
+```console
+az role assignment create --role "Reader" --assignee <user, group, or service principal> --scope /subscriptions/<subscription-id>
+```
+2. If the command is executed successfully, the output is going to be similar to the following:
+```json
+{
+    "condition": null,
+    "conditionVersion": null,
+    "createdBy": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+    "createdOn": "YYYY-MM-DDTHH:MM:SS.SSSSSS+00:00",
+    "delegatedManagedIdentityResourceId": null,
+    "description": null,
+    "id": "/subscriptions/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/providers/Microsoft.Authorization/roleAssignments/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+    "name": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+    "principalId": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+    "principalName": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+    "principalType": "ServicePrincipal",
+    "roleDefinitionId": "/subscriptions/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/providers/Microsoft.Authorization/roleDefinitions/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+    "roleDefinitionName": "Reader",
+    "scope": "/subscriptions/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+    "type": "Microsoft.Authorization/roleAssignments",
+    "updatedBy": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+    "updatedOn": "YYYY-MM-DDTHH:MM:SS.SSSSSS+00:00"
+}
+```
+
+### Prowler Custom Role
+
+Moreover, some additional read-only permissions not included in the built-in reader role are needed for some checks, for this kind of checks we use a custom role. This role is defined in [prowler-azure-custom-role](https://github.com/prowler-cloud/prowler/blob/master/permissions/prowler-azure-custom-role.json). Once the custom role is created you can assign it in the same way as the `Reader` role.
+
+The checks that needs the `ProwlerRole` can be consulted in the [requirements section](../../getting-started/requirements.md#checks-that-require-prowlerrole).
+
+#### Create ProwlerRole from Azure Portal
+
+1. Download the [prowler-azure-custom-role](https://github.com/prowler-cloud/prowler/blob/master/permissions/prowler-azure-custom-role.json) file and modify the `assignableScopes` field to be the subscription ID where the role assignment is going to be made, it should be shomething like `/subscriptions/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`.
+2. Access your subscription.
+3. Select "Access control (IAM)".
+4. Click on "+ Add" and select "Add custom role".
+5. In the "Baseline permissions" select "Start from JSON" and upload the file downloaded and modified in the step 1.
+7. Click on "Review + create" to create the new role.
+
+#### Create ProwlerRole from Azure CLI
+
+1. Open a terminal and execute the following command to create a new custom role:
+```console
+az role definition create --role-definition '{                                                                                                                   640ms  lun 16 dic 17:04:17 2024
+                     "Name": "ProwlerRole",
+                     "IsCustom": true,
+                     "Description": "Role used for checks that require read-only access to Azure resources and are not covered by the Reader role.",
+                     "AssignableScopes": [
+                       "/subscriptions/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" // USE YOUR SUBSCRIPTION ID
+                     ],
+                     "Actions": [
+                       "Microsoft.Web/sites/host/listkeys/action",
+                       "Microsoft.Web/sites/config/list/Action"
+                     ]
+                   }'
+```
+3. If the command is executed successfully, the output is going to be similar to the following:
+```json
+{
+    "assignableScopes": [
+        "/subscriptions/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    ],
+    "createdBy": null,
+    "createdOn": "YYYY-MM-DDTHH:MM:SS.SSSSSS+00:00",
+    "description": "Role used for checks that require read-only access to Azure resources and are not covered by the Reader role.",
+    "id": "/subscriptions/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/providers/Microsoft.Authorization/roleDefinitions/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+    "name": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+    "permissions": [
+        {
+            "actions": [
+                "Microsoft.Web/sites/host/listkeys/action",
+                "Microsoft.Web/sites/config/list/Action"
+            ],
+            "condition": null,
+            "conditionVersion": null,
+            "dataActions": [],
+            "notActions": [],
+            "notDataActions": []
+        }
+    ],
+    "roleName": "ProwlerRole",
+    "roleType": "CustomRole",
+    "type": "Microsoft.Authorization/roleDefinitions",
+    "updatedBy": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+    "updatedOn": "YYYY-MM-DDTHH:MM:SS.SSSSSS+00:00"
+}
+```
 
 ## Recommendation for multiple subscriptions
 
-While scanning multiple subscriptions could be tedious to create and assign roles for each one. For this reason in Prowler we recommend the usage of *[management groups](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview)* to group all subscriptions that are going to be audited by Prowler.
+Scanning multiple subscriptions can be tedious due to the need to create and assign roles for each one. To simplify this process, we recommend using management groups to organize and audit subscriptions collectively with Prowler.
 
-To do this in a proper way you have to [create a new management group](https://learn.microsoft.com/en-us/azure/governance/management-groups/create-management-group-portal) and add all roles in the same way that have been done for subscription scope.
-
+1. **Create a Management Group**: Follow the [official guide](https://learn.microsoft.com/en-us/azure/governance/management-groups/create-management-group-portal) to create a new management group.
 ![Create management group](../../img/create-management-group.gif)
-
-Once the management group is properly set you can add all the subscription that you want to audit.
-
+2. **Add all roles**: Assign roles at to the new management group like in the [past section](#assign-the-appropriate-permissions-to-the-identity-that-is-going-to-be-assumed-by-prowler) but at the management group level instead of the subscription level.
+3. **Add subscriptions**: Add all the subscriptions you want to audit to the management group.
 ![Add subscription to management group](../../img/add-sub-to-management-group.gif)
-
-???+ note
-    By default, `prowler` will scan all subscriptions in the Azure tenant, use the flag `--subscription-id` to specify the subscriptions to be scanned.

--- a/docs/tutorials/prowler-app.md
+++ b/docs/tutorials/prowler-app.md
@@ -74,7 +74,7 @@ For AWS, enter your `AWS Account ID` and choose one of the following methods to 
 ---
 
 ### **Step 4.2: Azure Credentials**
-For Azure, Prowler App uses a Service Principal to authenticate. See the steps in https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/azure/create-prowler-service-principal/ to create a Service Principal. Then, enter the `Tenant ID`, `Client ID` and `Client Secret` of the Service Principal.
+For Azure, Prowler App uses a service principal application to authenticate, for more information about the process of creating and adding permissions to a service principal check this [section](../getting-started/requirements.md#azure). When you finish creating and adding the [Entra](./azure/create-prowler-service-principal.md#assigning-the-proper-permissions) and [Subscription](./azure/subscriptions.md#assign-the-appropriate-permissions-to-the-identity-that-is-going-to-be-assumed-by-prowler) scope permissions to the service principal, enter the `Tenant ID`, `Client ID` and `Client Secret` of the service principal application.
 
 <img src="../../img/azure-credentials.png" alt="Azure Credentials" width="700"/>
 


### PR DESCRIPTION
### Context

The current Azure tutorials needs to be improved because it is not clear at all how to assign proper permission to Service Principal only with the Service Principal tutorial, maybe a reference to other tutorials or documentation pages would be helpfull.

Related issue: #6167 

### Description

- Improve Azure Requirements
- Add link to requirements in Prowler App tutorial
- Improve the writing of tutorials
- Add Az CLI steps for tutorials

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.