### PR TITLE
feat(dashboard): take the latest finding uid by timestamp

### DIFF
--- a/dashboard/pages/overview.py
+++ b/dashboard/pages/overview.py
@@ -171,7 +171,7 @@ else:
         data.rename(columns={"FINDING_UNIQUE_ID": "FINDING_UID"}, inplace=True)
     if "ACCOUNT_ID" in data.columns:
         data.rename(columns={"ACCOUNT_ID": "ACCOUNT_UID"}, inplace=True)
-    if "ASSERMENT_START_TIME" in data.columns:
+    if "ASSESSMENT_START_TIME" in data.columns:
         data.rename(columns={"ASSESSMENT_START_TIME": "TIMESTAMP"}, inplace=True)
     if "RESOURCE_ID" in data.columns:
         data.rename(columns={"RESOURCE_ID": "RESOURCE_UID"}, inplace=True)

--- a/dashboard/pages/overview.py
+++ b/dashboard/pages/overview.py
@@ -165,9 +165,21 @@ else:
         )
 
     # For the timestamp, remove the two columns and keep only the date
-
     data["TIMESTAMP"] = pd.to_datetime(data["TIMESTAMP"])
-    data["ASSESSMENT_TIME"] = data["TIMESTAMP"].dt.strftime("%Y-%m-%d %H:%M:%S")
+    # Handle findings from v3 outputs
+    if "FINDING_UNIQUE_ID" in data.columns:
+        data.rename(columns={"FINDING_UNIQUE_ID": "FINDING_UID"}, inplace=True)
+    if "ACCOUNT_ID" in data.columns:
+        data.rename(columns={"ACCOUNT_ID": "ACCOUNT_UID"}, inplace=True)
+    if "ASSERMENT_START_TIME" in data.columns:
+        data.rename(columns={"ASSESSMENT_START_TIME": "TIMESTAMP"}, inplace=True)
+    if "RESOURCE_ID" in data.columns:
+        data.rename(columns={"RESOURCE_ID": "RESOURCE_UID"}, inplace=True)
+
+    # Remove dupplicates on the finding_uid colummn but keep the last one taking into account the timestamp
+    data = data.sort_values("TIMESTAMP").drop_duplicates("FINDING_UID", keep="last")
+
+    data["ASSESSMENT_TIME"] = data["TIMESTAMP"].dt.strftime("%Y-%m-%d")
     data_valid = pd.DataFrame()
     for account in data["ACCOUNT_UID"].unique():
         all_times = data[data["ACCOUNT_UID"] == account]["ASSESSMENT_TIME"].unique()


### PR DESCRIPTION
### Context

Fix #6953

### Description

This PR changes the behaviour of prowler dashboard:

* If you run a scan for an specific service and later another one for other service you'll see the findings related from both scans in prowler dashboard.
* If you run a scan for one service and later the same service you'll get the findings from the latests execution.

Thanks @agasthik for the insight.
### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
