### PR TITLE
docs(gcp): update GCP permissions

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -109,13 +109,12 @@ Prowler will follow the same credentials search as [Google authentication librar
 
 Prowler for Google Cloud needs the following permissions to be set:
 
-- **Viewer (`roles/viewer`) IAM role**: granted at the project / folder / org level in order to scan the target projects
+- **Reader (`roles/reader`) IAM role**: granted at the project / folder / org level in order to scan the target projects
 
 - **Project level settings**: you need to have at least one project with the below settings:
     - Identity and Access Management (IAM) API (`iam.googleapis.com`) enabled by either using the
     [Google Cloud API UI](https://console.cloud.google.com/apis/api/iam.googleapis.com/metrics) or
     by using the gcloud CLI `gcloud services enable iam.googleapis.com --project <your-project-id>` command
-    - Service Usage Consumer (`roles/serviceusage.serviceUsageConsumer`) IAM role
     - Set the quota project to be this project by either running `gcloud auth application-default set-quota-project <project-id>` or by setting an environment variable:
     `export GOOGLE_CLOUD_QUOTA_PROJECT=<project-id>`
 

--- a/docs/tutorials/gcp/authentication.md
+++ b/docs/tutorials/gcp/authentication.md
@@ -51,7 +51,7 @@ Prowler follows the same search order as [Google authentication libraries](https
 
 ???+ note
     The credentials must belong to a user or service account with the necessary permissions.
-    To ensure full access, assign the roles/viewer IAM role to the identity being used.
+    To ensure full access, assign the roles/reader IAM role to the identity being used.
 
 ???+ note
     Prowler will use the enabled Google Cloud APIs to get the information needed to perform the checks.
@@ -63,13 +63,12 @@ Prowler follows the same search order as [Google authentication libraries](https
 
 Prowler for Google Cloud needs the following permissions to be set:
 
-- **Viewer (`roles/viewer`) IAM role**: granted at the project / folder / org level in order to scan the target projects
+- **Reader (`roles/reader`) IAM role**: granted at the project / folder / org level in order to scan the target projects
 
 - **Project level settings**: you need to have at least one project with the below settings:
     - Identity and Access Management (IAM) API (`iam.googleapis.com`) enabled by either using the
     [Google Cloud API UI](https://console.cloud.google.com/apis/api/iam.googleapis.com/metrics) or
     by using the gcloud CLI `gcloud services enable iam.googleapis.com --project <your-project-id>` command
-    - Service Usage Consumer (`roles/serviceusage.serviceUsageConsumer`) IAM role
     - Set the quota project to be this project by either running `gcloud auth application-default set-quota-project <project-id>` or by setting an environment variable:
     `export GOOGLE_CLOUD_QUOTA_PROJECT=<project-id>`
 

--- a/docs/tutorials/gcp/organization.md
+++ b/docs/tutorials/gcp/organization.md
@@ -9,7 +9,7 @@ prowler gcp --organization-id organization-id
 ```
 
 ???+ warning
-    Make sure that the used credentials have the role Cloud Asset Viewer (`roles/cloudasset.viewer`) or Cloud Asset Owner (`roles/cloudasset.owner`) on the organization level.
+    Make sure that the used credentials have a role with the `cloudasset.assets.listResource` permission on the organization level like `roles/cloudasset.viewer` (Cloud Asset Viewer) or `roles/cloudasset.owner` (Cloud Asset Owner).
 
 ???+ note
     With this option, Prowler retrieves all projects within the specified organization, including those organized in folders and nested subfolders. This ensures that every project under the organization’s hierarchy is scanned, providing full visibility across the entire organization.


### PR DESCRIPTION
### Description

Update GCP permissions that are needed for Prowler scans and stop recommending legacy GCP viewer role.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
