### PR TITLE
fix(docs): overview m365 auth

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -134,6 +134,8 @@ Prowler for M365 currently supports the following authentication types:
 
 ### Service Principal authentication
 
+Authentication flag: `--sp-env-auth`
+
 To allow Prowler assume the service principal identity to start the scan it is needed to configure the following environment variables:
 
 ```console
@@ -146,6 +148,9 @@ If you try to execute Prowler with the `--sp-env-auth` flag and those variables 
 Follow the instructions in the [Create Prowler Service Principal](../tutorials/azure/create-prowler-service-principal.md) section to create a service principal.
 
 ### Service Principal and User Credentials authentication (recommended)
+
+Authentication flag: `--env-auth`
+
 This authentication method follows the same approach as the service principal method but introduces two additional environment variables for user credentials:  `M365_USER` and `M365_ENCRYPTED_PASSWORD`.
 
 ```console
@@ -176,4 +181,6 @@ Write-Output $encryptedPassword
 
 ### Interactive Browser authentication
 
-To use `--browser-auth`  the user needs to authenticate against Azure using the default browser to start the scan, also `--tenant-id` flag is required.
+Authentication flag: `--browser-auth`
+
+This authentication method requires the user to authenticate against Azure using the default browser to start the scan, also `--tenant-id` flag is required.

--- a/docs/index.md
+++ b/docs/index.md
@@ -570,6 +570,10 @@ kubectl logs prowler-XXXXX --namespace prowler-ns
 With M365 you need to specify which auth method is going to be used:
 
 ```console
+
+# To use both service principal (for MSGraph) and user credentials (for PowerShell modules)
+prowler m365 --env-auth
+
 # To use service principal authentication
 prowler m365 --sp-env-auth
 


### PR DESCRIPTION
### Context

M365 provider auth was not updated in overview page.

### Description

Thi pr updates this section with the new `--env-auth` option.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
