### PR TITLE
feat(docs): remove old requirements links

### DIFF
--- a/docs/basic-usage/prowler-cli.md
+++ b/docs/basic-usage/prowler-cli.md
@@ -11,7 +11,7 @@ prowler <provider>
 ![Prowler Execution](../img/short-display.png)
 
 ???+ note
-    Running the `prowler` command without options will uses environment variable credentials. Refer to the [Requirements](../getting-started/requirements.md) section for credential configuration details.
+    Running the `prowler` command without options will uses environment variable credentials. Refer to the Authentication section of each provider for credential configuration details.
 
 ## Verbose Output
 
@@ -77,7 +77,7 @@ prowler aws --profile custom-profile -f us-east-1 eu-south-2
 ???+ note
     By default, `prowler` will scan all AWS regions.
 
-See more details about AWS Authentication in the [Requirements](../getting-started/requirements.md#aws) section.
+See more details about AWS Authentication in the [Authentication Section](../tutorials/aws/authentication.md) section.
 
 ## Azure
 
@@ -97,7 +97,7 @@ prowler azure --browser-auth --tenant-id "XXXXXXXX"
 prowler azure --managed-identity-auth
 ```
 
-See more details about Azure Authentication in [Requirements](../getting-started/requirements.md#azure)
+See more details about Azure Authentication in the [Authentication Section](../tutorials/azure/authentication.md)
 
 By default, Prowler scans all accessible subscriptions. Scan specific subscriptions using the following flag (using az cli auth as example):
 
@@ -193,7 +193,7 @@ prowler m365 --browser-auth --tenant-id "XXXXXXXX"
 
 ```
 
-See more details about M365 Authentication in the [Requirements](../getting-started/requirements.md#microsoft-365) section.
+See more details about M365 Authentication in the [Authentication Section](../tutorials/microsoft365/authentication.md) section.
 
 ## GitHub
 

--- a/docs/developer-guide/m365-details.md
+++ b/docs/developer-guide/m365-details.md
@@ -15,7 +15,7 @@ By default, Prowler will audit the Microsoft Entra ID tenant and its supported s
 - **Required modules:**
     - [ExchangeOnlineManagement](https://www.powershellgallery.com/packages/ExchangeOnlineManagement/3.6.0) (≥ 3.6.0)
     - [MicrosoftTeams](https://www.powershellgallery.com/packages/MicrosoftTeams/6.6.0) (≥ 6.6.0)
-- If you use Prowler Cloud or the official containers, PowerShell is pre-installed. For local or pip installations, you must install PowerShell and the modules yourself. See [Requirements: Supported PowerShell Versions](../getting-started/requirements.md#supported-powershell-versions) and [Needed PowerShell Modules](../getting-started/requirements.md#needed-powershell-modules).
+- If you use Prowler Cloud or the official containers, PowerShell is pre-installed. For local or pip installations, you must install PowerShell and the modules yourself. See [Authentication: Supported PowerShell Versions](../tutorials/microsoft365/authentication.md#supported-powershell-versions) and [Needed PowerShell Modules](../tutorials/microsoft365/authentication.md#required-powershell-modules).
 - For more details and troubleshooting, see [Use of PowerShell in M365](../tutorials/microsoft365/use-of-powershell.md).
 
 ---

--- a/docs/developer-guide/services.md
+++ b/docs/developer-guide/services.md
@@ -231,11 +231,11 @@ Before implementing a new service, verify that Prowler's existing permissions fo
 
 Provider-Specific Permissions Documentation:
 
-- [AWS](../getting-started/requirements.md#authentication)
-- [Azure](../getting-started/requirements.md#needed-permissions)
-- [GCP](../getting-started/requirements.md#needed-permissions_1)
-- [M365](../getting-started/requirements.md#needed-permissions_2)
-- [GitHub](../getting-started/requirements.md#authentication_2)
+- [AWS](../tutorials/aws/authentication.md#required-permissions)
+- [Azure](../tutorials/azure/authentication.md#required-permissions)
+- [GCP](../tutorials/gcp/authentication.md#required-permissions)
+- [M365](../tutorials/microsoft365/authentication.md#required-permissions)
+- [GitHub](../tutorials/github/authentication.md)
 
 ## Best Practices
 

--- a/docs/tutorials/azure/subscriptions.md
+++ b/docs/tutorials/azure/subscriptions.md
@@ -76,7 +76,7 @@ Navigate to the subscription you want to audit with Prowler.
 
 Some read-only permissions required for specific security checks are not included in the built-in Reader role. To support these checks, Prowler utilizes a custom role, defined in [prowler-azure-custom-role](https://github.com/prowler-cloud/prowler/blob/master/permissions/prowler-azure-custom-role.json). Once created, this role can be assigned following the same process as the `Reader` role.
 
-The checks requiring this `ProwlerRole` can be found in the [requirements section](../../getting-started/requirements.md#checks-that-require-prowlerrole).
+The checks requiring this `ProwlerRole` can be found in this [section](../../tutorials/azure/authentication.md#checks-requiring-prowlerrole).
 
 #### Create ProwlerRole via Azure Portal
 

--- a/docs/tutorials/microsoft365/getting-started-m365.md
+++ b/docs/tutorials/microsoft365/getting-started-m365.md
@@ -257,7 +257,8 @@ This method is not recommended because it requires a user with MFA enabled and M
     - `AZURE_CLIENT_SECRET` from earlier
 
     If you are using user authentication, also add:
-    - `M365_USER` the user using the correct assigned domain, more info [here](../../getting-started/requirements.md#service-principal-and-user-credentials-authentication)
+
+    - `M365_USER` the user using the correct assigned domain, more info [here](../../tutorials/microsoft365/authentication.md#service-principal-and-user-credentials-authentication)
     - `M365_PASSWORD` the password of the user
 
     ![Prowler Cloud M365 Credentials](./img/m365-credentials.png)

--- a/docs/tutorials/microsoft365/use-of-powershell.md
+++ b/docs/tutorials/microsoft365/use-of-powershell.md
@@ -4,9 +4,9 @@ PowerShell is required by this provider because it is the only way to retrieve d
 
 If you are using Prowler Cloud, you don't need to worry about PowerShell — it is already installed in our infrastructure.
 However, if you want to run Prowler on your own, you must have PowerShell installed to execute the full M365 provider and retrieve all findings.
-To learn more about how to install PowerShell and which versions are supported, click [here](../../getting-started/requirements.md#supported-powershell-versions).
+To learn more about how to install PowerShell and which versions are supported, click [here](../../tutorials/microsoft365/authentication.md#supported-powershell-versions).
 
 ## Required Modules
 
 The necessary modules will not be installed automatically by Prowler. Nevertheless, if you want Prowler to install them for you, you can execute the provider with the flag `--init-modules`, which will run the script to install and import them.
-If you want to learn more about this process or you are running some issues with this, click [here](../../getting-started/requirements.md#needed-powershell-modules).
+If you want to learn more about this process or you are running some issues with this, click [here](../../tutorials/microsoft365/authentication.md#required-powershell-modules).

--- a/docs/tutorials/prowler-app.md
+++ b/docs/tutorials/prowler-app.md
@@ -109,7 +109,7 @@ For AWS, enter your `AWS Account ID` and choose one of the following methods to 
 
 ### **Step 4.2: Azure Credentials**:
 
-For Azure, Prowler App uses a service principal application to authenticate. For more information about the process of creating and adding permissions to a service principal refer to this [section](../getting-started/requirements.md#azure). When you finish creating and adding the [Entra](./azure/create-prowler-service-principal.md#assigning-the-proper-permissions) and [Subscription](./azure/subscriptions.md#assign-the-appropriate-permissions-to-the-identity-that-is-going-to-be-assumed-by-prowler) scope permissions to the service principal, enter the `Tenant ID`, `Client ID` and `Client Secret` of the service principal application.
+For Azure, Prowler App uses a service principal application to authenticate. For more information about the process of creating and adding permissions to a service principal refer to this [section](../tutorials/azure/authentication.md). When you finish creating and adding the [Entra](./azure/create-prowler-service-principal.md#assigning-the-proper-permissions) and [Subscription](./azure/subscriptions.md#assign-the-appropriate-permissions-to-the-identity-that-is-going-to-be-assumed-by-prowler) scope permissions to the service principal, enter the `Tenant ID`, `Client ID` and `Client Secret` of the service principal application.
 
 <img src="../../img/azure-credentials.png" alt="Azure Credentials" width="700"/>
 


### PR DESCRIPTION
### Context

Update docs with new links instead of using links to the deleted page requirements.

### Description

I've noticed there were some links not working and it was because we deleted requirements page but there were links pointing to that page.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
