### PR TITLE
fix(gcp): remove azure video from gcp docs

### DIFF
--- a/docs/tutorials/gcp/getting-started-gcp.md
+++ b/docs/tutorials/gcp/getting-started-gcp.md
@@ -1,7 +1,5 @@
 # Getting Started with GCP on Prowler Cloud/App
 
-<iframe width="560" height="380" src="https://www.youtube-nocookie.com/embed/v1as8vTFlMg" title="Prowler Cloud Onboarding GCP" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>
-
 Set up your GCP project to enable security scanning using Prowler Cloud/App.
 
 ## Requirements


### PR DESCRIPTION
### Context

In GCP getting started docs we have the Azure getting started video, so I have removed it since we don't have video for GCP yet.

### Description

Removed video from GCP docs

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
