### PR TITLE
docs: add new format CloudFormation for ResourceType in check metadata

### DIFF
--- a/docs/developer-guide/checks.md
+++ b/docs/developer-guide/checks.md
@@ -279,7 +279,7 @@ Each Prowler check has metadata associated which is stored at the same level of 
   "Severity": "critical",
   # ResourceType only for AWS, holds the type from here
   # https://docs.aws.amazon.com/securityhub/latest/userguide/asff-resources.html
-  # In case of not exists, use CloudFormation type but removing the "::" and using capital letters only at the beginning of each word. Example: "AWS::EC2::Instance" -> "AwsEc2Instance"
+  # In case of not existing, use CloudFormation type but removing the "::" and using capital letters only at the beginning of each word. Example: "AWS::EC2::Instance" -> "AwsEc2Instance"
   # CloudFormation type reference: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html
   # If the resource type does not exist in the CloudFormation types, use "Other".
   "ResourceType": "Other",

--- a/docs/developer-guide/checks.md
+++ b/docs/developer-guide/checks.md
@@ -279,6 +279,9 @@ Each Prowler check has metadata associated which is stored at the same level of 
   "Severity": "critical",
   # ResourceType only for AWS, holds the type from here
   # https://docs.aws.amazon.com/securityhub/latest/userguide/asff-resources.html
+  # In case of not exists, use CloudFormation type but removing the "::" and using capital letters only at the beginning of each word. Example: "AWS::EC2::Instance" -> "AwsEc2Instance"
+  # CloudFormation type reference: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html
+  # If the resource type does not exist in the CloudFormation types, use "Other".
   "ResourceType": "Other",
   # Description holds the title of the check, for now is the same as CheckTitle
   "Description": "Ensure there are no EC2 AMIs set as Public.",


### PR DESCRIPTION
### Context

Add to Metadata doc that in ResourceType is accepted the [CloudFormation types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html) but removing the :: and only using capital letters at the beginning of each part

### Description

Changed doc to indicate this new CloudFormation format.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.