### PR TITLE
fix(docs): m365 requirements `Needed permissions` link

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -209,7 +209,7 @@ Refer to the [Create Prowler Service Principal](../tutorials/microsoft365/gettin
 If the external API permissions described in the mentioned section above are not added only checks that work through MS Graph will be executed. This means that the full provider will not be executed.
 
 ???+ note
-    In order to scan all the checks from M365 required permissions to the service principal application must be added. Refer to the [Needed permissions](/docs/tutorials/microsoft365/getting-started-m365.md#needed-permissions) section for more information.
+    In order to scan all the checks from M365 required permissions to the service principal application must be added. Refer to the [External API Permissions Assignment](../tutorials/microsoft365/getting-started-m365.md#grant-powershell-modules-permissions) section for more information.
 
 ### Service Principal and User Credentials Authentication
 

--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -33,8 +33,8 @@ export AWS_SESSION_TOKEN="XXXXXXXXX"
 
 The credentials used must be associated with a user or role that has appropriate permissions for security checks. Attach the following AWS managed policies to ensure access:
 
-  - `arn:aws:iam::aws:policy/SecurityAudit`
-  - `arn:aws:iam::aws:policy/job-function/ViewOnlyAccess`
+- `arn:aws:iam::aws:policy/SecurityAudit`
+- `arn:aws:iam::aws:policy/job-function/ViewOnlyAccess`
 
 #### Additional Permissions
 
@@ -101,9 +101,8 @@ Required permissions:
 - `Policy.Read.All`
 - `UserAuthenticationMethod.Read.All` (used for Entra multifactor authentication checks)
 
-    ???+ note
-        You can replace `Directory.Read.All` with `Domain.Read.All` that is a more restrictive permission but you won't be able to run the Entra checks related with DirectoryRoles and GetUsers.
-
+  ???+ note
+  You can replace `Directory.Read.All` with `Domain.Read.All` that is a more restrictive permission but you won't be able to run the Entra checks related with DirectoryRoles and GetUsers.
 
 #### Subscription Scope Permissions
 
@@ -113,7 +112,7 @@ These permissions are required to perform security checks against Azure resource
 - `ProwlerRole` – A custom role with minimal permissions, defined in the [prowler-azure-custom-role](https://github.com/prowler-cloud/prowler/blob/master/permissions/prowler-azure-custom-role.json).
 
 ???+ note
-    The `assignableScopes` field in the JSON custom role file must be updated to reflect the correct subscription or management group. Use one of the following formats: `/subscriptions/<subscription-id>` or `/providers/Microsoft.Management/managementGroups/<management-group-id>`.
+The `assignableScopes` field in the JSON custom role file must be updated to reflect the correct subscription or management group. Use one of the following formats: `/subscriptions/<subscription-id>` or `/providers/Microsoft.Management/managementGroups/<management-group-id>`.
 
 ### Assigning Permissions
 
@@ -123,7 +122,7 @@ To properly configure permissions, follow these guides:
 - [Azure subscription permissions](../tutorials/azure/subscriptions.md#assign-the-appropriate-permissions-to-the-identity-that-is-going-to-be-assumed-by-prowler)
 
 ???+ warning
-     Some permissions in `ProwlerRole` involve **write access**. If a `ReadOnly` lock is attached to certain resources, you may encounter errors, and findings for those checks will not be available.
+Some permissions in `ProwlerRole` involve **write access**. If a `ReadOnly` lock is attached to certain resources, you may encounter errors, and findings for those checks will not be available.
 
 #### Checks Requiring `ProwlerRole`
 
@@ -147,6 +146,7 @@ Prowler follows the same credential discovery process as the [Google authenticat
 Prowler for Google Cloud requires the following permissions:
 
 #### IAM Roles
+
 - **Reader (`roles/reader`)** – Must be granted at the **project, folder, or organization** level to allow scanning of target projects.
 
 #### Project-Level Settings
@@ -188,7 +188,7 @@ Prowler for Microsoft 365 (M365) supports the following authentication methods:
 - **Interactive browser authentication**
 
 ???+ warning
-    Prowler App supports the **Service Principal** authentication method and the **Service Principal with User Credentials** authentication method, but this last one will be deprecated in September once Microsoft will enforce MFA in all tenants not allowing User authentication without interactive method.
+Prowler App supports the **Service Principal** authentication method and the **Service Principal with User Credentials** authentication method, but this last one will be deprecated in September once Microsoft will enforce MFA in all tenants not allowing User authentication without interactive method.
 
 ### Service Principal Authentication (Recommended)
 
@@ -209,7 +209,7 @@ Refer to the [Create Prowler Service Principal](../tutorials/microsoft365/gettin
 If the external API permissions described in the mentioned section above are not added only checks that work through MS Graph will be executed. This means that the full provider will not be executed.
 
 ???+ note
-    In order to scan all the checks from M365 required permissions to the service principal application must be added. Refer to the [Needed permissions](/docs/tutorials/microsoft365/getting-started-m365.md#needed-permissions) section for more information.
+In order to scan all the checks from M365 required permissions to the service principal application must be added. Refer to the [External API Permissions Assignment](../tutorials/microsoft365/getting-started-m365.md#if-using-applicationservice-principal-authentication-recommended) section for more information.
 
 ### Service Principal and User Credentials Authentication
 
@@ -232,28 +232,26 @@ These two new environment variables are **required** in this authentication meth
 
 - `M365_USER` should be your Microsoft account email using the **assigned domain in the tenant**. This means it must look like `example@YourCompany.onmicrosoft.com` or `example@YourCompany.com`, but it must be the exact domain assigned to that user in the tenant.
 
-    ???+ warning
-        If the user is newly created, you need to sign in with that account first, as Microsoft will prompt you to change the password. If you don’t complete this step, user authentication will fail because Microsoft marks the initial password as expired.
+  ???+ warning
+  If the user is newly created, you need to sign in with that account first, as Microsoft will prompt you to change the password. If you don’t complete this step, user authentication will fail because Microsoft marks the initial password as expired.
 
-    ???+ warning
-        If the user is newly created, you need to sign in with that account first, as Microsoft will prompt you to change the password. If you don’t complete this step, user authentication will fail because Microsoft marks the initial password as expired.
+  ???+ warning
+  If the user is newly created, you need to sign in with that account first, as Microsoft will prompt you to change the password. If you don’t complete this step, user authentication will fail because Microsoft marks the initial password as expired.
 
-    ???+ warning
-        The user must not be MFA capable. Microsoft does not allow MFA capable users to authenticate programmatically. See [Microsoft documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scenario-desktop-acquire-token-username-password?tabs=dotnet) for more information.
+  ???+ warning
+  The user must not be MFA capable. Microsoft does not allow MFA capable users to authenticate programmatically. See [Microsoft documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scenario-desktop-acquire-token-username-password?tabs=dotnet) for more information.
 
-    ???+ warning
-        Using a tenant domain other than the one assigned — even if it belongs to the same tenant — will cause Prowler to fail, as Microsoft authentication will not succeed.
+  ???+ warning
+  Using a tenant domain other than the one assigned — even if it belongs to the same tenant — will cause Prowler to fail, as Microsoft authentication will not succeed.
 
-    Ensure you are using the right domain for the user you are trying to authenticate with.
+  Ensure you are using the right domain for the user you are trying to authenticate with.
 
-    ![User Domains](../tutorials/microsoft365/img/user-domains.png)
+  ![User Domains](../tutorials/microsoft365/img/user-domains.png)
 
 - `M365_PASSWORD` must be the user password.
 
-    ???+ note
-        Before we asked for a encrypted password, but now we ask for the user password directly. Prowler will now handle the password encryption for you.
-
-
+  ???+ note
+  Before we asked for a encrypted password, but now we ask for the user password directly. Prowler will now handle the password encryption for you.
 
 ### Interactive Browser Authentication
 
@@ -287,19 +285,19 @@ When using service principal authentication, you need to add the following **App
 - `application_access` from external API `Skype and Teams Tenant Admin API`: Required for Teams PowerShell module app authentication.
 
 ???+ note
-    `Directory.Read.All` can be replaced with `Domain.Read.All` that is a more restrictive permission but you won't be able to run the Entra checks related with DirectoryRoles and GetUsers.
+`Directory.Read.All` can be replaced with `Domain.Read.All` that is a more restrictive permission but you won't be able to run the Entra checks related with DirectoryRoles and GetUsers.
 
     > If you do this you will need to add also the `Organization.Read.All` permission to the service principal application in order to authenticate.
 
 ???+ note
-    This is the **recommended authentication method** because it allows you to run the full M365 provider including PowerShell checks, providing complete coverage of all available security checks, same as the Service Principal Authentication + User Credentials Authentication but this last one will be deprecated in September once Microsoft will enforce MFA in all tenants not allowing User authentication without interactive method.
-
+This is the **recommended authentication method** because it allows you to run the full M365 provider including PowerShell checks, providing complete coverage of all available security checks, same as the Service Principal Authentication + User Credentials Authentication but this last one will be deprecated in September once Microsoft will enforce MFA in all tenants not allowing User authentication without interactive method.
 
 #### For Service Principal + User Credentials Authentication (`--env-auth`)
 
 When using service principal with user credentials authentication, you need **both** sets of permissions:
 
 **1. Service Principal Application Permissions**:
+
 - You **will need** all the Microsoft Graph API permissions listed above.
 - You **won't need** the External API permissions listed above.
 
@@ -308,17 +306,17 @@ When using service principal with user credentials authentication, you need **bo
 - `Global Reader` (recommended): this allows you to read all roles needed.
 - `Exchange Administrator` and `Teams Administrator`: user needs both roles but with this [roles](https://learn.microsoft.com/en-us/exchange/permissions-exo/permissions-exo#microsoft-365-permissions-in-exchange-online) you can access to the same information as a Global Reader (since only read access is needed, Global Reader is recommended).
 
-
 #### For Browser Authentication (`--browser-auth`)
 
 When using browser authentication, permissions are delegated to the user, so the user must have the appropriate permissions rather than the application.
 
 ???+ warning
-    With browser authentication, you will only be able to run checks that work through MS Graph API. PowerShell module checks will not be executed.
+With browser authentication, you will only be able to run checks that work through MS Graph API. PowerShell module checks will not be executed.
 
 ### Assigning Permissions and Roles
 
 For guidance on assigning the necessary permissions and roles, follow these instructions:
+
 - [Grant API Permissions](../tutorials/microsoft365/getting-started-m365.md#grant-required-graph-api-permissions)
 - [Assign Required Roles](../tutorials/microsoft365/getting-started-m365.md#if-using-user-authentication)
 
@@ -327,6 +325,7 @@ For guidance on assigning the necessary permissions and roles, follow these inst
 PowerShell is required to run certain M365 checks.
 
 **Supported versions:**
+
 - **PowerShell 7.4 or higher** (7.5 is recommended)
 
 #### Why Is PowerShell 7.4+ Required?
@@ -335,7 +334,7 @@ PowerShell is required to run certain M365 checks.
 - Older [cross-platform PowerShell versions](https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle?view=powershell-7.5) are **unsupported**, leading to potential errors.
 
 ???+ note
-    Installing PowerShell is only necessary if you install Prowler via **pip or other sources**. **SDK and API containers include PowerShell by default.**
+Installing PowerShell is only necessary if you install Prowler via **pip or other sources**. **SDK and API containers include PowerShell by default.**
 
 ### Installing PowerShell
 
@@ -347,7 +346,6 @@ Installing PowerShell is different depending on your OS.
 winget install --id Microsoft.PowerShell --source winget
 ```
 
-
 - [MacOS](https://learn.microsoft.com/es-es/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.5#install-the-latest-stable-release-of-powershell): installing PowerShell on MacOS needs to have installed [brew](https://brew.sh/), once you have it is just running the command above, Pwsh is only supported in macOS 15 (Sequoia) x64 and Arm64, macOS 14 (Sonoma) x64 and Arm64, macOS 13 (Ventura) x64 and Arm64
 
 ```console
@@ -358,159 +356,159 @@ Once it's installed run `pwsh` on your terminal to verify it's working.
 
 - Linux: installing PowerShell on Linux depends on the distro you are using:
 
-    - [Ubuntu](https://learn.microsoft.com/es-es/powershell/scripting/install/install-ubuntu?view=powershell-7.5#installation-via-package-repository-the-package-repository): The required version for installing PowerShell +7.4 on Ubuntu are Ubuntu 22.04 and Ubuntu 24.04. The recommended way to install it is downloading the package available on PMC. You just need to follow the following steps:
+  - [Ubuntu](https://learn.microsoft.com/es-es/powershell/scripting/install/install-ubuntu?view=powershell-7.5#installation-via-package-repository-the-package-repository): The required version for installing PowerShell +7.4 on Ubuntu are Ubuntu 22.04 and Ubuntu 24.04. The recommended way to install it is downloading the package available on PMC. You just need to follow the following steps:
 
-    ```console
-    ###################################
-    # Prerequisites
+  ```console
+  ###################################
+  # Prerequisites
 
-    # Update the list of packages
-    sudo apt-get update
+  # Update the list of packages
+  sudo apt-get update
 
-    # Install pre-requisite packages.
-    sudo apt-get install -y wget apt-transport-https software-properties-common
+  # Install pre-requisite packages.
+  sudo apt-get install -y wget apt-transport-https software-properties-common
 
-    # Get the version of Ubuntu
-    source /etc/os-release
+  # Get the version of Ubuntu
+  source /etc/os-release
 
-    # Download the Microsoft repository keys
-    wget -q https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb
+  # Download the Microsoft repository keys
+  wget -q https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb
 
-    # Register the Microsoft repository keys
-    sudo dpkg -i packages-microsoft-prod.deb
+  # Register the Microsoft repository keys
+  sudo dpkg -i packages-microsoft-prod.deb
 
-    # Delete the Microsoft repository keys file
-    rm packages-microsoft-prod.deb
+  # Delete the Microsoft repository keys file
+  rm packages-microsoft-prod.deb
 
-    # Update the list of packages after we added packages.microsoft.com
-    sudo apt-get update
+  # Update the list of packages after we added packages.microsoft.com
+  sudo apt-get update
 
-    ###################################
-    # Install PowerShell
-    sudo apt-get install -y powershell
+  ###################################
+  # Install PowerShell
+  sudo apt-get install -y powershell
 
-    # Start PowerShell
-    pwsh
-    ```
+  # Start PowerShell
+  pwsh
+  ```
 
-    - [Alpine](https://learn.microsoft.com/es-es/powershell/scripting/install/install-alpine?view=powershell-7.5#installation-steps): The only supported version for installing PowerShell +7.4 on Alpine is Alpine 3.20. The unique way to install it is downloading the tar.gz package available on [PowerShell github](https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/powershell-7.5.0-linux-musl-x64.tar.gz). You just need to follow the following steps:
+  - [Alpine](https://learn.microsoft.com/es-es/powershell/scripting/install/install-alpine?view=powershell-7.5#installation-steps): The only supported version for installing PowerShell +7.4 on Alpine is Alpine 3.20. The unique way to install it is downloading the tar.gz package available on [PowerShell github](https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/powershell-7.5.0-linux-musl-x64.tar.gz). You just need to follow the following steps:
 
-    ```console
-    # Install the requirements
-    sudo apk add --no-cache \
-        ca-certificates \
-        less \
-        ncurses-terminfo-base \
-        krb5-libs \
-        libgcc \
-        libintl \
-        libssl3 \
-        libstdc++ \
-        tzdata \
-        userspace-rcu \
-        zlib \
-        icu-libs \
-        curl
+  ```console
+  # Install the requirements
+  sudo apk add --no-cache \
+      ca-certificates \
+      less \
+      ncurses-terminfo-base \
+      krb5-libs \
+      libgcc \
+      libintl \
+      libssl3 \
+      libstdc++ \
+      tzdata \
+      userspace-rcu \
+      zlib \
+      icu-libs \
+      curl
 
-    apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
-        lttng-ust \
-        openssh-client \
+  apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
+      lttng-ust \
+      openssh-client \
 
-    # Download the powershell '.tar.gz' archive
-    curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/powershell-7.5.0-linux-musl-x64.tar.gz -o /tmp/powershell.tar.gz
+  # Download the powershell '.tar.gz' archive
+  curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/powershell-7.5.0-linux-musl-x64.tar.gz -o /tmp/powershell.tar.gz
 
-    # Create the target folder where powershell will be placed
-    sudo mkdir -p /opt/microsoft/powershell/7
+  # Create the target folder where powershell will be placed
+  sudo mkdir -p /opt/microsoft/powershell/7
 
-    # Expand powershell to the target folder
-    sudo tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7
+  # Expand powershell to the target folder
+  sudo tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7
 
-    # Set execute permissions
-    sudo chmod +x /opt/microsoft/powershell/7/pwsh
+  # Set execute permissions
+  sudo chmod +x /opt/microsoft/powershell/7/pwsh
 
-    # Create the symbolic link that points to pwsh
-    sudo ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+  # Create the symbolic link that points to pwsh
+  sudo ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
 
-    # Start PowerShell
-    pwsh
-    ```
+  # Start PowerShell
+  pwsh
+  ```
 
-    - [Debian](https://learn.microsoft.com/es-es/powershell/scripting/install/install-debian?view=powershell-7.5#installation-on-debian-11-or-12-via-the-package-repository): The required version for installing PowerShell +7.4 on Debian are Debian 11 and Debian 12. The recommended way to install it is downloading the package available on PMC. You just need to follow the following steps:
+  - [Debian](https://learn.microsoft.com/es-es/powershell/scripting/install/install-debian?view=powershell-7.5#installation-on-debian-11-or-12-via-the-package-repository): The required version for installing PowerShell +7.4 on Debian are Debian 11 and Debian 12. The recommended way to install it is downloading the package available on PMC. You just need to follow the following steps:
 
-    ```console
-    ###################################
-    # Prerequisites
+  ```console
+  ###################################
+  # Prerequisites
 
-    # Update the list of packages
-    sudo apt-get update
+  # Update the list of packages
+  sudo apt-get update
 
-    # Install pre-requisite packages.
-    sudo apt-get install -y wget
+  # Install pre-requisite packages.
+  sudo apt-get install -y wget
 
-    # Get the version of Debian
-    source /etc/os-release
+  # Get the version of Debian
+  source /etc/os-release
 
-    # Download the Microsoft repository GPG keys
-    wget -q https://packages.microsoft.com/config/debian/$VERSION_ID/packages-microsoft-prod.deb
+  # Download the Microsoft repository GPG keys
+  wget -q https://packages.microsoft.com/config/debian/$VERSION_ID/packages-microsoft-prod.deb
 
-    # Register the Microsoft repository GPG keys
-    sudo dpkg -i packages-microsoft-prod.deb
+  # Register the Microsoft repository GPG keys
+  sudo dpkg -i packages-microsoft-prod.deb
 
-    # Delete the Microsoft repository GPG keys file
-    rm packages-microsoft-prod.deb
+  # Delete the Microsoft repository GPG keys file
+  rm packages-microsoft-prod.deb
 
-    # Update the list of packages after we added packages.microsoft.com
-    sudo apt-get update
+  # Update the list of packages after we added packages.microsoft.com
+  sudo apt-get update
 
-    ###################################
-    # Install PowerShell
-    sudo apt-get install -y powershell
+  ###################################
+  # Install PowerShell
+  sudo apt-get install -y powershell
 
-    # Start PowerShell
-    pwsh
-    ```
+  # Start PowerShell
+  pwsh
+  ```
 
-    - [Rhel](https://learn.microsoft.com/es-es/powershell/scripting/install/install-rhel?view=powershell-7.5#installation-via-the-package-repository): The required version for installing PowerShell +7.4 on Red Hat are RHEL 8 and RHEL 9. The recommended way to install it is downloading the package available on PMC. You just need to follow the following steps:
+  - [Rhel](https://learn.microsoft.com/es-es/powershell/scripting/install/install-rhel?view=powershell-7.5#installation-via-the-package-repository): The required version for installing PowerShell +7.4 on Red Hat are RHEL 8 and RHEL 9. The recommended way to install it is downloading the package available on PMC. You just need to follow the following steps:
 
-    ```console
-    ###################################
-    # Prerequisites
+  ```console
+  ###################################
+  # Prerequisites
 
-    # Get version of RHEL
-    source /etc/os-release
-    if [ ${VERSION_ID%.*} -lt 8 ]
-    then majorver=7
-    elif [ ${VERSION_ID%.*} -lt 9 ]
-    then majorver=8
-    else majorver=9
-    fi
+  # Get version of RHEL
+  source /etc/os-release
+  if [ ${VERSION_ID%.*} -lt 8 ]
+  then majorver=7
+  elif [ ${VERSION_ID%.*} -lt 9 ]
+  then majorver=8
+  else majorver=9
+  fi
 
-    # Download the Microsoft RedHat repository package
-    curl -sSL -O https://packages.microsoft.com/config/rhel/$majorver/packages-microsoft-prod.rpm
+  # Download the Microsoft RedHat repository package
+  curl -sSL -O https://packages.microsoft.com/config/rhel/$majorver/packages-microsoft-prod.rpm
 
-    # Register the Microsoft RedHat repository
-    sudo rpm -i packages-microsoft-prod.rpm
+  # Register the Microsoft RedHat repository
+  sudo rpm -i packages-microsoft-prod.rpm
 
-    # Delete the downloaded package after installing
-    rm packages-microsoft-prod.rpm
+  # Delete the downloaded package after installing
+  rm packages-microsoft-prod.rpm
 
-    # Update package index files
-    sudo dnf update
-    # Install PowerShell
-    sudo dnf install powershell -y
-    ```
+  # Update package index files
+  sudo dnf update
+  # Install PowerShell
+  sudo dnf install powershell -y
+  ```
 
 - [Docker](https://learn.microsoft.com/es-es/powershell/scripting/install/powershell-in-docker?view=powershell-7.5#use-powershell-in-a-container): The following command download the latest stable versions of PowerShell:
 
-    ```console
-    docker pull mcr.microsoft.com/dotnet/sdk:9.0
-    ```
+  ```console
+  docker pull mcr.microsoft.com/dotnet/sdk:9.0
+  ```
 
-    To start an interactive shell of Pwsh you just need to run:
+  To start an interactive shell of Pwsh you just need to run:
 
-    ```console
-    docker run -it mcr.microsoft.com/dotnet/sdk:9.0 pwsh
-    ```
+  ```console
+  docker run -it mcr.microsoft.com/dotnet/sdk:9.0 pwsh
+  ```
 
 ### Required PowerShell Modules
 
@@ -526,15 +524,16 @@ Example command:
 ```console
 python3 prowler-cli.py m365 --verbose --log-level ERROR --env-auth --init-modules
 ```
+
 If the modules are already installed, running this command will not cause issues—it will simply verify that the necessary modules are available.
 
 ???+ note
-    Prowler installs the modules using `-Scope CurrentUser`.
-    If you encounter any issues with services not working after the automatic installation, try installing the modules manually using `-Scope AllUsers` (administrator permissions are required for this).
-    The command needed to install a module manually is:
-    ```powershell
+Prowler installs the modules using `-Scope CurrentUser`.
+If you encounter any issues with services not working after the automatic installation, try installing the modules manually using `-Scope AllUsers` (administrator permissions are required for this).
+The command needed to install a module manually is:
+`powershell
     Install-Module -Name "ModuleName" -Scope AllUsers -Force
-    ```
+    `
 
 #### Modules Version
 
@@ -557,7 +556,7 @@ Prowler supports multiple [authentication methods for GitHub](https://docs.githu
 These options provide flexibility for scanning and analyzing your GitHub account, repositories, organizations, and applications. Choose the authentication method that best suits your security needs.
 
 ???+ note
-    GitHub App Credentials support less checks than other authentication methods.
+GitHub App Credentials support less checks than other authentication methods.
 
 ## Infrastructure as Code (IaC)
 
@@ -567,9 +566,9 @@ Prowler's Infrastructure as Code (IaC) provider enables you to scan local or rem
 
 - For local scans, no authentication is required.
 - For remote repository scans, authentication can be provided via:
-    - [**GitHub Username and Personal Access Token (PAT)**](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)
-    - [**GitHub OAuth App Token**](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)
-    - [**Git URL**](https://git-scm.com/docs/git-clone#_git_urls)
+  - [**GitHub Username and Personal Access Token (PAT)**](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)
+  - [**GitHub OAuth App Token**](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)
+  - [**Git URL**](https://git-scm.com/docs/git-clone#_git_urls)
 
 ### Supported Frameworks
 

--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -33,8 +33,8 @@ export AWS_SESSION_TOKEN="XXXXXXXXX"
 
 The credentials used must be associated with a user or role that has appropriate permissions for security checks. Attach the following AWS managed policies to ensure access:
 
-- `arn:aws:iam::aws:policy/SecurityAudit`
-- `arn:aws:iam::aws:policy/job-function/ViewOnlyAccess`
+  - `arn:aws:iam::aws:policy/SecurityAudit`
+  - `arn:aws:iam::aws:policy/job-function/ViewOnlyAccess`
 
 #### Additional Permissions
 
@@ -101,8 +101,9 @@ Required permissions:
 - `Policy.Read.All`
 - `UserAuthenticationMethod.Read.All` (used for Entra multifactor authentication checks)
 
-  ???+ note
-  You can replace `Directory.Read.All` with `Domain.Read.All` that is a more restrictive permission but you won't be able to run the Entra checks related with DirectoryRoles and GetUsers.
+    ???+ note
+        You can replace `Directory.Read.All` with `Domain.Read.All` that is a more restrictive permission but you won't be able to run the Entra checks related with DirectoryRoles and GetUsers.
+
 
 #### Subscription Scope Permissions
 
@@ -112,7 +113,7 @@ These permissions are required to perform security checks against Azure resource
 - `ProwlerRole` – A custom role with minimal permissions, defined in the [prowler-azure-custom-role](https://github.com/prowler-cloud/prowler/blob/master/permissions/prowler-azure-custom-role.json).
 
 ???+ note
-The `assignableScopes` field in the JSON custom role file must be updated to reflect the correct subscription or management group. Use one of the following formats: `/subscriptions/<subscription-id>` or `/providers/Microsoft.Management/managementGroups/<management-group-id>`.
+    The `assignableScopes` field in the JSON custom role file must be updated to reflect the correct subscription or management group. Use one of the following formats: `/subscriptions/<subscription-id>` or `/providers/Microsoft.Management/managementGroups/<management-group-id>`.
 
 ### Assigning Permissions
 
@@ -122,7 +123,7 @@ To properly configure permissions, follow these guides:
 - [Azure subscription permissions](../tutorials/azure/subscriptions.md#assign-the-appropriate-permissions-to-the-identity-that-is-going-to-be-assumed-by-prowler)
 
 ???+ warning
-Some permissions in `ProwlerRole` involve **write access**. If a `ReadOnly` lock is attached to certain resources, you may encounter errors, and findings for those checks will not be available.
+     Some permissions in `ProwlerRole` involve **write access**. If a `ReadOnly` lock is attached to certain resources, you may encounter errors, and findings for those checks will not be available.
 
 #### Checks Requiring `ProwlerRole`
 
@@ -146,7 +147,6 @@ Prowler follows the same credential discovery process as the [Google authenticat
 Prowler for Google Cloud requires the following permissions:
 
 #### IAM Roles
-
 - **Reader (`roles/reader`)** – Must be granted at the **project, folder, or organization** level to allow scanning of target projects.
 
 #### Project-Level Settings
@@ -188,7 +188,7 @@ Prowler for Microsoft 365 (M365) supports the following authentication methods:
 - **Interactive browser authentication**
 
 ???+ warning
-Prowler App supports the **Service Principal** authentication method and the **Service Principal with User Credentials** authentication method, but this last one will be deprecated in September once Microsoft will enforce MFA in all tenants not allowing User authentication without interactive method.
+    Prowler App supports the **Service Principal** authentication method and the **Service Principal with User Credentials** authentication method, but this last one will be deprecated in September once Microsoft will enforce MFA in all tenants not allowing User authentication without interactive method.
 
 ### Service Principal Authentication (Recommended)
 
@@ -209,7 +209,7 @@ Refer to the [Create Prowler Service Principal](../tutorials/microsoft365/gettin
 If the external API permissions described in the mentioned section above are not added only checks that work through MS Graph will be executed. This means that the full provider will not be executed.
 
 ???+ note
-In order to scan all the checks from M365 required permissions to the service principal application must be added. Refer to the [External API Permissions Assignment](../tutorials/microsoft365/getting-started-m365.md#if-using-applicationservice-principal-authentication-recommended) section for more information.
+    In order to scan all the checks from M365 required permissions to the service principal application must be added. Refer to the [Needed permissions](/docs/tutorials/microsoft365/getting-started-m365.md#needed-permissions) section for more information.
 
 ### Service Principal and User Credentials Authentication
 
@@ -232,26 +232,28 @@ These two new environment variables are **required** in this authentication meth
 
 - `M365_USER` should be your Microsoft account email using the **assigned domain in the tenant**. This means it must look like `example@YourCompany.onmicrosoft.com` or `example@YourCompany.com`, but it must be the exact domain assigned to that user in the tenant.
 
-  ???+ warning
-  If the user is newly created, you need to sign in with that account first, as Microsoft will prompt you to change the password. If you don’t complete this step, user authentication will fail because Microsoft marks the initial password as expired.
+    ???+ warning
+        If the user is newly created, you need to sign in with that account first, as Microsoft will prompt you to change the password. If you don’t complete this step, user authentication will fail because Microsoft marks the initial password as expired.
 
-  ???+ warning
-  If the user is newly created, you need to sign in with that account first, as Microsoft will prompt you to change the password. If you don’t complete this step, user authentication will fail because Microsoft marks the initial password as expired.
+    ???+ warning
+        If the user is newly created, you need to sign in with that account first, as Microsoft will prompt you to change the password. If you don’t complete this step, user authentication will fail because Microsoft marks the initial password as expired.
 
-  ???+ warning
-  The user must not be MFA capable. Microsoft does not allow MFA capable users to authenticate programmatically. See [Microsoft documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scenario-desktop-acquire-token-username-password?tabs=dotnet) for more information.
+    ???+ warning
+        The user must not be MFA capable. Microsoft does not allow MFA capable users to authenticate programmatically. See [Microsoft documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scenario-desktop-acquire-token-username-password?tabs=dotnet) for more information.
 
-  ???+ warning
-  Using a tenant domain other than the one assigned — even if it belongs to the same tenant — will cause Prowler to fail, as Microsoft authentication will not succeed.
+    ???+ warning
+        Using a tenant domain other than the one assigned — even if it belongs to the same tenant — will cause Prowler to fail, as Microsoft authentication will not succeed.
 
-  Ensure you are using the right domain for the user you are trying to authenticate with.
+    Ensure you are using the right domain for the user you are trying to authenticate with.
 
-  ![User Domains](../tutorials/microsoft365/img/user-domains.png)
+    ![User Domains](../tutorials/microsoft365/img/user-domains.png)
 
 - `M365_PASSWORD` must be the user password.
 
-  ???+ note
-  Before we asked for a encrypted password, but now we ask for the user password directly. Prowler will now handle the password encryption for you.
+    ???+ note
+        Before we asked for a encrypted password, but now we ask for the user password directly. Prowler will now handle the password encryption for you.
+
+
 
 ### Interactive Browser Authentication
 
@@ -285,19 +287,19 @@ When using service principal authentication, you need to add the following **App
 - `application_access` from external API `Skype and Teams Tenant Admin API`: Required for Teams PowerShell module app authentication.
 
 ???+ note
-`Directory.Read.All` can be replaced with `Domain.Read.All` that is a more restrictive permission but you won't be able to run the Entra checks related with DirectoryRoles and GetUsers.
+    `Directory.Read.All` can be replaced with `Domain.Read.All` that is a more restrictive permission but you won't be able to run the Entra checks related with DirectoryRoles and GetUsers.
 
     > If you do this you will need to add also the `Organization.Read.All` permission to the service principal application in order to authenticate.
 
 ???+ note
-This is the **recommended authentication method** because it allows you to run the full M365 provider including PowerShell checks, providing complete coverage of all available security checks, same as the Service Principal Authentication + User Credentials Authentication but this last one will be deprecated in September once Microsoft will enforce MFA in all tenants not allowing User authentication without interactive method.
+    This is the **recommended authentication method** because it allows you to run the full M365 provider including PowerShell checks, providing complete coverage of all available security checks, same as the Service Principal Authentication + User Credentials Authentication but this last one will be deprecated in September once Microsoft will enforce MFA in all tenants not allowing User authentication without interactive method.
+
 
 #### For Service Principal + User Credentials Authentication (`--env-auth`)
 
 When using service principal with user credentials authentication, you need **both** sets of permissions:
 
 **1. Service Principal Application Permissions**:
-
 - You **will need** all the Microsoft Graph API permissions listed above.
 - You **won't need** the External API permissions listed above.
 
@@ -306,17 +308,17 @@ When using service principal with user credentials authentication, you need **bo
 - `Global Reader` (recommended): this allows you to read all roles needed.
 - `Exchange Administrator` and `Teams Administrator`: user needs both roles but with this [roles](https://learn.microsoft.com/en-us/exchange/permissions-exo/permissions-exo#microsoft-365-permissions-in-exchange-online) you can access to the same information as a Global Reader (since only read access is needed, Global Reader is recommended).
 
+
 #### For Browser Authentication (`--browser-auth`)
 
 When using browser authentication, permissions are delegated to the user, so the user must have the appropriate permissions rather than the application.
 
 ???+ warning
-With browser authentication, you will only be able to run checks that work through MS Graph API. PowerShell module checks will not be executed.
+    With browser authentication, you will only be able to run checks that work through MS Graph API. PowerShell module checks will not be executed.
 
 ### Assigning Permissions and Roles
 
 For guidance on assigning the necessary permissions and roles, follow these instructions:
-
 - [Grant API Permissions](../tutorials/microsoft365/getting-started-m365.md#grant-required-graph-api-permissions)
 - [Assign Required Roles](../tutorials/microsoft365/getting-started-m365.md#if-using-user-authentication)
 
@@ -325,7 +327,6 @@ For guidance on assigning the necessary permissions and roles, follow these inst
 PowerShell is required to run certain M365 checks.
 
 **Supported versions:**
-
 - **PowerShell 7.4 or higher** (7.5 is recommended)
 
 #### Why Is PowerShell 7.4+ Required?
@@ -334,7 +335,7 @@ PowerShell is required to run certain M365 checks.
 - Older [cross-platform PowerShell versions](https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle?view=powershell-7.5) are **unsupported**, leading to potential errors.
 
 ???+ note
-Installing PowerShell is only necessary if you install Prowler via **pip or other sources**. **SDK and API containers include PowerShell by default.**
+    Installing PowerShell is only necessary if you install Prowler via **pip or other sources**. **SDK and API containers include PowerShell by default.**
 
 ### Installing PowerShell
 
@@ -346,6 +347,7 @@ Installing PowerShell is different depending on your OS.
 winget install --id Microsoft.PowerShell --source winget
 ```
 
+
 - [MacOS](https://learn.microsoft.com/es-es/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.5#install-the-latest-stable-release-of-powershell): installing PowerShell on MacOS needs to have installed [brew](https://brew.sh/), once you have it is just running the command above, Pwsh is only supported in macOS 15 (Sequoia) x64 and Arm64, macOS 14 (Sonoma) x64 and Arm64, macOS 13 (Ventura) x64 and Arm64
 
 ```console
@@ -356,159 +358,159 @@ Once it's installed run `pwsh` on your terminal to verify it's working.
 
 - Linux: installing PowerShell on Linux depends on the distro you are using:
 
-  - [Ubuntu](https://learn.microsoft.com/es-es/powershell/scripting/install/install-ubuntu?view=powershell-7.5#installation-via-package-repository-the-package-repository): The required version for installing PowerShell +7.4 on Ubuntu are Ubuntu 22.04 and Ubuntu 24.04. The recommended way to install it is downloading the package available on PMC. You just need to follow the following steps:
+    - [Ubuntu](https://learn.microsoft.com/es-es/powershell/scripting/install/install-ubuntu?view=powershell-7.5#installation-via-package-repository-the-package-repository): The required version for installing PowerShell +7.4 on Ubuntu are Ubuntu 22.04 and Ubuntu 24.04. The recommended way to install it is downloading the package available on PMC. You just need to follow the following steps:
 
-  ```console
-  ###################################
-  # Prerequisites
+    ```console
+    ###################################
+    # Prerequisites
 
-  # Update the list of packages
-  sudo apt-get update
+    # Update the list of packages
+    sudo apt-get update
 
-  # Install pre-requisite packages.
-  sudo apt-get install -y wget apt-transport-https software-properties-common
+    # Install pre-requisite packages.
+    sudo apt-get install -y wget apt-transport-https software-properties-common
 
-  # Get the version of Ubuntu
-  source /etc/os-release
+    # Get the version of Ubuntu
+    source /etc/os-release
 
-  # Download the Microsoft repository keys
-  wget -q https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb
+    # Download the Microsoft repository keys
+    wget -q https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb
 
-  # Register the Microsoft repository keys
-  sudo dpkg -i packages-microsoft-prod.deb
+    # Register the Microsoft repository keys
+    sudo dpkg -i packages-microsoft-prod.deb
 
-  # Delete the Microsoft repository keys file
-  rm packages-microsoft-prod.deb
+    # Delete the Microsoft repository keys file
+    rm packages-microsoft-prod.deb
 
-  # Update the list of packages after we added packages.microsoft.com
-  sudo apt-get update
+    # Update the list of packages after we added packages.microsoft.com
+    sudo apt-get update
 
-  ###################################
-  # Install PowerShell
-  sudo apt-get install -y powershell
+    ###################################
+    # Install PowerShell
+    sudo apt-get install -y powershell
 
-  # Start PowerShell
-  pwsh
-  ```
+    # Start PowerShell
+    pwsh
+    ```
 
-  - [Alpine](https://learn.microsoft.com/es-es/powershell/scripting/install/install-alpine?view=powershell-7.5#installation-steps): The only supported version for installing PowerShell +7.4 on Alpine is Alpine 3.20. The unique way to install it is downloading the tar.gz package available on [PowerShell github](https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/powershell-7.5.0-linux-musl-x64.tar.gz). You just need to follow the following steps:
+    - [Alpine](https://learn.microsoft.com/es-es/powershell/scripting/install/install-alpine?view=powershell-7.5#installation-steps): The only supported version for installing PowerShell +7.4 on Alpine is Alpine 3.20. The unique way to install it is downloading the tar.gz package available on [PowerShell github](https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/powershell-7.5.0-linux-musl-x64.tar.gz). You just need to follow the following steps:
 
-  ```console
-  # Install the requirements
-  sudo apk add --no-cache \
-      ca-certificates \
-      less \
-      ncurses-terminfo-base \
-      krb5-libs \
-      libgcc \
-      libintl \
-      libssl3 \
-      libstdc++ \
-      tzdata \
-      userspace-rcu \
-      zlib \
-      icu-libs \
-      curl
+    ```console
+    # Install the requirements
+    sudo apk add --no-cache \
+        ca-certificates \
+        less \
+        ncurses-terminfo-base \
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl3 \
+        libstdc++ \
+        tzdata \
+        userspace-rcu \
+        zlib \
+        icu-libs \
+        curl
 
-  apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
-      lttng-ust \
-      openssh-client \
+    apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
+        lttng-ust \
+        openssh-client \
 
-  # Download the powershell '.tar.gz' archive
-  curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/powershell-7.5.0-linux-musl-x64.tar.gz -o /tmp/powershell.tar.gz
+    # Download the powershell '.tar.gz' archive
+    curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/powershell-7.5.0-linux-musl-x64.tar.gz -o /tmp/powershell.tar.gz
 
-  # Create the target folder where powershell will be placed
-  sudo mkdir -p /opt/microsoft/powershell/7
+    # Create the target folder where powershell will be placed
+    sudo mkdir -p /opt/microsoft/powershell/7
 
-  # Expand powershell to the target folder
-  sudo tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7
+    # Expand powershell to the target folder
+    sudo tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7
 
-  # Set execute permissions
-  sudo chmod +x /opt/microsoft/powershell/7/pwsh
+    # Set execute permissions
+    sudo chmod +x /opt/microsoft/powershell/7/pwsh
 
-  # Create the symbolic link that points to pwsh
-  sudo ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+    # Create the symbolic link that points to pwsh
+    sudo ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
 
-  # Start PowerShell
-  pwsh
-  ```
+    # Start PowerShell
+    pwsh
+    ```
 
-  - [Debian](https://learn.microsoft.com/es-es/powershell/scripting/install/install-debian?view=powershell-7.5#installation-on-debian-11-or-12-via-the-package-repository): The required version for installing PowerShell +7.4 on Debian are Debian 11 and Debian 12. The recommended way to install it is downloading the package available on PMC. You just need to follow the following steps:
+    - [Debian](https://learn.microsoft.com/es-es/powershell/scripting/install/install-debian?view=powershell-7.5#installation-on-debian-11-or-12-via-the-package-repository): The required version for installing PowerShell +7.4 on Debian are Debian 11 and Debian 12. The recommended way to install it is downloading the package available on PMC. You just need to follow the following steps:
 
-  ```console
-  ###################################
-  # Prerequisites
+    ```console
+    ###################################
+    # Prerequisites
 
-  # Update the list of packages
-  sudo apt-get update
+    # Update the list of packages
+    sudo apt-get update
 
-  # Install pre-requisite packages.
-  sudo apt-get install -y wget
+    # Install pre-requisite packages.
+    sudo apt-get install -y wget
 
-  # Get the version of Debian
-  source /etc/os-release
+    # Get the version of Debian
+    source /etc/os-release
 
-  # Download the Microsoft repository GPG keys
-  wget -q https://packages.microsoft.com/config/debian/$VERSION_ID/packages-microsoft-prod.deb
+    # Download the Microsoft repository GPG keys
+    wget -q https://packages.microsoft.com/config/debian/$VERSION_ID/packages-microsoft-prod.deb
 
-  # Register the Microsoft repository GPG keys
-  sudo dpkg -i packages-microsoft-prod.deb
+    # Register the Microsoft repository GPG keys
+    sudo dpkg -i packages-microsoft-prod.deb
 
-  # Delete the Microsoft repository GPG keys file
-  rm packages-microsoft-prod.deb
+    # Delete the Microsoft repository GPG keys file
+    rm packages-microsoft-prod.deb
 
-  # Update the list of packages after we added packages.microsoft.com
-  sudo apt-get update
+    # Update the list of packages after we added packages.microsoft.com
+    sudo apt-get update
 
-  ###################################
-  # Install PowerShell
-  sudo apt-get install -y powershell
+    ###################################
+    # Install PowerShell
+    sudo apt-get install -y powershell
 
-  # Start PowerShell
-  pwsh
-  ```
+    # Start PowerShell
+    pwsh
+    ```
 
-  - [Rhel](https://learn.microsoft.com/es-es/powershell/scripting/install/install-rhel?view=powershell-7.5#installation-via-the-package-repository): The required version for installing PowerShell +7.4 on Red Hat are RHEL 8 and RHEL 9. The recommended way to install it is downloading the package available on PMC. You just need to follow the following steps:
+    - [Rhel](https://learn.microsoft.com/es-es/powershell/scripting/install/install-rhel?view=powershell-7.5#installation-via-the-package-repository): The required version for installing PowerShell +7.4 on Red Hat are RHEL 8 and RHEL 9. The recommended way to install it is downloading the package available on PMC. You just need to follow the following steps:
 
-  ```console
-  ###################################
-  # Prerequisites
+    ```console
+    ###################################
+    # Prerequisites
 
-  # Get version of RHEL
-  source /etc/os-release
-  if [ ${VERSION_ID%.*} -lt 8 ]
-  then majorver=7
-  elif [ ${VERSION_ID%.*} -lt 9 ]
-  then majorver=8
-  else majorver=9
-  fi
+    # Get version of RHEL
+    source /etc/os-release
+    if [ ${VERSION_ID%.*} -lt 8 ]
+    then majorver=7
+    elif [ ${VERSION_ID%.*} -lt 9 ]
+    then majorver=8
+    else majorver=9
+    fi
 
-  # Download the Microsoft RedHat repository package
-  curl -sSL -O https://packages.microsoft.com/config/rhel/$majorver/packages-microsoft-prod.rpm
+    # Download the Microsoft RedHat repository package
+    curl -sSL -O https://packages.microsoft.com/config/rhel/$majorver/packages-microsoft-prod.rpm
 
-  # Register the Microsoft RedHat repository
-  sudo rpm -i packages-microsoft-prod.rpm
+    # Register the Microsoft RedHat repository
+    sudo rpm -i packages-microsoft-prod.rpm
 
-  # Delete the downloaded package after installing
-  rm packages-microsoft-prod.rpm
+    # Delete the downloaded package after installing
+    rm packages-microsoft-prod.rpm
 
-  # Update package index files
-  sudo dnf update
-  # Install PowerShell
-  sudo dnf install powershell -y
-  ```
+    # Update package index files
+    sudo dnf update
+    # Install PowerShell
+    sudo dnf install powershell -y
+    ```
 
 - [Docker](https://learn.microsoft.com/es-es/powershell/scripting/install/powershell-in-docker?view=powershell-7.5#use-powershell-in-a-container): The following command download the latest stable versions of PowerShell:
 
-  ```console
-  docker pull mcr.microsoft.com/dotnet/sdk:9.0
-  ```
+    ```console
+    docker pull mcr.microsoft.com/dotnet/sdk:9.0
+    ```
 
-  To start an interactive shell of Pwsh you just need to run:
+    To start an interactive shell of Pwsh you just need to run:
 
-  ```console
-  docker run -it mcr.microsoft.com/dotnet/sdk:9.0 pwsh
-  ```
+    ```console
+    docker run -it mcr.microsoft.com/dotnet/sdk:9.0 pwsh
+    ```
 
 ### Required PowerShell Modules
 
@@ -524,16 +526,15 @@ Example command:
 ```console
 python3 prowler-cli.py m365 --verbose --log-level ERROR --env-auth --init-modules
 ```
-
 If the modules are already installed, running this command will not cause issues—it will simply verify that the necessary modules are available.
 
 ???+ note
-Prowler installs the modules using `-Scope CurrentUser`.
-If you encounter any issues with services not working after the automatic installation, try installing the modules manually using `-Scope AllUsers` (administrator permissions are required for this).
-The command needed to install a module manually is:
-`powershell
+    Prowler installs the modules using `-Scope CurrentUser`.
+    If you encounter any issues with services not working after the automatic installation, try installing the modules manually using `-Scope AllUsers` (administrator permissions are required for this).
+    The command needed to install a module manually is:
+    ```powershell
     Install-Module -Name "ModuleName" -Scope AllUsers -Force
-    `
+    ```
 
 #### Modules Version
 
@@ -556,7 +557,7 @@ Prowler supports multiple [authentication methods for GitHub](https://docs.githu
 These options provide flexibility for scanning and analyzing your GitHub account, repositories, organizations, and applications. Choose the authentication method that best suits your security needs.
 
 ???+ note
-GitHub App Credentials support less checks than other authentication methods.
+    GitHub App Credentials support less checks than other authentication methods.
 
 ## Infrastructure as Code (IaC)
 
@@ -566,9 +567,9 @@ Prowler's Infrastructure as Code (IaC) provider enables you to scan local or rem
 
 - For local scans, no authentication is required.
 - For remote repository scans, authentication can be provided via:
-  - [**GitHub Username and Personal Access Token (PAT)**](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)
-  - [**GitHub OAuth App Token**](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)
-  - [**Git URL**](https://git-scm.com/docs/git-clone#_git_urls)
+    - [**GitHub Username and Personal Access Token (PAT)**](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)
+    - [**GitHub OAuth App Token**](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)
+    - [**Git URL**](https://git-scm.com/docs/git-clone#_git_urls)
 
 ### Supported Frameworks
 


### PR DESCRIPTION
### Context

We had an error in `Needed permissions` link for M365 requirements.

### Description

The link has been updated with a more appropriate name and now points to the correct documentation page.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
