### PR TITLE
chore(deployment tooling): Update Prowler API with rotating K8S access keys

### DIFF
--- a/docs/tutorials/prowler-app.md
+++ b/docs/tutorials/prowler-app.md
@@ -102,7 +102,7 @@ By default, the `kubeconfig` file is located at `~/.kube/config`.
 ???+ note
     If you are adding an **EKS**, **GKE**, **AKS** or external cluster, follow these additional steps to ensure proper authentication:
 
-    ** Make sure your cluster allow traffic from the Prowler Cloud IP address `52.48.254.174/32` **
+    ** Make sure your cluster allows traffic from the Prowler Cloud IP address `52.48.254.174/32` **
 
     1. Apply the necessary Kubernetes resources to your EKS, GKE, AKS or external cluster (you can find the files in the [`kubernetes` directory of the Prowler repository](https://github.com/prowler-cloud/prowler/tree/master/kubernetes)):
     ```console
@@ -128,6 +128,40 @@ By default, the `kubeconfig` file is located at `~/.kube/config`.
     4. Now you can add the modified `kubeconfig` in Prowler Cloud. Then simply test the connection.
 
 ---
+
+???+ note
+    Newer versions of Kubernetes have depreciated the creation of long-lived service account tokens. While there are work-arounds, these may be disabled on some managed Kubernetes clusters (or your user may not have the required Kubernetes permissions to change the settings)
+
+    In this scenario, we provide an API endpoint and local pod to dynamically update your kubeconfig when the ServiceAccount token rotates:
+
+    ** As above, make sure your cluster allows traffic from the Prowler Cloud IP address `52.48.254.174/32` **
+
+    1. We use the existing prowler `ServiceAccount`, `Role` and `RoleBinding`, so as above, apply the necessary Kubernetes resources to your cluster (you can find the files in the [`kubernetes` directory of the Prowler repository](https://github.com/prowler-cloud/prowler/tree/master/kubernetes)):
+    ```console
+    kubectl apply -f kubernetes/prowler-sa.yaml
+    kubectl apply -f kubernetes/prowler-role.yaml
+    kubectl apply -f kubernetes/prowler-rolebinding.yaml
+    ```
+
+    2. Fill in required details for the Token Update Service via a Kubernetes Secret, there is a template `secrets.yaml` in the[`kubernetes/prowler-api-auth-updater` directory of the Prowler repository](https://github.com/prowler-cloud/prowler/tree/master/kubernetes/prowler-api-auth-updater))
+
+
+     - api-url: The endpoint for your Prowler installation. Prowler cloud for example is https://api.prowler.com
+     - username: An account on your Prowler installation with permission to update your Provider configuration
+     - password: The credentials for the above Prowler account
+     - k8s-url: The public API endpoint for your Kubernetes cluster, for example on EKS this may look similar to https://ABCDEF11234567890ABCDEF.gr7.eu-west-1.eks.amazonaws.com
+
+
+    Then deploy the application to auto-update your prowler Kubernetes credentials.
+    ```console
+    kubectl apply -f kubernetes/prowler-api-auth-updater/secret.yaml
+    kubectl apply -f kubernetes/prowler-api-auth-updater/deployment.yaml
+    ```
+    
+    3. You can re-test the connection from the Prowler App's Providers screen.
+
+---
+
 
 ## **Step 5: Test Connection**
 After adding your credentials of your cloud account, click the `Launch` button to verify that the Prowler App can successfully connect to your provider:

--- a/kubernetes/prowler-api-auth-updater/Dockerfile
+++ b/kubernetes/prowler-api-auth-updater/Dockerfile
@@ -1,0 +1,10 @@
+FROM --platform=linux/amd64 python:3.12-slim
+
+WORKDIR /app
+
+COPY /src/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src/main.py .
+
+CMD ["python", "/app/main.py"]

--- a/kubernetes/prowler-api-auth-updater/deployment.yaml
+++ b/kubernetes/prowler-api-auth-updater/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prowler-api-auth-updater
+  namespace: prowler-ns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prowler-api-auth-updater
+  template:
+    metadata:
+      labels:
+        app: prowler-api-auth-updater
+    spec:
+      serviceAccountName: prowler-sa
+      containers:
+      - name: watcher
+        image: <YOUR_IMAGE_NAME>
+        env:
+        - name: PROWLER_API_URL
+          valueFrom:
+            secretKeyRef:
+              name: prowler-api-credentials
+              key: api-url
+        - name: PROWLER_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: prowler-api-credentials
+              key: username
+        - name: PROWLER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: prowler-api-credentials
+              key: password
+        - name: K8S_EXTERNAL_HOST
+          valueFrom:
+            secretKeyRef:
+              name: prowler-api-credentials
+              key: k8s-url
+        volumeMounts:
+        - name: sa-token
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
+      volumes:
+      - name: sa-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: 3600
+              audience: "https://kubernetes.default.svc"
+          - configMap:
+              name: kube-root-ca.crt
+              items:
+                - key: ca.crt
+                  path: ca.crt

--- a/kubernetes/prowler-api-auth-updater/secret.yaml
+++ b/kubernetes/prowler-api-auth-updater/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prowler-api-credentials
+  namespace: prowler-ns
+type: Opaque
+data:
+  api-url: <HTTPS_YOUR_PROWLER_API_URL_BASE64>
+  username: <YOUR_PROWLER_UI_USERNAME_BASE64>
+  password: <YOUR_PROWLER_UI_PASSWORD_BASE64>
+  k8s-url: <YOUR_PUBLIC_K8S_URL_INCL_HTTPS_BASE64>

--- a/kubernetes/prowler-api-auth-updater/src/main.py
+++ b/kubernetes/prowler-api-auth-updater/src/main.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+import os
+import time
+import yaml
+import base64
+import logging
+from pathlib import Path
+import requests
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+logger = logging.getLogger(__name__)
+
+TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+CA_CERT_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+PROWLER_API_URL = os.environ["PROWLER_API_URL"]
+K8S_EXTERNAL_HOST = os.environ["K8S_EXTERNAL_HOST"]
+PROWLER_USERNAME = os.environ["PROWLER_USERNAME"]
+PROWLER_PASSWORD = os.environ["PROWLER_PASSWORD"]
+#K8S_HOST = os.environ.get("KUBERNETES_SERVICE_HOST")
+#K8S_PORT = os.environ.get("KUBERNETES_SERVICE_PORT")
+
+class TokenFileHandler(FileSystemEventHandler):
+    def __init__(self):
+        self.last_token = None
+        self.prowler_auth_token = self.get_prowler_auth_token()
+        # Initial read of the token
+        self.check_and_update_token()
+
+
+    def get_prowler_auth_token(self):
+
+        postData = {
+            "data": {
+                "type": "tokens",
+                "attributes": {
+                    "email": f"{PROWLER_USERNAME}",
+                    "password": f"{PROWLER_PASSWORD}"
+                }
+            }
+        }
+
+        try:
+            response = requests.post(
+                f"{PROWLER_API_URL}/api/v1/tokens",
+                headers={  'Content-Type': 'application/vnd.api+json',
+                            'Accept': 'application/vnd.api+json'},
+                json=postData
+            )
+            response.raise_for_status()
+            return response.json()["data"]["attributes"]["access"]
+        except Exception as e:
+            logger.error(f"Error getting Prowler auth token: {e}")
+            raise
+
+    def get_current_token(self):
+        return Path(TOKEN_PATH).read_text().strip()
+
+    def get_ca_cert(self):
+        return Path(CA_CERT_PATH).read_text()
+
+    def build_kubeconfig(self, token, uid):
+        # Read the CA cert
+        ca_cert_data = self.get_ca_cert()
+        
+        # Build the kubeconfig structure
+        kubeconfig = {
+            "apiVersion": "v1",
+            "kind": "Config",
+            "current-context": f"{uid}",
+            "clusters": [{
+                "name": f"{uid}",
+                "cluster": {
+                    "server": f"{K8S_EXTERNAL_HOST}",
+                    "certificate-authority-data": base64.b64encode(ca_cert_data.encode()).decode()
+                }
+            }],
+            "contexts": [{
+                "name": f"{uid}",
+                "context": {
+                    "cluster": f"{uid}",
+                    "user": f"{uid}"
+                }
+            }],
+            "users": [{
+                "name": f"{uid}",
+                "user": {
+                    "token": token
+                }
+            }]
+        }
+        
+        return yaml.dump(kubeconfig)
+
+    def update_prowler_api(self, token):
+        try:
+
+            # Check for existing Kubernetes providers
+            try:
+                response = requests.get(
+                    f"{PROWLER_API_URL}/api/v1/providers?filter[provider]=kubernetes",
+                    headers={
+                        "Authorization": f"Bearer {self.prowler_auth_token}",
+                        'Content-Type': 'application/vnd.api+json',
+                        'Accept': 'application/vnd.api+json'
+                    }
+                )
+                response.raise_for_status()
+                providers_data = response.json()
+
+                if len(providers_data["data"]) > 1:
+                    logger.error("More than one Kubernetes provider found. Cannot determine the correct provider to update.")
+                    raise Exception("More than one Kubernetes provider found.")
+                elif len(providers_data["data"]) == 0:
+                    logger.error("No Kubernetes provider found.")
+                    raise Exception("No Kubernetes provider found.")
+                
+                provider = providers_data["data"][0]
+                secret_id = provider["relationships"]["secret"]["data"]["id"]
+                uid = provider["attributes"]["uid"]
+            except Exception as e:
+                logger.error(f"Error checking for existing Kubernetes providers: {e}")
+                raise
+            # Build the kubeconfig file
+            kubeconfig = self.build_kubeconfig(token, uid)
+            
+            response = requests.patch(
+                f"{PROWLER_API_URL}/api/v1/providers/secrets/{secret_id}",
+                headers={
+                    "Authorization": f"Bearer {self.prowler_auth_token}",
+                    'Content-Type': 'application/vnd.api+json',
+                    'Accept': 'application/vnd.api+json'},
+                json={
+                    "data": {
+                        "type": "provider-secrets",
+                        "id": secret_id,
+                        "attributes": {
+                            "secret": {
+                                "kubeconfig_content": kubeconfig
+                            },
+                            "name": f"Kubernetes service account token - {time.strftime('%Y-%m-%d %H:%M:%S')}"
+                        },
+                        "relationships": {}
+                    }
+                }
+            )
+            response.raise_for_status()
+            logger.info("Successfully updated Prowler API with new kubeconfig")
+        except Exception as e:
+            logger.error(f"Error updating Prowler API: {e}")
+
+    def check_and_update_token(self):
+        current_token = self.get_current_token()
+        if current_token != self.last_token:
+            logger.info("Token changed, updating Prowler API...")
+            self.update_prowler_api(current_token)
+            self.last_token = current_token
+
+    def on_modified(self, event):
+        if event.src_path == TOKEN_PATH:
+            self.check_and_update_token()
+
+def main():
+    # Verify required environment variables and files
+    required_paths = [TOKEN_PATH, CA_CERT_PATH]
+    required_env = [PROWLER_API_URL, PROWLER_USERNAME, PROWLER_PASSWORD]
+    
+    for path in required_paths:
+        if not Path(path).exists():
+            logger.error(f"Required file not found: {path}")
+            raise FileNotFoundError(f"Required file not found: {path}")
+    
+    for var in required_env:
+        if not var:
+            logger.error("Missing required environment variable")
+            raise EnvironmentError(f"Required environment variable not set")
+
+    # Create an observer and handler
+    observer = Observer()
+    handler = TokenFileHandler()
+    
+    # Schedule watching the directory containing the token
+    token_dir = str(Path(TOKEN_PATH).parent)
+    observer.schedule(handler, token_dir, recursive=False)
+    
+    # Start the observer
+    observer.start()
+    logger.info(f"Started watching {TOKEN_PATH} for changes...")
+    
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+        logger.info("Stopping token watcher...")
+    
+    observer.join()
+
+if __name__ == "__main__":
+    main()

--- a/kubernetes/prowler-api-auth-updater/src/main.py
+++ b/kubernetes/prowler-api-auth-updater/src/main.py
@@ -187,7 +187,7 @@ def main():
     
     # Schedule watching the directory containing the token
     token_dir = str(Path(TOKEN_PATH).parent)
-    observer.schedule(handler, token_dir, recursive=False)
+    observer.schedule(handler, token_dir, recursive=True)
     
     # Start the observer
     observer.start()

--- a/kubernetes/prowler-api-auth-updater/src/requirements.txt
+++ b/kubernetes/prowler-api-auth-updater/src/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.31.0
+watchdog>=3.0.0
+PyYAML>=6.0


### PR DESCRIPTION

### Context
newer versions of the kubernetes API do not allow long-lived/non-expiring tokens to be bound to a service account, while there are workarounds, certain clusters (Auto EKS from my current experience and others on the Community Slack) do now allow non-expiring tokens and force the TTL/Expiry down to a global value.

Solution here is the Kubernetes-documented way to access rotating service credentials, via a 'projected' volume type into a POD inside the k8s cluster; which will provide a mount with a rotating token for that service account. 
Example Pod Snippet:
```
      volumes:
      - name: sa-token
        projected:
          sources:
          - serviceAccountToken:
              path: token
              expirationSeconds: 3600
```
This PR adds a simple deployment, running a pod, mounting the existing prowler `prowler-ns/prowler-sa` service account and a filesystem listener to auto update our Prowler API with any auth changes.

### Description
See documentation in PR.

### Checklist

- Are there new checks included in this PR? No
- [N/A] If so, do we need to update permissions for the provider? Please review this carefully.
- [NO - DISCUSS?] Review if the code is being covered by tests.
- [YES] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [NO] Review if backport is needed.
- [NO] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [NO] Verify if API specs need to be regenerated.
- [NO] Check if version updates are required (e.g., specs, Poetry, etc.).
- [NO] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
