### PR TITLE
fix(run-sh): Use poetry's env

### DIFF
--- a/contrib/aws/multi-account-securityhub/run-prowler-securityhub.sh
+++ b/contrib/aws/multi-account-securityhub/run-prowler-securityhub.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Run Prowler against All AWS Accounts in an AWS Organization
 
+# Activate Poetry Environment
+eval "$(poetry env activate)"
+
 # Show Prowler Version
 prowler -v
 


### PR DESCRIPTION
### Description

As part of the Poetry v2 migration, the way to execute Prowler within the container has changed to `poetry run prowler`. So to run it we need to either activate the poetry environment or use poetry as the command. 

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
