### PR TITLE
fix(docs): incorrect permission in sp creation guide

### DIFF
--- a/docs/tutorials/azure/create-prowler-service-principal.md
+++ b/docs/tutorials/azure/create-prowler-service-principal.md
@@ -73,7 +73,7 @@ Permissions can be assigned via the Azure Portal or the Azure CLI.
 
 7. Finally, search for "Directory", "Policy" and "UserAuthenticationMethod" select the following permissions:
 
-    - `Domain.Read.All`
+    - `Directory.Read.All`
 
     - `Policy.Read.All`
 


### PR DESCRIPTION
### Context

Currently we have inconsistencies in permissions for Azure in our docs, specifically in how to create a service principal guide.

### Description

This PR fixes this problem by removing all permission inconsistencies.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
