### PR TITLE
fix(docs): change typo from provideruid in k8s

### DIFF
--- a/docs/tutorials/prowler-app.md
+++ b/docs/tutorials/prowler-app.md
@@ -45,7 +45,7 @@ Once you’ve selected a provider, you need to provide the Provider UID:
 - **AWS**: Enter your AWS Account ID.
 - **GCP**: Enter your GCP Project ID.
 - **Azure**: Enter your Azure Subscription ID.
-- **Kubernetes**: Enter your Kubernetes Cluster context.
+- **Kubernetes**: Enter your Kubernetes Cluster context of your kubeconfig file.
 
 Optionally, provide a **Provider Alias** for easier identification. Follow the instructions provided to add your credentials:
 

--- a/docs/tutorials/prowler-app.md
+++ b/docs/tutorials/prowler-app.md
@@ -45,7 +45,7 @@ Once you’ve selected a provider, you need to provide the Provider UID:
 - **AWS**: Enter your AWS Account ID.
 - **GCP**: Enter your GCP Project ID.
 - **Azure**: Enter your Azure Subscription ID.
-- **Kubernetes**: Enter your Kubernetes Cluster name.
+- **Kubernetes**: Enter your Kubernetes Cluster context.
 
 Optionally, provide a **Provider Alias** for easier identification. Follow the instructions provided to add your credentials:
 


### PR DESCRIPTION
### Description

This pull request includes a small but important change to the `docs/tutorials/prowler-app.md` file. The change corrects the instructions for Kubernetes providers.

Documentation update:

* [`docs/tutorials/prowler-app.md`](diffhunk://#diff-2001144bfb68e64b2c1dcbe5435f0cced70a25d202cafa0e4464ed152373b1aaL48-R48): Updated the Kubernetes provider instructions to require the Kubernetes Cluster context instead of the Kubernetes Cluster name.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.