### PR TITLE
fix(k8s): Remove command as it is not needed

### DIFF
--- a/contrib/k8s/helm/prowler-cli/templates/job.yaml
+++ b/contrib/k8s/helm/prowler-cli/templates/job.yaml
@@ -16,7 +16,6 @@ spec:
           containers:
           - name: prowler
             image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-            command: ["prowler"]
             args: ["kubernetes", "-z", "-b"]
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             volumeMounts:

--- a/kubernetes/job.yaml
+++ b/kubernetes/job.yaml
@@ -13,7 +13,6 @@ spec:
       containers:
       - name: prowler
         image: toniblyx/prowler:stable
-        command: ["prowler"]
         args: ["kubernetes", "-z"]
         imagePullPolicy: Always
         volumeMounts:


### PR DESCRIPTION
### Context

Fix #7530 

### Description

Remove the `command` from the Prowler K8s job spec as it will use the container's `ENTRYPOINT`.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
